### PR TITLE
fix for IE11 by removing family

### DIFF
--- a/src/signals/incident/components/IncidentPreview/components/ListObjectValue/style.scss
+++ b/src/signals/incident/components/IncidentPreview/components/ListObjectValue/style.scss
@@ -6,8 +6,6 @@
 
   &__item-value {
     margin: 0;
-    font-family: Avenir;
-    font-size: 16px;
     line-height: 22px;
   }
 }


### PR DESCRIPTION
before:
![afbeelding](https://user-images.githubusercontent.com/4640157/68395198-9ae64000-016f-11ea-8a23-10bb842a8d64.png)



after:
![Screenshot 2019-11-07 at 15 00 23](https://user-images.githubusercontent.com/4640157/68395089-5eb2df80-016f-11ea-89c3-0f3f7139765a.png)

