### PR TITLE
SIG-1563 Clearing date field fix

### DIFF
--- a/src/signals/incident-management/components/FilterForm/__test__/FilterForm.test.js
+++ b/src/signals/incident-management/components/FilterForm/__test__/FilterForm.test.js
@@ -30,7 +30,11 @@ describe('signals/incident-management/components/FilterForm', () => {
   it('should render a hidden id field', () => {
     const { container } = render(
       withAppContext(
-        <FilterForm categories={categories} onSubmit={() => {}} activeFilter={{ id: 1234, name: 'FooBar' }} />,
+        <FilterForm
+          categories={categories}
+          onSubmit={() => {}}
+          activeFilter={{ id: 1234, name: 'FooBar' }}
+        />,
       ),
     );
 
@@ -38,7 +42,9 @@ describe('signals/incident-management/components/FilterForm', () => {
       container.querySelectorAll('input[type="hidden"][name="id"]'),
     ).toHaveLength(1);
 
-    expect(container.querySelector('input[type="hidden"][name="id"]').value).toEqual('1234');
+    expect(
+      container.querySelector('input[type="hidden"][name="id"]').value,
+    ).toEqual('1234');
   });
 
   it('should render buttons in the footer', () => {
@@ -245,7 +251,13 @@ describe('signals/incident-management/components/FilterForm', () => {
     ];
 
     const { container, rerender, queryByTestId } = render(
-      withAppContext(<FilterForm categories={categories} onSubmit={() => {}} feedbackList={[]} />),
+      withAppContext(
+        <FilterForm
+          categories={categories}
+          onSubmit={() => {}}
+          feedbackList={[]}
+        />,
+      ),
     );
 
     expect(queryByTestId('feedbackFilterGroup')).toBeNull();
@@ -258,7 +270,11 @@ describe('signals/incident-management/components/FilterForm', () => {
 
     rerender(
       withAppContext(
-        <FilterForm categories={categories} onSubmit={() => {}} feedbackList={feedback} />,
+        <FilterForm
+          categories={categories}
+          onSubmit={() => {}}
+          feedbackList={feedback}
+        />,
       ),
     );
 

--- a/src/signals/incident-management/components/FilterForm/__test__/parse.test.js
+++ b/src/signals/incident-management/components/FilterForm/__test__/parse.test.js
@@ -5,7 +5,7 @@ import stadsdeelList from 'signals/incident-management/definitions/stadsdeelList
 import { parseOutputFormData, parseInputFormData } from '../parse';
 import categories from './fixtures/categories.json';
 
-describe.skip('signals/incident-management/components/FilterForm/parse', () => {
+describe('signals/incident-management/components/FilterForm/parse', () => {
   it('should parse output FormData', () => {
     const form = document.createElement('form');
     const nameField = document.createElement('input');
@@ -31,8 +31,10 @@ describe.skip('signals/incident-management/components/FilterForm/parse', () => {
 
     const expected1 = {
       name: 'Afval in Westpoort',
-      maincategory_slug: ['afval'],
-      category_slug: ['drijfvuil'],
+      options: {
+        maincategory_slug: ['afval'],
+        category_slug: ['drijfvuil'],
+      },
     };
 
     const parsedOutput1 = parseOutputFormData(form);
@@ -62,8 +64,10 @@ describe.skip('signals/incident-management/components/FilterForm/parse', () => {
 
     const expected2 = {
       name: 'Afval in Westpoort',
-      maincategory_slug: ['afval', 'wegen-verkeer-straatmeubilair'],
-      category_slug: ['drijfvuil', 'maaien-snoeien', 'maaien-snoeien-2'],
+      options: {
+        maincategory_slug: ['afval', 'wegen-verkeer-straatmeubilair'],
+        category_slug: ['drijfvuil', 'maaien-snoeien', 'maaien-snoeien-2'],
+      },
     };
 
     const parsedOutput2 = parseOutputFormData(form);
@@ -74,10 +78,12 @@ describe.skip('signals/incident-management/components/FilterForm/parse', () => {
   it('should parse input FormData', () => {
     const input = {
       name: 'Afval in Westpoort',
-      stadsdeel: 'B',
-      address_text: '',
-      maincategory_slug: 'afval',
-      category_slug: ['maaien-snoeien', 'onkruid', 'autom-verzinkbare-palen'],
+      options: {
+        stadsdeel: ['B'],
+        address_text: '',
+        maincategory_slug: ['afval'],
+        category_slug: ['maaien-snoeien', 'onkruid', 'autom-verzinkbare-palen'],
+      },
     };
 
     const expected = {

--- a/src/signals/incident-management/components/FilterForm/index.js
+++ b/src/signals/incident-management/components/FilterForm/index.js
@@ -231,11 +231,9 @@ const FilterForm = ({
                  */
                 onChange={
                   /* istanbul ignore next */ (dateValue) => {
-                    if (!dateValue) return;
-
-                    const formattedDate = moment(dateValue).format(
-                      'YYYY-MM-DD',
-                    );
+                    const formattedDate = dateValue
+                      ? moment(dateValue).format('YYYY-MM-DD')
+                      : '';
 
                     setFilterData({
                       ...filterData,
@@ -280,7 +278,9 @@ const FilterForm = ({
         <Fieldset>
           <legend>Filter categorieën</legend>
 
-          <Label $as="span" htmlFor="not_used">Categorie</Label>
+          <Label $as="span" htmlFor="not_used">
+            Categorie
+          </Label>
 
           {Object.keys(categories.mainToSub)
             .filter((key) => !!key) // remove elements without 'key' prop


### PR DESCRIPTION
This PR contains a fix for the date field where, when the value was cleared after it contained a value before, the filter would still pick up the previous filled value.
Note that this fix doesn't come with a test, because of the inability to test the datepicker package. See https://github.com/Hacker0x01/react-datepicker/issues/1578 for reference.