### PR TITLE
Hot fix om login-knoppen onzichtbaar te maken voor burgers.

### DIFF
--- a/src/components/Header/__snapshots__/index.test.js.snap
+++ b/src/components/Header/__snapshots__/index.test.js.snap
@@ -67,22 +67,6 @@ exports[`<Header /> should render correctly 1`] = `
               <b />
             </span>
           </li>
-          <li>
-            <a
-              href=""
-              onClick={[Function]}
-            >
-              Inloggen
-            </a>
-          </li>
-          <li>
-            <a
-              href=""
-              onClick={[Function]}
-            >
-              Inloggen ADW
-            </a>
-          </li>
         </ul>
       </nav>
     </div>

--- a/src/components/Header/index.js
+++ b/src/components/Header/index.js
@@ -35,13 +35,13 @@ class Header extends React.Component { // eslint-disable-line react/prefer-state
                     {this.props.isAuthenticated && ('Ingelogd als: ')}<b>{this.props.userName}</b>
                   </span>
                 </li>
-                {!this.props.isAuthenticated ?
+                {!this.props.isPublicPage && !this.props.isAuthenticated ?
                   <li>
                     <a href="" onClick={(event) => this.props.onLoginLogoutButtonClick(event, 'datapunt')}>
                       {'Inloggen'}
                     </a>
                   </li> : ''}
-                {!this.props.isAuthenticated ?
+                {!this.props.isPublicPage && !this.props.isAuthenticated ?
                   <li>
                     <a href="" onClick={(event) => this.props.onLoginLogoutButtonClick(event, 'grip')}>
                       {'Inloggen ADW'}
@@ -65,12 +65,14 @@ class Header extends React.Component { // eslint-disable-line react/prefer-state
 
 Header.propTypes = {
   isAuthenticated: PropTypes.bool,
+  isPublicPage: PropTypes.bool,
   onLoginLogoutButtonClick: PropTypes.func,
   userName: PropTypes.string
 };
 
 Header.defaultProps = {
   isAuthenticated: false,
+  isPublicPage: true,
   onLoginLogoutButtonClick: undefined,
   userName: ''
 };

--- a/src/containers/App/index.js
+++ b/src/containers/App/index.js
@@ -30,6 +30,7 @@ export class App extends React.Component { // eslint-disable-line react/prefer-s
         <div className="content container">
           <Switch>
             <Redirect exact from="/" to="/incident" />
+            <Redirect exact from="/login" to="/manage" />
             <Route path="/manage" component={IncidentManagementModule} />
             <Route path="/incident" component={IncidentContainer} />
             <Route path="" component={NotFoundPage} />

--- a/src/containers/HeaderContainer/__snapshots__/index.test.js.snap
+++ b/src/containers/HeaderContainer/__snapshots__/index.test.js.snap
@@ -3,6 +3,7 @@
 exports[`<HeaderContainer /> should render correctly when authenticated 1`] = `
 <Header
   isAuthenticated={true}
+  isPublicPage={true}
   onLoginLogoutButtonClick={[Function]}
   userName="user"
 />

--- a/src/containers/HeaderContainer/index.js
+++ b/src/containers/HeaderContainer/index.js
@@ -16,7 +16,7 @@ import { doLogin, doLogout } from '../App/actions';
 
 import './style.scss';
 
-import { isAuthenticated } from '../../shared/services/auth/auth';
+import { isAuthenticated, isPublicPage } from '../../shared/services/auth/auth';
 
 export class HeaderContainer extends React.Component { // eslint-disable-line react/prefer-stateless-function
   constructor(props) {
@@ -39,6 +39,7 @@ export class HeaderContainer extends React.Component { // eslint-disable-line re
     return (
       <Header
         isAuthenticated={isAuthenticated()}
+        isPublicPage={isPublicPage()}
         onLoginLogoutButtonClick={this.onLoginLogoutButtonClick}
         userName={this.props.userName}
       />

--- a/src/shared/services/auth/auth.js
+++ b/src/shared/services/auth/auth.js
@@ -234,6 +234,10 @@ export function isAuthenticated() {
   return Boolean(getAccessToken());
 }
 
+export function isPublicPage() {
+  return window.location.pathname.startsWith('/incident/');
+}
+
 export function getScopes() {
   return tokenData.scopes || [];
 }

--- a/src/signals/incident-management/components/IncidentManagementModule/__snapshots__/index.test.js.snap
+++ b/src/signals/incident-management/components/IncidentManagementModule/__snapshots__/index.test.js.snap
@@ -25,7 +25,17 @@ exports[`<IncidentManagementModule /> should render correctly when authenticated
 </div>
 `;
 
-exports[`<IncidentManagementModule /> should render correctly when not authenticated 1`] = `
+exports[`<IncidentManagementModule /> should render correctly when not authenticated on management page 1`] = `
+<div
+  className="manage-incident"
+>
+  <Route
+    component={[Function]}
+  />
+</div>
+`;
+
+exports[`<IncidentManagementModule /> should render correctly when not authenticated on public page 1`] = `
 <div
   className="manage-incident"
 >

--- a/src/signals/incident-management/components/IncidentManagementModule/index.test.js
+++ b/src/signals/incident-management/components/IncidentManagementModule/index.test.js
@@ -9,7 +9,8 @@ describe('<IncidentManagementModule />', () => {
   beforeEach(() => {
     props = {
       match: { params: { id: 1 }, url: 'http://test/url' },
-      isAuthenticated: true
+      isAuthenticated: true,
+      isPublicPage: false
     };
   });
 
@@ -20,8 +21,18 @@ describe('<IncidentManagementModule />', () => {
     expect(renderedComponent).toMatchSnapshot();
   });
 
-  it('should render correctly when not authenticated', () => {
+  it('should render correctly when not authenticated on public page', () => {
     props.isAuthenticated = false;
+    props.isPublicPage = true;
+    const renderedComponent = shallow(
+      <IncidentManagementModule {...props} />
+    );
+    expect(renderedComponent).toMatchSnapshot();
+  });
+
+  it('should render correctly when not authenticated on management page', () => {
+    props.isAuthenticated = false;
+    props.isPublicPage = false;
     const renderedComponent = shallow(
       <IncidentManagementModule {...props} />
     );


### PR DESCRIPTION
Men vond het verwarrend dat er in de incident-wizard pagina's (ook zichtbaar
voor burgers) inlog-knoppen zichtbaar waren, terwijl burgers niet kunnen
inloggen.

Deze patch maakt de inlog-knoppen onzichtbaar wanneer het pad van de huidige
URL begint met "/incident/".

Before opening a pull request, please ensure:

- [ ] double-check your branch is based on `develop` and targets `develop`
  Niet gedaan. Het betreft een hot-fix, base en target zijn daarom `master`.
- [ ] Internal code generators and templates are updated (if necessary)
  Ik kon nergens vinden hoe dat moet...

