### PR TITLE
[SIG-1732] Mobile header fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9210,7 +9210,7 @@
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+          "resolved": false,
           "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "requires": {
             "minipass": "^2.2.1"
@@ -9228,7 +9228,7 @@
         },
         "minipass": {
           "version": "2.3.5",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+          "resolved": false,
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "requires": {
             "safe-buffer": "^5.1.2",

--- a/src/components/SiteHeader/index.js
+++ b/src/components/SiteHeader/index.js
@@ -90,6 +90,16 @@ const HeaderWrapper = styled.div`
       #header {
         position: static;
 
+        header {
+          height: 160px;
+        }
+
+        @media screen and (max-width: 539px) {
+          header {
+            height: 116px;
+          }
+        }
+
         &:after {
           max-width: 1400px;
           margin-left: auto;


### PR DESCRIPTION
This PR fixes an issue where the site header would not be displayed correctly on smaller screens. This was due to a change in a component in the ASC-UI lib.

**Before**
![Screenshot 2019-11-04 at 11 08 15](https://user-images.githubusercontent.com/1062191/68113198-79792000-fef3-11e9-9b06-290c49aadcf4.png)

**After**
![Screenshot 2019-11-04 at 11 07 36](https://user-images.githubusercontent.com/1062191/68113204-7ed66a80-fef3-11e9-8986-16d56cac9894.png)
![Screenshot 2019-11-04 at 11 07 44](https://user-images.githubusercontent.com/1062191/68113205-7ed66a80-fef3-11e9-8008-5f7d69c7330c.png)
