### PR TITLE
(chore) Hardcode 403 message

### DIFF
--- a/src/models/incident/saga.js
+++ b/src/models/incident/saga.js
@@ -52,8 +52,7 @@ export function* patchIncident(action) {
     const { response } = error;
 
     if (response.status === 403) {
-      const { jsonBody } = response;
-      global.alert(jsonBody.detail);
+      global.alert('Je hebt geen toestemming om deze actie uit te voeren.');
     }
 
     yield put(patchIncidentError({ type: payload.type, error }));

--- a/src/models/incident/saga.test.js
+++ b/src/models/incident/saga.test.js
@@ -159,7 +159,7 @@ describe('models/incident/saga', () => {
         .put(patchIncidentError({ type, error }))
         .silentRun();
 
-      expect(global.alert).toHaveBeenCalled();
+      expect(global.alert).toHaveBeenCalledWith('Je hebt geen toestemming om deze actie uit te voeren.');
 
       global.alert.mockRestore();
     });


### PR DESCRIPTION
The API response bodies haven't got a uniform format. This PR hardcodes the 403 alert message to overcome that problem.

