### PR TITLE
(chore) Prevent log pollution

### DIFF
--- a/internals/testing/test-bundler.js
+++ b/internals/testing/test-bundler.js
@@ -15,6 +15,11 @@ Enzyme.configure({ adapter: new Adapter() });
 global.window.L = L;
 global.window.alert = msg => msg;
 
+if (process.env.CI) {
+  // prevent pollution of the build log when running tests in CI
+  global.console.warn = () => {};
+}
+
 /**
  * Element.closest() polyfill
  *


### PR DESCRIPTION
This PR contains a change to the test setup so that, when tests are run in Jenkins, or whatever CI, console warn messages will be suppressed. Those messages are generated by dependencies are of no importance in the CI log.