### PR TITLE
SIG-1676 Fix keypad issue

### DIFF
--- a/src/containers/SearchBar/__tests__/SearchBar.test.js
+++ b/src/containers/SearchBar/__tests__/SearchBar.test.js
@@ -1,11 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import {
-  render,
-  fireEvent,
-  cleanup,
-  createEvent,
-} from '@testing-library/react';
+import { render, fireEvent, cleanup } from '@testing-library/react';
 import { withAppContext } from 'test/utils';
 import SearchBarContainer, { SearchBarComponent } from '../';
 
@@ -13,65 +8,13 @@ describe.skip('containers/SearchBar', () => {
   afterEach(cleanup);
 
   it('should have props from structured selector', () => {
-    const tree = mount(withAppContext(
-      <SearchBarContainer />
-    ));
+    const tree = mount(withAppContext(<SearchBarContainer />));
 
     const props = tree.find(SearchBarComponent).props();
 
     expect(props.onRequestIncidents).toBeDefined();
     expect(props.onSetSearchQuery).toBeDefined();
     expect(props.query).toBeDefined();
-  });
-
-  it('should only accept numeric characters in the search field', () => {
-    const onRequestIncidents = () => {};
-    const onSetSearchQuery = () => {};
-    const query = '';
-
-    const { queryByTestId } = render(
-      withAppContext(
-        <SearchBarComponent
-          onRequestIncidents={onRequestIncidents}
-          onSetSearchQuery={onSetSearchQuery}
-          query={query}
-        />,
-      ),
-    );
-
-    const input = queryByTestId('searchBar').querySelector('input');
-
-    // simulate the input of allowed keys
-    const numericKeyCodes = [...Array(58).keys()].slice(48);
-    numericKeyCodes.forEach((keyCode, value) => {
-      fireEvent.change(input, { target: { value, keyCode } });
-      expect(parseInt(input.value, 10)).toEqual(value);
-    });
-
-    // simulate the input of navigational keys
-    const navKeyCodes = [
-      8, // backspace
-      37, // left
-      39, // right
-      46, // delete
-    ];
-    navKeyCodes.forEach((keyCode) => {
-      const myEvent = createEvent.change(input, { target: { keyCode } });
-      const preventDefaultSpy = jest.spyOn(myEvent, 'preventDefault');
-      fireEvent(input, myEvent);
-
-      expect(preventDefaultSpy).not.toHaveBeenCalled();
-    });
-
-    // simulate other keys
-    const invalidKeyCodes = [1, 2, 3, 4, 58, 60, 90];
-    invalidKeyCodes.forEach((keyCode) => {
-      const myEvent = createEvent.keyDown(input, { target: { keyCode } });
-      const preventDefaultSpy = jest.spyOn(myEvent, 'preventDefault');
-      fireEvent(input, myEvent);
-
-      expect(preventDefaultSpy).toHaveBeenCalled();
-    });
   });
 
   it('should call searchSubmit handler', () => {

--- a/src/containers/SearchBar/index.js
+++ b/src/containers/SearchBar/index.js
@@ -9,24 +9,12 @@ import { requestIncidents } from 'signals/incident-management/containers/Inciden
 import { setSearchQuery } from 'models/search/actions';
 import { makeSelectQuery } from 'models/search/selectors';
 
-const allowedButtonCodes = [
-  8, // backspace
-  37, // left
-  39, // right
-  46, // delete
-  48, // 0
-  49, // 1
-  50, // 2
-  51, // 3
-  52, // 4
-  53, // 5
-  54, // 6
-  55, // 7
-  56, // 8
-  57, // 9
-];
-
-export const SearchBarComponent = ({ className, query, onSetSearchQuery, onRequestIncidents }) => {
+export const SearchBarComponent = ({
+  className,
+  query,
+  onSetSearchQuery,
+  onRequestIncidents,
+}) => {
   /**
    * Send search form input to actions
    *
@@ -52,13 +40,6 @@ export const SearchBarComponent = ({ className, query, onSetSearchQuery, onReque
       onChange={onChange}
       onSubmit={onSearchSubmit}
       value={query}
-      onKeyDown={(event) => {
-        const { keyCode } = event;
-        /* istanbul ignore else */
-        if (!allowedButtonCodes.includes(keyCode)) {
-          event.preventDefault();
-        }
-      }}
     />
   );
 };
@@ -87,6 +68,9 @@ export const mapDispatchToProps = (dispatch) =>
     dispatch,
   );
 
-const withConnect = connect(mapStateToProps, mapDispatchToProps);
+const withConnect = connect(
+  mapStateToProps,
+  mapDispatchToProps,
+);
 
 export default compose(withConnect)(SearchBarComponent);


### PR DESCRIPTION
This PR contains a fix for the issue where, when pressing keys on a numeric keypad, the keys would not be accepted by the `SearchBar` input element. The restriction has been removed completely, since entering invalid values doesn't lead to a breaking application and we will have to remove the restriction anyway when search is expanded from ID to all fields in the db.