### PR TITLE
SIG-1640 Checkbox group selection fix

### DIFF
--- a/src/shared/services/map-categories/index.js
+++ b/src/shared/services/map-categories/index.js
@@ -25,7 +25,6 @@ function mapCategories(data) {
 
           mainToSub[category.slug].push({
             id: subcategory._links && subcategory._links.self && subcategory._links.self.href,
-            // key: subcategory.slug, // replacing 'key' prop since its value isn't used and it makes more sense for the filter form to have to deal with just one prop; 'key'
             value: subcategory.name,
             slug: subcategory.slug,
             category_slug: category.slug,

--- a/src/shared/services/map-categories/index.js
+++ b/src/shared/services/map-categories/index.js
@@ -24,7 +24,8 @@ function mapCategories(data) {
           });
 
           mainToSub[category.slug].push({
-            key: subcategory.slug, // replacing 'key' prop since its value isn't used and it makes more sense for the filter form to have to deal with just one prop; 'key'
+            id: subcategory._links && subcategory._links.self && subcategory._links.self.href,
+            // key: subcategory.slug, // replacing 'key' prop since its value isn't used and it makes more sense for the filter form to have to deal with just one prop; 'key'
             value: subcategory.name,
             slug: subcategory.slug,
             category_slug: category.slug,

--- a/src/shared/services/map-categories/index.test.js
+++ b/src/shared/services/map-categories/index.test.js
@@ -110,7 +110,8 @@ describe('The mapCategories service', () => {
       mainToSub: {
         'overlast-van-dieren': [
           {
-            key: 'dode-dieren',
+            id:
+              'https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/overlast-van-dieren/sub_categories/dode-dieren',
             value: 'Dode dieren',
             slug: 'dode-dieren',
             category_slug: 'overlast-van-dieren',
@@ -119,7 +120,8 @@ describe('The mapCategories service', () => {
         ],
         'wegen-verkeer-straatmeubilair': [
           {
-            key: 'gladheid',
+            id:
+              'https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/gladheid',
             value: 'Gladheid',
             slug: 'gladheid',
             handling_message: 'handling gladheid',

--- a/src/signals/incident-management/components/CheckboxList/__test__/CheckboxList.test.js
+++ b/src/signals/incident-management/components/CheckboxList/__test__/CheckboxList.test.js
@@ -12,7 +12,12 @@ describe('signals/incident-management/components/CheckboxList', () => {
     const title = 'This is my title';
     const { getByLabelText } = render(
       withAppContext(
-        <CheckboxList groupName="newGroup" options={options} title={title} />,
+        <CheckboxList
+          groupName="newGroup"
+          groupId="newGroup"
+          options={options}
+          title={title}
+        />,
       ),
     );
 
@@ -21,7 +26,13 @@ describe('signals/incident-management/components/CheckboxList', () => {
 
   it('should render a toggle', () => {
     const { getAllByLabelText, rerender } = render(
-      withAppContext(<CheckboxList groupName="newGroup" options={options} />),
+      withAppContext(
+        <CheckboxList
+          groupName="newGroup"
+          groupId="newGroup"
+          options={options}
+        />,
+      ),
     );
 
     // should not render a toggle checkbox, expecting number of checkboxes to be equal to the number of options
@@ -34,6 +45,7 @@ describe('signals/incident-management/components/CheckboxList', () => {
       withAppContext(
         <CheckboxList
           groupName="newGroup"
+          groupId="newGroup"
           options={options}
           toggleLabel="Toggle me"
         />,
@@ -50,6 +62,7 @@ describe('signals/incident-management/components/CheckboxList', () => {
       withAppContext(
         <CheckboxList
           groupName="newGroup"
+          groupId="newGroup"
           options={options}
           toggleLabel="Toggle me"
           toggleFieldName={toggleFieldName}
@@ -70,7 +83,7 @@ describe('signals/incident-management/components/CheckboxList', () => {
 
     const { rerender } = render(
       withAppContext(
-        <CheckboxList groupName={groupName} options={truncated} />,
+        <CheckboxList groupName={groupName} groupId={groupName} options={truncated} />,
       ),
     );
 
@@ -88,6 +101,7 @@ describe('signals/incident-management/components/CheckboxList', () => {
       withAppContext(
         <CheckboxList
           groupName="newGroup"
+          groupId="newGroup"
           options={truncated}
           clusterName={clusterName}
         />,
@@ -103,7 +117,13 @@ describe('signals/incident-management/components/CheckboxList', () => {
 
   it('should set default checked', () => {
     const { container, rerender } = render(
-      withAppContext(<CheckboxList groupName="newGroup" options={options} />),
+      withAppContext(
+        <CheckboxList
+          groupName="newGroup"
+          groupId="newGroup"
+          options={options}
+        />,
+      ),
     );
 
     // nothing should be checked
@@ -119,6 +139,7 @@ describe('signals/incident-management/components/CheckboxList', () => {
       withAppContext(
         <CheckboxList
           groupName="newGroup"
+          groupId="newGroup"
           options={options}
           defaultValue={defaultValue}
         />,
@@ -137,6 +158,7 @@ describe('signals/incident-management/components/CheckboxList', () => {
       withAppContext(
         <CheckboxList
           groupName="newGroup"
+          groupId="newGroup"
           options={options}
           toggleLabel="Toggle me"
           toggleFieldName={toggleFieldName}
@@ -177,7 +199,13 @@ describe('signals/incident-management/components/CheckboxList', () => {
 
   it('should handle individual checkbox interaction without a toggle checkbox', () => {
     const { container } = render(
-      withAppContext(<CheckboxList groupName="newGroup" options={options} />),
+      withAppContext(
+        <CheckboxList
+          groupName="newGroup"
+          groupId="newGroup"
+          options={options}
+        />,
+      ),
     );
 
     const individualBoxes = container.querySelectorAll(
@@ -205,6 +233,7 @@ describe('signals/incident-management/components/CheckboxList', () => {
       withAppContext(
         <CheckboxList
           groupName="newGroup"
+          groupId="newGroup"
           options={options}
           toggleLabel="Toggle me"
           toggleFieldName={toggleFieldName}
@@ -261,6 +290,7 @@ describe('signals/incident-management/components/CheckboxList', () => {
         <CheckboxList
           defaultValue={defaultValue}
           groupName={groupName}
+          groupId={groupName}
           options={options}
           toggleLabel="Toggle me"
           toggleFieldName={toggleFieldName}

--- a/src/signals/incident-management/components/FilterForm/__test__/parse.test.js
+++ b/src/signals/incident-management/components/FilterForm/__test__/parse.test.js
@@ -97,14 +97,15 @@ describe('signals/incident-management/components/FilterForm/parse', () => {
       address_text: '',
       maincategory_slug: [
         {
-          key: 'afval',
+          key: 'https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/afval',
           slug: 'afval',
           value: 'Afval',
         },
       ],
       category_slug: [
         {
-          key: 'maaien-snoeien',
+          key:
+            'https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/openbaar-groen-en-water/sub_categories/maaien-snoeien',
           value: 'Maaien / snoeien',
           slug: 'maaien-snoeien',
           category_slug: 'openbaar-groen-en-water',
@@ -112,7 +113,8 @@ describe('signals/incident-management/components/FilterForm/parse', () => {
             '\nUw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail.',
         },
         {
-          key: 'onkruid',
+          key:
+            'https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/openbaar-groen-en-water/sub_categories/onkruid',
           value: 'Onkruid',
           slug: 'onkruid',
           category_slug: 'openbaar-groen-en-water',
@@ -120,7 +122,8 @@ describe('signals/incident-management/components/FilterForm/parse', () => {
             '\nUw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail.',
         },
         {
-          key: 'autom-verzinkbare-palen',
+          key:
+            'https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/autom-verzinkbare-palen',
           value: 'Autom. Verzinkbare palen',
           slug: 'autom-verzinkbare-palen',
           category_slug: 'wegen-verkeer-straatmeubilair',

--- a/src/signals/incident-management/components/FilterForm/index.js
+++ b/src/signals/incident-management/components/FilterForm/index.js
@@ -180,6 +180,7 @@ const FilterForm = ({
               <CheckboxList
                 defaultValue={filterData.status}
                 groupName="status"
+                groupId="status"
                 options={status}
               />
             </FilterGroup>
@@ -191,6 +192,7 @@ const FilterForm = ({
               <CheckboxList
                 defaultValue={filterData.stadsdeel}
                 groupName="stadsdeel"
+                groupId="stadsdeel"
                 options={stadsdeel}
               />
             </FilterGroup>
@@ -285,21 +287,26 @@ const FilterForm = ({
           {Object.keys(categories.mainToSub)
             .filter((key) => !!key) // remove elements without 'key' prop
             .sort()
-            .map((mainCategory) => (
-              <CheckboxList
-                clusterName="category_slug"
-                defaultValue={filterSlugs}
-                groupName={mainCategory}
-                hasToggle
-                key={mainCategory}
-                options={categories.mainToSub[mainCategory]}
-                title={
-                  categories.main.find(({ slug }) => slug === mainCategory)
-                    .value
-                }
-                toggleFieldName="maincategory_slug"
-              />
-            ))}
+            .map((mainCategory) => {
+              const mainCatObj = categories.main.find(
+                ({ slug }) => slug === mainCategory,
+              );
+              const options = categories.mainToSub[mainCategory];
+
+              return (
+                <CheckboxList
+                  clusterName="category_slug"
+                  defaultValue={filterSlugs}
+                  groupName={mainCategory}
+                  groupId={mainCatObj.key}
+                  hasToggle
+                  key={mainCategory}
+                  options={options}
+                  title={mainCatObj.value}
+                  toggleFieldName="maincategory_slug"
+                />
+              );
+            })}
         </Fieldset>
       </ControlsWrapper>
 

--- a/src/signals/incident-management/components/FilterForm/parse.js
+++ b/src/signals/incident-management/components/FilterForm/parse.js
@@ -99,21 +99,6 @@ export const parseInputFormData = (filterData, dataLists) => {
           ),
         );
       });
-
-    // make sure all objects in filterData have the correct values for their 'key' prop
-    if (parsed.maincategory_slug) {
-      parsed.maincategory_slug = parsed.maincategory_slug.map((obj) => ({
-        ...obj,
-        key: obj.slug,
-      }));
-    }
-
-    if (parsed.category_slug) {
-      parsed.category_slug = parsed.category_slug.map((obj) => ({
-        ...obj,
-        key: obj.slug,
-      }));
-    }
   }
 
   return parsed;

--- a/src/signals/incident-management/containers/Filter/index.js
+++ b/src/signals/incident-management/containers/Filter/index.js
@@ -12,7 +12,9 @@ import {
   requestIncidents,
   incidentSelected as onIncidentSelected,
 } from 'signals/incident-management/containers/IncidentOverviewPage/actions';
-import makeSelectOverviewPage, { makeSelectFilter } from 'signals/incident-management/containers/IncidentOverviewPage/selectors';
+import makeSelectOverviewPage, {
+  makeSelectFilter,
+} from 'signals/incident-management/containers/IncidentOverviewPage/selectors';
 import FilterForm from 'signals/incident-management/components/FilterForm';
 import { resetSearchQuery } from 'models/search/actions';
 

--- a/src/signals/incident-management/containers/IncidentOverviewPage/index.test.js
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/index.test.js
@@ -75,10 +75,10 @@ describe('signals/incident-management/containers/IncidentOverviewPage', () => {
 
   it('should render correctly with search query present', () => {
     render(
-      withAppContext(<IncidentOverviewPageContainerComponent {...props} searchQuery={666} />),
+      withAppContext(<IncidentOverviewPageContainerComponent {...props} searchQuery="666" />),
     );
 
-    expect(props.onRequestIncidents).toBeCalledWith({ filter: { searchQuery: 666 } });
+    expect(props.onRequestIncidents).toBeCalledWith({ filter: { searchQuery: '666' } });
   });
 
   it('should have props from structured selector', () => {


### PR DESCRIPTION
This PR contains changes that fix an issue where checkboxes in a group were checked where they shouldn't be. The origin of the issue was values of slug properties of categories coming from the API. This fix in this PR no longer matches on slugs, but on id's (or keys).