### PR TITLE
[SIG-1841] - Textarea spellcheck allow

### DIFF
--- a/src/components/SiteHeader/index.js
+++ b/src/components/SiteHeader/index.js
@@ -102,6 +102,7 @@ const HeaderWrapper = styled.div`
           height: 44px;
           margin-top: -44px;
           background-color: ${themeColor('tint', 'level2')};
+          width: 100%;
         }
 
         nav,

--- a/src/components/TextArea/index.js
+++ b/src/components/TextArea/index.js
@@ -4,9 +4,10 @@ import { styles } from '@datapunt/asc-ui';
 
 const { InputStyle } = styles;
 
-const TextArea = props => <InputStyle as="textarea" {...props} />;
+const TextArea = props => <textarea {...props} />;
 
 const StyledArea = styled(TextArea)`
+  ${InputStyle.componentStyle.rules}
   font-family: inherit;
 `;
 


### PR DESCRIPTION
This PR renders a `<textarea>` element instead the `<TextArea>` component from `asc-ui` to overcome attributes being applied that shouldn't be applied, like `spellCheck={false}`.

In addition to that, this PR corrects the position of the `#header:after` element in IE11.