### PR TITLE
[SIG-1818] 0 Meldingen gevonden

### DIFF
--- a/src/components/Pagination/__tests__/Pagination.test.js
+++ b/src/components/Pagination/__tests__/Pagination.test.js
@@ -6,6 +6,26 @@ import Pagination from '..';
 describe('src/components/Pagination', () => {
   const totalPages = 10;
 
+  it('should not render anything when there is just one page', () => {
+    const { queryByTestId, rerender } = render(
+      withAppContext(<Pagination totalPages={0} currentPage={1} />)
+    );
+
+    expect(queryByTestId('pagination')).not.toBeInTheDocument();
+
+    rerender(
+      withAppContext(<Pagination totalPages={1} currentPage={1} />)
+    );
+
+    expect(queryByTestId('pagination')).not.toBeInTheDocument();
+
+    rerender(
+      withAppContext(<Pagination totalPages={2} currentPage={1} />)
+    );
+
+    expect(queryByTestId('pagination')).toBeInTheDocument();
+  });
+
   it('should render only next button', () => {
     const { queryByTestId } = render(
       withAppContext(<Pagination totalPages={totalPages} currentPage={1} />)

--- a/src/components/Pagination/index.js
+++ b/src/components/Pagination/index.js
@@ -58,6 +58,10 @@ const Pagination = ({
 }) => {
   const pagesInRange = pageNumbersList(currentPage, totalPages);
 
+  if (totalPages <= 1) {
+    return null;
+  }
+
   const items = pagesInRange.map((pageNum, index) => {
     const prevIndex = getPreviousIndex(currentPage);
     const nextIndex = getNextIndex(currentPage, totalPages);

--- a/src/signals/incident-management/containers/IncidentOverviewPage/index.js
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/index.js
@@ -3,7 +3,14 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import { compose, bindActionCreators } from 'redux';
-import { Row, Column, Button, themeSpacing } from '@datapunt/asc-ui';
+import {
+  Row,
+  Column,
+  Button,
+  themeSpacing,
+  Paragraph,
+  themeColor,
+} from '@datapunt/asc-ui';
 import { disablePageScroll, enablePageScroll } from 'scroll-lock';
 import styled from 'styled-components';
 
@@ -46,6 +53,13 @@ const StyledButton = styled(Button)`
 
 const StyledPagination = styled(Pagination)`
   margin-top: ${themeSpacing(12)};
+`;
+
+const NoResults = styled(Paragraph)`
+  width: 100%;
+  text-align: center;
+  font-family: Avenir Next LT W01 Demi, arial, sans-serif;
+  color: ${themeColor('tint', 'level4')};
 `;
 
 export const IncidentOverviewPageContainerComponent = ({
@@ -117,6 +131,7 @@ export const IncidentOverviewPageContainerComponent = ({
   }, []);
 
   const { incidents, loading } = overviewpage;
+  const totalPages = Math.ceil(incidentsCount / FILTER_PAGE_SIZE);
 
   return (
     <div className="incident-overview-page">
@@ -163,9 +178,9 @@ export const IncidentOverviewPageContainerComponent = ({
       <Row>
         <Column span={12} wrap>
           <Column span={12}>
-            {loading ? (
-              <LoadingIndicator />
-            ) : (
+            {loading && <LoadingIndicator />}
+
+            {!loading && totalPages > 0 && (
               <ListComponent
                 incidents={incidents}
                 onChangeOrdering={onChangeOrdering}
@@ -173,6 +188,10 @@ export const IncidentOverviewPageContainerComponent = ({
                 incidentsCount={incidentsCount}
                 {...dataLists}
               />
+            )}
+
+            {!loading && totalPages === 0 && (
+              <NoResults>Geen meldingen</NoResults>
             )}
           </Column>
 
@@ -185,7 +204,7 @@ export const IncidentOverviewPageContainerComponent = ({
                   global.window.scrollTo(0, 0);
                   onPageIncidentsChanged(pageToNavigateTo);
                 }}
-                totalPages={Math.ceil(incidentsCount / FILTER_PAGE_SIZE)}
+                totalPages={totalPages}
               />
             )}
           </Column>
@@ -233,11 +252,7 @@ export const mapDispatchToProps = dispatch =>
     dispatch
   );
 
-const withConnect = connect(
-  mapStateToProps,
-  mapDispatchToProps
-);
-
+const withConnect = connect(mapStateToProps, mapDispatchToProps);
 const withReducer = injectReducer({ key: 'incidentOverviewPage', reducer });
 const withSaga = injectSaga({ key: 'incidentOverviewPage', saga });
 

--- a/src/signals/incident-management/containers/IncidentOverviewPage/index.test.js
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/index.test.js
@@ -110,6 +110,14 @@ describe('signals/incident-management/containers/IncidentOverviewPage', () => {
     expect(props.onRequestIncidents).toBeCalledWith();
   });
 
+  it('should show notification when no results can be rendered', () => {
+    const { getByText } = render(
+      withAppContext(<IncidentOverviewPageContainerComponent {...props} incidentsCount={0} />)
+    );
+
+    expect(getByText('Geen meldingen')).toBeInTheDocument();
+  });
+
   it('should have props from structured selector', () => {
     const tree = mount(withAppContext(<IncidentOverviewPage />));
 


### PR DESCRIPTION
This PR:

replaces the incidents list with a notification when no incidents are returned from the filter request
makes sure that the Pagination component doesn't render any navigation buttons when there isn't more than one page to be displayed