### PR TITLE
(chore) Simplify useFetchUser hook

### DIFF
--- a/src/signals/settings/users/containers/Detail/__tests__/Detail.test.js
+++ b/src/signals/settings/users/containers/Detail/__tests__/Detail.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, cleanup } from '@testing-library/react';
 import * as reactRouterDom from 'react-router-dom';
 import { withAppContext } from 'test/utils';
 import routes from 'signals/settings/routes';
@@ -83,6 +83,14 @@ describe('signals/settings/users/containers/Detail', () => {
     jest.spyOn(reactRouterDom, 'useParams').mockImplementationOnce(() => ({
       userId,
     }));
+
+    useFetchUser.mockImplementationOnce(() => ({ loading: true }));
+
+    const { queryByTestId } = await render(withAppContext(<UserDetail />));
+
+    expect(queryByTestId('detailUserForm')).toBeNull();
+
+    cleanup();
 
     useFetchUser.mockImplementationOnce(() => ({ data: userJSON }));
 

--- a/src/signals/settings/users/containers/Detail/__tests__/Detail.test.js
+++ b/src/signals/settings/users/containers/Detail/__tests__/Detail.test.js
@@ -66,10 +66,39 @@ describe('signals/settings/users/containers/Detail', () => {
     expect(getByTestId('loadingIndicator')).toBeInTheDocument();
   });
 
-  it('should render a form', () => {
+  it('should not render a form when the data from the API is not yet available', async () => {
+    const userId = userJSON.id;
+    jest.spyOn(reactRouterDom, 'useParams').mockImplementationOnce(() => ({
+      userId,
+    }));
+
+    const { queryByTestId } = await render(withAppContext(<UserDetail />));
+
+    expect(queryByTestId('detailUserForm')).toBeNull();
+
+  });
+
+  it('should render a form when the URL contains a user ID AND the data has been retrieved from the API', async () => {
+    const userId = userJSON.id;
+    jest.spyOn(reactRouterDom, 'useParams').mockImplementationOnce(() => ({
+      userId,
+    }));
+
     useFetchUser.mockImplementationOnce(() => ({ data: userJSON }));
 
-    const { getByTestId } = render(withAppContext(<UserDetail />));
+    const { getByTestId } = await render(withAppContext(<UserDetail />));
+
+    expect(getByTestId('detailUserForm')).toBeInTheDocument();
+  });
+
+  it('should render a form when the URL does not contain a user ID', async () => {
+    jest.spyOn(reactRouterDom, 'useParams').mockImplementationOnce(() => ({
+      userId: undefined,
+    }));
+
+    useFetchUser.mockImplementationOnce(() => ({ data: userJSON }));
+
+    const { getByTestId } = await render(withAppContext(<UserDetail />));
 
     expect(getByTestId('detailUserForm')).toBeInTheDocument();
   });

--- a/src/signals/settings/users/containers/Detail/hooks/__tests__/useFetchUser.test.js
+++ b/src/signals/settings/users/containers/Detail/hooks/__tests__/useFetchUser.test.js
@@ -1,4 +1,5 @@
-import { renderHook, act , cleanup} from '@testing-library/react-hooks';
+import { renderHook, act , cleanup } from '@testing-library/react-hooks';
+import { wait } from '@testing-library/react';
 import userJSON from 'utils/__tests__/fixtures/user.json';
 import useFetchUser from '../useFetchUser';
 
@@ -160,5 +161,15 @@ describe('signals/settings/users/containers/Detail/hooks/useFetchUser', () => {
       expect(result.current.isSuccess).toEqual(false);
       expect(result.current.isLoading).toEqual(false);
     });
+  });
+
+  it('should NOT request user from API on mount', async () => {
+    const { waitForNextUpdate } = renderHook(() =>
+      useFetchUser()
+    );
+
+    waitForNextUpdate();
+
+    await wait(() => expect(global.fetch).not.toHaveBeenCalled());
   });
 });

--- a/src/signals/settings/users/containers/Detail/hooks/useFetchUser.js
+++ b/src/signals/settings/users/containers/Detail/hooks/useFetchUser.js
@@ -13,8 +13,7 @@ import configuration from 'shared/services/configuration/configuration';
 const useFetchUser = id => {
   const [isLoading, setLoading] = useState();
   const [isSuccess, setSuccess] = useState();
-  const initialState = id ? undefined : {};
-  const [data, setData] = useState(initialState);
+  const [data, setData] = useState();
   const [error, setError] = useState(false);
 
   const url = [configuration.USERS_ENDPOINT, id].filter(Boolean).join('/');

--- a/src/signals/settings/users/containers/Detail/index.js
+++ b/src/signals/settings/users/containers/Detail/index.js
@@ -27,6 +27,7 @@ const UserDetail = () => {
   const history = useHistory();
   const { userId } = useParams();
   const { isLoading, isSuccess, error, data, patch } = useFetchUser(userId);
+  const shouldRenderForm = userId === undefined || (userId !== undefined && data !== undefined);
 
   const getFormData = e =>
     [...new FormData(e.target.form).entries()]
@@ -81,8 +82,16 @@ const UserDetail = () => {
       </Row>
 
       <FormContainer>
-        <StyledColumn span={{ small: 1, medium: 2, big: 4, large: 5, xLarge: 4 }}>
-          {data && <UserForm data={data} onCancel={onCancel} onSubmitForm={onSubmitForm} />}
+        <StyledColumn
+          span={{ small: 1, medium: 2, big: 4, large: 5, xLarge: 4 }}
+        >
+          {shouldRenderForm && (
+            <UserForm
+              data={data}
+              onCancel={onCancel}
+              onSubmitForm={onSubmitForm}
+            />
+          )}
         </StyledColumn>
       </FormContainer>
     </Fragment>


### PR DESCRIPTION
This PR puts the responsibility for determining if a form should based on the state in the `UserDetail` component instead of tightly coupling the component and the `useFetchUser` hook.
Additional test were added to ensure the functional side of the change.