### PR TITLE
(Chore) Remove container

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,21 +58,6 @@ node {
             }
         }
     }
-
-    if (BRANCH != "develop" && BRANCH != 'master') {
-        stage("Build") {
-            String PROJECT = "sia-build"
-
-            tryStep "build start", {
-                sh "docker-compose -p ${PROJECT} up --build --exit-code-from build-container build-container"
-            }
-            always {
-                tryStep "build stop", {
-                    sh "docker-compose -p ${PROJECT} down -v || true"
-                }
-            }
-        }
-    }
 }
 
 if (BRANCH == "develop") {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,11 +30,3 @@ services:
       - CI=true
       - TZ=Europe/Amsterdam
     command: npm run test
-
-  build-container:
-    build:
-      context: .
-      target: builder
-    environment:
-      - TZ=Europe/Amsterdam
-    command: npm run build


### PR DESCRIPTION
This PR removes the `build` stage from the current build stages. The `build` stage wasn't needed since, when there is a new version of the code, the build is run anyway, regardless of which stage runs when.