### PR TITLE
(chore) Change Docker project name

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,7 +32,7 @@ node {
     }
 
     stage("Lint") {
-        String PROJECT = "sia-eslint-${env.GIT_COMMIT}"
+        String PROJECT = "sia-eslint-${env.BUILD_TAG}"
 
         tryStep "lint start", {
             sh "docker-compose -p ${PROJECT} up --build --exit-code-from lint-container lint-container"
@@ -42,7 +42,7 @@ node {
     }
 
     stage("Test") {
-        String PROJECT = "sia-unittests-${env.GIT_COMMIT}"
+        String PROJECT = "sia-unittests-${env.BUILD_TAG}"
 
         tryStep "unittests start", {
             sh "docker-compose -p ${PROJECT} up --build --exit-code-from unittest-container unittest-container"


### PR DESCRIPTION
This PR contains a change that will (hopefully) prevent failing Jenkins builds in the future. An analysis of failing jobs lead to finding error messages that were related to Docker trying to remove already removed containers or trying to remove containers that already had been marked for removal. 

The issue, as it turned out, was that names used for individual containers, weren't unique. Because any pull request runs two builds that use a container with the same name, the clean-up process encountered problems unrelated to the code, but still failed.

Replacing `GIT_COMMIT` with `BUILD_TAG` should fix this issue, because the build tag contains either the Github PR number or the branch name as well as the current build number. That combination makes it unique across builds.