### PR TITLE
(Fix) Filter post payload

### DIFF
--- a/src/signals/incident-management/components/FilterForm/__test__/FilterForm.test.js
+++ b/src/signals/incident-management/components/FilterForm/__test__/FilterForm.test.js
@@ -14,22 +14,38 @@ describe('signals/incident-management/components/FilterForm', () => {
 
   it('should render filter fields', () => {
     const { container } = render(
-      withAppContext(<FilterForm categories={categories} onSubmit={() => {}} />),
+      withAppContext(
+        <FilterForm categories={categories} onSubmit={() => {}} />,
+      ),
     );
 
     expect(
       container.querySelectorAll('input[type="text"][name="name"]'),
     ).toHaveLength(1);
     expect(
-      container.querySelectorAll(
-        'input[type="text"][name="address_text"]',
-      ),
+      container.querySelectorAll('input[type="text"][name="address_text"]'),
     ).toHaveLength(1);
+  });
+
+  it('should render a hidden id field', () => {
+    const { container } = render(
+      withAppContext(
+        <FilterForm categories={categories} onSubmit={() => {}} activeFilter={{ id: 1234, name: 'FooBar' }} />,
+      ),
+    );
+
+    expect(
+      container.querySelectorAll('input[type="hidden"][name="id"]'),
+    ).toHaveLength(1);
+
+    expect(container.querySelector('input[type="hidden"][name="id"]').value).toEqual('1234');
   });
 
   it('should render buttons in the footer', () => {
     const { container, getAllByTestId } = render(
-      withAppContext(<FilterForm categories={categories} onSubmit={() => {}} />),
+      withAppContext(
+        <FilterForm categories={categories} onSubmit={() => {}} />,
+      ),
     );
 
     expect(container.querySelectorAll('button[type="reset"]')).toHaveLength(1);
@@ -39,12 +55,16 @@ describe('signals/incident-management/components/FilterForm', () => {
 
   it('should render groups of category checkboxes', () => {
     const { container } = render(
-      withAppContext(<FilterForm categories={categories} onSubmit={() => {}} />),
+      withAppContext(
+        <FilterForm categories={categories} onSubmit={() => {}} />,
+      ),
     );
 
     // category groups
     expect(
-      container.querySelectorAll('input[type="checkbox"][name="maincategory_slug"]'),
+      container.querySelectorAll(
+        'input[type="checkbox"][name="maincategory_slug"]',
+      ),
     ).toHaveLength(Object.keys(categories.mainToSub).length);
 
     Object.keys(categories.mainToSub).forEach((category) => {
@@ -59,128 +79,156 @@ describe('signals/incident-management/components/FilterForm', () => {
   it('should render a list of priority options', () => {
     const { container, rerender, queryByTestId } = render(
       withAppContext(
-        <FilterForm categories={categories} priorityList={null} onSubmit={() => {}} />,
+        <FilterForm
+          categories={categories}
+          priorityList={null}
+          onSubmit={() => {}}
+        />,
       ),
     );
 
     expect(queryByTestId('priorityFilterGroup')).toBeNull();
 
     expect(
-      container.querySelectorAll(
-        'input[type="checkbox"][name="priority"]',
-      ),
-    ).toHaveLength(0);
-
-    cleanup();
-
-    rerender(
-      withAppContext(<FilterForm categories={categories} priorityList={[]} onSubmit={() => {}} />),
-    );
-
-    expect(queryByTestId('priorityFilterGroup')).toBeNull();
-
-    expect(
-      container.querySelectorAll(
-        'input[type="checkbox"][name="priority"]',
-      ),
+      container.querySelectorAll('input[type="radio"][name="priority"]'),
     ).toHaveLength(0);
 
     cleanup();
 
     rerender(
       withAppContext(
-        <FilterForm categories={categories} priorityList={priorityList} onSubmit={() => {}} />,
+        <FilterForm
+          categories={categories}
+          priorityList={[]}
+          onSubmit={() => {}}
+        />,
+      ),
+    );
+
+    expect(queryByTestId('priorityFilterGroup')).toBeNull();
+
+    expect(
+      container.querySelectorAll('input[type="radio"][name="priority"]'),
+    ).toHaveLength(0);
+
+    cleanup();
+
+    rerender(
+      withAppContext(
+        <FilterForm
+          categories={categories}
+          priorityList={priorityList}
+          onSubmit={() => {}}
+        />,
       ),
     );
 
     expect(
-      container.querySelectorAll(
-        'input[type="checkbox"][name="priority"]',
-      ),
-    ).toHaveLength(priorityList.length);
+      container.querySelectorAll('input[type="radio"][name="priority"]'),
+    ).toHaveLength(priorityList.length + 1);
   });
 
   it('should render a list of status options', () => {
     const { container, rerender, queryByTestId } = render(
-      withAppContext(<FilterForm categories={categories} statusList={null} onSubmit={() => {}} />),
+      withAppContext(
+        <FilterForm
+          categories={categories}
+          statusList={null}
+          onSubmit={() => {}}
+        />,
+      ),
     );
 
     expect(queryByTestId('statusFilterGroup')).toBeNull();
 
     expect(
-      container.querySelectorAll(
-        'input[type="checkbox"][name="status"]',
-      ),
-    ).toHaveLength(0);
-
-    cleanup();
-
-    rerender(
-      withAppContext(<FilterForm categories={categories} statusList={[]} onSubmit={() => {}} />),
-    );
-
-    expect(queryByTestId('statusFilterGroup')).toBeNull();
-
-    expect(
-      container.querySelectorAll(
-        'input[type="checkbox"][name="status"]',
-      ),
+      container.querySelectorAll('input[type="checkbox"][name="status"]'),
     ).toHaveLength(0);
 
     cleanup();
 
     rerender(
       withAppContext(
-        <FilterForm categories={categories} statusList={statusList} onSubmit={() => {}} />,
+        <FilterForm
+          categories={categories}
+          statusList={[]}
+          onSubmit={() => {}}
+        />,
+      ),
+    );
+
+    expect(queryByTestId('statusFilterGroup')).toBeNull();
+
+    expect(
+      container.querySelectorAll('input[type="checkbox"][name="status"]'),
+    ).toHaveLength(0);
+
+    cleanup();
+
+    rerender(
+      withAppContext(
+        <FilterForm
+          categories={categories}
+          statusList={statusList}
+          onSubmit={() => {}}
+        />,
       ),
     );
 
     expect(
-      container.querySelectorAll(
-        'input[type="checkbox"][name="status"]',
-      ),
+      container.querySelectorAll('input[type="checkbox"][name="status"]'),
     ).toHaveLength(statusList.length);
   });
 
   it('should render a list of stadsdeel options', () => {
     const { container, rerender, queryByTestId } = render(
-      withAppContext(<FilterForm categories={categories} stadsdeelList={[]} onSubmit={() => {}} />),
+      withAppContext(
+        <FilterForm
+          categories={categories}
+          stadsdeelList={[]}
+          onSubmit={() => {}}
+        />,
+      ),
     );
 
     expect(queryByTestId('stadsdeelFilterGroup')).toBeNull();
 
     expect(
-      container.querySelectorAll(
-        'input[type="checkbox"][name="stadsdeel"]',
-      ),
-    ).toHaveLength(0);
-
-    cleanup();
-
-    rerender(
-      withAppContext(<FilterForm categories={categories} stadsdeelList={[]} onSubmit={() => {}} />),
-    );
-
-    expect(queryByTestId('stadsdeelFilterGroup')).toBeNull();
-
-    expect(
-      container.querySelectorAll(
-        'input[type="checkbox"][name="stadsdeel"]',
-      ),
+      container.querySelectorAll('input[type="checkbox"][name="stadsdeel"]'),
     ).toHaveLength(0);
 
     cleanup();
 
     rerender(
       withAppContext(
-        <FilterForm categories={categories} stadsdeelList={stadsdeelList} onSubmit={() => {}} />,
+        <FilterForm
+          categories={categories}
+          stadsdeelList={[]}
+          onSubmit={() => {}}
+        />,
+      ),
+    );
+
+    expect(queryByTestId('stadsdeelFilterGroup')).toBeNull();
+
+    expect(
+      container.querySelectorAll('input[type="checkbox"][name="stadsdeel"]'),
+    ).toHaveLength(0);
+
+    cleanup();
+
+    rerender(
+      withAppContext(
+        <FilterForm
+          categories={categories}
+          stadsdeelList={stadsdeelList}
+          onSubmit={() => {}}
+        />,
       ),
     );
 
     expect(
-      container.querySelectorAll(
-        'input[type="checkbox"][name="stadsdeel"]',
-      ),
+      container.querySelectorAll('input[type="checkbox"][name="stadsdeel"]'),
     ).toHaveLength(stadsdeelList.length);
   });
 
@@ -197,39 +245,37 @@ describe('signals/incident-management/components/FilterForm', () => {
     ];
 
     const { container, rerender, queryByTestId } = render(
-      withAppContext(<FilterForm categories={categories} feedback={[]} />),
+      withAppContext(<FilterForm categories={categories} onSubmit={() => {}} feedbackList={[]} />),
     );
 
     expect(queryByTestId('feedbackFilterGroup')).toBeNull();
 
     expect(
-      container.querySelectorAll(
-        'input[type="checkbox"][name="feedback"]',
-      ),
+      container.querySelectorAll('input[type="radio"][name="feedback"]'),
     ).toHaveLength(0);
 
     cleanup();
 
     rerender(
-      withAppContext(<FilterForm categories={categories} feedback={feedback} />),
+      withAppContext(
+        <FilterForm categories={categories} onSubmit={() => {}} feedbackList={feedback} />,
+      ),
     );
 
     expect(
-      container.querySelectorAll(
-        'input[type="checkbox"][name="feedback"]',
-      ),
-    ).toHaveLength(feedback.length);
+      container.querySelectorAll('input[type="radio"][name="feedback"]'),
+    ).toHaveLength(feedback.length + 1); // by default, a radio button with an empty value is rendered
   });
 
   it('should render a datepicker', () => {
     const { container, rerender } = render(
-      withAppContext(<FilterForm categories={categories} onSubmit={() => {}} />),
+      withAppContext(
+        <FilterForm categories={categories} onSubmit={() => {}} />,
+      ),
     );
 
     expect(
-      container.querySelectorAll(
-        'input[type="hidden"][name="incident_date"]',
-      ),
+      container.querySelectorAll('input[type="hidden"][name="incident_date"]'),
     ).toHaveLength(0);
 
     expect(document.getElementById('filter_date')).toBeTruthy();
@@ -241,16 +287,14 @@ describe('signals/incident-management/components/FilterForm', () => {
       withAppContext(
         <FilterForm
           categories={categories}
-          filter={{ incident_date: '1970-01-01' }}
+          activeFilter={{ options: { incident_date: '1970-01-01' } }}
           onSubmit={() => {}}
         />,
       ),
     );
 
     expect(
-      container.querySelectorAll(
-        'input[type="hidden"][name="incident_date"]',
-      ),
+      container.querySelectorAll('input[type="hidden"][name="incident_date"]'),
     ).toHaveLength(1);
   });
 
@@ -261,7 +305,11 @@ describe('signals/incident-management/components/FilterForm', () => {
     const onClearFilter = jest.fn();
     const { container } = render(
       withAppContext(
-        <FilterForm categories={categories} onClearFilter={onClearFilter} onSubmit={() => {}} />,
+        <FilterForm
+          categories={categories}
+          onClearFilter={onClearFilter}
+          onSubmit={() => {}}
+        />,
       ),
     );
 
@@ -296,7 +344,11 @@ describe('signals/incident-management/components/FilterForm', () => {
     const onCancel = jest.fn();
     const { getByTestId } = render(
       withAppContext(
-        <FilterForm categories={categories} onCancel={onCancel} onSubmit={() => {}} />,
+        <FilterForm
+          categories={categories}
+          onCancel={onCancel}
+          onSubmit={() => {}}
+        />,
       ),
     );
 
@@ -334,7 +386,10 @@ describe('signals/incident-management/components/FilterForm', () => {
           <FilterForm
             categories={categories}
             {...handlers}
-            filter={{ name: '', incident_date: '1970-01-01' }}
+            activeFilter={{
+              name: '',
+              options: { incident_date: '1970-01-01' },
+            }}
           />,
         ),
       );
@@ -346,6 +401,7 @@ describe('signals/incident-management/components/FilterForm', () => {
     });
 
     it('should handle submit for existing filter', () => {
+      jest.spyOn(window, 'alert').mockImplementation(() => {});
       const handlers = {
         onUpdateFilter: jest.fn(),
         onSubmit: jest.fn(),
@@ -356,7 +412,12 @@ describe('signals/incident-management/components/FilterForm', () => {
           <FilterForm
             categories={categories}
             {...handlers}
-            filter={{ name: 'My filter', incident_date_start: '1970-01-01' }}
+            activeFilter={{
+              name: 'My filter',
+              options: {
+                incident_date_start: '1970-01-01',
+              },
+            }}
           />,
         ),
       );
@@ -371,9 +432,14 @@ describe('signals/incident-management/components/FilterForm', () => {
 
       handlers.onUpdateFilter.mockReset();
 
-      fireEvent.change(nameField, { target: { value: '' } });
+      fireEvent.change(nameField, { target: { value: ' ' } });
+
+      fireEvent.click(container.querySelector('button[type="submit"]'));
 
       expect(handlers.onUpdateFilter).not.toHaveBeenCalled();
+      expect(window.alert).toHaveBeenCalled();
+
+      window.alert.mockRestore();
     });
   });
 
@@ -382,7 +448,7 @@ describe('signals/incident-management/components/FilterForm', () => {
       withAppContext(
         <FilterForm
           categories={categories}
-          filter={{ name: 'My saved filter' }}
+          activeFilter={{ name: 'My saved filter' }}
           onSubmit={() => {}}
         />,
       ),

--- a/src/signals/incident-management/components/FilterForm/__test__/parse.test.js
+++ b/src/signals/incident-management/components/FilterForm/__test__/parse.test.js
@@ -31,7 +31,7 @@ describe('signals/incident-management/components/FilterForm/parse', () => {
 
     const expected1 = {
       name: 'Afval in Westpoort',
-      maincategory_slug: 'afval',
+      maincategory_slug: ['afval'],
       category_slug: ['drijfvuil'],
     };
 

--- a/src/signals/incident-management/components/FilterForm/index.js
+++ b/src/signals/incident-management/components/FilterForm/index.js
@@ -7,6 +7,7 @@ import DatePicker from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
 
 import CheckboxList from '../CheckboxList';
+import RadioButtonList from '../RadioButtonList';
 import Label from '../Label';
 import { parseInputFormData, parseOutputFormData } from './parse';
 import {
@@ -28,8 +29,7 @@ export const saveSubmitBtnLabel = 'Opslaan en filteren';
  * Component that renders the incident filter form
  */
 const FilterForm = ({
-  feedback,
-  filter,
+  activeFilter,
   onCancel,
   onClearFilter,
   onSaveFilter,
@@ -38,11 +38,15 @@ const FilterForm = ({
   ...dataLists
 }) => {
   const {
+    feedbackList: feedback,
     categories,
     priorityList: priority,
     stadsdeelList: stadsdeel,
     statusList: status,
   } = dataLists;
+
+  const { id, name, options } = activeFilter;
+  const filter = { id, name, ...options };
 
   const parsedfilterData = parseInputFormData(filter, {
     feedback,
@@ -55,7 +59,6 @@ const FilterForm = ({
 
   const [submitBtnLabel, setSubmitBtnLabel] = useState(defaultSubmitBtnLabel);
   const [filterData, setFilterData] = useState(parsedfilterData);
-
   const filterSlugs = (filterData.maincategory_slug || []).concat(
     filterData.category_slug || [],
   );
@@ -152,6 +155,9 @@ const FilterForm = ({
   return (
     <Form action="" novalidate onChange={onChangeForm}>
       <ControlsWrapper>
+        {filterData.id && (
+          <input type="hidden" name="id" value={filterData.id} />
+        )}
         <Fieldset>
           <legend className="hiddenvisually">Naam van het filter</legend>
 
@@ -182,26 +188,21 @@ const FilterForm = ({
             </FilterGroup>
           )}
 
-          {Array.isArray(stadsdeel) &&
-            stadsdeel.length > 0 && (
-              <FilterGroup data-testid="stadsdeelFilterGroup">
-                <Label htmlFor={`status_${stadsdeel[0].key}`}>
-                  Stadsdeel
-                </Label>
-                <CheckboxList
-                  defaultValue={filterData.stadsdeel}
-                  groupName="stadsdeel"
-                  options={stadsdeel}
-                />
-              </FilterGroup>
+          {Array.isArray(stadsdeel) && stadsdeel.length > 0 && (
+            <FilterGroup data-testid="stadsdeelFilterGroup">
+              <Label htmlFor={`status_${stadsdeel[0].key}`}>Stadsdeel</Label>
+              <CheckboxList
+                defaultValue={filterData.stadsdeel}
+                groupName="stadsdeel"
+                options={stadsdeel}
+              />
+            </FilterGroup>
           )}
 
           {Array.isArray(priority) && priority.length > 0 && (
             <FilterGroup data-testid="priorityFilterGroup">
-              <Label htmlFor={`status_${priority[0].key}`}>
-                Urgentie
-              </Label>
-              <CheckboxList
+              <Label htmlFor={`status_${priority[0].key}`}>Urgentie</Label>
+              <RadioButtonList
                 defaultValue={filterData.priority}
                 groupName="priority"
                 options={priority}
@@ -214,7 +215,7 @@ const FilterForm = ({
               <Label htmlFor={`feedback_${feedback[0].key}`}>
                 Tevredenheid
               </Label>
-              <CheckboxList
+              <RadioButtonList
                 defaultValue={filterData.feedback}
                 groupName="feedback"
                 options={feedback}
@@ -247,8 +248,7 @@ const FilterForm = ({
                 }
                 placeholderText="DD-MM-JJJJ"
                 selected={
-                  filterData.incident_date &&
-                  moment(filterData.incident_date)
+                  filterData.incident_date && moment(filterData.incident_date)
                 }
               />
 
@@ -340,7 +340,7 @@ const FilterForm = ({
 };
 
 FilterForm.defaultProps = {
-  filter: {
+  activeFilter: {
     name: '',
   },
 };
@@ -374,31 +374,34 @@ FilterForm.propTypes = {
       value: PropTypes.string.isRequired,
     }),
   ),
-  filter: PropTypes.shape({
-    feedback: PropTypes.string,
-    incident_date: PropTypes.string,
-    address_text: PropTypes.string,
-    stadsdeel: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.arrayOf(PropTypes.string),
-    ]),
-    maincategory_slug: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.arrayOf(PropTypes.string),
-    ]),
+  activeFilter: PropTypes.shape({
+    id: PropTypes.number,
     name: PropTypes.string,
-    priority: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.arrayOf(PropTypes.string),
-    ]),
-    status: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.arrayOf(PropTypes.string),
-    ]),
-    category_slug: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.arrayOf(PropTypes.string),
-    ]),
+    options: PropTypes.shape({
+      feedback: PropTypes.string,
+      incident_date: PropTypes.string,
+      address_text: PropTypes.string,
+      stadsdeel: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.arrayOf(PropTypes.string),
+      ]),
+      maincategory_slug: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.arrayOf(PropTypes.string),
+      ]),
+      priority: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.arrayOf(PropTypes.string),
+      ]),
+      status: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.arrayOf(PropTypes.string),
+      ]),
+      category_slug: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.arrayOf(PropTypes.string),
+      ]),
+    }),
   }),
   /** Callback handler for when filter settings should not be applied */
   onCancel: PropTypes.func,

--- a/src/signals/incident-management/components/FilterForm/parse.js
+++ b/src/signals/incident-management/components/FilterForm/parse.js
@@ -1,5 +1,12 @@
 import clonedeep from 'lodash.clonedeep';
 
+const arrayFields = [
+  'stadsdeel',
+  'maincategory_slug',
+  'status',
+  'category_slug',
+];
+
 /**
  * Parse form data for consumption by global store actions
  *
@@ -21,7 +28,7 @@ export const parseOutputFormData = (form) => {
 
       parsed[key] = Array.isArray(val) ? [...val, value] : [val, value];
     } else {
-      parsed[key] = value;
+      parsed[key] = arrayFields.includes(key) ? [value] : value;
     }
   });
 
@@ -64,15 +71,6 @@ export const parseOutputFormData = (form) => {
  * @returns {Object}
  */
 export const parseInputFormData = (filterData, dataLists) => {
-  const arrayFields = [
-    'feedback',
-    'stadsdeel',
-    'maincategory_slug',
-    'priority',
-    'status',
-    'category_slug',
-  ];
-
   const parsed = clonedeep(filterData);
 
   /* istanbul ignore else */

--- a/src/signals/incident-management/components/RadioButtonList/index.js
+++ b/src/signals/incident-management/components/RadioButtonList/index.js
@@ -1,0 +1,90 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+import Label from '../Label';
+
+const FilterGroup = styled.div`
+  position: relative;
+
+  & + & {
+    margin-top: 30px;
+  }
+`;
+
+/**
+ * Component that renders a group of radio buttons
+ */
+const RadioButtonList = ({
+  emptySelectionLabel,
+  hasEmptySelectionButton,
+  defaultValue,
+  groupName,
+  options,
+  title,
+}) => (
+  <FilterGroup>
+    {title && (
+      <Label htmlFor={options[0].key} isGroupHeader={false}>
+        {title}
+      </Label>
+    )}
+
+    {hasEmptySelectionButton && emptySelectionLabel && (
+      <div className="antwoord">
+        <input
+          type="radio"
+          id={`empty_${groupName}`}
+          name={groupName}
+          value=""
+          defaultChecked={defaultValue === ''}
+        />
+        <label htmlFor={`empty_${groupName}`}>{emptySelectionLabel}</label>
+      </div>
+    )}
+
+    {options.map(({ key, value }) => (
+      <div className="antwoord" key={key}>
+        <input
+          type="radio"
+          id={key}
+          name={groupName}
+          value={key}
+          defaultChecked={key === defaultValue}
+        />
+        <label htmlFor={key}>{value}</label>
+      </div>
+    ))}
+  </FilterGroup>
+);
+
+RadioButtonList.defaultProps = {
+  emptySelectionLabel: 'Alles',
+  defaultValue: '',
+  hasEmptySelectionButton: true,
+};
+
+RadioButtonList.propTypes = {
+  /** List of keys for elements that need to be checked by default */
+  defaultValue: PropTypes.string,
+  /** Text label for the radio button with the empty value */
+  emptySelectionLabel: PropTypes.string,
+  /**
+   * Value of the `name` attribute of the toggle box. This value is used to identify all children by without having
+   * to select them all.
+   */
+  groupName: PropTypes.string.isRequired,
+  /** When false, will only render the passed in options instead of having an extra radio button with an empty value */
+  hasEmptySelectionButton: PropTypes.bool,
+  /** Values to be rendered as checkbox elements */
+  options: PropTypes.arrayOf(
+    PropTypes.shape({
+      key: PropTypes.string.isRequired,
+      value: PropTypes.string.isRequired,
+    }),
+  ).isRequired,
+  /** Group label contents */
+  title: PropTypes.string,
+};
+
+export default RadioButtonList;

--- a/src/signals/incident-management/containers/Filter/index.js
+++ b/src/signals/incident-management/containers/Filter/index.js
@@ -25,6 +25,8 @@ import {
   filterCleared as onClearFilter,
 } from './actions';
 
+import { makeSelectActiveFilter } from './selectors';
+
 export const FilterContainerComponent = ({
   onResetSearchQuery,
   onRequestIncidents,
@@ -42,6 +44,34 @@ export const FilterContainerComponent = ({
 };
 
 FilterContainerComponent.propTypes = {
+  activeFilter: PropTypes.shape({
+    id: PropTypes.number,
+    name: PropTypes.string,
+    options: PropTypes.shape({
+      incident_date: PropTypes.string,
+      address_text: PropTypes.string,
+      stadsdeel: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.arrayOf(PropTypes.string),
+      ]),
+      maincategory_slug: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.arrayOf(PropTypes.string),
+      ]),
+      priority: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.arrayOf(PropTypes.string),
+      ]),
+      status: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.arrayOf(PropTypes.string),
+      ]),
+      category_slug: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.arrayOf(PropTypes.string),
+      ]),
+    }),
+  }),
   categories: PropTypes.shape({
     main: PropTypes.arrayOf(
       PropTypes.shape({
@@ -75,32 +105,7 @@ FilterContainerComponent.propTypes = {
   onSubmit: PropTypes.func.isRequired,
   onUpdateFilter: PropTypes.func.isRequired,
   overviewpage: PropTypes.shape({
-    filter: PropTypes.shape({
-      incident_date: PropTypes.string,
-      address_text: PropTypes.string,
-      stadsdeel: PropTypes.oneOfType([
-        PropTypes.string,
-        PropTypes.arrayOf(PropTypes.string),
-      ]),
-      maincategory_slug: PropTypes.oneOfType([
-        PropTypes.string,
-        PropTypes.arrayOf(PropTypes.string),
-      ]),
-      name: PropTypes.string,
-      priority: PropTypes.oneOfType([
-        PropTypes.string,
-        PropTypes.arrayOf(PropTypes.string),
-      ]),
-      status: PropTypes.oneOfType([
-        PropTypes.string,
-        PropTypes.arrayOf(PropTypes.string),
-      ]),
-      category_slug: PropTypes.oneOfType([
-        PropTypes.string,
-        PropTypes.arrayOf(PropTypes.string),
-      ]),
-    }),
-    feedback: PropTypes.arrayOf(
+    feedbackList: PropTypes.arrayOf(
       PropTypes.shape({
         key: PropTypes.string.isRequired,
         value: PropTypes.string.isRequired,
@@ -134,6 +139,7 @@ const mapStateToProps = () =>
   createStructuredSelector({
     overviewpage: makeSelectOverviewPage(),
     categories: makeSelectCategories(),
+    activeFilter: makeSelectActiveFilter,
   });
 
 const mapDispatchToProps = (dispatch) =>

--- a/src/signals/incident-management/containers/IncidentOverviewPage/reducer.js
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/reducer.js
@@ -19,7 +19,7 @@ export const initialState = fromJS({
   sort: '-created_at',
   stadsdeelList,
   statusList,
-  feedback: [
+  feedbackList: [
     {
       key: 'satisfied',
       value: 'Tevreden',


### PR DESCRIPTION
This PR:
- Alters the `Form` container's saga so that updating and saving filter a filter is handled by a detached task. This was necessary, because the actions to update and save a filter were called from the `Filter` form component that was unmounted before the saga's async request could be completed.
- Also changes said saga so that the filter endpoints receive the data format they expect; the `options` prop was missing.
- Inject the `activeFilter` data from the store into the `Filter` form component; the data from `IncidentOverviewPage` didn't have all the props, like `id`
- Changes saga tests to unit tests to ensure coverage
- Adds a `RadioButtonList` component