### PR TITLE
[SIG-1803] when REQUEST_HISTORY_LIST the redux state is emptied now

### DIFF
--- a/src/models/history/reducer.js
+++ b/src/models/history/reducer.js
@@ -15,6 +15,7 @@ function historyReducer(state = initialState, action) {
   switch (action.type) {
     case REQUEST_HISTORY_LIST:
       return state
+        .set('list', fromJS([]))
         .set('loading', true)
         .set('error', false);
 


### PR DESCRIPTION
Please note: When the detail page is loaded, all services are called simultaneously:
`this.props.onRequestIncident(this.props.id);
    this.props.onRequestHistoryList(this.props.id);
    this.props.onRequestAttachments(this.props.id);
`

the incident is already emptied:
`    case REQUEST_INCIDENT:`
  `    return state`
    `    .set('loading', true)`
  `      .set('error', false)`
`        .set('id', action.payload)`
`        .set('incident', null);`


and the attachments are already emptied:
`case REQUEST_ATTACHMENTS:`
`    return state`
`    .set('attachments', fromJS([]));`

In this PR:
- added only emptying of the history when called.