### PR TITLE
(fix) Removes async indicator

### DIFF
--- a/src/signals/incident-management/containers/IncidentOverviewPage/index.test.js
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/index.test.js
@@ -138,7 +138,7 @@ describe('signals/incident-management/containers/IncidentOverviewPage', () => {
     expect(typeof containerProps.onChangeOrdering).toEqual('function');
   });
 
-  it('should scroll page to top after navigating with pagination', async () => {
+  it('should scroll page to top after navigating with pagination', () => {
     constants.FILTER_PAGE_SIZE = 30;
     Object.defineProperty(window, 'scrollTo', {
       value: () => { },


### PR DESCRIPTION
This PR removes an `async` declaration from a test case. Jest kept waiting for the function to be resolved, but that never happened within the configured default timeout (5000 ms).