### PR TITLE
(Chore) Remove .htaccess reference

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -68,7 +68,6 @@ if (BRANCH == "develop") {
 
                     def image = docker.build("ois/signalsfrontend:${env.BUILD_NUMBER}",
                     "--shm-size 1G " +
-                    "--build-arg NODE_ENV=acceptance " +
                     "--build-arg BUILD_ENV=acc " +
                     "--build-arg BUILD_NUMBER=${env.BUILD_NUMBER} " +
                     "--build-arg GIT_COMMIT=${env.GIT_COMMIT} " +
@@ -104,7 +103,6 @@ if (BRANCH == "master") {
 
                     def image = docker.build("ois/signalsfrontend:${env.BUILD_NUMBER}",
                         "--shm-size 1G " +
-                        "--build-arg NODE_ENV=production " +
                         "--build-arg BUILD_ENV=prod " +
                         "--build-arg BUILD_NUMBER=${env.BUILD_NUMBER} " +
                         "--build-arg GIT_COMMIT=${env.GIT_COMMIT} " +

--- a/internals/webpack/webpack.prod.babel.js
+++ b/internals/webpack/webpack.prod.babel.js
@@ -89,10 +89,6 @@ module.exports = require('./webpack.base.babel')({
       publicPath: '/',
       appShell: '/',
 
-      // No need to cache .htaccess. See http://mxs.is/googmp,
-      // this is applied before any match in `caches` section
-      excludes: ['.htaccess'],
-
       caches: {
         main: [':rest:'],
 


### PR DESCRIPTION
This PR removes the reference to `.htaccess` from the offline plugin configuration. The plugin is set to not cache the `.htaccess` file, but since that file is forbidden to access and the server returns a 403, the service worker's response is faulty.
Next to that, the `NODE_ENV` settings in the `Jenkinsfile` have been removed since the `Dockerfile` always sets that var to 'production'