### PR TITLE
SIG-1665 Two minute incidents refresh

### DIFF
--- a/src/components/PageHeader/index.js
+++ b/src/components/PageHeader/index.js
@@ -43,7 +43,7 @@ PageHeader.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
   subTitle: PropTypes.string,
-  title: PropTypes.string.isRequired,
+  title: PropTypes.node.isRequired,
 };
 
 export default PageHeader;

--- a/src/containers/PageHeader/index.js
+++ b/src/containers/PageHeader/index.js
@@ -1,7 +1,7 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { compose, bindActionCreators } from 'redux';
+import { compose } from 'redux';
 import { createStructuredSelector } from 'reselect';
 import styled from 'styled-components';
 
@@ -11,7 +11,6 @@ import {
   makeSelectFilter,
 } from 'signals/incident-management/containers/IncidentOverviewPage/selectors';
 import { makeSelectQuery } from 'models/search/selectors';
-import { emptyReverted } from '../../signals/incident-management/containers/IncidentOverviewPage/actions';
 import Refresh from '../../shared/images/icon-refresh.svg';
 
 const RefreshIcon = styled(Refresh).attrs({
@@ -95,17 +94,6 @@ const mapStateToProps = createStructuredSelector({
   query: makeSelectQuery,
 });
 
-export const mapDispatchToProps = (dispatch) =>
-  bindActionCreators(
-    {
-      onClose: emptyReverted,
-    },
-    dispatch,
-  );
-
-const withConnect = connect(
-  mapStateToProps,
-  mapDispatchToProps,
-);
+const withConnect = connect(mapStateToProps);
 
 export default compose(withConnect)(PageHeaderContainerComponent);

--- a/src/signals/incident-management/components/FilterForm/__test__/FilterForm.test.js
+++ b/src/signals/incident-management/components/FilterForm/__test__/FilterForm.test.js
@@ -453,7 +453,7 @@ describe('signals/incident-management/components/FilterForm', () => {
 
       fireEvent.click(container.querySelector('button[type="submit"]'));
 
-      expect(handlers.onSaveFilter).toHaveBeenCalled();
+      expect(handlers.onSaveFilter).not.toHaveBeenCalled();
       expect(handlers.onSubmit).toHaveBeenCalled();
     });
 

--- a/src/signals/incident-management/components/FilterForm/index.js
+++ b/src/signals/incident-management/components/FilterForm/index.js
@@ -64,10 +64,11 @@ const FilterForm = ({
   const onSubmitForm = (event) => {
     const formData = parseOutputFormData(event.target.form);
     const isNewFilter = !filterData.name;
+    const hasName = formData.name.trim() !== '';
     const valuesHaveChanged = !isEqual(formData, filterData);
 
     /* istanbul ignore else */
-    if (typeof onSaveFilter === 'function' && isNewFilter) {
+    if (typeof onSaveFilter === 'function' && isNewFilter && hasName) {
       onSaveFilter(formData);
     }
 

--- a/src/signals/incident-management/containers/Filter/__tests__/saga.test.js
+++ b/src/signals/incident-management/containers/Filter/__tests__/saga.test.js
@@ -65,24 +65,24 @@ describe.skip('signals/incident-management/containers/Filter/saga', () => {
         .isDone();
     });
 
-    it('should dispatch success', () => {
+    it('should dispatch success', () =>
       expectSaga(doSaveFilter, action)
         .provide([[matchers.call.fn(authPostCall), payloadResponse]])
         .put({
           type: SAVE_FILTER_SUCCESS,
           payload: payloadResponse,
         })
-        .run();
-    });
+        .run());
 
-    it('should dispatch failed', () => {
-      expectSaga(doSaveFilter, { payload: { ...payload, name: undefined } })
+    it('should dispatch failed', () =>
+      expectSaga(doSaveFilter, {
+        payload: { ...payload, name: undefined },
+      })
         .put({
           type: SAVE_FILTER_FAILED,
           payload: 'No name supplied',
         })
-        .run();
-    });
+        .run());
 
     it('catches anything', () => {
       const error = new Error('Something bad happened');
@@ -156,7 +156,7 @@ describe.skip('signals/incident-management/containers/Filter/saga', () => {
 
     it('should dispatch success', () => {
       const payloadResponse = { ...updatePayload, payload };
-      expectSaga(doUpdateFilter, action)
+      return expectSaga(doUpdateFilter, action)
         .provide([[matchers.call.fn(authPatchCall), payloadResponse]])
         .put({
           type: UPDATE_FILTER_SUCCESS,
@@ -220,7 +220,7 @@ describe.skip('signals/incident-management/containers/Filter/saga', () => {
         payload,
       };
 
-      expectSaga(saveFilter, action)
+      return expectSaga(saveFilter, action)
         .spawn(doSaveFilter, action)
         .run();
     });
@@ -238,7 +238,7 @@ describe.skip('signals/incident-management/containers/Filter/saga', () => {
         payload,
       };
 
-      expectSaga(updateFilter, action)
+      return expectSaga(updateFilter, action)
         .spawn(doUpdateFilter, action)
         .run();
     });

--- a/src/signals/incident-management/containers/IncidentOverviewPage/actions.js
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/actions.js
@@ -5,20 +5,22 @@
  */
 
 import {
-  REQUEST_INCIDENTS,
-  REQUEST_INCIDENTS_SUCCESS,
-  REQUEST_INCIDENTS_ERROR,
-  INCIDENT_SELECTED,
-  FILTER_INCIDENTS_CHANGED,
-  PAGE_INCIDENTS_CHANGED,
-  SORT_INCIDENTS_CHANGED,
-  GET_FILTERS,
-  GET_FILTERS_SUCCESS,
-  GET_FILTERS_FAILED,
-  REMOVE_FILTER,
-  REMOVE_FILTER_SUCCESS,
-  REMOVE_FILTER_FAILED,
+  APPLY_FILTER_REFRESH_STOP,
+  APPLY_FILTER_REFRESH,
   APPLY_FILTER,
+  FILTER_INCIDENTS_CHANGED,
+  GET_FILTERS_FAILED,
+  GET_FILTERS_SUCCESS,
+  GET_FILTERS,
+  INCIDENT_SELECTED,
+  PAGE_INCIDENTS_CHANGED,
+  REMOVE_FILTER_FAILED,
+  REMOVE_FILTER_SUCCESS,
+  REMOVE_FILTER,
+  REQUEST_INCIDENTS_ERROR,
+  REQUEST_INCIDENTS_SUCCESS,
+  REQUEST_INCIDENTS,
+  SORT_INCIDENTS_CHANGED,
 } from './constants';
 
 export function requestIncidents({ filter, page, sort }) {
@@ -101,5 +103,14 @@ export const removeFilterFailed = (payload) => ({
 
 export const applyFilter = (payload) => ({
   type: APPLY_FILTER,
+  payload,
+});
+
+export const applyFilterRefresh = () => ({
+  type: APPLY_FILTER_REFRESH,
+});
+
+export const applyFilterRefreshStop = (payload) => ({
+  type: APPLY_FILTER_REFRESH_STOP,
   payload,
 });

--- a/src/signals/incident-management/containers/IncidentOverviewPage/actions.test.js
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/actions.test.js
@@ -1,6 +1,8 @@
 import { testActionCreator } from 'test/utils';
 
 import {
+  APPLY_FILTER_REFRESH,
+  APPLY_FILTER_REFRESH_STOP,
   REQUEST_INCIDENTS,
   REQUEST_INCIDENTS_SUCCESS,
   REQUEST_INCIDENTS_ERROR,
@@ -9,6 +11,8 @@ import {
 } from './constants';
 
 import {
+  applyFilterRefresh,
+  applyFilterRefreshStop,
   requestIncidents,
   requestIncidentsSuccess,
   requestIncidentsError,
@@ -24,5 +28,7 @@ describe('OverviewPage actions', () => {
     testActionCreator(requestIncidentsError, REQUEST_INCIDENTS_ERROR, payload);
     testActionCreator(incidentSelected, INCIDENT_SELECTED, payload);
     testActionCreator(filterIncidentsChanged, FILTER_INCIDENTS_CHANGED, payload);
+    testActionCreator(applyFilterRefresh, APPLY_FILTER_REFRESH);
+    testActionCreator(applyFilterRefreshStop, APPLY_FILTER_REFRESH_STOP, payload);
   });
 });

--- a/src/signals/incident-management/containers/IncidentOverviewPage/constants.js
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/constants.js
@@ -16,3 +16,5 @@ export const REMOVE_FILTER_SUCCESS = 'sia/IncidentOverviewPage/REMOVE_FILTER_SUC
 export const REMOVE_FILTER_FAILED = 'sia/IncidentOverviewPage/REMOVE_FILTER_FAILED';
 
 export const APPLY_FILTER = 'sia/IncidentOverviewPage/APPLY_FILTER';
+export const APPLY_FILTER_REFRESH = 'sia/IncidentOverviewPage/APPLY_FILTER_REFRESH';
+export const APPLY_FILTER_REFRESH_STOP = 'sia/IncidentOverviewPage/APPLY_FILTER_REFRESH_STOP';


### PR DESCRIPTION
This PR:
- Adds a generator to the `IncidentOverviewPage` saga that is invoked whenever the `fetchIncidents` generator is invoked
- The new generator contains a race condition between two different actions; one that starts and another one that ends the generator
- Sets a 2 minute refresh interval for incidents. The interval only applies whenever the active filter has been set to be refreshed periodically