### PR TITLE
SIG-1637 Standaard teksten lay-out adjustments

### DIFF
--- a/src/signals/incident-management/components/SelectInput/index.js
+++ b/src/signals/incident-management/components/SelectInput/index.js
@@ -6,18 +6,34 @@ import Label from '../Label';
 import './style.scss';
 
 export const SelectInput = (props) => {
-  const { name, display, values, multiple, useSlug, emptyOptionText, size } = props;
-  const options = values.map(({ key, value, slug }) =>
-    <option key={useSlug ? slug : key} title={key ? value : emptyOptionText || value} value={useSlug ? slug : key}>{key ? value : emptyOptionText || value}</option>
-  );
-  const listSize = (values.length > size) ? size : values.length;
+  const {
+    name,
+    display,
+    values,
+    multiple,
+    useSlug,
+    emptyOptionText,
+    size,
+  } = props;
+  const options = values.map(({ key, value, slug }) => (
+    <option
+      key={useSlug ? slug : key}
+      title={key ? value : emptyOptionText || value}
+      value={useSlug ? slug : key}
+    >
+      {key ? value : emptyOptionText || value}
+    </option>
+  ));
+  const listSize = values.length > size ? size : values.length;
 
   const render = ({ handler }) => (
     <div className="select-input">
       <div className="mode_input text rij_verplicht">
-        <div className="select-input__label">
-          <Label htmlFor={`form${name}`}>{display}</Label>
-        </div>
+        {display && (
+          <div className="select-input__label">
+            <Label htmlFor={`form${name}`}>{display}</Label>
+          </div>
+        )}
 
         <div className="select-input__control invoer">
           <select
@@ -31,18 +47,18 @@ export const SelectInput = (props) => {
           </select>
         </div>
       </div>
-    </div>);
+    </div>
+  );
 
   render.defaultProps = {
     touched: false,
-    size: 10
+    size: 10,
   };
 
   render.propTypes = {
-    handler: PropTypes.func.isRequired
+    handler: PropTypes.func.isRequired,
   };
   return render;
 };
-
 
 export default SelectInput;

--- a/src/signals/incident-management/containers/DefaultTextsAdmin/components/DefaultTextsForm/index.js
+++ b/src/signals/incident-management/containers/DefaultTextsAdmin/components/DefaultTextsForm/index.js
@@ -2,42 +2,27 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormBuilder, FieldGroup, Validators } from 'react-reactive-form';
 import isEqual from 'lodash.isequal';
+import styled from 'styled-components';
 
 import FieldControlWrapper from 'signals/incident-management/components/FieldControlWrapper';
 import TextInput from 'signals/incident-management/components/TextInput';
 import TextAreaInput from 'signals/incident-management/components/TextAreaInput';
 import HiddenInput from 'signals/incident-management/components/HiddenInput';
 
+import { ChevronDown, ChevronUp } from '@datapunt/asc-assets';
+import { Button } from '@datapunt/asc-ui';
+
 import './style.scss';
 
-class DefaultTextsForm extends React.Component { // eslint-disable-line react/prefer-stateless-function
-  form = FormBuilder.group({ // eslint-disable-line react/sort-comp
-    item0: FormBuilder.group({
-      title: [''],
-      text: [''],
-    }),
-    item1: FormBuilder.group({
-      title: [''],
-      text: [''],
-    }),
-    item2: FormBuilder.group({
-      title: [''],
-      text: [''],
-    }),
-    item3: FormBuilder.group({
-      title: [''],
-      text: [''],
-    }),
-    item4: FormBuilder.group({
-      title: [''],
-      text: [''],
-    }),
-    categoryUrl: ['', Validators.required],
-    state: ['', Validators.required]
-  });
+const StyledButton = styled(Button)`
+  border: 1px solid black;
 
-  items = Object.keys(this.form.controls).slice(0, -2);
+  & + button:not([disabled]) {
+    margin-top: -1px;
+  }
+`;
 
+class DefaultTextsForm extends React.Component {
   constructor(props) {
     super(props);
 
@@ -50,12 +35,6 @@ class DefaultTextsForm extends React.Component { // eslint-disable-line react/pr
       this.form.get(item).valueChanges.subscribe((data) => {
         this.props.onSaveDefaultTextsItem({ index, data });
       });
-    });
-  }
-
-  componentWillUnmount() {
-    this.items.forEach((item) => {
-      this.form.get(item).valueChanges.unsubscribe();
     });
   }
 
@@ -81,6 +60,41 @@ class DefaultTextsForm extends React.Component { // eslint-disable-line react/pr
     this.form.updateValueAndValidity();
   }
 
+  componentWillUnmount() {
+    this.items.forEach((item) => {
+      this.form.get(item).valueChanges.unsubscribe();
+    });
+  }
+
+  // eslint-disable-line react/prefer-stateless-function
+  form = FormBuilder.group({
+    // eslint-disable-line react/sort-comp
+    item0: FormBuilder.group({
+      title: [''],
+      text: [''],
+    }),
+    item1: FormBuilder.group({
+      title: [''],
+      text: [''],
+    }),
+    item2: FormBuilder.group({
+      title: [''],
+      text: [''],
+    }),
+    item3: FormBuilder.group({
+      title: [''],
+      text: [''],
+    }),
+    item4: FormBuilder.group({
+      title: [''],
+      text: [''],
+    }),
+    categoryUrl: ['', Validators.required],
+    state: ['', Validators.required],
+  });
+
+  items = Object.keys(this.form.controls).slice(0, -2);
+
   handleSubmit(e) {
     e.preventDefault();
 
@@ -88,10 +102,12 @@ class DefaultTextsForm extends React.Component { // eslint-disable-line react/pr
     const payload = {
       post: {
         state: this.form.get('state').value,
-        templates: []
-      }
+        templates: [],
+      },
     };
-    const found = this.props.subCategories.find((sub) => sub.key === categoryUrl);
+    const found = this.props.subCategories.find(
+      (sub) => sub.key === categoryUrl,
+    );
     if (found && found.slug && found.category_slug) {
       payload.sub_slug = found.slug;
       payload.main_slug = found.category_slug;
@@ -121,7 +137,10 @@ class DefaultTextsForm extends React.Component { // eslint-disable-line react/pr
         <FieldGroup
           control={this.form}
           render={({ invalid }) => (
-            <form onSubmit={this.handleSubmit} className="default-texts-form__form">
+            <form
+              onSubmit={this.handleSubmit}
+              className="default-texts-form__form"
+            >
               <FieldControlWrapper
                 render={HiddenInput}
                 name="state"
@@ -152,25 +171,36 @@ class DefaultTextsForm extends React.Component { // eslint-disable-line react/pr
                     />
                   </div>
                   <div className="col-2 default-texts-form__actions">
-                    <div>
-                      <button
-                        disabled={index === 0 || !this.form.get(`${item}.text`).value}
-                        className="default-texts-form__order-button default-texts-form__order-button--up"
-                        onClick={(e) => this.changeOrdering(e, index, 'up')}
-                      />
-                    </div>
-                    <button
-                      disabled={index === this.items.length - 1 || !this.form.get(`item${index + 1}.text`).value}
-                      className="default-texts-form__order-button default-texts-form__order-button--down"
+                    <StyledButton
+                      size={44}
+                      variant="blank"
+                      disabled={
+                        index === 0 || !this.form.get(`${item}.text`).value
+                      }
+                      iconSize={16}
+                      icon={<ChevronUp />}
+                      onClick={(e) => this.changeOrdering(e, index, 'up')}
+                    />
+                    <StyledButton
+                      size={44}
+                      variant="blank"
+                      disabled={
+                        index === this.items.length - 1 ||
+                        !this.form.get(`item${index + 1}.text`).value
+                      }
+                      iconSize={16}
+                      icon={<ChevronDown />}
                       onClick={(e) => this.changeOrdering(e, index, 'down')}
                     />
                   </div>
                 </div>
               ))}
 
-              <button className="status-form__form-submit action primary" type="submit" disabled={invalid}>Opslaan</button>
+              <Button variant="secondary" type="submit" disabled={invalid}>
+                Opslaan
+              </Button>
             </form>
-              )}
+          )}
         />
       </div>
     );
@@ -186,7 +216,7 @@ DefaultTextsForm.defaultProps = {
   onSubmitTexts: () => {},
   onOrderDefaultTexts: () => {},
   onSaveDefaultTexts: () => {},
-  onSaveDefaultTextsItem: () => {}
+  onSaveDefaultTextsItem: () => {},
 };
 
 DefaultTextsForm.propTypes = {
@@ -197,7 +227,7 @@ DefaultTextsForm.propTypes = {
 
   onSubmitTexts: PropTypes.func,
   onOrderDefaultTexts: PropTypes.func,
-  onSaveDefaultTextsItem: PropTypes.func
+  onSaveDefaultTextsItem: PropTypes.func,
 };
 
 export default DefaultTextsForm;

--- a/src/signals/incident-management/containers/DefaultTextsAdmin/components/DefaultTextsForm/style.scss
+++ b/src/signals/incident-management/containers/DefaultTextsAdmin/components/DefaultTextsForm/style.scss
@@ -8,36 +8,4 @@
   &__row {
     margin-top: 19px;
   }
-
-  &__order-button {
-    width: 44px;
-    height: 44px;
-    padding: 0;
-    margin: 0;
-    border: 1px solid  $ams-zwart;
-    border-radius: 0;
-    background-repeat: no-repeat;
-    background-position: 11px;
-    background-size: 22px;
-
-    &--up {
-      background-image: url("../../../../../../shared/images/Chevron-Top.svg");
-
-      &:disabled {
-        background-image: url("../../../../../../shared/images/icon-chevron-up-disabled.svg");
-      }
-    }
-
-    &--down {
-      background-image: url("../../../../../../shared/images/Chevron-Down.svg");
-
-      &:disabled {
-        background-image: url("../../../../../../shared/images/icon-chevron-down-disabled.svg");
-      }
-    }
-
-    &:disabled {
-      border-color: #b4b4b4;
-    }
-  }
 }

--- a/src/signals/incident-management/containers/DefaultTextsAdmin/components/SelectForm/index.js
+++ b/src/signals/incident-management/containers/DefaultTextsAdmin/components/SelectForm/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormBuilder, FieldGroup } from 'react-reactive-form';
+import { Heading } from '@datapunt/asc-ui';
 
 import FieldControlWrapper from '../../../../components/FieldControlWrapper';
 import SelectInput from '../../../../components/SelectInput';
@@ -9,14 +10,7 @@ import HiddenInput from '../../../../components/HiddenInput';
 
 import './style.scss';
 
-class SelectForm extends React.Component { // eslint-disable-line react/prefer-stateless-function
-  form = FormBuilder.group({ // eslint-disable-line react/sort-comp
-    category_url: ['https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/asbest-accu'],
-    state: ['o'],
-    sub_slug: ['asbest-accu'],
-    main_slug: ['afval']
-  });
-
+class SelectForm extends React.Component {
   constructor(props) {
     super(props);
 
@@ -25,11 +19,13 @@ class SelectForm extends React.Component { // eslint-disable-line react/prefer-s
 
   componentDidMount() {
     this.form.controls.category_url.valueChanges.subscribe((category_url) => {
-      const found = this.props.subCategories.find((sub) => sub.key === category_url);
+      const found = this.props.subCategories.find(
+        (sub) => sub.key === category_url,
+      );
       if (found && found.slug && found.category_slug) {
         this.form.patchValue({
           sub_slug: found.slug,
-          main_slug: found.category_slug
+          main_slug: found.category_slug,
         });
 
         this.handleChange({ category_url });
@@ -47,14 +43,23 @@ class SelectForm extends React.Component { // eslint-disable-line react/prefer-s
     this.form.updateValueAndValidity();
   }
 
+  form = FormBuilder.group({
+    category_url: [
+      'https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/asbest-accu',
+    ],
+    state: ['o'],
+    sub_slug: ['asbest-accu'],
+    main_slug: ['afval'],
+  });
+
   handleChange = (changed) => {
     const newValues = {
       ...this.form.value,
-      ...changed
+      ...changed,
     };
 
     this.props.onFetchDefaultTexts(newValues);
-  }
+  };
 
   render() {
     const { subCategories, statusList } = this.props;
@@ -64,8 +69,10 @@ class SelectForm extends React.Component { // eslint-disable-line react/prefer-s
           control={this.form}
           render={() => (
             <form className="select-form__form">
+              <Heading $as="h2" styleAs="h4" compact>
+                Subcategorie
+              </Heading>
               <FieldControlWrapper
-                display="Subcategorie"
                 render={SelectInput}
                 name="category_url"
                 values={subCategories}
@@ -74,8 +81,10 @@ class SelectForm extends React.Component { // eslint-disable-line react/prefer-s
                 sort
               />
 
+              <Heading $as="h2" styleAs="h4">
+                Status
+              </Heading>
               <FieldControlWrapper
-                display="Status"
                 render={RadioInput}
                 name="state"
                 values={statusList}
@@ -93,9 +102,8 @@ class SelectForm extends React.Component { // eslint-disable-line react/prefer-s
                 control={this.form.get('main_slug')}
               />
             </form>
-              )}
+          )}
         />
-
       </div>
     );
   }
@@ -105,14 +113,14 @@ SelectForm.defaultProps = {
   subCategories: [],
   stateList: [],
 
-  onFetchDefaultTexts: () => {}
+  onFetchDefaultTexts: () => {},
 };
 
 SelectForm.propTypes = {
   subCategories: PropTypes.array,
   statusList: PropTypes.array,
 
-  onFetchDefaultTexts: PropTypes.func
+  onFetchDefaultTexts: PropTypes.func,
 };
 
 export default SelectForm;


### PR DESCRIPTION
This PR:
- Adjusts the appearance of defaults texts section headers
- Uses `@datapunt/asc-ui` component to style the form's buttons
- Adds a check to the `SelectInput` component so that, when no value is passed for its `display` prop, no container element is rendered