### PR TITLE
(chore) Remove async from tests

### DIFF
--- a/src/signals/incident-management/components/FilterForm/__test__/FilterForm.test.js
+++ b/src/signals/incident-management/components/FilterForm/__test__/FilterForm.test.js
@@ -421,7 +421,7 @@ describe('signals/incident-management/components/FilterForm', () => {
   // Note that jsdom has a bug where `submit` and `reset` handlers are not called when those handlers
   // are defined as callback attributes on the form element. Instead, handlers are invoked when the
   // corresponding buttons are clicked.
-  it('should handle reset', async () => {
+  it('should handle reset', () => {
     const onClearFilter = jest.fn();
     const { container } = render(
       withAppContext(

--- a/src/signals/settings/__tests__/index.test.js
+++ b/src/signals/settings/__tests__/index.test.js
@@ -23,7 +23,7 @@ describe('signals/settings', () => {
     reactRouterDom.useLocation.mockRestore();
   });
 
-  it('should render login page', async () => {
+  it('should render login page', () => {
     jest.spyOn(auth, 'isAuthenticated').mockImplementationOnce(() => false);
 
     const { queryByTestId, getByTestId, rerender } = render(
@@ -39,7 +39,7 @@ describe('signals/settings', () => {
     expect(queryByTestId('loginPage')).toBeNull();
   });
 
-  it('should render a 404', async () => {
+  it('should render a 404', () => {
     jest.spyOn(auth, 'isAuthenticated').mockImplementation(() => true);
 
     const { getByTestId } = render(withAppContext(<SettingsModule />));


### PR DESCRIPTION
This PR contains changes that should prevent Jenkins from tripping over async tests that do not use `await` or return anything