### PR TITLE
SIG-1563 Melden page lay-out fix

### DIFF
--- a/src/signals/incident/containers/IncidentContainer/index.js
+++ b/src/signals/incident/containers/IncidentContainer/index.js
@@ -4,7 +4,7 @@
  *
  */
 
-import React, { Fragment } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
@@ -34,26 +34,18 @@ export class IncidentContainer extends React.Component {
 
   render() {
     return (
-      <Fragment>
-        <Row>
-          <Column span={{ small: 0, medium: 0, big: 2, large: 2, xLarge: 2 }} />
-
-          <Column
-            span={{ small: 12, medium: 12, big: 8, large: 8, xLarge: 8 }}
-          >
-            <IncidentWizard
-              wizardDefinition={wizardDefinition}
-              getClassification={this.getClassification}
-              updateIncident={this.updateIncident}
-              createIncident={this.createIncident}
-              incidentContainer={this.props.incidentContainer}
-              isAuthenticated={this.props.isAuthenticated}
-            />
-          </Column>
-
-          <Column span={{ small: 0, medium: 0, big: 2, large: 2, xLarge: 2 }} />
-        </Row>
-      </Fragment>
+      <Row>
+        <Column span={12}>
+          <IncidentWizard
+            wizardDefinition={wizardDefinition}
+            getClassification={this.getClassification}
+            updateIncident={this.updateIncident}
+            createIncident={this.createIncident}
+            incidentContainer={this.props.incidentContainer}
+            isAuthenticated={this.props.isAuthenticated}
+          />
+        </Column>
+      </Row>
     );
   }
 }


### PR DESCRIPTION
This PR reverts a previous change (https://github.com/Amsterdam/signals-frontend/commit/1dfe492b05b2c74b35dd3a402f93b4bbec94af95#diff-285fc137232757bf65f49b8a2d7515e2) that inadvertedly reverted other changes which caused the 'Melden' page to have a wrong lay-out.