### PR TITLE
(Fix) Active element warning

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/index.js
@@ -208,13 +208,15 @@ class StatusForm extends React.Component {
                     variant="secondary"
                     disabled={invalid}
                     type="submit"
-                    iconRight={patching.status ? <StyledSpinner /> : null}>
+                    iconRight={patching.status ? <StyledSpinner /> : null}
+                  >
                     Status opslaan
                   </StyledButton>
                   <StyledButton
                     data-testid="statusFormCancelButton"
                     variant="tertiary"
-                    onClick={onClose}>
+                    onClick={onClose}
+                  >
                     Annuleren
                   </StyledButton>
                 </StyledColumn>

--- a/src/signals/incident-management/containers/IncidentOverviewPage/index.js
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/index.js
@@ -67,7 +67,10 @@ export const IncidentOverviewPageContainerComponent = ({
   function closeMyFiltersModal() {
     enablePageScroll();
     toggleMyFiltersModal(false);
-    lastActiveElement.focus();
+
+    if (lastActiveElement) {
+      lastActiveElement.focus();
+    }
   }
 
   const openFilterModal = () => {
@@ -79,7 +82,10 @@ export const IncidentOverviewPageContainerComponent = ({
   function closeFilterModal() {
     enablePageScroll();
     toggleFilterModal(false);
-    lastActiveElement.focus();
+
+    if (lastActiveElement) {
+      lastActiveElement.focus();
+    }
   }
 
   useEffect(() => {

--- a/src/signals/incident-management/containers/IncidentOverviewPage/index.js
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/index.js
@@ -68,6 +68,7 @@ export const IncidentOverviewPageContainerComponent = ({
     enablePageScroll();
     toggleMyFiltersModal(false);
 
+    /* istanbul ignore next */
     if (lastActiveElement) {
       lastActiveElement.focus();
     }
@@ -83,6 +84,7 @@ export const IncidentOverviewPageContainerComponent = ({
     enablePageScroll();
     toggleFilterModal(false);
 
+    /* istanbul ignore next */
     if (lastActiveElement) {
       lastActiveElement.focus();
     }


### PR DESCRIPTION
This PR adds extra checks to the `IncidentOverviewPage` component for the modal closing logic. It sometimes happens that `closeFilterModal` handler is called when the modal isn't opened. This happened for me when I tried to make a screenshot of a part of the page and pressed the ESCAPE button to cancel making a screenshot.