### PR TITLE
SIG-1630 Filter save bug

### DIFF
--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -1,3 +1,22 @@
 if (window.NodeList && !NodeList.prototype.forEach) {
   NodeList.prototype.forEach = Array.prototype.forEach;
 }
+
+/**
+ * Object.entries polyfill
+ * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries#Polyfill}
+ */
+if (!Object.entries) {
+  Object.entries = function entries(obj) {
+    const ownProps = Object.keys(obj);
+    let i = ownProps.length;
+    const resArray = new Array(i); // preallocate the Array
+
+    // eslint-disable-next-line no-plusplus
+    while (i--) {
+      resArray[i] = [ownProps[i], obj[ownProps[i]]];
+    }
+
+    return resArray;
+  };
+}


### PR DESCRIPTION
This PR contains an extra polyfill that targets missing support for `Object.entries` which targets older browsers and IE specifically.

