### PR TITLE
(chore) Remove complex logic

### DIFF
--- a/src/signals/settings/users/containers/Overview/__tests__/Overview.test.js
+++ b/src/signals/settings/users/containers/Overview/__tests__/Overview.test.js
@@ -108,27 +108,6 @@ describe('signals/settings/users/containers/Overview', () => {
     global.window.scrollTo.mockRestore();
   });
 
-  it('should push on update when page parameter and page state var differ', async () => {
-    const historyMockObj = {
-      ...historyMock,
-      action: 'PUSH',
-    };
-
-    jest.spyOn(reactRouterDom, 'useParams').mockImplementation(() => ({
-      pageNum: 2,
-    }));
-
-    await reAct(async () => {
-      await render(withAppContext(<UsersOverview history={historyMockObj} />));
-    });
-
-    expect(historyMockObj.push).toHaveBeenCalledWith(
-      expect.stringContaining(`${routes.users}/page/1`)
-    );
-
-    expect(historyMockObj.replace).not.toHaveBeenCalled();
-  });
-
   it('should not push', async () => {
     const historyMockObj = {
       ...historyMock,

--- a/src/signals/settings/users/containers/Overview/index.js
+++ b/src/signals/settings/users/containers/Overview/index.js
@@ -24,19 +24,6 @@ const UsersOverview = ({ pageSize, history }) => {
    */
   const getPageNumFromQueryString = () => pageNum && parseInt(pageNum, 10);
 
-  // subscribe to 'page' state value changes
-  useEffect(() => {
-    if (history.action === 'POP') {
-      return;
-    }
-
-    const pageNumber = getPageNumFromQueryString();
-
-    if (pageNumber && pageNumber !== page) {
-      history.push(routes.usersPaged.replace(':pageNum', page));
-    }
-  }, [page]);
-
   // subscribe to 'location' changes
   useEffect(() => {
     const pageNumber = getPageNumFromQueryString();


### PR DESCRIPTION
This PR removes one of the listeners in the `UsersOverview` container component. As it turns out, the logic wasn't necessary and was actually blocking navigation from the users detail page back to the overview page.