### PR TITLE
(Chore) Prevent warning

### DIFF
--- a/src/signals/incident/components/form/RadioInput/__snapshots__/index.test.js.snap
+++ b/src/signals/incident/components/form/RadioInput/__snapshots__/index.test.js.snap
@@ -40,7 +40,7 @@ exports[`Form component <RadioInput /> rendering should render radio fields corr
             checked={true}
             className="kenmerkradio"
             id="input-field-name-foo1"
-            onClick={[Function]}
+            onChange={[Function]}
             type="radio"
           />
           <label
@@ -57,7 +57,7 @@ exports[`Form component <RadioInput /> rendering should render radio fields corr
             checked={false}
             className="kenmerkradio"
             id="input-field-name-bar1"
-            onClick={[Function]}
+            onChange={[Function]}
             type="radio"
           />
           <label

--- a/src/signals/incident/components/form/RadioInput/index.js
+++ b/src/signals/incident/components/form/RadioInput/index.js
@@ -24,7 +24,7 @@ const RadioInput = ({ handler, touched, hasError, meta, parent, getError, valida
                   className="kenmerkradio"
                   type="radio"
                   checked={handler().value.id === key}
-                  onClick={() => parent.meta.updateIncident({ [meta.name]: {
+                  onChange={() => parent.meta.updateIncident({ [meta.name]: {
                     id: key,
                     label: value
                   } })}

--- a/src/signals/incident/components/form/RadioInput/index.test.js
+++ b/src/signals/incident/components/form/RadioInput/index.test.js
@@ -93,7 +93,7 @@ describe('Form component <RadioInput />', () => {
         }
       });
 
-      wrapper.find('input').first().simulate('click', event);
+      wrapper.find('input').first().simulate('change', event);
 
       expect(parent.meta.updateIncident).toHaveBeenCalledWith({
         'input-field-name': {


### PR DESCRIPTION
This PR alters the `RadioInput` component so that the warning with regards to using the `checked` attribute in combination with a `onClick` handler instead of an `onChange` handler, isn't shown anymore.