### PR TITLE
SIG-1659 Incident detail preview full-width

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/index.js
@@ -199,7 +199,7 @@ export class IncidentDetail extends React.Component {
 
               {previewState && (
                 <Row>
-                  <DetailContainer span={7}>
+                  <DetailContainer span={12}>
                     <button
                       className="incident-detail__preview-close incident-detail__button--close"
                       onClick={this.onCloseAll}


### PR DESCRIPTION
This PR fixes an issue where both map and pictures weren't displayed at 100% of the width of their container.
Before:
![Screenshot 2019-09-24 at 14 37 09](https://user-images.githubusercontent.com/1062191/65512283-316ce380-ded9-11e9-9e34-ffc42095597f.png)

After:
![Screenshot 2019-09-24 at 14 36 50](https://user-images.githubusercontent.com/1062191/65512279-30d44d00-ded9-11e9-8696-4974e6cca47d.png)