### PR TITLE
Sig 1965 open melding in browser tab fix

### DIFF
--- a/src/signals/incident-management/containers/IncidentOverviewPage/components/List/index.js
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/components/List/index.js
@@ -60,7 +60,7 @@ class List extends React.Component {
                 const detailLink = `/manage/incident/${incident.id}`;
                 return (
                   <tr key={incident.id}>
-                    <td><Link className="id" to={detailLink}>{incident.id}</Link></td>
+                    <td><Link to={detailLink}>{incident.id}</Link></td>
                     <td data-testid="incidentDaysOpen"><Link to={detailLink}>{this.getDaysOpen(incident)}</Link></td>
                     <td className="no-wrap"><Link to={detailLink}>{string2date(incident.created_at)} {string2time(incident.created_at)}</Link></td>
                     <td><Link to={detailLink}>{getListValueByKey(stadsdeel, incident.location && incident.location.stadsdeel)}</Link></td>
@@ -74,7 +74,7 @@ class List extends React.Component {
             </tbody>
           </table>
         </div>
-      </div>
+      </div >
     );
   }
 }

--- a/src/signals/incident-management/containers/IncidentOverviewPage/components/List/style.scss
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/components/List/style.scss
@@ -16,11 +16,6 @@
       padding: 0;
 
       a {
-        &.id {
-          color: #004699;
-          text-decoration: underline
-        }
-
         text-decoration: none;
         color: black;
         display: inline-block;

--- a/src/signals/incident-management/containers/IncidentOverviewPage/components/List/style.scss
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/components/List/style.scss
@@ -11,6 +11,7 @@
   &__table {
     border-collapse: separate;
     width: 100%;
+    height: 100%;
 
     td {
       padding: 0;
@@ -18,8 +19,9 @@
       a {
         text-decoration: none;
         color: black;
-        display: inline-block;
+        display: block;
         width: 100%;
+        height: 100%;
         padding: 8px;
       }
     }


### PR DESCRIPTION
In this PR:
- removed id styling 
- in the incident list table cells are now completely clickable

Please note the version has been approved by Herjen
