### PR TITLE
[SIG-1745] Move authenticated session from sessionstorage to localstorage

### DIFF
--- a/src/containers/App/index.test.js
+++ b/src/containers/App/index.test.js
@@ -26,7 +26,7 @@ describe('<App />', () => {
   });
 
   it('should render the correct theme', () => {
-    global.sessionStorage.getItem.mockImplementation(() => undefined);
+    global.localStorage.getItem.mockImplementation(() => undefined);
 
     const { queryByTestId, rerender } = render(
       withAppContext(<AppContainer requestCategoriesAction={() => {}} />),
@@ -36,7 +36,7 @@ describe('<App />', () => {
 
     cleanup();
 
-    global.sessionStorage.getItem.mockImplementation(() => '42');
+    global.localStorage.getItem.mockImplementation(() => '42');
 
     rerender(
       withAppContext(<AppContainer requestCategoriesAction={() => {}} />),

--- a/src/containers/App/reducer.js
+++ b/src/containers/App/reducer.js
@@ -47,7 +47,7 @@ export const initialState = fromJS({
 function appReducer(state = initialState, action) {
   switch (action.type) {
     case AUTHORIZE_USER:
-      global.sessionStorage.setItem(ACCESS_TOKEN, action.payload.accessToken);
+      global.localStorage.setItem(ACCESS_TOKEN, action.payload.accessToken);
 
       return state
         .set('userName', action.payload.userName)

--- a/src/containers/App/reducer.test.js
+++ b/src/containers/App/reducer.test.js
@@ -53,7 +53,7 @@ describe('appReducer', () => {
 
       appReducer(fromJS({}), action);
 
-      expect(global.sessionStorage.setItem).toHaveBeenCalledWith(
+      expect(global.localStorage.setItem).toHaveBeenCalledWith(
         ACCESS_TOKEN,
         accessToken,
       );

--- a/src/containers/App/saga.test.js
+++ b/src/containers/App/saga.test.js
@@ -55,8 +55,8 @@ describe('App saga', () => {
       () => 'n8vd9fv528934n797cv342bj3h56',
     );
     global.window.open = jest.fn();
-    origSessionStorage = global.sessionStorage;
-    global.sessionStorage = {
+    origSessionStorage = global.localStorage;
+    global.localStorage = {
       getItem: key => {
         switch (key) {
           case 'accessToken':
@@ -73,7 +73,7 @@ describe('App saga', () => {
   });
 
   afterEach(() => {
-    global.sessionStorage = origSessionStorage;
+    global.localStorage = origSessionStorage;
     jest.resetAllMocks();
   });
 
@@ -132,7 +132,7 @@ describe('App saga', () => {
 
     it('should grip success', () => {
       jest
-        .spyOn(global.sessionStorage, 'getItem')
+        .spyOn(global.localStorage, 'getItem')
         .mockImplementationOnce(key => {
           switch (key) {
             case 'oauthDomain':
@@ -152,7 +152,7 @@ describe('App saga', () => {
     it('should dispatch error', () => {
       const message = 'no remove';
       jest
-        .spyOn(global.sessionStorage, 'removeItem')
+        .spyOn(global.localStorage, 'removeItem')
         .mockImplementationOnce(() => {
           throw new Error(message);
         });

--- a/src/shared/services/api/api.test.js
+++ b/src/shared/services/api/api.test.js
@@ -38,7 +38,7 @@ describe('api service', () => {
 
   describe('authCall', () => {
     it('should generate the right call', () => {
-      sessionStorage.getItem.mockImplementationOnce(() => token);
+      localStorage.getItem.mockImplementationOnce(() => token);
 
       const fullUrl = `${url}?${queryString}`;
       const options = {
@@ -54,7 +54,7 @@ describe('api service', () => {
     });
 
     it('should generate a call without token if it is not present', () => {
-      sessionStorage.getItem.mockImplementationOnce(() => undefined);
+      localStorage.getItem.mockImplementationOnce(() => undefined);
 
       const fullUrl = `${url}?${queryString}`;
       const options = {
@@ -68,7 +68,7 @@ describe('api service', () => {
     });
 
     it('should generate the right call when params are not defined', () => {
-      sessionStorage.getItem.mockImplementationOnce(() => token);
+      localStorage.getItem.mockImplementationOnce(() => token);
 
       const fullUrl = `${url}`;
       const options = {
@@ -98,7 +98,7 @@ describe('api service', () => {
 
   describe('authCallWithPayload', () => {
     it('should generate the right call', () => {
-      sessionStorage.getItem.mockImplementationOnce(() => token);
+      localStorage.getItem.mockImplementationOnce(() => token);
       const options = {
         method: 'METHOD',
         headers: {
@@ -112,7 +112,7 @@ describe('api service', () => {
     });
 
     it('should generate a call without token if it is not present', () => {
-      sessionStorage.getItem.mockImplementationOnce(() => undefined);
+      localStorage.getItem.mockImplementationOnce(() => undefined);
       const options = {
         method: 'METHOD',
         headers: {

--- a/src/shared/services/auth/auth.js
+++ b/src/shared/services/auth/auth.js
@@ -73,7 +73,7 @@ let tokenData = {};
  * service.
  */
 function handleError(code, description) {
-  sessionStorage.removeItem(STATE_TOKEN);
+  localStorage.removeItem(STATE_TOKEN);
 
   // Remove parameters from the URL, as set by the error callback from the
   // OAuth2 authorization service, to clean up the URL.
@@ -109,7 +109,7 @@ function getAccessTokenFromParams(params) {
     return null;
   }
 
-  const stateToken = sessionStorage.getItem(STATE_TOKEN);
+  const stateToken = localStorage.getItem(STATE_TOKEN);
 
   // The state param must be exactly the same as the state token we
   // have saved in the session (to prevent CSRF)
@@ -138,10 +138,10 @@ function handleCallback() {
   const accessToken = getAccessTokenFromParams(params);
   if (accessToken) {
     tokenData = accessTokenParser(accessToken);
-    sessionStorage.setItem(ACCESS_TOKEN, accessToken);
-    returnPath = sessionStorage.getItem(RETURN_PATH);
-    sessionStorage.removeItem(RETURN_PATH);
-    sessionStorage.removeItem(STATE_TOKEN);
+    localStorage.setItem(ACCESS_TOKEN, accessToken);
+    returnPath = localStorage.getItem(RETURN_PATH);
+    localStorage.removeItem(RETURN_PATH);
+    localStorage.removeItem(STATE_TOKEN);
 
     // Clean up URL; remove query and hash
     // https://stackoverflow.com/questions/4508574/remove-hash-from-url
@@ -155,11 +155,11 @@ function handleCallback() {
  * @returns {string} The access token.
  */
 export function getAccessToken() {
-  return sessionStorage.getItem(ACCESS_TOKEN);
+  return localStorage.getItem(ACCESS_TOKEN);
 }
 
 export function getOauthDomain() {
-  return sessionStorage.getItem(OAUTH_DOMAIN);
+  return localStorage.getItem(OAUTH_DOMAIN);
 }
 
 /**
@@ -186,18 +186,18 @@ export function login(domain) {
     throw new Error('crypto library is not available on the current browser');
   }
 
-  sessionStorage.removeItem(ACCESS_TOKEN);
-  sessionStorage.setItem(RETURN_PATH, global.location.hash);
-  sessionStorage.setItem(STATE_TOKEN, stateToken);
-  sessionStorage.setItem(OAUTH_DOMAIN, domain);
+  localStorage.removeItem(ACCESS_TOKEN);
+  localStorage.setItem(RETURN_PATH, global.location.hash);
+  localStorage.setItem(STATE_TOKEN, stateToken);
+  localStorage.setItem(OAUTH_DOMAIN, domain);
 
   const redirectUri = encodeURIComponent(`${global.location.protocol}//${global.location.host}/manage/incidents`);
   global.location.assign(`${CONFIGURATION.AUTH_ROOT}${AUTH_PATH(domain)}&state=${encodedStateToken}&redirect_uri=${redirectUri}`);
 }
 
 export function logout() {
-  sessionStorage.removeItem(ACCESS_TOKEN);
-  sessionStorage.removeItem(OAUTH_DOMAIN);
+  localStorage.removeItem(ACCESS_TOKEN);
+  localStorage.removeItem(OAUTH_DOMAIN);
   global.location.reload();
 }
 

--- a/src/shared/services/auth/auth.test.js
+++ b/src/shared/services/auth/auth.test.js
@@ -32,7 +32,7 @@ describe('The auth service', () => {
   let stateToken;
 
   beforeEach(() => {
-    global.sessionStorage.getItem.mockImplementation(key => {
+    global.localStorage.getItem.mockImplementation(key => {
       switch (key) {
         case 'accessToken':
           return savedAccessToken;
@@ -66,8 +66,8 @@ describe('The auth service', () => {
     global.location.assign.mockRestore();
     global.location.reload.mockRestore();
 
-    global.sessionStorage.removeItem.mockReset();
-    global.sessionStorage.setItem.mockReset();
+    global.localStorage.removeItem.mockReset();
+    global.localStorage.setItem.mockReset();
   });
 
   describe('init funtion', () => {
@@ -112,7 +112,7 @@ describe('The auth service', () => {
         expect(() => {
           initAuth();
         }).toThrow();
-        expect(global.sessionStorage.removeItem).toHaveBeenCalledWith(
+        expect(global.localStorage.removeItem).toHaveBeenCalledWith(
           'stateToken'
         );
       });
@@ -123,7 +123,7 @@ describe('The auth service', () => {
         expect(() => {
           initAuth();
         }).not.toThrow();
-        expect(global.sessionStorage.removeItem).not.toHaveBeenCalledWith(
+        expect(global.localStorage.removeItem).not.toHaveBeenCalledWith(
           'stateToken'
         );
       });
@@ -134,7 +134,7 @@ describe('The auth service', () => {
         expect(() => {
           initAuth();
         }).not.toThrow();
-        expect(global.sessionStorage.removeItem).not.toHaveBeenCalledWith(
+        expect(global.localStorage.removeItem).not.toHaveBeenCalledWith(
           'stateToken'
         );
       });
@@ -175,17 +175,17 @@ describe('The auth service', () => {
         savedReturnPath = '/path/leading/back';
 
         initAuth();
-        expect(global.sessionStorage.setItem).toHaveBeenCalledWith(
+        expect(global.localStorage.setItem).toHaveBeenCalledWith(
           'accessToken',
           '123AccessToken'
         );
-        expect(global.sessionStorage.getItem).toHaveBeenCalledWith(
+        expect(global.localStorage.getItem).toHaveBeenCalledWith(
           'returnPath'
         );
-        expect(global.sessionStorage.removeItem).toHaveBeenCalledWith(
+        expect(global.localStorage.removeItem).toHaveBeenCalledWith(
           'returnPath'
         );
-        expect(global.sessionStorage.removeItem).toHaveBeenCalledWith(
+        expect(global.localStorage.removeItem).toHaveBeenCalledWith(
           'stateToken'
         );
       });
@@ -205,7 +205,7 @@ describe('The auth service', () => {
         savedReturnPath = '/path/leading/back';
 
         initAuth();
-        expect(global.sessionStorage.setItem).toHaveBeenCalledWith(
+        expect(global.localStorage.setItem).toHaveBeenCalledWith(
           'accessToken',
           '123AccessToken'
         );
@@ -223,14 +223,14 @@ describe('The auth service', () => {
         savedStateToken = '123StateToken';
 
         initAuth();
-        expect(global.sessionStorage.setItem).not.toHaveBeenCalledWith(
+        expect(global.localStorage.setItem).not.toHaveBeenCalledWith(
           'accessToken',
           '123AccessToken'
         );
-        expect(global.sessionStorage.removeItem).not.toHaveBeenCalledWith(
+        expect(global.localStorage.removeItem).not.toHaveBeenCalledWith(
           'returnPath'
         );
-        expect(global.sessionStorage.removeItem).not.toHaveBeenCalledWith(
+        expect(global.localStorage.removeItem).not.toHaveBeenCalledWith(
           'stateToken'
         );
       });
@@ -251,14 +251,14 @@ describe('The auth service', () => {
 
       login();
 
-      expect(global.sessionStorage.removeItem).toHaveBeenCalledWith(
+      expect(global.localStorage.removeItem).toHaveBeenCalledWith(
         'accessToken'
       );
-      expect(global.sessionStorage.setItem).toHaveBeenCalledWith(
+      expect(global.localStorage.setItem).toHaveBeenCalledWith(
         'returnPath',
         hash
       );
-      expect(global.sessionStorage.setItem).toHaveBeenCalledWith(
+      expect(global.localStorage.setItem).toHaveBeenCalledWith(
         'stateToken',
         stateToken
       );
@@ -282,7 +282,7 @@ describe('The auth service', () => {
   describe('Logout process', () => {
     it('Removes the access token from the session storage', () => {
       logout();
-      expect(global.sessionStorage.removeItem).toHaveBeenCalledWith(
+      expect(global.localStorage.removeItem).toHaveBeenCalledWith(
         'accessToken'
       );
     });

--- a/src/signals/incident-management/__tests__/index.test.js
+++ b/src/signals/incident-management/__tests__/index.test.js
@@ -37,14 +37,14 @@ describe('signals/incident-management', () => {
   });
 
   it('should render correctly', () => {
-    sessionStorage.getItem.mockImplementationOnce(() => 'token');
+    localStorage.getItem.mockImplementationOnce(() => 'token');
 
     const { rerender, asFragment } = render(
       withAppContext(<IncidentManagementModuleComponent {...props} />)
     );
     const firstRender = asFragment();
 
-    sessionStorage.getItem.mockImplementationOnce(() => undefined);
+    localStorage.getItem.mockImplementationOnce(() => undefined);
 
     rerender(withAppContext(<IncidentManagementModuleComponent {...props} />));
 
@@ -59,7 +59,7 @@ describe('signals/incident-management', () => {
     it('can navigate to incident list', () => {
       history.push('/manage/incidents');
 
-      sessionStorage.getItem.mockImplementationOnce(() => undefined);
+      localStorage.getItem.mockImplementationOnce(() => undefined);
 
       const { rerender, queryByText } = render(
         withAppContext(<IncidentManagementModuleComponent {...props} />)
@@ -67,7 +67,7 @@ describe('signals/incident-management', () => {
 
       expect(queryByText(loginText)).not.toBeNull();
 
-      sessionStorage.getItem.mockImplementationOnce(() => 'token');
+      localStorage.getItem.mockImplementationOnce(() => 'token');
 
       rerender(
         withAppContext(<IncidentManagementModuleComponent {...props} />)
@@ -79,7 +79,7 @@ describe('signals/incident-management', () => {
     it('can navigate to incident detail', () => {
       history.push('/manage/incident/1101');
 
-      sessionStorage.getItem.mockImplementationOnce(() => undefined);
+      localStorage.getItem.mockImplementationOnce(() => undefined);
 
       const { rerender, queryByText } = render(
         withAppContext(<IncidentManagementModuleComponent {...props} />)
@@ -87,7 +87,7 @@ describe('signals/incident-management', () => {
 
       expect(queryByText(loginText)).not.toBeNull();
 
-      sessionStorage.getItem.mockImplementationOnce(() => 'token');
+      localStorage.getItem.mockImplementationOnce(() => 'token');
 
       rerender(
         withAppContext(<IncidentManagementModuleComponent {...props} />)
@@ -99,7 +99,7 @@ describe('signals/incident-management', () => {
     it('can navigate to incident split', () => {
       history.push('/manage/incident/1101/split');
 
-      sessionStorage.getItem.mockImplementationOnce(() => undefined);
+      localStorage.getItem.mockImplementationOnce(() => undefined);
 
       const { rerender, queryByText } = render(
         withAppContext(<IncidentManagementModuleComponent {...props} />)
@@ -107,7 +107,7 @@ describe('signals/incident-management', () => {
 
       expect(queryByText(loginText)).not.toBeNull();
 
-      sessionStorage.getItem.mockImplementationOnce(() => 'token');
+      localStorage.getItem.mockImplementationOnce(() => 'token');
 
       rerender(
         withAppContext(<IncidentManagementModuleComponent {...props} />)

--- a/src/signals/incident-management/containers/IncidentDetail/components/DetailHeader/components/DownloadButton/index.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/DetailHeader/components/DownloadButton/index.test.js
@@ -56,7 +56,7 @@ describe('<DownloadButton />', () => {
     });
 
     it('should download document with token when present', () => {
-      sessionStorage.getItem.mockImplementation(() => 'MOCK-TOKEN');
+      localStorage.getItem.mockImplementation(() => 'MOCK-TOKEN');
       const { queryByTestId } = render(
         <DownloadButton {...props} />
       );

--- a/src/signals/incident/containers/IncidentContainer/index.test.js
+++ b/src/signals/incident/containers/IncidentContainer/index.test.js
@@ -18,9 +18,9 @@ describe('<IncidentContainer />', () => {
       updateIncident: jest.fn(),
       createIncident: jest.fn(),
     };
-    origSessionStorage = global.sessionStorage;
+    origSessionStorage = global.localStorage;
 
-    global.sessionStorage = {
+    global.localStorage = {
       getItem: key => {
         switch (key) {
           case 'accessToken':
@@ -32,9 +32,9 @@ describe('<IncidentContainer />', () => {
       setItem: jest.fn(),
       removeItem: jest.fn(),
     };
-    origSessionStorage = global.sessionStorage;
+    origSessionStorage = global.localStorage;
 
-    global.sessionStorage = {
+    global.localStorage = {
       getItem: key => {
         switch (key) {
           case 'accessToken':
@@ -50,7 +50,7 @@ describe('<IncidentContainer />', () => {
 
   afterEach(() => {
     jest.resetAllMocks();
-    global.sessionStorage = origSessionStorage;
+    global.localStorage = origSessionStorage;
   });
 
   describe('rendering', () => {


### PR DESCRIPTION
This PR replaces all occurrences of `sessionStorage` with `localStorage` which persists the authenticated user across browser windows and tabs.

Note: for now, only authentication data is stored in `localStorage` so it's okay to have tests mock `localStorage.getItem` and `localStorage.getItem`, but when more data is stored, those tests need to be changed and their mocks be more specific.