### PR TITLE
SIG-1713 Textarea scroll lines fix

### DIFF
--- a/src/components/TextArea/__tests__/TextArea.test.js
+++ b/src/components/TextArea/__tests__/TextArea.test.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { withAppContext } from 'test/utils';
+
+import TextArea from '../';
+
+describe('components/TextArea', () => {
+  it('renders correctly', () => {
+    const { container } = render(
+      withAppContext(<TextArea cols="40" rows="5" className="txtArea" />),
+    );
+
+    expect(container.querySelector('textarea[cols="40"][rows="5"].txtArea')).toBeTruthy();
+  });
+});

--- a/src/components/TextArea/index.js
+++ b/src/components/TextArea/index.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import { styles } from '@datapunt/asc-ui';
+
+const { InputStyle } = styles;
+
+export default (props) => <InputStyle as="textarea" {...props} />;

--- a/src/signals/incident-management/components/TextAreaInput/__snapshots__/index.test.js.snap
+++ b/src/signals/incident-management/components/TextAreaInput/__snapshots__/index.test.js.snap
@@ -17,9 +17,9 @@ exports[`<TextAreaInput /> should render character counter correctly 1`] = `
       </label>
     </div>
     <div
-      className="text-area-input__control invoer"
+      className="text-area-input__control"
     >
-      <textarea
+      <Component
         id="formname"
         name=""
         placeholder="placeholder"
@@ -57,9 +57,9 @@ exports[`<TextAreaInput /> should render character counter with value correctly 
       </label>
     </div>
     <div
-      className="text-area-input__control invoer"
+      className="text-area-input__control"
     >
-      <textarea
+      <Component
         id="formname"
         name=""
         placeholder="placeholder"
@@ -97,9 +97,9 @@ exports[`<TextAreaInput /> should render correctly 1`] = `
       </label>
     </div>
     <div
-      className="text-area-input__control invoer"
+      className="text-area-input__control"
     >
-      <textarea
+      <Component
         id="formname"
         name=""
         placeholder="placeholder"

--- a/src/signals/incident-management/components/TextAreaInput/index.js
+++ b/src/signals/incident-management/components/TextAreaInput/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import TextArea from 'components/TextArea';
 
 import './style.scss';
 
@@ -12,8 +13,8 @@ const TextAreaInput = (props) => {
           <label htmlFor={`form${name}`}>{display}</label>
         </div>
 
-        <div className="text-area-input__control invoer">
-          <textarea
+        <div className="text-area-input__control">
+          <TextArea
             name=""
             id={`form${name}`}
             value=""

--- a/src/signals/incident-management/components/TextInput/index.js
+++ b/src/signals/incident-management/components/TextInput/index.js
@@ -1,17 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Input } from '@datapunt/asc-ui';
 import Label from '../Label';
 
 import './style.scss';
 
 const TextInput = ({ name, display, placeholder }) => {
   const Render = ({ handler }) => (
-    <div className="text-input invoer">
+    <div>
       <Label htmlFor={`form${name}`}>{display}</Label>
 
-      <input
+      <Input
         id={`form${name}`}
-        className="input"
         type="text"
         {...handler()}
         placeholder={placeholder}

--- a/src/signals/incident/components/form/DescriptionWithClassificationInput/__snapshots__/index.test.js.snap
+++ b/src/signals/incident/components/form/DescriptionWithClassificationInput/__snapshots__/index.test.js.snap
@@ -19,11 +19,15 @@ exports[`Form component <DescriptionWithClassificationInput /> rendering should 
       }
       touched={false}
     >
-      <Component
-        onBlur={[Function]}
-        placeholder="type here"
-        rows={6}
-      />
+      <div
+        className="invoer"
+      >
+        <textarea
+          onBlur={[Function]}
+          placeholder="type here"
+          rows={6}
+        />
+      </div>
     </Header>
   </div>
 </div>
@@ -55,19 +59,23 @@ exports[`Form component <DescriptionWithClassificationInput /> rendering should 
       }
       touched={false}
     >
-      <Component
-        onBlur={[Function]}
-        placeholder="type here"
-        rows={6}
-      />
       <div
-        className="input-help"
+        className="invoer"
       >
-        <span
-          className="text-area-input__counter"
+        <textarea
+          onBlur={[Function]}
+          placeholder="type here"
+          rows={6}
+        />
+        <div
+          className="input-help"
         >
-          0/3000 tekens
-        </span>
+          <span
+            className="text-area-input__counter"
+          >
+            0/3000 tekens
+          </span>
+        </div>
       </div>
     </Header>
   </div>
@@ -94,19 +102,23 @@ exports[`Form component <DescriptionWithClassificationInput /> rendering should 
       }
       touched={false}
     >
-      <Component
-        onBlur={[Function]}
-        placeholder="type here"
-        rows={6}
-      />
       <div
-        className="input-help"
+        className="invoer"
       >
-        <span
-          className="text-area-input__counter"
+        <textarea
+          onBlur={[Function]}
+          placeholder="type here"
+          rows={6}
+        />
+        <div
+          className="input-help"
         >
-          4/3000 tekens
-        </span>
+          <span
+            className="text-area-input__counter"
+          >
+            4/3000 tekens
+          </span>
+        </div>
       </div>
     </Header>
   </div>

--- a/src/signals/incident/components/form/DescriptionWithClassificationInput/__snapshots__/index.test.js.snap
+++ b/src/signals/incident/components/form/DescriptionWithClassificationInput/__snapshots__/index.test.js.snap
@@ -22,7 +22,7 @@ exports[`Form component <DescriptionWithClassificationInput /> rendering should 
       <div
         className="invoer"
       >
-        <textarea
+        <Component
           onBlur={[Function]}
           placeholder="type here"
           rows={6}
@@ -62,7 +62,7 @@ exports[`Form component <DescriptionWithClassificationInput /> rendering should 
       <div
         className="invoer"
       >
-        <textarea
+        <Component
           onBlur={[Function]}
           placeholder="type here"
           rows={6}
@@ -105,7 +105,7 @@ exports[`Form component <DescriptionWithClassificationInput /> rendering should 
       <div
         className="invoer"
       >
-        <textarea
+        <Component
           onBlur={[Function]}
           placeholder="type here"
           rows={6}

--- a/src/signals/incident/components/form/DescriptionWithClassificationInput/__snapshots__/index.test.js.snap
+++ b/src/signals/incident/components/form/DescriptionWithClassificationInput/__snapshots__/index.test.js.snap
@@ -19,15 +19,11 @@ exports[`Form component <DescriptionWithClassificationInput /> rendering should 
       }
       touched={false}
     >
-      <div
-        className="invoer"
-      >
-        <textarea
-          onBlur={[Function]}
-          placeholder="type here"
-          rows={6}
-        />
-      </div>
+      <Component
+        onBlur={[Function]}
+        placeholder="type here"
+        rows={6}
+      />
     </Header>
   </div>
 </div>
@@ -59,23 +55,19 @@ exports[`Form component <DescriptionWithClassificationInput /> rendering should 
       }
       touched={false}
     >
+      <Component
+        onBlur={[Function]}
+        placeholder="type here"
+        rows={6}
+      />
       <div
-        className="invoer"
+        className="input-help"
       >
-        <textarea
-          onBlur={[Function]}
-          placeholder="type here"
-          rows={6}
-        />
-        <div
-          className="input-help"
+        <span
+          className="text-area-input__counter"
         >
-          <span
-            className="text-area-input__counter"
-          >
-            0/3000 tekens
-          </span>
-        </div>
+          0/3000 tekens
+        </span>
       </div>
     </Header>
   </div>
@@ -102,23 +94,19 @@ exports[`Form component <DescriptionWithClassificationInput /> rendering should 
       }
       touched={false}
     >
+      <Component
+        onBlur={[Function]}
+        placeholder="type here"
+        rows={6}
+      />
       <div
-        className="invoer"
+        className="input-help"
       >
-        <textarea
-          onBlur={[Function]}
-          placeholder="type here"
-          rows={6}
-        />
-        <div
-          className="input-help"
+        <span
+          className="text-area-input__counter"
         >
-          <span
-            className="text-area-input__counter"
-          >
-            4/3000 tekens
-          </span>
-        </div>
+          4/3000 tekens
+        </span>
       </div>
     </Header>
   </div>

--- a/src/signals/incident/components/form/DescriptionWithClassificationInput/index.js
+++ b/src/signals/incident/components/form/DescriptionWithClassificationInput/index.js
@@ -1,62 +1,47 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
-import TextArea from 'components/TextArea';
 
 import Header from '../Header/';
 
 import './style.scss';
 
-const DescriptionWithClassificationInput = ({
-  handler,
-  touched,
-  value,
-  hasError,
-  meta,
-  parent,
-  getError,
-  validatorsOrOpts,
-}) => {
-  const get = (e) => {
-    if (e.target.value.trim() !== '') {
-      parent.meta.getClassification(e.target.value);
-      parent.meta.updateIncident({ [meta.name]: e.target.value });
-    }
-  };
+function get(e, meta, parent) {
+  parent.meta.getClassification(e.target.value);
+  parent.meta.updateIncident({ [meta.name]: e.target.value });
+}
 
-  return (
-    <div className={`${meta && meta.isVisible ? 'row' : ''}`}>
-      {meta && meta.isVisible ? (
-        <div className={`${meta.className || 'col-12'} mode_input`}>
-          <Header
-            meta={meta}
-            options={validatorsOrOpts}
-            touched={touched}
-            hasError={hasError}
-            getError={getError}
-          >
-            <Fragment>
-              <TextArea
-                rows={meta.rows || 6}
-                placeholder={meta.placeholder}
-                {...handler()}
-                onBlur={get}
-              />
-              {meta.maxLength && (
-                <div className="input-help">
-                  <span className="text-area-input__counter">
-                    {`${value ? value.length : '0'}/${meta.maxLength} tekens`}
-                  </span>
-                </div>
-              )}
-            </Fragment>
-          </Header>
-        </div>
-      ) : (
-        ''
-      )}
-    </div>
-  );
-};
+
+const DescriptionWithClassificationInput = ({ handler, touched, value, hasError, meta, parent, getError, validatorsOrOpts }) => (
+  <div className={`${meta && meta.isVisible ? 'row' : ''}`}>
+    {meta && meta.isVisible ?
+      <div className={`${meta.className || 'col-12'} mode_input`}>
+        <Header
+          meta={meta}
+          options={validatorsOrOpts}
+          touched={touched}
+          hasError={hasError}
+          getError={getError}
+        >
+          <div className="invoer">
+            <textarea
+              rows={meta.rows || 6}
+              placeholder={meta.placeholder}
+              {...handler()}
+              onBlur={(e) => get(e, meta, parent)}
+            />
+            { meta.maxLength &&
+              <div className="input-help">
+                <span className="text-area-input__counter">
+                  {`${value ? value.length : '0'}/${meta.maxLength} tekens` }
+                </span>
+              </div>
+            }
+          </div>
+        </Header>
+      </div>
+       : ''}
+  </div>
+);
 
 DescriptionWithClassificationInput.propTypes = {
   handler: PropTypes.func,
@@ -66,7 +51,7 @@ DescriptionWithClassificationInput.propTypes = {
   meta: PropTypes.object,
   parent: PropTypes.object,
   getError: PropTypes.func,
-  validatorsOrOpts: PropTypes.object,
+  validatorsOrOpts: PropTypes.object
 };
 
 export default DescriptionWithClassificationInput;

--- a/src/signals/incident/components/form/DescriptionWithClassificationInput/index.js
+++ b/src/signals/incident/components/form/DescriptionWithClassificationInput/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import TextArea from 'components/TextArea';
 
 import Header from '../Header/';
 
@@ -23,7 +24,7 @@ const DescriptionWithClassificationInput = ({ handler, touched, value, hasError,
           getError={getError}
         >
           <div className="invoer">
-            <textarea
+            <TextArea
               rows={meta.rows || 6}
               placeholder={meta.placeholder}
               {...handler()}

--- a/src/signals/incident/components/form/DescriptionWithClassificationInput/index.js
+++ b/src/signals/incident/components/form/DescriptionWithClassificationInput/index.js
@@ -1,47 +1,62 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
+import TextArea from 'components/TextArea';
 
 import Header from '../Header/';
 
 import './style.scss';
 
-function get(e, meta, parent) {
-  parent.meta.getClassification(e.target.value);
-  parent.meta.updateIncident({ [meta.name]: e.target.value });
-}
+const DescriptionWithClassificationInput = ({
+  handler,
+  touched,
+  value,
+  hasError,
+  meta,
+  parent,
+  getError,
+  validatorsOrOpts,
+}) => {
+  const get = (e) => {
+    if (e.target.value.trim() !== '') {
+      parent.meta.getClassification(e.target.value);
+      parent.meta.updateIncident({ [meta.name]: e.target.value });
+    }
+  };
 
-
-const DescriptionWithClassificationInput = ({ handler, touched, value, hasError, meta, parent, getError, validatorsOrOpts }) => (
-  <div className={`${meta && meta.isVisible ? 'row' : ''}`}>
-    {meta && meta.isVisible ?
-      <div className={`${meta.className || 'col-12'} mode_input`}>
-        <Header
-          meta={meta}
-          options={validatorsOrOpts}
-          touched={touched}
-          hasError={hasError}
-          getError={getError}
-        >
-          <div className="invoer">
-            <textarea
-              rows={meta.rows || 6}
-              placeholder={meta.placeholder}
-              {...handler()}
-              onBlur={(e) => get(e, meta, parent)}
-            />
-            { meta.maxLength &&
-              <div className="input-help">
-                <span className="text-area-input__counter">
-                  {`${value ? value.length : '0'}/${meta.maxLength} tekens` }
-                </span>
-              </div>
-            }
-          </div>
-        </Header>
-      </div>
-       : ''}
-  </div>
-);
+  return (
+    <div className={`${meta && meta.isVisible ? 'row' : ''}`}>
+      {meta && meta.isVisible ? (
+        <div className={`${meta.className || 'col-12'} mode_input`}>
+          <Header
+            meta={meta}
+            options={validatorsOrOpts}
+            touched={touched}
+            hasError={hasError}
+            getError={getError}
+          >
+            <Fragment>
+              <TextArea
+                rows={meta.rows || 6}
+                placeholder={meta.placeholder}
+                {...handler()}
+                onBlur={get}
+              />
+              {meta.maxLength && (
+                <div className="input-help">
+                  <span className="text-area-input__counter">
+                    {`${value ? value.length : '0'}/${meta.maxLength} tekens`}
+                  </span>
+                </div>
+              )}
+            </Fragment>
+          </Header>
+        </div>
+      ) : (
+        ''
+      )}
+    </div>
+  );
+};
 
 DescriptionWithClassificationInput.propTypes = {
   handler: PropTypes.func,
@@ -51,7 +66,7 @@ DescriptionWithClassificationInput.propTypes = {
   meta: PropTypes.object,
   parent: PropTypes.object,
   getError: PropTypes.func,
-  validatorsOrOpts: PropTypes.object
+  validatorsOrOpts: PropTypes.object,
 };
 
 export default DescriptionWithClassificationInput;

--- a/src/signals/incident/components/form/DescriptionWithClassificationInput/index.test.js
+++ b/src/signals/incident/components/form/DescriptionWithClassificationInput/index.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import TextArea from 'components/TextArea';
 
 import DescriptionWithClassificationInput from './index';
 
@@ -98,7 +99,7 @@ describe('Form component <DescriptionWithClassificationInput />', () => {
         }
       });
 
-      wrapper.find('textarea').simulate('blur', event);
+      wrapper.find(TextArea).simulate('blur', event);
       expect(parent.meta.getClassification).toHaveBeenCalledWith('diabolo');
       expect(parent.meta.updateIncident).toHaveBeenCalledWith({
         'input-field-name': 'diabolo'

--- a/src/signals/incident/components/form/MultiTextInput/__snapshots__/index.test.js.snap
+++ b/src/signals/incident/components/form/MultiTextInput/__snapshots__/index.test.js.snap
@@ -30,10 +30,9 @@ exports[`Form component <MultiTextInput /> rendering should render multi text co
           }
         />
         <div
-          className="invoer"
           key="input-field-name-1"
         >
-          <input
+          <Input
             className="multi-text-input__input col-3"
             id="input-field-name-1"
             maxLength="15"
@@ -80,10 +79,9 @@ exports[`Form component <MultiTextInput /> rendering should render multi text wi
           type="hidden"
         />
         <div
-          className="invoer"
           key="input-field-name-1"
         >
-          <input
+          <Input
             className="multi-text-input__input "
             id="input-field-name-1"
             maxLength="15"

--- a/src/signals/incident/components/form/MultiTextInput/index.js
+++ b/src/signals/incident/components/form/MultiTextInput/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import map from 'lodash.map';
+import { Input } from '@datapunt/asc-ui';
 
 import './style.scss';
 
@@ -50,8 +51,8 @@ const MultiTextInput = ({ handler, touched, hasError, meta, parent, getError, va
             />
 
             {map(handler().value || [''], (input, index) =>
-              (<div key={`${meta.name}-${index + 1}`} className="invoer">
-                <input
+              (<div key={`${meta.name}-${index + 1}`}>
+                <Input
                   className={`multi-text-input__input ${meta.itemClassName ? meta.itemClassName : ''}`}
                   id={`${meta.name}-${index + 1}`}
                   name={`${meta.name}-${index + 1}`}

--- a/src/signals/incident/components/form/MultiTextInput/index.test.js
+++ b/src/signals/incident/components/form/MultiTextInput/index.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import { Input } from '@datapunt/asc-ui';
 
 import MultiTextInput from './index';
 
@@ -88,7 +89,7 @@ describe('Form component <MultiTextInput />', () => {
         }
       });
 
-      wrapper.find('input.multi-text-input__input').simulate('change', event);
+      wrapper.find(Input).simulate('change', event);
 
       expect(parent.meta.updateIncident).toHaveBeenCalledWith({
         'input-field-name': ['Ipsum']
@@ -121,8 +122,8 @@ describe('Form component <MultiTextInput />', () => {
       const invalidKeyEvent = { key: '@', preventDefault: jest.fn() };
       const validKeyEvent = { key: '5', preventDefault: jest.fn() };
 
-      wrapper.find('input.multi-text-input__input').simulate('keypress', invalidKeyEvent);
-      wrapper.find('input.multi-text-input__input').simulate('keypress', validKeyEvent);
+      wrapper.find(Input).simulate('keypress', invalidKeyEvent);
+      wrapper.find(Input).simulate('keypress', validKeyEvent);
 
       expect(invalidKeyEvent.preventDefault).toHaveBeenCalled();
       expect(validKeyEvent.preventDefault).not.toHaveBeenCalled();

--- a/src/signals/incident/components/form/TextInput/__snapshots__/index.test.js.snap
+++ b/src/signals/incident/components/form/TextInput/__snapshots__/index.test.js.snap
@@ -26,15 +26,11 @@ exports[`Form component <TextInput /> rendering should render text field correct
       }
       touched={false}
     >
-      <div
-        className="invoer"
-      >
-        <input
-          onBlur={[Function]}
-          placeholder="type here"
-          type="text"
-        />
-      </div>
+      <Input
+        onBlur={[Function]}
+        placeholder="type here"
+        type="text"
+      />
     </Header>
   </div>
 </div>

--- a/src/signals/incident/components/form/TextInput/index.js
+++ b/src/signals/incident/components/form/TextInput/index.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Input } from '@datapunt/asc-ui';
 
 import Header from '../Header/';
 
@@ -14,16 +15,14 @@ const TextInput = ({ handler, touched, hasError, meta, parent, getError, validat
           hasError={hasError}
           getError={getError}
         >
-          <div className="invoer">
-            <input
-              type={meta.type}
-              placeholder={meta.placeholder}
-              {...handler()}
-              onBlur={(e) => parent.meta.updateIncident({
-                [meta.name]: meta.autoRemove ? e.target.value.replace(meta.autoRemove, '') : e.target.value
-              })}
-            />
-          </div>
+          <Input
+            type={meta.type}
+            placeholder={meta.placeholder}
+            {...handler()}
+            onBlur={(e) => parent.meta.updateIncident({
+              [meta.name]: meta.autoRemove ? e.target.value.replace(meta.autoRemove, '') : e.target.value
+            })}
+          />
         </Header>
       </div>
        : ''}

--- a/src/signals/incident/components/form/TextInput/index.test.js
+++ b/src/signals/incident/components/form/TextInput/index.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import { Input } from '@datapunt/asc-ui';
 
 import TextInput from './index';
 
@@ -73,7 +74,7 @@ describe('Form component <TextInput />', () => {
         }
       });
 
-      wrapper.find('input').simulate('blur', event);
+      wrapper.find(Input).simulate('blur', event);
 
       expect(parent.meta.updateIncident).toHaveBeenCalledWith({
         'input-field-name': 'diabolo'
@@ -89,7 +90,7 @@ describe('Form component <TextInput />', () => {
         }
       });
 
-      wrapper.find('input').simulate('blur', event);
+      wrapper.find(Input).simulate('blur', event);
 
       expect(parent.meta.updateIncident).toHaveBeenCalledWith({
         'input-field-name': 'iaoo'

--- a/src/signals/incident/components/form/TextareaInput/__snapshots__/index.test.js.snap
+++ b/src/signals/incident/components/form/TextareaInput/__snapshots__/index.test.js.snap
@@ -20,22 +20,18 @@ exports[`Form component <TextareaInput /> rendering should render character coun
       }
       touched={false}
     >
+      <Component
+        onBlur={[Function]}
+        placeholder="type here"
+      />
       <div
-        className="invoer"
+        className="input-help"
       >
-        <textarea
-          onBlur={[Function]}
-          placeholder="type here"
-        />
-        <div
-          className="input-help"
+        <span
+          className="text-area-input__counter"
         >
-          <span
-            className="text-area-input__counter"
-          >
-            0/300 tekens
-          </span>
-        </div>
+          0/300 tekens
+        </span>
       </div>
     </Header>
   </div>
@@ -62,22 +58,18 @@ exports[`Form component <TextareaInput /> rendering should render character coun
       }
       touched={false}
     >
+      <Component
+        onBlur={[Function]}
+        placeholder="type here"
+      />
       <div
-        className="invoer"
+        className="input-help"
       >
-        <textarea
-          onBlur={[Function]}
-          placeholder="type here"
-        />
-        <div
-          className="input-help"
+        <span
+          className="text-area-input__counter"
         >
-          <span
-            className="text-area-input__counter"
-          >
-            4/300 tekens
-          </span>
-        </div>
+          4/300 tekens
+        </span>
       </div>
     </Header>
   </div>
@@ -109,14 +101,10 @@ exports[`Form component <TextareaInput /> rendering should render text area fiel
       }
       touched={false}
     >
-      <div
-        className="invoer"
-      >
-        <textarea
-          onBlur={[Function]}
-          placeholder="type here"
-        />
-      </div>
+      <Component
+        onBlur={[Function]}
+        placeholder="type here"
+      />
     </Header>
   </div>
 </div>

--- a/src/signals/incident/components/form/TextareaInput/index.js
+++ b/src/signals/incident/components/form/TextareaInput/index.js
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
+import TextArea from 'components/TextArea';
 
 import Header from '../Header/';
 
@@ -14,8 +15,8 @@ const TextareaInput = ({ handler, touched, value, hasError, meta, parent, getErr
           hasError={hasError}
           getError={getError}
         >
-          <div className="invoer">
-            <textarea
+          <Fragment>
+            <TextArea
               placeholder={meta.placeholder}
               {...handler()}
               onBlur={(e) => parent.meta.updateIncident({
@@ -29,7 +30,7 @@ const TextareaInput = ({ handler, touched, value, hasError, meta, parent, getErr
                 </span>
               </div>
             }
-          </div>
+          </Fragment>
         </Header>
       </div>
        : ''}

--- a/src/signals/incident/components/form/TextareaInput/index.test.js
+++ b/src/signals/incident/components/form/TextareaInput/index.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import TextArea from 'components/TextArea';
 
 import TextareaInput from './index';
 
@@ -97,7 +98,7 @@ describe('Form component <TextareaInput />', () => {
         }
       });
 
-      wrapper.find('textarea').simulate('blur', event);
+      wrapper.find(TextArea).simulate('blur', event);
 
       expect(parent.meta.updateIncident).toHaveBeenCalledWith({
         'input-field-name': 'diabolo'
@@ -113,7 +114,7 @@ describe('Form component <TextareaInput />', () => {
         }
       });
 
-      wrapper.find('textarea').simulate('blur', event);
+      wrapper.find(TextArea).simulate('blur', event);
 
       expect(parent.meta.updateIncident).toHaveBeenCalledWith({
         'input-field-name': 'dbl'


### PR DESCRIPTION
This PR fixes an issue in IE11 where, when the contents of a textarea was scrolled, it would leave a trail of horizontal lines in front of the content. The cause of this behaviour was the element's box-shadow.

In order to fix the problem, the `<textarea>` elements in the application have been replaced by styled components. This also goes for `<input type"text">` elements where applicable.