### PR TITLE
SIG-1563 CheckboxList error fix

### DIFF
--- a/src/signals/incident-management/components/CheckboxList/__test__/CheckboxList.test.js
+++ b/src/signals/incident-management/components/CheckboxList/__test__/CheckboxList.test.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import { fireEvent, render, cleanup } from '@testing-library/react';
 import { withAppContext } from 'test/utils';
-import options from 'signals/incident-management/definitions/statusList';
+import statuses from 'signals/incident-management/definitions/statusList';
+import categories from 'utils/__tests__/fixtures/categories.json';
 
 import CheckboxList from '../';
 
@@ -15,7 +16,7 @@ describe('signals/incident-management/components/CheckboxList', () => {
         <CheckboxList
           groupName="newGroup"
           groupId="newGroup"
-          options={options}
+          options={statuses}
           title={title}
         />,
       ),
@@ -30,14 +31,14 @@ describe('signals/incident-management/components/CheckboxList', () => {
         <CheckboxList
           groupName="newGroup"
           groupId="newGroup"
-          options={options}
+          options={statuses}
         />,
       ),
     );
 
     // should not render a toggle checkbox, expecting number of checkboxes to be equal to the number of options
     expect(document.querySelectorAll('input[type="checkbox"]')).toHaveLength(
-      options.length,
+      statuses.length,
     );
 
     // still shouldn't render a toggle checkbox
@@ -46,14 +47,14 @@ describe('signals/incident-management/components/CheckboxList', () => {
         <CheckboxList
           groupName="newGroup"
           groupId="newGroup"
-          options={options}
+          options={statuses}
           toggleLabel="Toggle me"
         />,
       ),
     );
 
     expect(document.querySelectorAll('input[type="checkbox"]')).toHaveLength(
-      options.length,
+      statuses.length,
     );
 
     // now it should
@@ -63,7 +64,7 @@ describe('signals/incident-management/components/CheckboxList', () => {
         <CheckboxList
           groupName="newGroup"
           groupId="newGroup"
-          options={options}
+          options={statuses}
           toggleLabel="Toggle me"
           toggleFieldName={toggleFieldName}
         />,
@@ -78,7 +79,7 @@ describe('signals/incident-management/components/CheckboxList', () => {
 
   it('should render a list of checkboxes ', () => {
     const numOptions = 5;
-    const truncated = options.slice(0, numOptions);
+    const truncated = statuses.slice(0, numOptions);
     const groupName = 'newGroup';
 
     const { rerender } = render(
@@ -121,7 +122,7 @@ describe('signals/incident-management/components/CheckboxList', () => {
         <CheckboxList
           groupName="newGroup"
           groupId="newGroup"
-          options={options}
+          options={statuses}
         />,
       ),
     );
@@ -131,7 +132,7 @@ describe('signals/incident-management/components/CheckboxList', () => {
       expect(el.checked).toEqual(false);
     });
 
-    const defaultValue = [options[1], options[3], options[5]];
+    const defaultValue = [statuses[1], statuses[3], statuses[5]];
 
     cleanup();
 
@@ -140,7 +141,7 @@ describe('signals/incident-management/components/CheckboxList', () => {
         <CheckboxList
           groupName="newGroup"
           groupId="newGroup"
-          options={options}
+          options={statuses}
           defaultValue={defaultValue}
         />,
       ),
@@ -159,7 +160,7 @@ describe('signals/incident-management/components/CheckboxList', () => {
         <CheckboxList
           groupName="newGroup"
           groupId="newGroup"
-          options={options}
+          options={statuses}
           toggleLabel="Toggle me"
           toggleFieldName={toggleFieldName}
         />,
@@ -203,7 +204,7 @@ describe('signals/incident-management/components/CheckboxList', () => {
         <CheckboxList
           groupName="newGroup"
           groupId="newGroup"
-          options={options}
+          options={statuses}
         />,
       ),
     );
@@ -213,7 +214,7 @@ describe('signals/incident-management/components/CheckboxList', () => {
     );
 
     const singleBox = individualBoxes.item(
-      Math.floor(Math.random() * options.length),
+      Math.floor(Math.random() * statuses.length),
     );
 
     fireEvent.click(singleBox);
@@ -234,7 +235,7 @@ describe('signals/incident-management/components/CheckboxList', () => {
         <CheckboxList
           groupName="newGroup"
           groupId="newGroup"
-          options={options}
+          options={statuses}
           toggleLabel="Toggle me"
           toggleFieldName={toggleFieldName}
         />,
@@ -254,7 +255,7 @@ describe('signals/incident-management/components/CheckboxList', () => {
 
     // click one of the checkboxes in the list. This should deselect the toggle and leave all the other boxes checked
     const singleBox = individualBoxes.item(
-      Math.floor(Math.random() * options.length),
+      Math.floor(Math.random() * statuses.length),
     );
 
     fireEvent.click(singleBox);
@@ -291,7 +292,7 @@ describe('signals/incident-management/components/CheckboxList', () => {
           defaultValue={defaultValue}
           groupName={groupName}
           groupId={groupName}
-          options={options}
+          options={statuses}
           toggleLabel="Toggle me"
           toggleFieldName={toggleFieldName}
         />,
@@ -304,5 +305,47 @@ describe('signals/incident-management/components/CheckboxList', () => {
 
     expect(toggleBox.checked).toEqual(true);
     expect(toggleBox.dataset.value).toEqual('all');
+  });
+
+  it('should give preference to slugs over keys for checkbox values from the incoming data', () => {
+    const options = categories.mainToSub.afval;
+    const slugs = options.map(({ slug }) => slug);
+    const { container, rerender } = render(
+      withAppContext(
+        <CheckboxList
+          defaultValue={options.slice(0, 2)}
+          groupName="afval"
+          groupId="afval"
+          options={options}
+          toggleLabel="Toggle me"
+          toggleFieldName="main"
+        />,
+      ),
+    );
+
+    container.querySelectorAll('input[type="checkbox"]').forEach((element) => {
+      expect(slugs.includes(element.value));
+    });
+
+    cleanup();
+
+    const keys = statuses.map(({ key }) => key);
+
+    rerender(
+      withAppContext(
+        <CheckboxList
+          defaultValue={statuses.slice(0, 2)}
+          groupName="status"
+          groupId="status"
+          options={statuses}
+          toggleLabel="Toggle me"
+          toggleFieldName="main"
+        />,
+      ),
+    );
+
+    container.querySelectorAll('input[type="checkbox"]').forEach((element) => {
+      expect(keys.includes(element.value));
+    });
   });
 });

--- a/src/signals/incident-management/components/CheckboxList/index.js
+++ b/src/signals/incident-management/components/CheckboxList/index.js
@@ -148,7 +148,7 @@ const CheckboxList = ({
 
       {options.map(({ id, key, slug, value }) => {
         const optionIdentifier = id || key;
-        const optionValue = slug || value;
+        const optionValue = slug || key;
 
         return (
           <div className="antwoord" key={optionIdentifier}>

--- a/src/utils/__tests__/fixtures/categories.json
+++ b/src/utils/__tests__/fixtures/categories.json
@@ -315,105 +315,105 @@
   "mainToSub": {
     "afval": [
       {
-        "key": "asbest-accu",
+        "key": "https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/asbest-accu",
         "value": "Asbest / accu",
         "slug": "asbest-accu",
         "category_slug": "afval",
         "handling_message": "\nWe laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
       },
       {
-        "key": "container-is-kapot",
+        "key": "https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/container-is-kapot",
         "value": "Container is kapot",
         "slug": "container-is-kapot",
         "category_slug": "afval",
         "handling_message": "\nWe laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
       },
       {
-        "key": "container-is-vol",
+        "key": "https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/container-is-vol",
         "value": "Container is vol",
         "slug": "container-is-vol",
         "category_slug": "afval",
         "handling_message": "\nWe laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
       },
       {
-        "key": "container-voor-papier-is-stuk",
+        "key": "https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/container-voor-papier-is-stuk",
         "value": "Container papier kapot",
         "slug": "container-voor-papier-is-stuk",
         "category_slug": "afval",
         "handling_message": "\nWe laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
       },
       {
-        "key": "container-voor-papier-is-vol",
+        "key": "https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/container-voor-papier-is-vol",
         "value": "Container papier vol",
         "slug": "container-voor-papier-is-vol",
         "category_slug": "afval",
         "handling_message": "\nWe laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
       },
       {
-        "key": "container-voor-plastic-afval-is-vol",
+        "key": "https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/container-voor-plastic-afval-is-vol",
         "value": "Container plastic afval vol",
         "slug": "container-voor-plastic-afval-is-vol",
         "category_slug": "afval",
         "handling_message": "\nWe laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
       },
       {
-        "key": "container-voor-plastic-afval-is-kapot",
+        "key": "https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/container-voor-plastic-afval-is-kapot",
         "value": "Container plastic kapot",
         "slug": "container-voor-plastic-afval-is-kapot",
         "category_slug": "afval",
         "handling_message": "\nWe laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
       },
       {
-        "key": "grofvuil",
+        "key": "https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/grofvuil",
         "value": "Grofvuil",
         "slug": "grofvuil",
         "category_slug": "afval",
         "handling_message": "\nWe laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.  In Nieuw-West komen we de volgende ophaaldag.\nWe houden u op de hoogte via e-mail."
       },
       {
-        "key": "handhaving-op-afval",
+        "key": "https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/handhaving-op-afval",
         "value": "Handhaving op afval",
         "slug": "handhaving-op-afval",
         "category_slug": "afval",
         "handling_message": "\nWe laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
       },
       {
-        "key": "huisafval",
+        "key": "https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/huisafval",
         "value": "Huisafval",
         "slug": "huisafval",
         "category_slug": "afval",
         "handling_message": "\nWe laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
       },
       {
-        "key": "overig-afval",
+        "key": "https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/overig-afval",
         "value": "Overig afval",
         "slug": "overig-afval",
         "category_slug": "afval",
         "handling_message": "\nWij bekijken uw melding en zorgen dat het juiste onderdeel van de gemeente deze gaat behandelen. Heeft u contactgegevens achtergelaten? Dan nemen wij bij onduidelijkheid contact met u op."
       },
       {
-        "key": "prullenbak-is-kapot",
+        "key": "https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/prullenbak-is-kapot",
         "value": "Prullenbak is kapot",
         "slug": "prullenbak-is-kapot",
         "category_slug": "afval",
         "handling_message": "\nWe laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
       },
       {
-        "key": "prullenbak-is-vol",
+        "key": "https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/prullenbak-is-vol",
         "value": "Prullenbak is vol",
         "slug": "prullenbak-is-vol",
         "category_slug": "afval",
         "handling_message": "\nWij handelen uw melding binnen drie werkdagen af. U ontvangt dan geen apart bericht meer.\nEn anders hoort u - via e-mail - wanneer wij uw melding kunnen oppakken."
       },
       {
-        "key": "puin-sloopafval",
+        "key": "https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/puin-sloopafval",
         "value": "Puin- / sloopafval",
         "slug": "puin-sloopafval",
         "category_slug": "afval",
         "handling_message": "\nWe laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
       },
       {
-        "key": "veeg-zwerfvuil",
+        "key": "https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/veeg-zwerfvuil",
         "value": "Veeg- / zwerfvuil",
         "slug": "veeg-zwerfvuil",
         "category_slug": "afval",


### PR DESCRIPTION
This PR contains a fix for errors that popped up when editing a stored filter. The cause was a faulty check in the `CheckboxList` component that determined what the value for a checkbox should be. A test has been added to ensure that this issue doesn't occur again.