### PR TITLE
(Chore) Remove authenticated selector

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11182,6 +11182,12 @@
         "pretty-format": "^23.6.0"
       }
     },
+    "jest-localstorage-mock": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jest-localstorage-mock/-/jest-localstorage-mock-2.4.0.tgz",
+      "integrity": "sha512-/mC1JxnMeuIlAaQBsDMilskC/x/BicsQ/BXQxEOw+5b1aGZkkOAqAF3nu8yq449CpzGtp5jJ5wCmDNxLgA2m6A==",
+      "dev": true
+    },
     "jest-matcher-utils": {
       "version": "23.6.0",
       "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-23.6.0.tgz",

--- a/package.json
+++ b/package.json
@@ -236,6 +236,9 @@
       ".*\\.(css|less|styl|scss|sass)$": "<rootDir>/internals/mocks/cssModule.js",
       ".*\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/internals/mocks/image.js"
     },
+    "setupFiles": [
+      "jest-localstorage-mock"
+    ],
     "setupTestFrameworkScriptFile": "<rootDir>/internals/testing/test-bundler.js",
     "testRegex": ".*\\.test\\.js$",
     "testEnvironment": "./internals/testing/jest-environment-jsdom-global-fix",
@@ -355,6 +358,7 @@
     "jest": "^23.6.0",
     "jest-environment-jsdom": "23.2.0",
     "jest-environment-jsdom-global": "^1.1.0",
+    "jest-localstorage-mock": "^2.4.0",
     "jsdom": "11.11.0",
     "leaflet-headless": "^0.2.6",
     "lint-staged": "3.5.1",

--- a/src/components/Footer/__snapshots__/index.test.js.snap
+++ b/src/components/Footer/__snapshots__/index.test.js.snap
@@ -3,6 +3,7 @@
 exports[`<Footer /> should render correctly 1`] = `
 <Footer__FooterWrapper
   className="app-container no-print"
+  data-testid="siteFooter"
 >
   <Footer__Disclaimer>
     <Row

--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -28,7 +28,7 @@ const FooterWrapper = styled.div`
 `;
 
 const Footer = () => (
-  <FooterWrapper className="app-container no-print">
+  <FooterWrapper className="app-container no-print" data-testid="siteFooter">
     <Disclaimer>
       <Row>
         <Column span={12}>

--- a/src/components/SiteHeader/__tests__/SiteHeader.test.js
+++ b/src/components/SiteHeader/__tests__/SiteHeader.test.js
@@ -163,7 +163,7 @@ describe('components/SiteHeader', () => {
     expect(queryByText('Uitloggen')).toBeTruthy();
   });
 
-  it.only('should handle login/logout callback', () => {
+  it('should handle login/logout callback', () => {
     const onLoginLogoutButtonClick = jest.fn();
 
     const { rerender, getByText } = render(

--- a/src/components/SiteHeader/index.js
+++ b/src/components/SiteHeader/index.js
@@ -206,6 +206,7 @@ export const SiteHeader = (props) => {
       isFrontOffice={isFrontOffice}
       tall={tall}
       className={`siteHeader ${tall ? 'isTall' : 'isShort'}`}
+      data-testid="siteHeader"
     >
       <StyledHeader
         isFrontOffice={isFrontOffice}

--- a/src/components/ThemeProvider/index.js
+++ b/src/components/ThemeProvider/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { ThemeProvider as ASCThemeProvider } from '@datapunt/asc-ui';
 
@@ -43,7 +43,10 @@ export const amsterdamThemeCfg = {
 
 const ThemeProvider = ({ children }) => (
   <ASCThemeProvider overrides={amsterdamThemeCfg}>
-    {children}
+    <Fragment>
+      <span data-testid="signalsThemeProvider" />
+      {children}
+    </Fragment>
   </ASCThemeProvider>
 );
 

--- a/src/containers/App/index.js
+++ b/src/containers/App/index.js
@@ -37,11 +37,7 @@ export const AppContainer = ({ requestCategoriesAction }) => {
   return (
     <ThemeWrapper as={isAuthenticated() ? AscThemeProvider : AmsThemeProvider}>
       <Fragment>
-        {/**
-         * Forcing rerender of SiteHeader component to reevaluate its props, because it will
-         * otherwise not pick up a navigation action and will not present the component as tall
-         */}
-        <SiteHeaderContainer key={Math.random()} />
+        <SiteHeaderContainer />
 
         <div className="app-container">
           <GlobalError />

--- a/src/containers/App/index.js
+++ b/src/containers/App/index.js
@@ -1,12 +1,12 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Switch, Route, Redirect, withRouter } from 'react-router-dom';
 import { compose, bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
-import { createStructuredSelector } from 'reselect';
 import styled from 'styled-components';
 import { ThemeProvider as AscThemeProvider } from '@datapunt/asc-ui';
 
+import { authenticate, isAuthenticated } from 'shared/services/auth/auth';
 import AmsThemeProvider from 'components/ThemeProvider';
 import injectSaga from 'utils/injectSaga';
 import injectReducer from 'utils/injectReducer';
@@ -15,80 +15,75 @@ import NotFoundPage from 'containers/NotFoundPage';
 import Footer from 'components/Footer';
 import SiteHeaderContainer from 'containers/SiteHeader';
 import GlobalError from 'containers/GlobalError';
-import { makeSelectIsAuthenticated } from 'containers/App/selectors';
+
+import IncidentManagementModule from 'signals/incident-management';
+import IncidentContainer from 'signals/incident/containers/IncidentContainer';
+import KtoContainer from 'signals/incident/containers/KtoContainer';
 
 import reducer from './reducer';
 import saga from './saga';
-import IncidentManagementModule from '../../signals/incident-management';
-import IncidentContainer from '../../signals/incident/containers/IncidentContainer';
-import KtoContainer from '../../signals/incident/containers/KtoContainer';
 import { requestCategories } from './actions';
 
 const ThemeWrapper = styled.div``;
 
-export class App extends React.Component {
-  // eslint-disable-line react/prefer-stateless-function
-  componentDidMount() {
-    this.props.requestCategories();
-  }
+export const AppContainer = ({ requestCategoriesAction }) => {
+  // on each component render, see if the current session is authenticated
+  authenticate();
 
-  render() {
-    return (
-      <ThemeWrapper
-        as={this.props.isAuthenticated ? AscThemeProvider : AmsThemeProvider}
-      >
-        <Fragment>
-          {/**
-           * Forcing rerender of SiteHeader component to reevaluate its props, because it will
-           * otherwise not pick up a navigation action and will not present the component as tall
-           */}
-          <SiteHeaderContainer key={Math.random()} />
+  useEffect(() => {
+    requestCategoriesAction();
+  }, []);
 
-          <div className="app-container">
-            <GlobalError />
-            <Switch>
-              <Redirect exact from="/" to="/incident" />
-              <Redirect exact from="/login" to="/manage" />
-              <Route path="/manage" component={IncidentManagementModule} />
-              <Route path="/incident" component={IncidentContainer} />
-              <Route
-                path="/kto/:yesNo/:uuid"
-                component={(props) => (
-                  <KtoContainer
-                    yesNo={props.match.params.yesNo}
-                    uuid={props.match.params.uuid}
-                  />
-                )}
-              />
-              <Route path="" component={NotFoundPage} />
-            </Switch>
-          </div>
-          <Footer />
-        </Fragment>
-      </ThemeWrapper>
-    );
-  }
-}
+  return (
+    <ThemeWrapper as={isAuthenticated() ? AscThemeProvider : AmsThemeProvider}>
+      <Fragment>
+        {/**
+         * Forcing rerender of SiteHeader component to reevaluate its props, because it will
+         * otherwise not pick up a navigation action and will not present the component as tall
+         */}
+        <SiteHeaderContainer key={Math.random()} />
 
-App.propTypes = {
-  requestCategories: PropTypes.func.isRequired,
-  isAuthenticated: PropTypes.bool,
+        <div className="app-container">
+          <GlobalError />
+          <Switch>
+            <Redirect exact from="/" to="/incident" />
+            <Redirect exact from="/login" to="/manage" />
+            <Route path="/manage" component={IncidentManagementModule} />
+            <Route path="/incident" component={IncidentContainer} />
+            <Route
+              path="/kto/:yesNo/:uuid"
+              component={(props) => (
+                <KtoContainer
+                  // eslint-disable-next-line react/prop-types
+                  yesNo={props.match.params.yesNo}
+                  // eslint-disable-next-line react/prop-types
+                  uuid={props.match.params.uuid}
+                />
+              )}
+            />
+            <Route path="" component={NotFoundPage} />
+          </Switch>
+        </div>
+        <Footer />
+      </Fragment>
+    </ThemeWrapper>
+  );
 };
 
-const mapStateToProps = createStructuredSelector({
-  isAuthenticated: makeSelectIsAuthenticated(),
-});
+AppContainer.propTypes = {
+  requestCategoriesAction: PropTypes.func.isRequired,
+};
 
 export const mapDispatchToProps = (dispatch) =>
   bindActionCreators(
     {
-      requestCategories,
+      requestCategoriesAction: requestCategories,
     },
     dispatch,
   );
 
 const withConnect = connect(
-  mapStateToProps,
+  null,
   mapDispatchToProps,
 );
 
@@ -100,4 +95,4 @@ export default compose(
   withSaga,
   withRouter,
   withConnect,
-)(App);
+)(AppContainer);

--- a/src/containers/App/index.test.js
+++ b/src/containers/App/index.test.js
@@ -1,17 +1,14 @@
 import React from 'react';
-import { shallow } from 'enzyme';
-import { Route } from 'react-router-dom';
-import SiteHeaderContainer from 'containers/SiteHeader';
-import Footer from 'components/Footer';
-import { App, mapDispatchToProps } from './index';
+import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
+import { withAppContext } from 'test/utils';
+import App, { AppContainer, mapDispatchToProps } from './index';
 import { REQUEST_CATEGORIES } from './constants';
+
+jest.mock('components/MapInteractive');
 
 describe('<App />', () => {
   let origSessionStorage;
-
-  const props = {
-    requestCategories: jest.fn()
-  };
 
   beforeEach(() => {
     origSessionStorage = global.sessionStorage;
@@ -25,7 +22,7 @@ describe('<App />', () => {
         }
       },
       setItem: jest.fn(),
-      removeItem: jest.fn()
+      removeItem: jest.fn(),
     };
   });
 
@@ -33,25 +30,19 @@ describe('<App />', () => {
     global.sessionStorage = origSessionStorage;
   });
 
-  it('should render the header', () => {
-    const wrapper = shallow(
-      <App {...props} />
-    );
-    expect(wrapper.find(SiteHeaderContainer).length).toBe(1);
+  it('should have props from structured selector', () => {
+    const tree = mount(withAppContext(<App />));
+
+    const props = tree.find(AppContainer).props();
+
+    expect(props.requestCategoriesAction).not.toBeUndefined();
   });
 
-  it('should render some routes', () => {
-    const wrapper = shallow(
-      <App {...props} />
-    );
-    expect(wrapper.find(Route).length).not.toBe(0);
-  });
+  it('should render correctly', () => {
+    const { getByTestId } = render(withAppContext(<AppContainer requestCategoriesAction={() => {}} />));
 
-  it('should render the footer', () => {
-    const wrapper = shallow(
-      <App {...props} />
-    );
-    expect(wrapper.find(Footer).length).toBe(1);
+    expect(getByTestId('siteFooter')).toBeTruthy();
+    expect(getByTestId('siteHeader')).toBeTruthy();
   });
 
   describe('mapDispatchToProps', () => {
@@ -60,7 +51,7 @@ describe('<App />', () => {
     it('onRequestIncident', () => {
       // For the `mapDispatchToProps`, call it directly but pass in
       // a mock function and check the arguments passed in are as expected
-      mapDispatchToProps(dispatch).requestCategories();
+      mapDispatchToProps(dispatch).requestCategoriesAction();
       expect(dispatch).toHaveBeenCalledWith({ type: REQUEST_CATEGORIES });
     });
   });

--- a/src/containers/App/index.test.js
+++ b/src/containers/App/index.test.js
@@ -8,28 +8,6 @@ import { REQUEST_CATEGORIES } from './constants';
 jest.mock('components/MapInteractive');
 
 describe('<App />', () => {
-  let origSessionStorage;
-
-  beforeEach(() => {
-    origSessionStorage = global.sessionStorage;
-    global.sessionStorage = {
-      getItem: (key) => {
-        switch (key) {
-          case 'accessToken':
-            return '42';
-          default:
-            return '';
-        }
-      },
-      setItem: jest.fn(),
-      removeItem: jest.fn(),
-    };
-  });
-
-  afterEach(() => {
-    global.sessionStorage = origSessionStorage;
-  });
-
   it('should have props from structured selector', () => {
     const tree = mount(withAppContext(<App />));
 
@@ -46,7 +24,7 @@ describe('<App />', () => {
   });
 
   it('should render the correct theme', () => {
-    jest.spyOn(global.sessionStorage, 'getItem').mockImplementation(() => undefined);
+    global.sessionStorage.getItem.mockImplementationOnce(() => undefined);
 
     const { getByTestId } = render(withAppContext(<AppContainer requestCategoriesAction={() => {}} />));
 

--- a/src/containers/App/index.test.js
+++ b/src/containers/App/index.test.js
@@ -45,6 +45,14 @@ describe('<App />', () => {
     expect(getByTestId('siteHeader')).toBeTruthy();
   });
 
+  it('should render the correct theme', () => {
+    jest.spyOn(global.sessionStorage, 'getItem').mockImplementation(() => undefined);
+
+    const { getByTestId } = render(withAppContext(<AppContainer requestCategoriesAction={() => {}} />));
+
+    expect(getByTestId('signalsThemeProvider')).toBeTruthy();
+  });
+
   describe('mapDispatchToProps', () => {
     const dispatch = jest.fn();
 

--- a/src/containers/App/reducer.js
+++ b/src/containers/App/reducer.js
@@ -46,7 +46,10 @@ export const initialState = fromJS({
 function appReducer(state = initialState, action) {
   switch (action.type) {
     case AUTHENTICATE_USER:
-      global.sessionStorage.setItem(ACCESS_TOKEN, action.payload.accessToken);
+      if (action.payload && action.payload.accessToken) {
+        global.sessionStorage.setItem(ACCESS_TOKEN, action.payload.accessToken);
+      }
+
       return state;
 
     case AUTHORIZE_USER:

--- a/src/containers/App/reducer.js
+++ b/src/containers/App/reducer.js
@@ -13,6 +13,8 @@
 import { fromJS } from 'immutable';
 
 import {
+  LOGOUT,
+  AUTHENTICATE_USER,
   AUTHORIZE_USER,
   SHOW_GLOBAL_ERROR,
   RESET_GLOBAL_ERROR,
@@ -20,7 +22,7 @@ import {
   UPLOAD_REQUEST,
   UPLOAD_PROGRESS,
   UPLOAD_SUCCESS,
-  UPLOAD_FAILURE
+  UPLOAD_FAILURE,
 } from './constants';
 
 // The initial state of the App
@@ -29,16 +31,25 @@ export const initialState = fromJS({
   error: false,
   upload: {},
   userPermissions: [],
+  userName: undefined,
+  userScopes: undefined,
+  accessToken: undefined,
   categories: {
     main: [],
     sub: [],
     mainToSub: {},
-  }
+  },
 });
 
 function appReducer(state = initialState, action) {
   switch (action.type) {
+    case AUTHENTICATE_USER:
+      global.sessionStorage.setItem('accessToken', action.payload.accessToken);
+      return state;
+
     case AUTHORIZE_USER:
+      global.sessionStorage.setItem('accessToken', action.payload.accessToken);
+
       return state
         .set('userName', action.payload.userName)
         .set('userScopes', fromJS(action.payload.userScopes))
@@ -47,7 +58,7 @@ function appReducer(state = initialState, action) {
 
     case SHOW_GLOBAL_ERROR:
       return state
-        .set('error', !!(action.payload))
+        .set('error', !!action.payload)
         .set('errorMessage', action.payload)
         .set('loading', false);
 
@@ -58,27 +69,38 @@ function appReducer(state = initialState, action) {
         .set('loading', false);
 
     case REQUEST_CATEGORIES_SUCCESS:
-      return state
-        .set('categories', fromJS(action.payload));
+      return state.set('categories', fromJS(action.payload));
 
     case UPLOAD_REQUEST:
-      return state
-        .set('upload', fromJS({
+      return state.set(
+        'upload',
+        fromJS({
           id: action.payload.id,
-          file: action.payload.file.name
-        }));
+          file: action.payload.file.name,
+        }),
+      );
 
     case UPLOAD_PROGRESS:
-      return state
-        .set('upload', fromJS({
+      return state.set(
+        'upload',
+        fromJS({
           ...state.get('upload').toJS(),
-          progress: action.payload
-        }));
+          progress: action.payload,
+        }),
+      );
 
     case UPLOAD_SUCCESS:
     case UPLOAD_FAILURE:
+      return state.set('upload', fromJS({}));
+
+    case LOGOUT:
+      global.sessionStorage.removeItem('accessToken');
+
       return state
-        .set('upload', fromJS({}));
+        .set('userName', undefined)
+        .set('userScopes', undefined)
+        .set('userPermissions', [])
+        .set('accessToken', undefined);
 
     default:
       return state;

--- a/src/containers/App/reducer.js
+++ b/src/containers/App/reducer.js
@@ -12,6 +12,8 @@
 
 import { fromJS } from 'immutable';
 
+import { ACCESS_TOKEN } from 'shared/services/auth/auth';
+
 import {
   LOGOUT,
   AUTHENTICATE_USER,
@@ -44,11 +46,11 @@ export const initialState = fromJS({
 function appReducer(state = initialState, action) {
   switch (action.type) {
     case AUTHENTICATE_USER:
-      global.sessionStorage.setItem('accessToken', action.payload.accessToken);
+      global.sessionStorage.setItem(ACCESS_TOKEN, action.payload.accessToken);
       return state;
 
     case AUTHORIZE_USER:
-      global.sessionStorage.setItem('accessToken', action.payload.accessToken);
+      global.sessionStorage.setItem(ACCESS_TOKEN, action.payload.accessToken);
 
       return state
         .set('userName', action.payload.userName)
@@ -94,7 +96,7 @@ function appReducer(state = initialState, action) {
       return state.set('upload', fromJS({}));
 
     case LOGOUT:
-      global.sessionStorage.removeItem('accessToken');
+      global.sessionStorage.removeItem(ACCESS_TOKEN);
 
       return state
         .set('userName', undefined)

--- a/src/containers/App/reducer.js
+++ b/src/containers/App/reducer.js
@@ -16,7 +16,6 @@ import { ACCESS_TOKEN } from 'shared/services/auth/auth';
 
 import {
   LOGOUT,
-  AUTHENTICATE_USER,
   AUTHORIZE_USER,
   SHOW_GLOBAL_ERROR,
   RESET_GLOBAL_ERROR,
@@ -45,13 +44,6 @@ export const initialState = fromJS({
 
 function appReducer(state = initialState, action) {
   switch (action.type) {
-    case AUTHENTICATE_USER:
-      if (action.payload && action.payload.accessToken) {
-        global.sessionStorage.setItem(ACCESS_TOKEN, action.payload.accessToken);
-      }
-
-      return state;
-
     case AUTHORIZE_USER:
       global.sessionStorage.setItem(ACCESS_TOKEN, action.payload.accessToken);
 

--- a/src/containers/App/reducer.js
+++ b/src/containers/App/reducer.js
@@ -91,9 +91,8 @@ function appReducer(state = initialState, action) {
       return state.set('upload', fromJS({}));
 
     case LOGOUT:
-      global.sessionStorage.removeItem(ACCESS_TOKEN);
-
       return state
+        .set('upload', fromJS({}))
         .set('userName', undefined)
         .set('userScopes', undefined)
         .set('userPermissions', [])

--- a/src/containers/App/reducer.test.js
+++ b/src/containers/App/reducer.test.js
@@ -17,7 +17,26 @@ import {
 } from './constants';
 
 describe('appReducer', () => {
+  let origSessionStorage;
+
   beforeEach(() => {
+    origSessionStorage = global.sessionStorage;
+    global.sessionStorage = {
+      getItem: (key) => {
+        switch (key) {
+          case 'accessToken':
+            return '42';
+          default:
+            return '';
+        }
+      },
+      setItem: jest.fn(),
+      removeItem: jest.fn(),
+    };
+  });
+
+  afterEach(() => {
+    global.sessionStorage = origSessionStorage;
   });
 
   it('should return the initial state', () => {

--- a/src/containers/App/reducer.test.js
+++ b/src/containers/App/reducer.test.js
@@ -5,7 +5,6 @@ import appReducer, { initialState } from './reducer';
 
 import {
   AUTHORIZE_USER,
-  LOGOUT,
   SHOW_GLOBAL_ERROR,
   RESET_GLOBAL_ERROR,
   REQUEST_CATEGORIES_SUCCESS,
@@ -189,33 +188,6 @@ describe('appReducer', () => {
       ).toEqual({
         upload: {},
       });
-    });
-  });
-
-  describe('LOGOUT', () => {
-    it('should remove the access token from session storage', () => {
-      const accessToken =
-        'eyJhbGciOiJFUzI1NiIsImtpZCI6ImU1MDJjOGYzLTNkOGEtNDBiMy1hYjZjLTEyOTQ4MzMyYWU5YyJ9';
-      const action = {
-        type: LOGOUT,
-      };
-
-      const newState = appReducer(
-        fromJS({
-          userName: 'Diabolo',
-          userScopes: ['SCOPE'],
-          accessToken,
-        }),
-        action,
-      ).toJS();
-
-      expect(global.sessionStorage.removeItem).toHaveBeenCalledWith(
-        ACCESS_TOKEN,
-      );
-
-      expect(newState.userName).toBeUndefined();
-      expect(newState.userScopes).toBeUndefined();
-      expect(newState.accessToken).toBeUndefined();
     });
   });
 });

--- a/src/containers/App/reducer.test.js
+++ b/src/containers/App/reducer.test.js
@@ -1,19 +1,19 @@
 import { fromJS } from 'immutable';
 
+import { ACCESS_TOKEN } from 'shared/services/auth/auth';
 import appReducer, { initialState } from './reducer';
 
 import {
   AUTHORIZE_USER,
-
+  AUTHENTICATE_USER,
+  LOGOUT,
   SHOW_GLOBAL_ERROR,
   RESET_GLOBAL_ERROR,
-
   REQUEST_CATEGORIES_SUCCESS,
-
   UPLOAD_REQUEST,
   UPLOAD_PROGRESS,
   UPLOAD_SUCCESS,
-  UPLOAD_FAILURE
+  UPLOAD_FAILURE,
 } from './constants';
 
 describe('appReducer', () => {
@@ -43,6 +43,28 @@ describe('appReducer', () => {
     expect(appReducer(undefined, {})).toEqual(fromJS(initialState));
   });
 
+  describe('AUTHENTICATE_USER', () => {
+    it('should set the access token in session storage', () => {
+      const accessToken =
+        'eyJhbGciOiJFUzI1NiIsImtpZCI6ImU1MDJjOGYzLTNkOGEtNDBiMy1hYjZjLTEyOTQ4MzMyYWU5YyJ9';
+      const action = {
+        type: AUTHENTICATE_USER,
+        payload: {
+          userName: 'Diabolo',
+          userScopes: ['SCOPE'],
+          accessToken,
+        },
+      };
+
+      appReducer(fromJS({}), action);
+
+      expect(global.sessionStorage.setItem).toHaveBeenCalledWith(
+        ACCESS_TOKEN,
+        accessToken,
+      );
+    });
+  });
+
   describe('AUTHORIZE_USER', () => {
     it('sets user name, scopes and access token', () => {
       expect(
@@ -51,14 +73,33 @@ describe('appReducer', () => {
           payload: {
             userName: 'Diabolo',
             userScopes: ['SCOPE'],
-            accessToken: 'DFGHJGFDSDFGHJKJH'
-          }
-        }).toJS()
+            accessToken: 'DFGHJGFDSDFGHJKJH',
+          },
+        }).toJS(),
       ).toEqual({
         userName: 'Diabolo',
         userScopes: ['SCOPE'],
-        accessToken: 'DFGHJGFDSDFGHJKJH'
+        accessToken: 'DFGHJGFDSDFGHJKJH',
       });
+    });
+
+    it('should set the access token in session storage', () => {
+      const accessToken = 'DFGHJGFDSDFGHJKJH';
+      const action = {
+        type: AUTHORIZE_USER,
+        payload: {
+          userName: 'Diabolo',
+          userScopes: ['SCOPE'],
+          accessToken,
+        },
+      };
+
+      appReducer(fromJS({}), action);
+
+      expect(global.sessionStorage.setItem).toHaveBeenCalledWith(
+        ACCESS_TOKEN,
+        accessToken,
+      );
     });
   });
 
@@ -67,12 +108,12 @@ describe('appReducer', () => {
       expect(
         appReducer(fromJS({}), {
           type: SHOW_GLOBAL_ERROR,
-          payload: 'ERROR_MESSAGE'
-        }).toJS()
+          payload: 'ERROR_MESSAGE',
+        }).toJS(),
       ).toEqual({
         error: true,
         errorMessage: 'ERROR_MESSAGE',
-        loading: false
+        loading: false,
       });
     });
   });
@@ -81,12 +122,12 @@ describe('appReducer', () => {
     it('resets global error message', () => {
       expect(
         appReducer(fromJS({}), {
-          type: RESET_GLOBAL_ERROR
-        }).toJS()
+          type: RESET_GLOBAL_ERROR,
+        }).toJS(),
       ).toEqual({
         error: false,
         errorMessage: '',
-        loading: false
+        loading: false,
       });
     });
   });
@@ -97,13 +138,13 @@ describe('appReducer', () => {
         appReducer(fromJS({}), {
           type: REQUEST_CATEGORIES_SUCCESS,
           payload: {
-            results: [1, 2]
-          }
-        }).toJS()
+            results: [1, 2],
+          },
+        }).toJS(),
       ).toEqual({
         categories: {
-          results: [1, 2]
-        }
+          results: [1, 2],
+        },
       });
     });
   });
@@ -116,15 +157,15 @@ describe('appReducer', () => {
           payload: {
             id: 666,
             file: {
-              name: 'image.jpg'
-            }
-          }
-        }).toJS()
+              name: 'image.jpg',
+            },
+          },
+        }).toJS(),
       ).toEqual({
         upload: {
           id: 666,
-          file: 'image.jpg'
-        }
+          file: 'image.jpg',
+        },
       });
     });
   });
@@ -132,21 +173,24 @@ describe('appReducer', () => {
   describe('UPLOAD_PROGRESS', () => {
     it('file upload progress', () => {
       expect(
-        appReducer(fromJS({
-          upload: {
-            id: 666,
-            file: 'image.jpg'
-          }
-        }), {
-          type: UPLOAD_PROGRESS,
-          payload: 0.345
-        }).toJS()
+        appReducer(
+          fromJS({
+            upload: {
+              id: 666,
+              file: 'image.jpg',
+            },
+          }),
+          {
+            type: UPLOAD_PROGRESS,
+            payload: 0.345,
+          },
+        ).toJS(),
       ).toEqual({
         upload: {
           id: 666,
           file: 'image.jpg',
-          progress: 0.345
-        }
+          progress: 0.345,
+        },
       });
     });
   });
@@ -154,17 +198,20 @@ describe('appReducer', () => {
   describe('UPLOAD_SUCCESS', () => {
     it('file upload success', () => {
       expect(
-        appReducer(fromJS({
-          upload: {
-            id: 666,
-            file: 'image.jpg',
-            progress: 0.678
-          }
-        }), {
-          type: UPLOAD_SUCCESS
-        }).toJS()
+        appReducer(
+          fromJS({
+            upload: {
+              id: 666,
+              file: 'image.jpg',
+              progress: 0.678,
+            },
+          }),
+          {
+            type: UPLOAD_SUCCESS,
+          },
+        ).toJS(),
       ).toEqual({
-        upload: {}
+        upload: {},
       });
     });
   });
@@ -172,18 +219,48 @@ describe('appReducer', () => {
   describe('UPLOAD_FAILURE', () => {
     it('file upload success', () => {
       expect(
-        appReducer(fromJS({
-          upload: {
-            id: 666,
-            file: 'image.jpg',
-            progress: 0.678
-          }
-        }), {
-          type: UPLOAD_FAILURE
-        }).toJS()
+        appReducer(
+          fromJS({
+            upload: {
+              id: 666,
+              file: 'image.jpg',
+              progress: 0.678,
+            },
+          }),
+          {
+            type: UPLOAD_FAILURE,
+          },
+        ).toJS(),
       ).toEqual({
-        upload: {}
+        upload: {},
       });
+    });
+  });
+
+  describe('LOGOUT', () => {
+    it('should remove the access token from session storage', () => {
+      const accessToken =
+        'eyJhbGciOiJFUzI1NiIsImtpZCI6ImU1MDJjOGYzLTNkOGEtNDBiMy1hYjZjLTEyOTQ4MzMyYWU5YyJ9';
+      const action = {
+        type: LOGOUT,
+      };
+
+      const newState = appReducer(
+        fromJS({
+          userName: 'Diabolo',
+          userScopes: ['SCOPE'],
+          accessToken,
+        }),
+        action,
+      ).toJS();
+
+      expect(global.sessionStorage.removeItem).toHaveBeenCalledWith(
+        ACCESS_TOKEN,
+      );
+
+      expect(newState.userName).toBeUndefined();
+      expect(newState.userScopes).toBeUndefined();
+      expect(newState.accessToken).toBeUndefined();
     });
   });
 });

--- a/src/containers/App/reducer.test.js
+++ b/src/containers/App/reducer.test.js
@@ -5,7 +5,6 @@ import appReducer, { initialState } from './reducer';
 
 import {
   AUTHORIZE_USER,
-  AUTHENTICATE_USER,
   LOGOUT,
   SHOW_GLOBAL_ERROR,
   RESET_GLOBAL_ERROR,
@@ -17,52 +16,8 @@ import {
 } from './constants';
 
 describe('appReducer', () => {
-  let origSessionStorage;
-
-  beforeEach(() => {
-    origSessionStorage = global.sessionStorage;
-    global.sessionStorage = {
-      getItem: (key) => {
-        switch (key) {
-          case 'accessToken':
-            return '42';
-          default:
-            return '';
-        }
-      },
-      setItem: jest.fn(),
-      removeItem: jest.fn(),
-    };
-  });
-
-  afterEach(() => {
-    global.sessionStorage = origSessionStorage;
-  });
-
   it('should return the initial state', () => {
     expect(appReducer(undefined, {})).toEqual(fromJS(initialState));
-  });
-
-  describe('AUTHENTICATE_USER', () => {
-    it('should set the access token in session storage', () => {
-      const accessToken =
-        'eyJhbGciOiJFUzI1NiIsImtpZCI6ImU1MDJjOGYzLTNkOGEtNDBiMy1hYjZjLTEyOTQ4MzMyYWU5YyJ9';
-      const action = {
-        type: AUTHENTICATE_USER,
-        payload: {
-          userName: 'Diabolo',
-          userScopes: ['SCOPE'],
-          accessToken,
-        },
-      };
-
-      appReducer(fromJS({}), action);
-
-      expect(global.sessionStorage.setItem).toHaveBeenCalledWith(
-        ACCESS_TOKEN,
-        accessToken,
-      );
-    });
   });
 
   describe('AUTHORIZE_USER', () => {

--- a/src/containers/App/saga.js
+++ b/src/containers/App/saga.js
@@ -57,6 +57,7 @@ export function* callAuthorize(action) {
 
       const user = yield authCall(requestURL, null, accessToken);
       const credentials = { ...action.payload, userScopes: [...user.groups], userPermissions: [...user.permissions] };
+
       yield put(authorizeUser(credentials));
     }
   } catch (error) {

--- a/src/containers/PageHeader/index.js
+++ b/src/containers/PageHeader/index.js
@@ -6,11 +6,10 @@ import { createStructuredSelector } from 'reselect';
 import styled from 'styled-components';
 
 import PageHeader from 'components/PageHeader';
-import {
-  makeSelectIncidentsCount,
-  makeSelectFilter,
-} from 'signals/incident-management/containers/IncidentOverviewPage/selectors';
+import { makeSelectIncidentsCount } from 'signals/incident-management/containers/IncidentOverviewPage/selectors';
+import { makeSelectFilter } from 'signals/incident-management/selectors';
 import { makeSelectQuery } from 'models/search/selectors';
+
 import Refresh from '../../shared/images/icon-refresh.svg';
 
 const RefreshIcon = styled(Refresh).attrs({

--- a/src/containers/PageHeader/index.js
+++ b/src/containers/PageHeader/index.js
@@ -6,8 +6,7 @@ import { createStructuredSelector } from 'reselect';
 import styled from 'styled-components';
 
 import PageHeader from 'components/PageHeader';
-import { makeSelectIncidentsCount } from 'signals/incident-management/containers/IncidentOverviewPage/selectors';
-import { makeSelectFilter } from 'signals/incident-management/selectors';
+import { makeSelectIncidentsCount, makeSelectFilter } from 'signals/incident-management/containers/IncidentOverviewPage/selectors';
 import { makeSelectQuery } from 'models/search/selectors';
 
 import Refresh from '../../shared/images/icon-refresh.svg';

--- a/src/containers/SiteHeader/index.js
+++ b/src/containers/SiteHeader/index.js
@@ -6,10 +6,10 @@ import { createStructuredSelector } from 'reselect';
 import {
   makeSelectUserName,
   makeSelectUserPermissions,
-  makeSelectIsAuthenticated,
 } from 'containers/App/selectors';
 import SiteHeader from 'components/SiteHeader';
 import { withRouter } from 'react-router-dom';
+import { isAuthenticated } from 'shared/services/auth/auth';
 
 import { doLogin, doLogout } from '../App/actions';
 
@@ -26,7 +26,7 @@ export class SiteHeaderContainer extends React.Component {
     event.persist();
     event.preventDefault();
     event.stopPropagation();
-    if (!this.props.isAuthenticated) {
+    if (!isAuthenticated()) {
       this.props.onLogin(domain);
     } else {
       this.props.onLogout();
@@ -34,11 +34,11 @@ export class SiteHeaderContainer extends React.Component {
   }
 
   render() {
-    const { isAuthenticated, permissions, userName } = this.props;
+    const { permissions, userName } = this.props;
 
     return (
       <HeaderWithRouter
-        isAuthenticated={isAuthenticated}
+        isAuthenticated={isAuthenticated()}
         onLoginLogoutButtonClick={this.onLoginLogoutButtonClick}
         permissions={permissions}
         userName={userName}
@@ -48,7 +48,6 @@ export class SiteHeaderContainer extends React.Component {
 }
 
 SiteHeaderContainer.propTypes = {
-  isAuthenticated: PropTypes.bool,
   onLogin: PropTypes.func,
   onLogout: PropTypes.func,
   permissions: PropTypes.arrayOf(PropTypes.string).isRequired,
@@ -56,7 +55,6 @@ SiteHeaderContainer.propTypes = {
 };
 
 const mapStateToProps = createStructuredSelector({
-  isAuthenticated: makeSelectIsAuthenticated(),
   permissions: makeSelectUserPermissions(),
   userName: makeSelectUserName(),
 });

--- a/src/models/incident/saga.test.js
+++ b/src/models/incident/saga.test.js
@@ -31,7 +31,7 @@ import watchIncidentModelSaga, {
 import { requestHistoryList } from '../history/actions';
 
 describe('models/incident/saga', () => {
-  it('should watch incidentModemSaga', () => {
+  it('should watch incidentModelSaga', () => {
     testSaga(watchIncidentModelSaga)
       .next()
       .all([
@@ -52,7 +52,7 @@ describe('models/incident/saga', () => {
         payload,
       };
 
-      expectSaga(fetchIncident, action)
+      return expectSaga(fetchIncident, action)
         .provide([[matchers.call.fn(requestURL)]])
         .call(authCall, `${requestURL}/${id}`)
         .run();
@@ -63,7 +63,7 @@ describe('models/incident/saga', () => {
       const action = { payload: id };
       const incident = { id, name: 'incident' };
 
-      expectSaga(fetchIncident, action)
+      return expectSaga(fetchIncident, action)
         .provide([[matchers.call.fn(authCall), incident]])
         .put(requestIncidentSuccess(incident))
         .run();
@@ -74,7 +74,7 @@ describe('models/incident/saga', () => {
       const action = { payload: id };
       const error = new Error('Whoops!!1!');
 
-      expectSaga(fetchIncident, action)
+      return expectSaga(fetchIncident, action)
         .provide([[matchers.call.fn(authCall), throwError(error)]])
         .put(requestIncidentError(error))
         .run();
@@ -85,6 +85,7 @@ describe('models/incident/saga', () => {
     it('should call endpoint with filter data', () => {
       const id = 123456;
       const payload = {
+        id,
         patch: {
           id,
         },
@@ -93,8 +94,7 @@ describe('models/incident/saga', () => {
         payload,
       };
 
-      expectSaga(patchIncident, action)
-        .provide([[matchers.call.fn(requestURL)]])
+      return expectSaga(patchIncident, action)
         .call(authPatchCall, `${requestURL}/${id}`, payload.patch)
         .run();
     });
@@ -115,7 +115,7 @@ describe('models/incident/saga', () => {
       };
       const incident = { id, name: 'incident' };
 
-      expectSaga(patchIncident, action)
+      return expectSaga(patchIncident, action)
         .provide([[matchers.call.fn(authPatchCall), incident]])
         .put(patchIncidentSuccess({ type, incident }))
         .put(requestHistoryList(id))
@@ -136,7 +136,7 @@ describe('models/incident/saga', () => {
       };
       const error = new Error('Whoops!!1!');
 
-      expectSaga(patchIncident, action)
+      return expectSaga(patchIncident, action)
         .provide([[matchers.call.fn(authPatchCall), throwError(error)]])
         .put(patchIncidentError({ type, error }))
         .run();
@@ -148,9 +148,8 @@ describe('models/incident/saga', () => {
       const id = 678543;
       const action = { payload: id };
 
-      expectSaga(requestAttachments, action)
-        .provide([[matchers.call.fn(requestURL)]])
-        .call(authPatchCall, `${requestURL}/${id}/attachments`, id)
+      return expectSaga(requestAttachments, action)
+        .call(authCall, `${requestURL}/${id}/attachments`)
         .run();
     });
 
@@ -187,7 +186,7 @@ describe('models/incident/saga', () => {
         ],
       };
 
-      expectSaga(requestAttachments, action)
+      return expectSaga(requestAttachments, action)
         .provide([[matchers.call.fn(authCall), attachments]])
         .put(requestAttachmentsSuccess(attachments.results.slice(0, 3)))
         .run();
@@ -198,7 +197,7 @@ describe('models/incident/saga', () => {
       const action = { payload: id };
       const error = new Error('Whoops!!1!');
 
-      expectSaga(requestAttachments, action)
+      return expectSaga(requestAttachments, action)
         .provide([[matchers.call.fn(authCall), throwError(error)]])
         .put(requestAttachmentsError())
         .run();
@@ -214,17 +213,14 @@ describe('models/incident/saga', () => {
       payload,
     };
 
-    it('should call endpoint with filter data', () => {
+    it('should call endpoint with filter data', () =>
       expectSaga(requestDefaultTexts, action)
         .provide([[matchers.call.fn(requestURL)]])
         .call(
-          authPatchCall,
-          `${requestTermsURL}/${payload.main_slug}/sub_categories/${
-            payload.sub_slug
-          }/status-message-templates`,
+          authCall,
+          `${requestTermsURL}/${payload.main_slug}/sub_categories/${payload.sub_slug}/status-message-templates`,
         )
-        .run();
-    });
+        .run());
 
     it('should dispatch success', () => {
       const templates = [
@@ -249,7 +245,7 @@ describe('models/incident/saga', () => {
           ],
         },
       ];
-      expectSaga(requestDefaultTexts, action)
+      return expectSaga(requestDefaultTexts, action)
         .provide([[matchers.call.fn(authCall), templates]])
         .put(requestDefaultTextsSuccess(templates))
         .run();
@@ -258,102 +254,10 @@ describe('models/incident/saga', () => {
     it('should dispatch failed', () => {
       const error = new Error('Whoops!!1!');
 
-      expectSaga(requestDefaultTexts, action)
+      return expectSaga(requestDefaultTexts, action)
         .provide([[matchers.call.fn(authCall), throwError(error)]])
         .put(requestDefaultTextsError(error))
         .run();
     });
   });
-  // it('should fetchIncident success ', () => {
-  //   const requestURL = 'https://acc.api.data.amsterdam.nl/signals/auth/signal';
-  //   const id = 1000;
-  //   const action = { payload: id };
-  //   const incident = { id, name: 'incident' };
-
-  //   const gen = fetchIncident(action);
-  //   expect(gen.next().value).toEqual(authCall(`${requestURL}/${id}`));
-  //   expect(gen.next(incident).value).toEqual(put(requestIncidentSuccess(incident))); // eslint-disable-line redux-saga/yield-effects
-  // });
-
-  // it('should fetchIncident error', () => {
-  //   const id = 1000;
-  //   const action = { payload: id };
-  //   const error = new Error('404 Not Found');
-
-  //   const gen = fetchIncident(action);
-  //   gen.next();
-  //   expect(gen.throw(error).value).toEqual(put(requestIncidentError(error))); // eslint-disable-line redux-saga/yield-effects
-  // });
-
-  // it('should fetchIncident success', () => {
-  //   const requestURL = 'https://acc.api.data.amsterdam.nl/signals/auth/signal';
-  //   const id = 1000;
-  //   const action = { payload: id };
-  //   const incident = { id, name: 'incident' };
-
-  //   const gen = fetchIncident(action);
-  //   expect(gen.next().value).toEqual(authCall(`${requestURL}/${id}`));
-  //   expect(gen.next(incident).value).toEqual(put(requestIncidentSuccess(incident))); // eslint-disable-line redux-saga/yield-effects
-  // });
-
-  // it('should patchIncident success', () => {
-  //   const id = 1000;
-  //   const requestURL = 'https://acc.api.data.amsterdam.nl/signals/v1/private/signals';
-  //   const action = {
-  //     payload: {
-  //       id,
-  //       type: 'location',
-  //       patch: {
-  //         location: { stadsdeel: 'A' }
-  //       }
-  //     }
-  //   };
-  //   const incident = { id };
-  //   const payload = { type: 'location', incident };
-
-  //   const gen = patchIncident(action);
-  //   expect(gen.next().value).toEqual(authPatchCall(`${requestURL}/${id}`));
-  //   expect(gen.next().value).toEqual(delay(1000)); // eslint-disable-line redux-saga/yield-effects
-  //   expect(gen.next().value).toEqual(put(patchIncidentSuccess(payload))); // eslint-disable-line redux-saga/yield-effects
-  // });
-
-  // it('should patchIncident error', () => {
-  //   const id = 1000;
-  //   const action = {
-  //     payload: {
-  //       id,
-  //       type: 'location',
-  //       patch: {
-  //         location: { stadsdeel: 'A' }
-  //       }
-  //     }
-  //   };
-  //   const error = new Error('404 Not Found');
-
-  //   const gen = patchIncident(action);
-  //   gen.next();
-  //   expect(gen.throw(error).value).toEqual(put(patchIncidentError({ type: action.payload.type, error }))); // eslint-disable-line redux-saga/yield-effects
-  // });
-
-  // it('should requestAttachment success', () => {
-  //   const requestURL = 'https://acc.api.data.amsterdam.nl/signals/v1/private/signals';
-  //   const id = 1000;
-  //   const action = { payload: id };
-  //   const attachments = { results: [{ file: 1 }, { file: 2 }, { file: 3 }, { file: 4 }] };
-  //   const firstThree = [{ file: 1 }, { file: 2 }, { file: 3 }];
-
-  //   const gen = requestAttachments(action);
-  //   expect(gen.next().value).toEqual(authCall(`${requestURL}/${id}/attachments`));
-  //   expect(gen.next(attachments).value).toEqual(put(requestAttachmentsSuccess(firstThree))); // eslint-disable-line redux-saga/yield-effects
-  // });
-
-  // it('should fetchIncident error', () => {
-  //   const id = 1000;
-  //   const action = { payload: id };
-  //   const error = new Error('404 Not Found');
-
-  //   const gen = requestAttachments(action);
-  //   gen.next();
-  //   expect(gen.throw(error).value).toEqual(put(requestAttachmentsError())); // eslint-disable-line redux-saga/yield-effects
-  // });
 });

--- a/src/shared/services/api/api.js
+++ b/src/shared/services/api/api.js
@@ -19,6 +19,7 @@ export function* authCall(url, params, authorizationToken) {
     headers.Authorization = `Bearer ${authorizationToken}`;
   } else {
     const token = getAccessToken();
+
     if (token) {
       headers.Authorization = `Bearer ${token}`;
     }

--- a/src/shared/services/api/api.js
+++ b/src/shared/services/api/api.js
@@ -1,7 +1,6 @@
-import { call, select } from 'redux-saga/effects';
+import { call } from 'redux-saga/effects';
 import request from 'utils/request';
-
-import { makeSelectAccessToken } from '../../../containers/App/selectors';
+import { getAccessToken } from 'shared/services/auth/auth';
 
 export const generateParams = (data) => Object.entries(data)
   .filter((pair) => pair[1])
@@ -19,7 +18,7 @@ export function* authCall(url, params, authorizationToken) {
   if (authorizationToken) {
     headers.Authorization = `Bearer ${authorizationToken}`;
   } else {
-    const token = yield select(makeSelectAccessToken());
+    const token = getAccessToken();
     if (token) {
       headers.Authorization = `Bearer ${token}`;
     }
@@ -38,7 +37,7 @@ export function* authCallWithPayload(url, params, method) {
     'Content-Type': 'application/json'
   };
 
-  const token = yield select(makeSelectAccessToken());
+  const token = getAccessToken();
   if (token) {
     headers.Authorization = `Bearer ${token}`;
   }

--- a/src/shared/services/api/api.test.js
+++ b/src/shared/services/api/api.test.js
@@ -3,14 +3,6 @@ import request from 'utils/request';
 
 import { generateParams, authCall, authCallWithPayload, authPostCall, authPatchCall } from './api';
 
-jest.mock('containers/App/selectors', () => {
-  function mockedMakeSelectAccessToken() { }
-
-  return ({
-    makeSelectAccessToken: () => mockedMakeSelectAccessToken,
-  });
-});
-
 describe('api service', () => {
   let params;
   const queryString = 'name1=value1&name2=value2&value3=foo&value3=bar';

--- a/src/shared/services/api/api.test.js
+++ b/src/shared/services/api/api.test.js
@@ -16,46 +16,17 @@ describe('api service', () => {
   const queryString = 'name1=value1&name2=value2&value3=foo&value3=bar';
   const url = 'https://url/to/test';
   const token = 'bearer-token';
-  let origSessionStorage;
-  let savedAccessToken;
-  let savedReturnPath;
-  let savedStateToken;
-  let savedOauthDomain;
 
   beforeEach(() => {
-    const noop = () => {};
     params = {
       name1: 'value1',
       name2: 'value2',
       value3: ['foo', 'bar']
     };
-    origSessionStorage = global.sessionStorage;
-    global.sessionStorage = {
-      getItem: (key) => {
-        switch (key) {
-          case 'accessToken':
-            return savedAccessToken;
-          case 'stateToken':
-            return savedStateToken;
-          case 'returnPath':
-            return savedReturnPath;
-          case 'oauthDomain':
-            return savedOauthDomain;
-          default:
-            return '';
-        }
-      },
-      setItem: noop,
-      removeItem: noop
-    };
-    savedStateToken = '';
-    savedReturnPath = '';
-    savedAccessToken = '';
   });
 
   afterEach(() => {
     jest.resetAllMocks();
-    global.sessionStorage = origSessionStorage;
   });
 
 
@@ -68,7 +39,8 @@ describe('api service', () => {
 
   describe('authCall', () => {
     it('should generate the right call', () => {
-      savedAccessToken = token;
+      global.sessionStorage.getItem.mockImplementationOnce(() => token);
+
       const fullUrl = `${url}?${queryString}`;
       const options = {
         method: 'GET',
@@ -94,7 +66,8 @@ describe('api service', () => {
     });
 
     it('should generate the right call when params are not defined', () => {
-      savedAccessToken = token;
+      global.sessionStorage.getItem.mockImplementationOnce(() => token);
+
       const fullUrl = `${url}`;
       const options = {
         method: 'GET',
@@ -123,7 +96,7 @@ describe('api service', () => {
 
   describe('authCallWithPayload', () => {
     it('should generate the right call', () => {
-      savedAccessToken = token;
+      global.sessionStorage.getItem.mockImplementationOnce(() => token);
       const options = {
         method: 'METHOD',
         headers: {

--- a/src/shared/services/auth/auth.js
+++ b/src/shared/services/auth/auth.js
@@ -58,7 +58,7 @@ const RETURN_PATH = 'returnPath';
 const STATE_TOKEN = 'stateToken';
 // The access token returned by the OAuth2 authorization service
 // containing user userScopes and name
-const ACCESS_TOKEN = 'accessToken';
+export const ACCESS_TOKEN = 'accessToken';
 
 const OAUTH_DOMAIN = 'oauthDomain';
 

--- a/src/shared/services/auth/auth.test.js
+++ b/src/shared/services/auth/auth.test.js
@@ -21,7 +21,6 @@ jest.mock('./services/access-token-parser/access-token-parser');
 describe('The auth service', () => {
   const noop = () => { };
 
-  let origSessionStorage;
   let queryObject;
   let savedAccessToken;
   let savedReturnPath;
@@ -30,32 +29,24 @@ describe('The auth service', () => {
   let stateToken;
 
   beforeEach(() => {
-    origSessionStorage = global.sessionStorage;
-    global.sessionStorage = {
-      getItem: (key) => {
-        switch (key) {
-          case 'accessToken':
-            return savedAccessToken;
-          case 'stateToken':
-            return savedStateToken;
-          case 'returnPath':
-            return savedReturnPath;
-          case 'oauthDomain':
-            return savedOauthDomain;
-          default:
-            return '';
-        }
-      },
-      setItem: noop,
-      removeItem: noop
-    };
+    global.sessionStorage.getItem.mockImplementation((key) => {
+      switch (key) {
+        case 'accessToken':
+          return savedAccessToken;
+        case 'stateToken':
+          return savedStateToken;
+        case 'returnPath':
+          return savedReturnPath;
+        case 'oauthDomain':
+          return savedOauthDomain;
+        default:
+          return '';
+      }
+    });
 
     jest.spyOn(global.history, 'replaceState').mockImplementation(noop);
     jest.spyOn(global.location, 'assign').mockImplementation(noop);
     jest.spyOn(global.location, 'reload').mockImplementation(noop);
-    jest.spyOn(global.sessionStorage, 'getItem');
-    jest.spyOn(global.sessionStorage, 'removeItem');
-    jest.spyOn(global.sessionStorage, 'setItem');
 
     queryStringParser.mockImplementation(() => queryObject);
     stateTokenGenerator.mockImplementation(() => stateToken);
@@ -71,7 +62,9 @@ describe('The auth service', () => {
     global.history.replaceState.mockRestore();
     global.location.assign.mockRestore();
     global.location.reload.mockRestore();
-    global.sessionStorage = origSessionStorage;
+
+    global.sessionStorage.removeItem.mockReset();
+    global.sessionStorage.setItem.mockReset();
   });
 
   describe('init funtion', () => {

--- a/src/shared/services/auth/auth.test.js
+++ b/src/shared/services/auth/auth.test.js
@@ -336,7 +336,7 @@ describe('The auth service', () => {
       expect(scopes).toEqual([]);
     });
 
-    it.skip('should return the scopes', () => {
+    it('should return the scopes', () => {
       parseAccessToken.mockImplementation(() => ({
         scopes: ['SIG/ALL']
       }));

--- a/src/signals/incident-management/components/IncidentManagementModule/index.js
+++ b/src/signals/incident-management/components/IncidentManagementModule/index.js
@@ -1,12 +1,9 @@
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
-import { connect } from 'react-redux';
-import { createStructuredSelector } from 'reselect';
-import { compose } from 'redux';
 import { Route } from 'react-router-dom';
+import { isAuthenticated } from 'shared/services/auth/auth';
 
 import LoginPage from 'components/LoginPage';
-import { makeSelectIsAuthenticated } from 'containers/App/selectors';
 
 import IncidentOverviewPage from '../../containers/IncidentOverviewPage';
 import IncidentDetail from '../../containers/IncidentDetail';
@@ -30,10 +27,9 @@ export const incidentSplitContainerWrapper = (baseUrl) => (props) => (
 );
 
 export const IncidentManagementModuleComponent = ({
-  isAuthenticated,
   match: { url },
 }) =>
-  !isAuthenticated ? (
+  !isAuthenticated() ? (
     <Route component={LoginPage} />
   ) : (
     <Fragment>
@@ -61,13 +57,6 @@ IncidentManagementModuleComponent.propTypes = {
   match: PropTypes.shape({
     url: PropTypes.string.isRequired,
   }),
-  isAuthenticated: PropTypes.bool.isRequired,
 };
 
-const mapStateToProps = createStructuredSelector({
-  isAuthenticated: makeSelectIsAuthenticated(),
-});
-
-const withConnect = connect(mapStateToProps);
-
-export default compose(withConnect)(IncidentManagementModuleComponent);
+export default IncidentManagementModuleComponent;

--- a/src/signals/incident-management/components/IncidentManagementModule/index.test.js
+++ b/src/signals/incident-management/components/IncidentManagementModule/index.test.js
@@ -9,18 +9,23 @@ import {
   incidentDetailWrapper,
   incidentOverviewPageWrapper,
   incidentSplitContainerWrapper,
-} from './index';
+} from './';
 
 const history = createMemoryHistory();
 
-describe('signals/incident-management/components/IncidentManagementModule', () => {
+describe('signals/incident-management', () => {
   let props;
+  let origSessionStorage;
 
   afterAll(() => {
     jest.restoreAllMocks();
   });
 
-  afterEach(cleanup);
+  afterEach(() => {
+    cleanup();
+
+    global.sessionStorage = origSessionStorage;
+  });
 
   beforeEach(() => {
     props = {
@@ -30,7 +35,22 @@ describe('signals/incident-management/components/IncidentManagementModule', () =
         path: '/manage/incidents',
         url: '/manage/incidents',
       },
-      isAuthenticated: true,
+      getFiltersAction: () => {},
+    };
+
+    origSessionStorage = global.sessionStorage;
+
+    global.sessionStorage = {
+      getItem: (key) => {
+        switch (key) {
+          case 'accessToken':
+            return '42';
+          default:
+            return '';
+        }
+      },
+      setItem: jest.fn(),
+      removeItem: jest.fn(),
     };
   });
 
@@ -40,14 +60,11 @@ describe('signals/incident-management/components/IncidentManagementModule', () =
     );
     const firstRender = asFragment();
 
-    rerender(
-      withAppContext(
-        <IncidentManagementModuleComponent
-          {...props}
-          isAuthenticated={false}
-        />,
-      ),
-    );
+    jest
+      .spyOn(global.sessionStorage, 'getItem')
+      .mockImplementationOnce(() => undefined);
+
+    rerender(withAppContext(<IncidentManagementModuleComponent {...props} />));
 
     expect(
       firstRender.firstElementChild === asFragment().firstElementChild,
@@ -60,21 +77,18 @@ describe('signals/incident-management/components/IncidentManagementModule', () =
     it('can navigate to incident list', () => {
       history.push('/manage/incidents');
 
+      jest
+        .spyOn(global.sessionStorage, 'getItem')
+        .mockImplementationOnce(() => undefined);
+
       const { rerender, queryByText } = render(
-        withAppContext(
-          <IncidentManagementModuleComponent
-            {...props}
-            isAuthenticated={false}
-          />,
-        ),
+        withAppContext(<IncidentManagementModuleComponent {...props} />),
       );
 
       expect(queryByText(loginText)).not.toBeNull();
 
       rerender(
-        withAppContext(
-          <IncidentManagementModuleComponent {...props} isAuthenticated />,
-        ),
+        withAppContext(<IncidentManagementModuleComponent {...props} />),
       );
 
       expect(queryByText(loginText)).toBeNull();
@@ -83,21 +97,18 @@ describe('signals/incident-management/components/IncidentManagementModule', () =
     it('can navigate to incident detail', () => {
       history.push('/manage/incident/1101');
 
+      jest
+        .spyOn(global.sessionStorage, 'getItem')
+        .mockImplementationOnce(() => undefined);
+
       const { rerender, queryByText } = render(
-        withAppContext(
-          <IncidentManagementModuleComponent
-            {...props}
-            isAuthenticated={false}
-          />,
-        ),
+        withAppContext(<IncidentManagementModuleComponent {...props} />),
       );
 
       expect(queryByText(loginText)).not.toBeNull();
 
       rerender(
-        withAppContext(
-          <IncidentManagementModuleComponent {...props} isAuthenticated />,
-        ),
+        withAppContext(<IncidentManagementModuleComponent {...props} />),
       );
 
       expect(queryByText(loginText)).toBeNull();
@@ -106,21 +117,18 @@ describe('signals/incident-management/components/IncidentManagementModule', () =
     it('can navigate to incident split', () => {
       history.push('/manage/incident/1101/split');
 
+      jest
+        .spyOn(global.sessionStorage, 'getItem')
+        .mockImplementationOnce(() => undefined);
+
       const { rerender, queryByText } = render(
-        withAppContext(
-          <IncidentManagementModuleComponent
-            {...props}
-            isAuthenticated={false}
-          />,
-        ),
+        withAppContext(<IncidentManagementModuleComponent {...props} />),
       );
 
       expect(queryByText(loginText)).not.toBeNull();
 
       rerender(
-        withAppContext(
-          <IncidentManagementModuleComponent {...props} isAuthenticated />,
-        ),
+        withAppContext(<IncidentManagementModuleComponent {...props} />),
       );
 
       expect(queryByText(loginText)).toBeNull();
@@ -152,7 +160,9 @@ describe('signals/incident-management/components/IncidentManagementModule', () =
 
     it('renders IncidentOverviewPageWrapper', () => {
       const baseUrl = '/manage';
-      const IncidentOverviewPage = withRouter(incidentOverviewPageWrapper(baseUrl));
+      const IncidentOverviewPage = withRouter(
+        incidentOverviewPageWrapper(baseUrl),
+      );
 
       const { container } = render(
         withCustomAppContext(<IncidentOverviewPage />)({
@@ -165,7 +175,9 @@ describe('signals/incident-management/components/IncidentManagementModule', () =
 
     it('renders IncidentSplitContainerWrapper', () => {
       const baseUrl = '/manage';
-      const IncidentSplitContainer = withRouter(incidentSplitContainerWrapper(baseUrl));
+      const IncidentSplitContainer = withRouter(
+        incidentSplitContainerWrapper(baseUrl),
+      );
 
       const { container } = render(
         withCustomAppContext(<IncidentSplitContainer />)({

--- a/src/signals/incident-management/components/IncidentManagementModule/index.test.js
+++ b/src/signals/incident-management/components/IncidentManagementModule/index.test.js
@@ -15,7 +15,6 @@ const history = createMemoryHistory();
 
 describe('signals/incident-management', () => {
   let props;
-  let origSessionStorage;
 
   afterAll(() => {
     jest.restoreAllMocks();
@@ -23,8 +22,6 @@ describe('signals/incident-management', () => {
 
   afterEach(() => {
     cleanup();
-
-    global.sessionStorage = origSessionStorage;
   });
 
   beforeEach(() => {
@@ -37,32 +34,17 @@ describe('signals/incident-management', () => {
       },
       getFiltersAction: () => {},
     };
-
-    origSessionStorage = global.sessionStorage;
-
-    global.sessionStorage = {
-      getItem: (key) => {
-        switch (key) {
-          case 'accessToken':
-            return '42';
-          default:
-            return '';
-        }
-      },
-      setItem: jest.fn(),
-      removeItem: jest.fn(),
-    };
   });
 
   it('should render correctly', () => {
+    sessionStorage.getItem.mockImplementationOnce(() => 'token');
+
     const { rerender, asFragment } = render(
       withAppContext(<IncidentManagementModuleComponent {...props} />),
     );
     const firstRender = asFragment();
 
-    jest
-      .spyOn(global.sessionStorage, 'getItem')
-      .mockImplementationOnce(() => undefined);
+    sessionStorage.getItem.mockImplementationOnce(() => undefined);
 
     rerender(withAppContext(<IncidentManagementModuleComponent {...props} />));
 
@@ -77,15 +59,15 @@ describe('signals/incident-management', () => {
     it('can navigate to incident list', () => {
       history.push('/manage/incidents');
 
-      jest
-        .spyOn(global.sessionStorage, 'getItem')
-        .mockImplementationOnce(() => undefined);
+      sessionStorage.getItem.mockImplementationOnce(() => undefined);
 
       const { rerender, queryByText } = render(
         withAppContext(<IncidentManagementModuleComponent {...props} />),
       );
 
       expect(queryByText(loginText)).not.toBeNull();
+
+      sessionStorage.getItem.mockImplementationOnce(() => 'token');
 
       rerender(
         withAppContext(<IncidentManagementModuleComponent {...props} />),
@@ -97,15 +79,15 @@ describe('signals/incident-management', () => {
     it('can navigate to incident detail', () => {
       history.push('/manage/incident/1101');
 
-      jest
-        .spyOn(global.sessionStorage, 'getItem')
-        .mockImplementationOnce(() => undefined);
+      sessionStorage.getItem.mockImplementationOnce(() => undefined);
 
       const { rerender, queryByText } = render(
         withAppContext(<IncidentManagementModuleComponent {...props} />),
       );
 
       expect(queryByText(loginText)).not.toBeNull();
+
+      sessionStorage.getItem.mockImplementationOnce(() => 'token');
 
       rerender(
         withAppContext(<IncidentManagementModuleComponent {...props} />),
@@ -117,15 +99,15 @@ describe('signals/incident-management', () => {
     it('can navigate to incident split', () => {
       history.push('/manage/incident/1101/split');
 
-      jest
-        .spyOn(global.sessionStorage, 'getItem')
-        .mockImplementationOnce(() => undefined);
+      sessionStorage.getItem.mockImplementationOnce(() => undefined);
 
       const { rerender, queryByText } = render(
         withAppContext(<IncidentManagementModuleComponent {...props} />),
       );
 
       expect(queryByText(loginText)).not.toBeNull();
+
+      sessionStorage.getItem.mockImplementationOnce(() => 'token');
 
       rerender(
         withAppContext(<IncidentManagementModuleComponent {...props} />),

--- a/src/signals/incident/containers/IncidentContainer/index.js
+++ b/src/signals/incident/containers/IncidentContainer/index.js
@@ -11,9 +11,9 @@ import { createStructuredSelector } from 'reselect';
 import { compose, bindActionCreators } from 'redux';
 import { Row, Column } from '@datapunt/asc-ui';
 
+import { isAuthenticated } from 'shared/services/auth/auth';
 import injectSaga from 'utils/injectSaga';
 import injectReducer from 'utils/injectReducer';
-import { makeSelectIsAuthenticated } from 'containers/App/selectors';
 import wizardDefinition from '../../definitions/wizard';
 import { getClassification, updateIncident, createIncident } from './actions';
 import makeSelectIncidentContainer from './selectors';
@@ -42,7 +42,7 @@ export class IncidentContainer extends React.Component {
             updateIncident={this.updateIncident}
             createIncident={this.createIncident}
             incidentContainer={this.props.incidentContainer}
-            isAuthenticated={this.props.isAuthenticated}
+            isAuthenticated={isAuthenticated()}
           />
         </Column>
       </Row>
@@ -55,12 +55,10 @@ IncidentContainer.propTypes = {
   getClassification: PropTypes.func.isRequired,
   updateIncident: PropTypes.func.isRequired,
   createIncident: PropTypes.func.isRequired,
-  isAuthenticated: PropTypes.bool,
 };
 
 const mapStateToProps = createStructuredSelector({
   incidentContainer: makeSelectIncidentContainer(),
-  isAuthenticated: makeSelectIsAuthenticated(),
 });
 
 export const mapDispatchToProps = (dispatch) =>

--- a/src/signals/incident/containers/IncidentContainer/index.test.js
+++ b/src/signals/incident/containers/IncidentContainer/index.test.js
@@ -5,11 +5,11 @@ import { withAppContext } from 'test/utils';
 import { IncidentContainer, mapDispatchToProps } from './index';
 import { GET_CLASSIFICATION, UPDATE_INCIDENT, CREATE_INCIDENT } from './constants';
 
-// jest.mock('../../components/IncidenptWizard', () => () => 'IncidentWizard');
 jest.mock('signals/incident/components/form/MapInput', () => () => 'MapInput');
 
 describe('<IncidentContainer />', () => {
   let props;
+  let origSessionStorage;
 
   beforeEach(() => {
     props = {
@@ -17,12 +17,26 @@ describe('<IncidentContainer />', () => {
       getClassification: jest.fn(),
       updateIncident: jest.fn(),
       createIncident: jest.fn(),
-      isAuthenticated: false
+    };
+    origSessionStorage = global.sessionStorage;
+
+    global.sessionStorage = {
+      getItem: (key) => {
+        switch (key) {
+          case 'accessToken':
+            return '42';
+          default:
+            return '';
+        }
+      },
+      setItem: jest.fn(),
+      removeItem: jest.fn(),
     };
   });
 
   afterEach(() => {
     jest.resetAllMocks();
+    global.sessionStorage = origSessionStorage;
   });
 
   describe('rendering', () => {


### PR DESCRIPTION
This PR contains changes that prevents component from rerendering when the `makeSelectIsAuthenticated` selector updates its value and passes a different prop value to the appropriate components. 
The previous asynchronous behaviour caused several issues.; logging in wouldn't always redirect the user to the incidents overview page and the header component would render its `tall` version and, after getting a different value for the authentication, would render its `short` version.