### PR TITLE
[SIG-2006] Clear address field on form reset

### DIFF
--- a/src/signals/incident-management/components/FilterForm/__test__/FilterForm.test.js
+++ b/src/signals/incident-management/components/FilterForm/__test__/FilterForm.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, cleanup } from '@testing-library/react';
+import { fireEvent, render, cleanup, act } from '@testing-library/react';
 import { withAppContext } from 'test/utils';
 
 import priorityList from 'signals/incident-management/definitions/priorityList';
@@ -19,8 +19,6 @@ const dataLists = {
 };
 
 describe('signals/incident-management/components/FilterForm', () => {
-  afterEach(cleanup);
-
   it('should render filter fields', () => {
     const { container } = render(
       withAppContext(
@@ -437,7 +435,7 @@ describe('signals/incident-management/components/FilterForm', () => {
   // Note that jsdom has a bug where `submit` and `reset` handlers are not called when those handlers
   // are defined as callback attributes on the form element. Instead, handlers are invoked when the
   // corresponding buttons are clicked.
-  it('should handle reset', async () => {
+  it('should handle reset', () => {
     const onClearFilter = jest.fn();
     const { container } = render(
       withAppContext(
@@ -471,7 +469,9 @@ describe('signals/incident-management/components/FilterForm', () => {
     expect(addressField.value).not.toBeFalsy();
     expect(afvalToggle.checked).toEqual(true);
 
-    fireEvent.click(container.querySelector('button[type="reset"]'));
+    act(() => {
+      fireEvent.click(container.querySelector('button[type="reset"]'));
+    });
 
     expect(onClearFilter).toHaveBeenCalled();
     // jsdom hasn't implemented form reset and submit handling, so we cannot test that the fields have been cleared

--- a/src/signals/incident-management/components/FilterForm/index.js
+++ b/src/signals/incident-management/components/FilterForm/index.js
@@ -285,9 +285,7 @@ const FilterForm = ({
                 type="text"
                 name="address_text"
                 id="filter_address"
-                defaultValue={
-                  (filterData.options && filterData.options.address_text) || ''
-                }
+                defaultValue={filterData.options.address_text || ''}
               />
             </div>
           </FilterGroup>

--- a/src/signals/incident-management/components/FilterForm/index.js
+++ b/src/signals/incident-management/components/FilterForm/index.js
@@ -286,7 +286,7 @@ const FilterForm = ({
                 name="address_text"
                 id="filter_address"
                 defaultValue={
-                  filterData.options && filterData.options.address_text
+                  (filterData.options && filterData.options.address_text) || ''
                 }
               />
             </div>


### PR DESCRIPTION
This PR contains that ensures that the address field in the filter form is emptied when the form's reset button is clicked.