### PR TITLE
(Chore) Remove .htaccess reference

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -26,10 +26,8 @@ import loadModels from 'models';
 // Import Language Provider
 import LanguageProvider from 'containers/LanguageProvider';
 
-// Load the favicon, the manifest.json file and the .htaccess file
 /* eslint-disable import/no-webpack-loader-syntax */
 import '!file-loader?name=[name].[ext]!./images/favicon.png';
-import 'file-loader?name=[name].[ext]!./.htaccess'; // eslint-disable-line import/extensions
 /* eslint-enable import/no-webpack-loader-syntax */
 
 // Import CSS and Global Styles


### PR DESCRIPTION
The `serviceworker` still generates a `403` for the `.htaccess` file where it shouldn't call that file in the first place.
This PR removes the loading of the `.htaccess` file from `app.js`.