### PR TITLE
(Chore) Adjust eslint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -72,6 +72,7 @@ module.exports = {
     'prefer-template': 2,
     'react/destructuring-assignment': 0,
     'react-hooks/rules-of-hooks': 'error',
+    'react/jsx-closing-bracket-location': [1, 'tag-aligned'],
     'react/jsx-closing-tag-location': 0,
     'react/forbid-prop-types': 0,
     'react/jsx-first-prop-new-line': [2, 'multiline-multiprop'],

--- a/.prettierrc
+++ b/.prettierrc
@@ -3,7 +3,6 @@
   "tabWidth": 2,
   "semi": true,
   "singleQuote": true,
-  "jsxBracketSameLine": true,
   "parser": "babel",
   "htmlWhitespaceSensitivity": "strict",
   "printWidth": 80

--- a/src/signals/incident-management/.eslintrc.js
+++ b/src/signals/incident-management/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+  extends: '../../../.eslintrc.js',
   rules: {
     camelcase: 0,
     'jsx-a11y/control-has-associated-label': 0,

--- a/src/signals/incident-management/components/FilterForm/index.js
+++ b/src/signals/incident-management/components/FilterForm/index.js
@@ -334,21 +334,24 @@ const FilterForm = ({
             <ResetButton
               data-testid="resetBtn"
               onClick={onResetForm}
-              type="reset">
+              type="reset"
+            >
               Nieuw filter
             </ResetButton>
 
             <CancelButton
               data-testid="cancelBtn"
               onClick={onCancel}
-              type="button">
+              type="button"
+            >
               Annuleren
             </CancelButton>
 
             <SubmitButton
               name="submit_button"
               onClick={onSubmitForm}
-              type="submit">
+              type="submit"
+            >
               {submitBtnLabel}
             </SubmitButton>
           </ButtonContainer>

--- a/src/signals/incident-management/containers/Filter/__tests__/Filter.test.js
+++ b/src/signals/incident-management/containers/Filter/__tests__/Filter.test.js
@@ -108,12 +108,14 @@ describe('signals/incident-management/containers/Filter', () => {
     it('handles canceling edit', () => {
       const onFilterEditCancel = jest.fn();
       const onCancel = jest.fn();
+
       const tree = mount(
         withAppContext(
           <FilterContainerComponent
             onApplyFilter={onApplyFilter}
             onRequestIncidents={onRequestIncidents}
             onClearFilter={() => {}}
+            onEditFilter={onEditFilter}
             onSaveFilter={() => {}}
             onUpdateFilter={() => {}}
             filter={filter}

--- a/src/signals/incident-management/containers/IncidentDetail/components/Highlight/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/Highlight/index.js
@@ -29,7 +29,7 @@ class Highlight extends React.Component { // eslint-disable-line react/prefer-st
     };
   }
 
-  componentDidUpdate = () => {
+  componentDidUpdate() {
     if (this.state.valueChanged) {
       this.timer = global.window.setTimeout(() => {
         this.clearHighlight();

--- a/src/signals/incident-management/containers/IncidentOverviewPage/index.js
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/index.js
@@ -12,8 +12,16 @@ import PageHeader from 'containers/PageHeader';
 import injectSaga from 'utils/injectSaga';
 import injectReducer from 'utils/injectReducer';
 import { makeSelectCategories } from 'containers/App/selectors';
-import { makeSelectDataLists, makeSelectActiveFilter, makeSelectPage, makeSelectOrdering } from 'signals/incident-management/selectors';
-import { pageIncidentsChanged, orderingIncidentsChanged } from 'signals/incident-management/actions';
+import {
+  makeSelectDataLists,
+  makeSelectActiveFilter,
+  makeSelectPage,
+  makeSelectOrdering,
+} from 'signals/incident-management/selectors';
+import {
+  pageIncidentsChanged,
+  orderingIncidentsChanged,
+} from 'signals/incident-management/actions';
 import LoadingIndicator from 'shared/components/LoadingIndicator';
 import Filter from 'signals/incident-management/containers/Filter';
 import Modal from 'components/Modal';
@@ -105,14 +113,16 @@ export const IncidentOverviewPageContainerComponent = ({
           <StyledButton
             data-testid="myFiltersModalBtn"
             color="primary"
-            onClick={openMyFiltersModal}>
+            onClick={openMyFiltersModal}
+          >
             Mijn filters
           </StyledButton>
 
           <StyledButton
             data-testid="filterModalBtn"
             color="primary"
-            onClick={openFilterModal}>
+            onClick={openFilterModal}
+          >
             Filteren
           </StyledButton>
         </div>
@@ -121,7 +131,8 @@ export const IncidentOverviewPageContainerComponent = ({
           data-testid="myFiltersModal"
           isOpen={modalMyFiltersIsOpen}
           onClose={closeMyFiltersModal}
-          title="Mijn filters">
+          title="Mijn filters"
+        >
           <MyFilters onClose={closeMyFiltersModal} />
         </Modal>
 
@@ -129,7 +140,8 @@ export const IncidentOverviewPageContainerComponent = ({
           data-testid="filterModal"
           isOpen={modalFilterIsOpen}
           onClose={closeFilterModal}
-          title="Filters">
+          title="Filters"
+        >
           <Filter onSubmit={closeFilterModal} onCancel={closeFilterModal} />
         </Modal>
 

--- a/src/signals/incident/components/form/CheckboxInput/index.test.js
+++ b/src/signals/incident/components/form/CheckboxInput/index.test.js
@@ -22,13 +22,15 @@ describe('Form component <CheckboxInput />', () => {
       },
     };
 
-    wrapper = shallow(<CheckboxInput
-      handler={handler}
-      parent={parent}
-      touched={touched}
-      hasError={hasError}
-      getError={getError}
-    />);
+    wrapper = shallow(
+      <CheckboxInput
+        handler={handler}
+        parent={parent}
+        touched={touched}
+        hasError={hasError}
+        getError={getError}
+      />
+    );
 
     handler.mockImplementation(() => ({
       value: {
@@ -122,7 +124,9 @@ describe('Form component <CheckboxInput />', () => {
     });
 
     it('can be checked and unchecked with multiple values', () => {
-      handler = handler.mockImplementation(() => ({ value: [{ id: 'blue', label: 'Blauw' }] }));
+      handler = handler.mockImplementation(() => ({
+        value: [{ id: 'blue', label: 'Blauw' }],
+      }));
 
       wrapper.setProps({
         meta: {
@@ -133,14 +137,23 @@ describe('Form component <CheckboxInput />', () => {
       });
 
       const checkEevent = { target: { checked: true } };
-      wrapper.find('input[type="checkbox"]').at(2).simulate('click', checkEevent);
+      wrapper
+        .find('input[type="checkbox"]')
+        .at(2)
+        .simulate('click', checkEevent);
 
       expect(parent.meta.updateIncident).toHaveBeenCalledWith({
-        'input-field-name': [{ id: 'blue', label: 'Blauw' }, { id: 'green', label: 'Groen' }],
+        'input-field-name': [
+          { id: 'blue', label: 'Blauw' },
+          { id: 'green', label: 'Groen' },
+        ],
       });
 
       const uncheckEevent = { target: { checked: false } };
-      wrapper.find('input[type="checkbox"]').at(2).simulate('click', uncheckEevent);
+      wrapper
+        .find('input[type="checkbox"]')
+        .at(2)
+        .simulate('click', uncheckEevent);
 
       expect(parent.meta.updateIncident).toHaveBeenCalledWith({
         'input-field-name': [{ id: 'blue', label: 'Blauw' }],

--- a/src/signals/incident/components/form/DateTimeInput/index.test.js
+++ b/src/signals/incident/components/form/DateTimeInput/index.test.js
@@ -24,9 +24,7 @@ describe('Form component <DateTimeInput />', () => {
       },
     };
 
-    wrapper = shallow(<DateTimeInput
-      parent={parent}
-    />);
+    wrapper = shallow(<DateTimeInput parent={parent} />);
   });
 
   describe('rendering', () => {
@@ -62,7 +60,9 @@ describe('Form component <DateTimeInput />', () => {
         },
       });
 
-      wrapper.find('.datetime-input__earlier-day').simulate('change', { target: { value: '2018-07-21' } });
+      wrapper
+        .find('.datetime-input__earlier-day')
+        .simulate('change', { target: { value: '2018-07-21' } });
 
       expect(parent.meta.updateIncident).toHaveBeenCalledWith({
         incident_date: '2018-07-21',
@@ -77,7 +77,9 @@ describe('Form component <DateTimeInput />', () => {
         },
       });
 
-      wrapper.find('.datetime-input__earlier-time-hours').simulate('change', { target: { value: '13' } });
+      wrapper
+        .find('.datetime-input__earlier-time-hours')
+        .simulate('change', { target: { value: '13' } });
 
       expect(parent.meta.updateIncident).toHaveBeenCalledWith({
         incident_time_hours: '13',
@@ -92,7 +94,9 @@ describe('Form component <DateTimeInput />', () => {
         },
       });
 
-      wrapper.find('.datetime-input__earlier-time-minutes').simulate('change', { target: { value: '42' } });
+      wrapper
+        .find('.datetime-input__earlier-time-minutes')
+        .simulate('change', { target: { value: '42' } });
 
       expect(parent.meta.updateIncident).toHaveBeenCalledWith({
         incident_time_minutes: '42',

--- a/src/signals/incident/components/form/DescriptionWithClassificationInput/index.test.js
+++ b/src/signals/incident/components/form/DescriptionWithClassificationInput/index.test.js
@@ -28,13 +28,15 @@ describe('Form component <DescriptionWithClassificationInput />', () => {
       },
     };
 
-    wrapper = shallow(<DescriptionWithClassificationInput
-      handler={handler}
-      parent={parent}
-      touched={touched}
-      hasError={hasError}
-      getError={getError}
-    />);
+    wrapper = shallow(
+      <DescriptionWithClassificationInput
+        handler={handler}
+        parent={parent}
+        touched={touched}
+        hasError={hasError}
+        getError={getError}
+      />
+    );
   });
 
   describe('rendering', () => {

--- a/src/signals/incident/components/form/FileInput/index.test.js
+++ b/src/signals/incident/components/form/FileInput/index.test.js
@@ -33,13 +33,15 @@ describe('Form component <FileInput />', () => {
       controls: parentControls,
     };
 
-    wrapper = shallow(<FileInput
-      handler={handler}
-      parent={parent}
-      touched={touched}
-      hasError={hasError}
-      getError={getError}
-    />);
+    wrapper = shallow(
+      <FileInput
+        handler={handler}
+        parent={parent}
+        touched={touched}
+        hasError={hasError}
+        getError={getError}
+      />
+    );
   });
 
   describe('rendering', () => {
@@ -57,7 +59,10 @@ describe('Form component <FileInput />', () => {
 
     it('should render upload field with one uploaded file and one loading correctly', () => {
       parent.value = {
-        'input-field-name_previews': ['blob:http://host/c00d2e14-ae1c-4bb3-b67c-86ea93130b1c', 'loading-42'],
+        'input-field-name_previews': [
+          'blob:http://host/c00d2e14-ae1c-4bb3-b67c-86ea93130b1c',
+          'loading-42',
+        ],
       };
       wrapper.setProps({
         meta: {
@@ -129,7 +134,9 @@ describe('Form component <FileInput />', () => {
 
     beforeEach(() => {
       readAsText = jest.fn();
-      addEventListener = jest.fn((_, evtHandler) => { evtHandler(); });
+      addEventListener = jest.fn((_, evtHandler) => {
+        evtHandler();
+      });
       window.FileReader = jest.fn(() => ({
         addEventListener,
         readAsText,
@@ -159,12 +166,16 @@ describe('Form component <FileInput />', () => {
         },
       });
 
-
       wrapper.find('input').simulate('change', { target: { files: [file1] } });
       expect(FileReader).toHaveBeenCalled();
-      expect(addEventListener).toHaveBeenCalledWith('load', expect.any(Function));
+      expect(addEventListener).toHaveBeenCalledWith(
+        'load',
+        expect.any(Function)
+      );
       expect(readAsText).toHaveBeenCalled();
-      expect(parentControls['input-field-name'].updateValueAndValidity).toHaveBeenCalledTimes(1);
+      expect(
+        parentControls['input-field-name'].updateValueAndValidity
+      ).toHaveBeenCalledTimes(1);
       expect(parent.meta.updateIncident).toHaveBeenCalled();
     });
 
@@ -188,9 +199,14 @@ describe('Form component <FileInput />', () => {
       jest.runTimersToTime(ERROR_TIMEOUT_INTERVAL - 1);
 
       expect(FileReader).toHaveBeenCalled();
-      expect(addEventListener).toHaveBeenCalledWith('load', expect.any(Function));
+      expect(addEventListener).toHaveBeenCalledWith(
+        'load',
+        expect.any(Function)
+      );
       expect(readAsText).toHaveBeenCalled();
-      expect(parentControls['input-field-name'].updateValueAndValidity).toHaveBeenCalledTimes(2);
+      expect(
+        parentControls['input-field-name'].updateValueAndValidity
+      ).toHaveBeenCalledTimes(2);
       expect(parent.meta.updateIncident).toHaveBeenCalledWith({
         'input-field-name_previews': expect.any(Array),
         'input-field-name': [file4, file1],
@@ -222,9 +238,14 @@ describe('Form component <FileInput />', () => {
 
       wrapper.find('input').simulate('change', { target: { files: [file1] } });
       expect(FileReader).toHaveBeenCalled();
-      expect(addEventListener).toHaveBeenCalledWith('load', expect.any(Function));
+      expect(addEventListener).toHaveBeenCalledWith(
+        'load',
+        expect.any(Function)
+      );
       expect(readAsText).toHaveBeenCalled();
-      expect(parentControls['input-field-name'].updateValueAndValidity).toHaveBeenCalledTimes(1);
+      expect(
+        parentControls['input-field-name'].updateValueAndValidity
+      ).toHaveBeenCalledTimes(1);
       expect(parent.meta.updateIncident).toHaveBeenCalledWith({
         'input-field-name_previews': expect.any(Array),
         'input-field-name': [file1],
@@ -234,7 +255,10 @@ describe('Form component <FileInput />', () => {
 
     it('it removes 1 file when remove button was clicked', () => {
       parent.value = {
-        'input-field-name_previews': ['blob:http://host/1', 'blob:http://host/2'],
+        'input-field-name_previews': [
+          'blob:http://host/1',
+          'blob:http://host/2',
+        ],
       };
 
       handler.mockImplementation(() => ({ value: [file1, file2] }));
@@ -246,7 +270,10 @@ describe('Form component <FileInput />', () => {
         },
       });
 
-      wrapper.find('button').first().simulate('click', { preventDefault: jest.fn(), foo: 'booo' });
+      wrapper
+        .find('button')
+        .first()
+        .simulate('click', { preventDefault: jest.fn(), foo: 'booo' });
 
       expect(parent.meta.updateIncident).toHaveBeenCalledWith({
         'input-field-name': [file2],

--- a/src/signals/incident/components/form/Header/index.test.js
+++ b/src/signals/incident/components/form/Header/index.test.js
@@ -20,13 +20,15 @@ describe('Form component <Header />', () => {
     getError = jest.fn();
     hasError = jest.fn();
 
-    wrapper = shallow(<Header
-      meta={meta}
-      options={options}
-      touched={touched}
-      hasError={hasError}
-      getError={getError}
-    />);
+    wrapper = shallow(
+      <Header
+        meta={meta}
+        options={options}
+        touched={touched}
+        hasError={hasError}
+        getError={getError}
+      />
+    );
   });
 
   it('should render correctly', () => {

--- a/src/signals/incident/components/form/HiddenInput/index.test.js
+++ b/src/signals/incident/components/form/HiddenInput/index.test.js
@@ -10,9 +10,7 @@ describe('Form component <HiddenInput />', () => {
   beforeEach(() => {
     handler = jest.fn();
 
-    wrapper = shallow(<HiddenInput
-      handler={handler}
-    />);
+    wrapper = shallow(<HiddenInput handler={handler} />);
   });
 
   describe('rendering', () => {

--- a/src/signals/incident/components/form/MapInput/index.test.js
+++ b/src/signals/incident/components/form/MapInput/index.test.js
@@ -29,21 +29,20 @@ describe('Form component <MapInput />', () => {
       value: {
         geometrie: {
           type: 'Point',
-          coordinates: [
-            4,
-            52,
-          ],
+          coordinates: [4, 52],
         },
       },
     }));
 
-    wrapper = shallow(<MapInput
-      handler={handler}
-      parent={parent}
-      touched={touched}
-      hasError={hasError}
-      getError={getError}
-    />);
+    wrapper = shallow(
+      <MapInput
+        handler={handler}
+        parent={parent}
+        touched={touched}
+        hasError={hasError}
+        getError={getError}
+      />
+    );
   });
 
   describe('rendering', () => {

--- a/src/signals/incident/components/form/MapSelect/index.test.js
+++ b/src/signals/incident/components/form/MapSelect/index.test.js
@@ -29,19 +29,19 @@ describe('Form component <MapSelectFormComponent />', () => {
       name: 'my_question',
       isVisible: true,
       endpoint: 'foo/bar?',
-      legend_items: [
-        'klok',
-      ],
+      legend_items: ['klok'],
     };
 
-    return shallow(<MapSelectFormComponent
-      handler={handler}
-      parent={parent}
-      touched={touched}
-      hasError={hasError}
-      getError={getError}
-      meta={meta}
-    />);
+    return shallow(
+      <MapSelectFormComponent
+        handler={handler}
+        parent={parent}
+        touched={touched}
+        hasError={hasError}
+        getError={getError}
+        meta={meta}
+      />
+    );
   };
 
   describe('rendering', () => {
@@ -63,9 +63,14 @@ describe('Form component <MapSelectFormComponent />', () => {
 
       const selection = new MaxSelection(3);
       selection.add('obj002');
-      wrapper.find('MapSelect').props().onSelectionChange(selection);
+      wrapper
+        .find('MapSelect')
+        .props()
+        .onSelectionChange(selection);
 
-      expect(parent.meta.updateIncident).toHaveBeenCalledWith({ my_question: ['obj002'] });
+      expect(parent.meta.updateIncident).toHaveBeenCalledWith({
+        my_question: ['obj002'],
+      });
     });
 
     it('should render no map field when not visible', () => {

--- a/src/signals/incident/components/form/MultiTextInput/index.test.js
+++ b/src/signals/incident/components/form/MultiTextInput/index.test.js
@@ -27,13 +27,15 @@ describe('Form component <MultiTextInput />', () => {
       },
     };
 
-    wrapper = shallow(<MultiTextInput
-      handler={handler}
-      parent={parent}
-      touched={touched}
-      hasError={hasError}
-      getError={getError}
-    />);
+    wrapper = shallow(
+      <MultiTextInput
+        handler={handler}
+        parent={parent}
+        touched={touched}
+        hasError={hasError}
+        getError={getError}
+      />
+    );
 
     handler.mockImplementation(() => ({
       value: ['Lorem'],

--- a/src/signals/incident/components/form/RadioInput/index.test.js
+++ b/src/signals/incident/components/form/RadioInput/index.test.js
@@ -30,13 +30,15 @@ describe('Form component <RadioInput />', () => {
       },
     };
 
-    wrapper = shallow(<RadioInput
-      handler={handler}
-      parent={parent}
-      touched={touched}
-      hasError={hasError}
-      getError={getError}
-    />);
+    wrapper = shallow(
+      <RadioInput
+        handler={handler}
+        parent={parent}
+        touched={touched}
+        hasError={hasError}
+        getError={getError}
+      />
+    );
 
     handler.mockImplementation(() => ({
       value: {
@@ -93,7 +95,10 @@ describe('Form component <RadioInput />', () => {
         },
       });
 
-      wrapper.find('input').first().simulate('change', event);
+      wrapper
+        .find('input')
+        .first()
+        .simulate('change', event);
 
       expect(parent.meta.updateIncident).toHaveBeenCalledWith({
         'input-field-name': {

--- a/src/signals/incident/components/form/SelectInput/index.test.js
+++ b/src/signals/incident/components/form/SelectInput/index.test.js
@@ -38,13 +38,15 @@ describe('Form component <SelectInput />', () => {
       },
     }));
 
-    wrapper = shallow(<SelectInput
-      handler={handler}
-      parent={parent}
-      touched={touched}
-      hasError={hasError}
-      getError={getError}
-    />);
+    wrapper = shallow(
+      <SelectInput
+        handler={handler}
+        parent={parent}
+        touched={touched}
+        hasError={hasError}
+        getError={getError}
+      />
+    );
   });
 
   describe('rendering', () => {

--- a/src/signals/incident/components/form/TextInput/index.test.js
+++ b/src/signals/incident/components/form/TextInput/index.test.js
@@ -28,13 +28,15 @@ describe('Form component <TextInput />', () => {
       },
     };
 
-    wrapper = shallow(<TextInput
-      handler={handler}
-      parent={parent}
-      touched={touched}
-      hasError={hasError}
-      getError={getError}
-    />);
+    wrapper = shallow(
+      <TextInput
+        handler={handler}
+        parent={parent}
+        touched={touched}
+        hasError={hasError}
+        getError={getError}
+      />
+    );
   });
 
   describe('rendering', () => {

--- a/src/signals/incident/components/form/TextareaInput/index.test.js
+++ b/src/signals/incident/components/form/TextareaInput/index.test.js
@@ -27,13 +27,15 @@ describe('Form component <TextareaInput />', () => {
       },
     };
 
-    wrapper = shallow(<TextareaInput
-      handler={handler}
-      parent={parent}
-      touched={touched}
-      hasError={hasError}
-      getError={getError}
-    />);
+    wrapper = shallow(
+      <TextareaInput
+        handler={handler}
+        parent={parent}
+        touched={touched}
+        hasError={hasError}
+        getError={getError}
+      />
+    );
   });
 
   describe('rendering', () => {

--- a/src/signals/incident/definitions/components/Concat/index.test.js
+++ b/src/signals/incident/definitions/components/Concat/index.test.js
@@ -5,20 +5,29 @@ import { shallow } from 'enzyme';
 import Concat from './index';
 
 describe('Definition component <Concat />', () => {
-  const MockListComponent = ({ items }) => <ul>{items.map(item => <li key={item}>{item}</li>)}</ul>;
+  const MockListComponent = ({ items }) => (
+    <ul>
+      {items.map(item => (
+        <li key={item}>{item}</li>
+      ))}
+    </ul>
+  );
   const MockChildComponent = ({ children }) => <span>{children}</span>;
   const MockComponent = () => <span>text 4</span>;
   let wrapper;
 
   describe('rendering', () => {
     it('should concat all texts and components of the array into spans', () => {
-      wrapper = shallow(<Concat
-        items={[
-          'text 1',
-          <MockListComponent items={['text 2']} />,
-          <MockChildComponent>text 3</MockChildComponent>,
-          <MockComponent />]}
-      />);
+      wrapper = shallow(
+        <Concat
+          items={[
+            'text 1',
+            <MockListComponent items={['text 2']} />,
+            <MockChildComponent>text 3</MockChildComponent>,
+            <MockComponent />,
+          ]}
+        />
+      );
 
       expect(wrapper).toMatchSnapshot();
     });

--- a/src/signals/incident/definitions/components/Ul/index.test.js
+++ b/src/signals/incident/definitions/components/Ul/index.test.js
@@ -5,20 +5,29 @@ import { shallow } from 'enzyme';
 import Ul from './index';
 
 describe('Definition component <Ul />', () => {
-  const MockListComponent = ({ items }) => <ul>{items.map(item => <li key={item}>{item}</li>)}</ul>;
+  const MockListComponent = ({ items }) => (
+    <ul>
+      {items.map(item => (
+        <li key={item}>{item}</li>
+      ))}
+    </ul>
+  );
   const MockChildComponent = ({ children }) => <span>{children}</span>;
   const MockComponent = () => <span>text 4</span>;
   let wrapper;
 
   describe('rendering', () => {
     it('should put all texts and components into a list', () => {
-      wrapper = shallow(<Ul
-        items={[
-          'text 1',
-          <MockListComponent items={['text 2']} />,
-          <MockChildComponent>text 3</MockChildComponent>,
-          <MockComponent />]}
-      />);
+      wrapper = shallow(
+        <Ul
+          items={[
+            'text 1',
+            <MockListComponent items={['text 2']} />,
+            <MockChildComponent>text 3</MockChildComponent>,
+            <MockComponent />,
+          ]}
+        />
+      );
 
       expect(wrapper).toMatchSnapshot();
     });


### PR DESCRIPTION
This PR contains a change that should improve readability. It changes this:

```jsx
wrapper = shallow(<CheckboxInput
  handler={handler}
  parent={parent}
  touched={touched}
  hasError={hasError}
  getError={getError}
/>);
```

into this:

```jsx
wrapper = shallow(
  <CheckboxInput
    handler={handler}
    parent={parent}
    touched={touched}
    hasError={hasError}
    getError={getError}
  />
);
```