### PR TITLE
(Chore) Exclude version.txt in serviceworker

### DIFF
--- a/internals/webpack/webpack.prod.babel.js
+++ b/internals/webpack/webpack.prod.babel.js
@@ -173,6 +173,8 @@ module.exports = require('./webpack.base.babel')({
       publicPath: '/',
       appShell: '/',
 
+      excludes: ['version.txt'],
+
       caches: {
         main: [':rest:'],
 


### PR DESCRIPTION
The health endpoint `version.txt` doesn't need to be cached by the serviceworker.