### PR TITLE
(chore) Change FormFooter render requirements

### DIFF
--- a/src/components/FormFooter/__tests__/FormFooter.test.js
+++ b/src/components/FormFooter/__tests__/FormFooter.test.js
@@ -14,6 +14,16 @@ describe('src/components/FormFooter', () => {
 
     rerender(
       withAppContext(
+        <FormFooter resetBtnLabel="Reset" />
+      )
+    );
+
+    expect(queryByTestId('resetBtn')).not.toBeNull();
+    expect(getByText('Reset')).toBeInTheDocument();
+    expect(queryByTestId('resetBtn').getAttribute('type')).toEqual('reset');
+
+    rerender(
+      withAppContext(
         <FormFooter onResetForm={() => {}} resetBtnLabel="Reset" />
       )
     );
@@ -23,12 +33,30 @@ describe('src/components/FormFooter', () => {
     expect(queryByTestId('resetBtn').getAttribute('type')).toEqual('reset');
 
     rerender(
+      withAppContext(<FormFooter cancelBtnLabel="Cancel" />)
+    );
+
+    expect(queryByTestId('cancelBtn')).not.toBeNull();
+    expect(getByText('Cancel')).toBeInTheDocument();
+    expect(queryByTestId('cancelBtn').getAttribute('type')).toEqual('button');
+
+    rerender(
       withAppContext(<FormFooter onCancel={() => {}} cancelBtnLabel="Cancel" />)
     );
 
     expect(queryByTestId('cancelBtn')).not.toBeNull();
     expect(getByText('Cancel')).toBeInTheDocument();
     expect(queryByTestId('cancelBtn').getAttribute('type')).toEqual('button');
+
+    rerender(
+      withAppContext(
+        <FormFooter submitBtnLabel="Submit" />
+      )
+    );
+
+    expect(queryByTestId('submitBtn')).not.toBeNull();
+    expect(getByText('Submit')).toBeInTheDocument();
+    expect(queryByTestId('submitBtn').getAttribute('type')).toEqual('submit');
 
     rerender(
       withAppContext(

--- a/src/components/FormFooter/index.js
+++ b/src/components/FormFooter/index.js
@@ -56,7 +56,7 @@ const FormFooter = ({
   <FooterWrapper className={className}>
     <Row>
       <ButtonContainer span={12}>
-        {onResetForm && resetBtnLabel && (
+        {resetBtnLabel && (
           <ResetButton
             data-testid="resetBtn"
             onClick={onResetForm}
@@ -66,7 +66,7 @@ const FormFooter = ({
           </ResetButton>
         )}
 
-        {onCancel && cancelBtnLabel && (
+        {cancelBtnLabel && (
           <CancelButton
             data-testid="cancelBtn"
             onClick={onCancel}
@@ -76,7 +76,7 @@ const FormFooter = ({
           </CancelButton>
         )}
 
-        {onSubmitForm && submitBtnLabel && (
+        {submitBtnLabel && (
           <SubmitButton
             data-testid="submitBtn"
             name="submit_button"
@@ -94,9 +94,9 @@ const FormFooter = ({
 FormFooter.defaultProps = {
   cancelBtnLabel: '',
   className: '',
-  onCancel: undefined,
-  onResetForm: undefined,
-  onSubmitForm: undefined,
+  onCancel: null,
+  onResetForm: null,
+  onSubmitForm: null,
   resetBtnLabel: '',
   submitBtnLabel: '',
 };


### PR DESCRIPTION
This PR alters the `FormFooter` component so that callback function props are no longer required to render any of the buttons. Callback functions can programmatically be set later or by setting a form
s `onReset` or `onSubmit` attributes.