### PR TITLE
(Chore) DownloadButton access token

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/components/DetailHeader/components/DownloadButton/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/DetailHeader/components/DownloadButton/index.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import 'whatwg-fetch';
+import { isAuthenticated, getAccessToken } from 'shared/services/auth/auth';
 
 class DownloadButton extends React.Component {
   constructor(props) {
@@ -10,11 +11,11 @@ class DownloadButton extends React.Component {
     this.handleDownload = this.handleDownload.bind(this);
   }
 
-  handleDownload(url, filename, accessToken) {
+  handleDownload(url, filename) {
     const headers = {};
 
-    if (accessToken) {
-      headers.Authorization = `Bearer ${accessToken}`;
+    if (isAuthenticated()) {
+      headers.Authorization = `Bearer ${getAccessToken()}`;
     }
 
     fetch(url, {
@@ -41,14 +42,14 @@ class DownloadButton extends React.Component {
   }
 
   render() {
-    const { label, url, filename, accessToken } = this.props;
+    const { label, url, filename } = this.props;
     return (
       <div className="download-button align-self-center">
         <button
           className="incident-detail__button"
           type="button"
           data-testid="download-button"
-          onClick={() => this.handleDownload(url, filename, accessToken)}
+          onClick={() => this.handleDownload(url, filename, getAccessToken())}
         >{label}</button>
       </div>
     );
@@ -60,7 +61,6 @@ DownloadButton.propTypes = {
   url: PropTypes.string.isRequired,
   filename: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,
-  accessToken: PropTypes.string
 };
 
 export default DownloadButton;

--- a/src/signals/incident-management/containers/IncidentDetail/components/DetailHeader/components/DownloadButton/index.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/DetailHeader/components/DownloadButton/index.test.js
@@ -56,8 +56,9 @@ describe('<DownloadButton />', () => {
     });
 
     it('should download document with token when present', () => {
+      sessionStorage.getItem.mockImplementation(() => 'MOCK-TOKEN');
       const { queryByTestId } = render(
-        <DownloadButton {...props} accessToken="MOCK-TOKEN" />
+        <DownloadButton {...props} />
         );
       fireEvent.click(queryByTestId('download-button'));
 

--- a/src/signals/incident-management/containers/IncidentDetail/components/DetailHeader/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/DetailHeader/index.js
@@ -8,7 +8,7 @@ import DownloadButton from './components/DownloadButton';
 
 import './style.scss';
 
-const DetailHeader = ({ incident, baseUrl, accessToken, onPatchIncident }) => {
+const DetailHeader = ({ incident, baseUrl, onPatchIncident }) => {
   const status = incident && incident.status && incident.status.state;
   const canSplit = (status === 'm') && !(incident && (incident._links['sia:children'] || incident._links['sia:parent']));
   const canThor = ['m', 'i', 'b', 'h', 'send failed', 'reopened'].some((value) => value === status);
@@ -57,7 +57,6 @@ const DetailHeader = ({ incident, baseUrl, accessToken, onPatchIncident }) => {
             label="PDF"
             url={downloadLink}
             filename={`SIA melding ${incident.id}.pdf`}
-            accessToken={accessToken}
             data-testid="detail-header-button-download"
           />
         </div>
@@ -69,8 +68,6 @@ const DetailHeader = ({ incident, baseUrl, accessToken, onPatchIncident }) => {
 DetailHeader.propTypes = {
   incident: incidentType.isRequired,
   baseUrl: PropTypes.string.isRequired,
-  accessToken: PropTypes.string.isRequired,
-
   onPatchIncident: PropTypes.func.isRequired
 };
 

--- a/src/signals/incident-management/containers/IncidentDetail/components/DetailHeader/index.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/DetailHeader/index.test.js
@@ -21,7 +21,6 @@ describe('<DetailHeader />', () => {
         }
       },
       baseUrl: '/manage',
-      accessToken: 'MOCK-TOKEN',
       onPatchIncident: jest.fn()
     };
   });

--- a/src/signals/incident-management/containers/IncidentDetail/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/index.js
@@ -21,7 +21,6 @@ import {
   makeSelectLoading,
   makeSelectError,
   makeSelectCategories,
-  makeSelectAccessToken,
 } from 'containers/App/selectors';
 import {
   requestIncident,
@@ -142,7 +141,6 @@ export class IncidentDetail extends React.Component {
     const {
       id,
       categories,
-      accessToken,
       onPatchIncident,
       onDismissError,
       onDismissSplitNotification,
@@ -181,7 +179,6 @@ export class IncidentDetail extends React.Component {
                     <DetailHeader
                       incident={incident}
                       baseUrl={this.props.baseUrl}
-                      accessToken={accessToken}
                       onPatchIncident={onPatchIncident}
                     />
                   </Column>
@@ -317,7 +314,6 @@ IncidentDetail.propTypes = {
     list: historyType.isRequired,
   }).isRequired,
   categories: categoriesType.isRequired,
-  accessToken: PropTypes.string.isRequired,
 
   id: PropTypes.string,
   baseUrl: PropTypes.string,
@@ -339,7 +335,6 @@ const mapStateToProps = () =>
     incidentModel: makeSelectIncidentModel(),
     categories: makeSelectCategories(),
     historyModel: makeSelectHistoryModel(),
-    accessToken: makeSelectAccessToken(),
   });
 
 export const mapDispatchToProps = (dispatch) =>

--- a/src/signals/incident-management/containers/IncidentDetail/index.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/index.test.js
@@ -196,7 +196,6 @@ describe('<IncidentDetail />', () => {
         }
       ]
     },
-    accessToken: '123',
     baseUrl: 'aaa/',
 
     onRequestIncident: jest.fn(),
@@ -417,4 +416,3 @@ describe('<IncidentDetail />', () => {
     });
   });
 });
-


### PR DESCRIPTION
This PR removes the requirement for both `IncidentDetail` container and its `DetailHeader` component for receiving a value for their `accessToken` props and moves that responsibility to the `DownloadButton` components.
The proposed change is a fix on top of the #351 PR.