### PR TITLE
(fix) Clear filter

### DIFF
--- a/src/signals/incident-management/__tests__/reducer.test.js
+++ b/src/signals/incident-management/__tests__/reducer.test.js
@@ -210,13 +210,25 @@ describe('signals/incident-management/reducer', () => {
       type: CLEAR_FILTER,
     };
 
+    const someState = fromJS({
+      ...initialState.toJS(),
+      editFilter: {
+        name: 'Foo bar baz',
+        options: {
+          created_after: '2019-18-12T00:00:00',
+        },
+      },
+      page: 1,
+      ordering: '-created_at',
+    });
+
     const expected = fromJS(initialState)
       .set('editFilter', initialState.get('editFilter'))
       .set('loading', false)
       .set('error', false)
       .set('errorMessage', undefined);
 
-    expect(reducer(initialState, clearFilter)).toEqual(expected);
+    expect(reducer(someState, clearFilter)).toEqual(expected);
     expect(reducer(undefined, clearFilter)).toEqual(expected);
   });
 

--- a/src/signals/incident-management/components/FilterForm/__test__/FilterForm.test.js
+++ b/src/signals/incident-management/components/FilterForm/__test__/FilterForm.test.js
@@ -506,7 +506,8 @@ describe('signals/incident-management/components/FilterForm', () => {
       const { container } = render(
         withAppContext(
           <FilterForm
-            {...formProps, ...handlers}
+            {...formProps}
+            {...handlers}
             filter={{
               name: '',
               options: { incident_date: '1970-01-01' },
@@ -544,7 +545,8 @@ describe('signals/incident-management/components/FilterForm', () => {
       const { container } = render(
         withAppContext(
           <FilterForm
-            {...formProps, ...handlers}
+            {...formProps}
+            {...handlers}
             filter={{
               name: 'My filter',
               options: {

--- a/src/signals/incident-management/components/FilterForm/__test__/FilterForm.test.js
+++ b/src/signals/incident-management/components/FilterForm/__test__/FilterForm.test.js
@@ -506,8 +506,7 @@ describe('signals/incident-management/components/FilterForm', () => {
       const { container } = render(
         withAppContext(
           <FilterForm
-            {...formProps}
-            {...handlers}
+            {...{...formProps, ...handlers}}
             filter={{
               name: '',
               options: { incident_date: '1970-01-01' },
@@ -545,8 +544,7 @@ describe('signals/incident-management/components/FilterForm', () => {
       const { container } = render(
         withAppContext(
           <FilterForm
-            {...formProps}
-            {...handlers}
+            {...{...formProps, ...handlers}}
             filter={{
               name: 'My filter',
               options: {

--- a/src/signals/incident-management/components/FilterForm/__test__/FilterForm.test.js
+++ b/src/signals/incident-management/components/FilterForm/__test__/FilterForm.test.js
@@ -506,8 +506,7 @@ describe('signals/incident-management/components/FilterForm', () => {
       const { container } = render(
         withAppContext(
           <FilterForm
-            {...formProps}
-            {...handlers}
+            {...formProps, ...handlers}
             filter={{
               name: '',
               options: { incident_date: '1970-01-01' },
@@ -545,8 +544,7 @@ describe('signals/incident-management/components/FilterForm', () => {
       const { container } = render(
         withAppContext(
           <FilterForm
-            {...formProps}
-            {...handlers}
+            {...formProps, ...handlers}
             filter={{
               name: 'My filter',
               options: {

--- a/src/signals/incident-management/components/FilterForm/__test__/FilterForm.test.js
+++ b/src/signals/incident-management/components/FilterForm/__test__/FilterForm.test.js
@@ -18,13 +18,19 @@ const dataLists = {
   source: definitions.sourceList,
 };
 
+const formProps = {
+  onClearFilter: () => {},
+  onSaveFilter: () => {},
+  categories,
+  onSubmit: () => {},
+};
+
 describe('signals/incident-management/components/FilterForm', () => {
   it('should render filter fields', () => {
     const { container } = render(
       withAppContext(
         <FilterForm
-          categories={categories}
-          onSubmit={() => {}}
+          {...formProps}
           dataLists={dataLists}
         />,
       ),
@@ -42,8 +48,7 @@ describe('signals/incident-management/components/FilterForm', () => {
     const { container } = render(
       withAppContext(
         <FilterForm
-          categories={categories}
-          onSubmit={() => {}}
+          {...formProps}
           filter={{ options: {} }}
           dataLists={dataLists}
         />,
@@ -59,8 +64,7 @@ describe('signals/incident-management/components/FilterForm', () => {
     const { container } = render(
       withAppContext(
         <FilterForm
-          categories={categories}
-          onSubmit={() => {}}
+          {...formProps}
           filter={{ id: 1234, name: 'FooBar', options: {} }}
           dataLists={dataLists}
         />,
@@ -88,8 +92,7 @@ describe('signals/incident-management/components/FilterForm', () => {
     const { container } = render(
       withAppContext(
         <FilterForm
-          categories={categories}
-          onSubmit={() => {}}
+          {...formProps}
           filter={{ id: 1234, name: 'FooBar', options: {} }}
           dataLists={dataLists}
         />,
@@ -109,8 +112,7 @@ describe('signals/incident-management/components/FilterForm', () => {
     const { container, getAllByTestId } = render(
       withAppContext(
         <FilterForm
-          categories={categories}
-          onSubmit={() => {}}
+          {...formProps}
           dataLists={dataLists}
         />,
       ),
@@ -125,8 +127,7 @@ describe('signals/incident-management/components/FilterForm', () => {
     const { container } = render(
       withAppContext(
         <FilterForm
-          categories={categories}
-          onSubmit={() => {}}
+          {...formProps}
           dataLists={dataLists}
         />,
       ),
@@ -155,8 +156,7 @@ describe('signals/incident-management/components/FilterForm', () => {
     const { container, rerender, queryByTestId } = render(
       withAppContext(
         <FilterForm
-          categories={categories}
-          onSubmit={() => {}}
+          {...formProps}
           dataLists={dataListsWithoutPriorityList}
         />,
       ),
@@ -176,8 +176,7 @@ describe('signals/incident-management/components/FilterForm', () => {
     rerender(
       withAppContext(
         <FilterForm
-          categories={categories}
-          onSubmit={() => {}}
+          {...formProps}
           dataLists={dataListsWithEmptyPriorityList}
         />,
       ),
@@ -194,8 +193,7 @@ describe('signals/incident-management/components/FilterForm', () => {
     rerender(
       withAppContext(
         <FilterForm
-          categories={categories}
-          onSubmit={() => {}}
+          {...formProps}
           dataLists={dataLists}
         />,
       ),
@@ -213,8 +211,7 @@ describe('signals/incident-management/components/FilterForm', () => {
     const { container, rerender, queryByTestId } = render(
       withAppContext(
         <FilterForm
-          categories={categories}
-          onSubmit={() => {}}
+          {...formProps}
           dataLists={dataListsWithoutStatusList}
         />,
       ),
@@ -234,8 +231,7 @@ describe('signals/incident-management/components/FilterForm', () => {
     rerender(
       withAppContext(
         <FilterForm
-          categories={categories}
-          onSubmit={() => {}}
+          {...formProps}
           dataLists={dataListsWithEmptyStatusList}
         />,
       ),
@@ -252,8 +248,7 @@ describe('signals/incident-management/components/FilterForm', () => {
     rerender(
       withAppContext(
         <FilterForm
-          categories={categories}
-          onSubmit={() => {}}
+          {...formProps}
           dataLists={dataLists}
         />,
       ),
@@ -271,8 +266,7 @@ describe('signals/incident-management/components/FilterForm', () => {
     const { container, rerender, queryByTestId } = render(
       withAppContext(
         <FilterForm
-          categories={categories}
-          onSubmit={() => {}}
+          {...formProps}
           dataLists={dataListsWithoutStadsdeelList}
         />,
       ),
@@ -292,8 +286,7 @@ describe('signals/incident-management/components/FilterForm', () => {
     rerender(
       withAppContext(
         <FilterForm
-          categories={categories}
-          onSubmit={() => {}}
+          {...formProps}
           dataLists={dataListsWithEmptyStadsdeelList}
         />,
       ),
@@ -310,8 +303,7 @@ describe('signals/incident-management/components/FilterForm', () => {
     rerender(
       withAppContext(
         <FilterForm
-          categories={categories}
-          onSubmit={() => {}}
+          {...formProps}
           dataLists={dataLists}
         />,
       ),
@@ -329,8 +321,7 @@ describe('signals/incident-management/components/FilterForm', () => {
     const { container, rerender, queryByTestId } = render(
       withAppContext(
         <FilterForm
-          categories={categories}
-          onSubmit={() => {}}
+          {...formProps}
           dataLists={dataListsWithoutFeedbackList}
         />,
       ),
@@ -347,8 +338,7 @@ describe('signals/incident-management/components/FilterForm', () => {
     rerender(
       withAppContext(
         <FilterForm
-          categories={categories}
-          onSubmit={() => {}}
+          {...formProps}
           dataLists={dataLists}
         />,
       ),
@@ -366,8 +356,7 @@ describe('signals/incident-management/components/FilterForm', () => {
     const { container, rerender, queryByTestId } = render(
       withAppContext(
         <FilterForm
-          categories={categories}
-          onSubmit={() => {}}
+          {...formProps}
           dataLists={dataListsWithoutSourceList}
         />,
       ),
@@ -384,8 +373,7 @@ describe('signals/incident-management/components/FilterForm', () => {
     rerender(
       withAppContext(
         <FilterForm
-          categories={categories}
-          onSubmit={() => {}}
+          {...formProps}
           dataLists={dataLists}
         />,
       ),
@@ -400,8 +388,7 @@ describe('signals/incident-management/components/FilterForm', () => {
     const { container, rerender } = render(
       withAppContext(
         <FilterForm
-          categories={categories}
-          onSubmit={() => {}}
+          {...formProps}
           dataLists={dataLists}
         />,
       ),
@@ -419,9 +406,8 @@ describe('signals/incident-management/components/FilterForm', () => {
     rerender(
       withAppContext(
         <FilterForm
-          categories={categories}
+          {...formProps}
           filter={{ options: { incident_date: '1970-01-01' } }}
-          onSubmit={() => {}}
           dataLists={dataLists}
         />,
       ),
@@ -440,9 +426,8 @@ describe('signals/incident-management/components/FilterForm', () => {
     const { container } = render(
       withAppContext(
         <FilterForm
-          categories={categories}
+          {...formProps}
           onClearFilter={onClearFilter}
-          onSubmit={() => {}}
           dataLists={dataLists}
         />,
       ),
@@ -482,9 +467,8 @@ describe('signals/incident-management/components/FilterForm', () => {
     const { getByTestId } = render(
       withAppContext(
         <FilterForm
-          categories={categories}
+          {...formProps}
           onCancel={onCancel}
-          onSubmit={() => {}}
           dataLists={dataLists}
         />,
       ),
@@ -522,7 +506,7 @@ describe('signals/incident-management/components/FilterForm', () => {
       const { container } = render(
         withAppContext(
           <FilterForm
-            categories={categories}
+            {...formProps}
             {...handlers}
             filter={{
               name: '',
@@ -533,10 +517,22 @@ describe('signals/incident-management/components/FilterForm', () => {
         ),
       );
 
+      expect(handlers.onSaveFilter).not.toHaveBeenCalled();
+      expect(handlers.onSubmit).not.toHaveBeenCalled();
+
+      const nameField = container.querySelector(
+        'input[type="text"][name="name"]',
+      );
+
       fireEvent.click(container.querySelector('button[type="submit"]'));
 
-      expect(handlers.onSaveFilter).not.toHaveBeenCalled();
       expect(handlers.onSubmit).toHaveBeenCalled();
+      expect(handlers.onSaveFilter).not.toHaveBeenCalled(); // name field is empty
+
+      fireEvent.change(nameField, { target: { value: 'New name' }});
+      fireEvent.click(container.querySelector('button[type="submit"]'));
+
+      expect(handlers.onSaveFilter).toHaveBeenCalled();
     });
 
     it('should handle submit for existing filter', () => {
@@ -549,7 +545,7 @@ describe('signals/incident-management/components/FilterForm', () => {
       const { container } = render(
         withAppContext(
           <FilterForm
-            categories={categories}
+            {...formProps}
             {...handlers}
             filter={{
               name: 'My filter',
@@ -587,9 +583,8 @@ describe('signals/incident-management/components/FilterForm', () => {
     const { container } = render(
       withAppContext(
         <FilterForm
-          categories={categories}
+          {...formProps}
           filter={{ name: 'My saved filter', options: {} }}
-          onSubmit={() => {}}
           dataLists={dataLists}
         />,
       ),

--- a/src/signals/incident-management/components/FilterForm/index.js
+++ b/src/signals/incident-management/components/FilterForm/index.js
@@ -44,8 +44,12 @@ const FilterForm = ({
   const { feedback, priority, stadsdeel, status, source } = dataLists;
   const [submitBtnLabel, setSubmitBtnLabel] = useState(defaultSubmitBtnLabel);
   const [filterData, setFilterData] = useState(filter);
-  const filterSlugs = (filterData.options.maincategory_slug || []).concat(
-    filterData.options.category_slug || []
+  const filterSlugs = useMemo(
+    () =>
+      (filterData.options.maincategory_slug || []).concat(
+        filterData.options.category_slug || []
+      ),
+    [filterData.options.category_slug, filterData.options.maincategory_slug]
   );
   const isNewFilter = useMemo(() => !filter.name, [filter.name]);
 

--- a/src/signals/incident-management/components/FilterForm/index.js
+++ b/src/signals/incident-management/components/FilterForm/index.js
@@ -55,17 +55,11 @@ const FilterForm = ({
       const hasName = formData.name.trim() !== '';
       const valuesHaveChanged = !isEqual(formData, filterData);
 
-      /* istanbul ignore else */
-      if (typeof onSaveFilter === 'function' && isNewFilter && hasName) {
+      if (isNewFilter && hasName) {
         onSaveFilter(formData);
       }
 
-      /* istanbul ignore else */
-      if (
-        typeof onUpdateFilter === 'function' &&
-        !isNewFilter &&
-        valuesHaveChanged
-      ) {
+      if (!isNewFilter && valuesHaveChanged) {
         if (formData.name.trim() === '') {
           event.preventDefault();
           global.window.alert('Filter naam mag niet leeg zijn');
@@ -74,10 +68,7 @@ const FilterForm = ({
         onUpdateFilter(formData);
       }
 
-      /* istanbul ignore else */
-      if (typeof onSubmit === 'function') {
-        onSubmit(event, formData);
-      }
+      onSubmit(event, formData);
     },
     [filterData, isNewFilter, onSaveFilter, onSubmit, onUpdateFilter]
   );
@@ -94,14 +85,10 @@ const FilterForm = ({
       options: {},
     });
 
-    /* istanbul ignore else */
-    if (typeof onClearFilter === 'function') {
-      onClearFilter();
-    }
+    onClearFilter();
   }, [onClearFilter]);
 
   const onChangeForm = useCallback(() => {
-    /* istanbul ignore else */
     if (isNewFilter) {
       return;
     }
@@ -110,21 +97,9 @@ const FilterForm = ({
     const valuesHaveChanged = !isEqual(formData, filterData);
     const btnHasSaveLabel = submitBtnLabel === saveSubmitBtnLabel;
 
-    /* istanbul ignore else */
-    if (valuesHaveChanged) {
-      if (!btnHasSaveLabel) {
-        setSubmitBtnLabel(saveSubmitBtnLabel);
-      }
-
-      return;
+    if (valuesHaveChanged && !btnHasSaveLabel) {
+      setSubmitBtnLabel(saveSubmitBtnLabel);
     }
-
-    /* istanbul ignore else */
-    if (!btnHasSaveLabel) {
-      return;
-    }
-
-    setSubmitBtnLabel(defaultSubmitBtnLabel);
   }, [filterData, isNewFilter, submitBtnLabel]);
 
   const onNameChange = useCallback(
@@ -157,6 +132,21 @@ const FilterForm = ({
       refresh: checked,
     }));
   }, []);
+
+  const updateFilterDate = useCallback(
+    /* istanbul ignore next */ (prop, dateValue) => {
+      setFilterData(state => ({
+        ...state,
+        options: {
+          ...state.options,
+          [prop]: dateValue,
+        },
+      }));
+
+      onChangeForm();
+    },
+    [setFilterData, onChangeForm]
+  );
 
   return (
     <Form action="" novalidate onChange={onChangeForm} ref={formRef}>
@@ -269,16 +259,13 @@ const FilterForm = ({
                  * Ignoring the internals of the `onChange` handler since they cannot be tested
                  * @see https://github.com/Hacker0x01/react-datepicker/issues/1578
                  */
-                /* istanbul ignore next */
                 onChange={dateValue => {
+                  /* istanbul ignore next */
                   const formattedDate = dateValue
                     ? moment(dateValue).format('YYYY-MM-DD')
                     : '';
 
-                  const updatedFilterData = { ...filterData };
-                  updatedFilterData.options.incident_date = formattedDate;
-
-                  setFilterData(updatedFilterData);
+                  updateFilterDate('incident_date', formattedDate);
                 }}
                 placeholderText="DD-MM-JJJJ"
                 selected={
@@ -412,9 +399,9 @@ FilterForm.propTypes = {
   /** Callback handler for when filter settings should not be applied */
   onCancel: PropTypes.func,
   /** Callback handler to reset filter */
-  onClearFilter: PropTypes.func,
+  onClearFilter: PropTypes.func.isRequired,
   /** Callback handler for new filter settings */
-  onSaveFilter: PropTypes.func,
+  onSaveFilter: PropTypes.func.isRequired,
   /**
    * Callback handler called whenever form is submitted
    * @param {Event} event

--- a/src/signals/incident-management/components/FilterForm/index.js
+++ b/src/signals/incident-management/components/FilterForm/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo, useCallback, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { Row } from '@datapunt/asc-ui';
 import isEqual from 'lodash.isequal';
@@ -40,50 +40,54 @@ const FilterForm = ({
   dataLists,
   categories,
 }) => {
+  const formRef = useRef(null);
   const { feedback, priority, stadsdeel, status, source } = dataLists;
   const [submitBtnLabel, setSubmitBtnLabel] = useState(defaultSubmitBtnLabel);
   const [filterData, setFilterData] = useState(filter);
   const filterSlugs = (filterData.options.maincategory_slug || []).concat(
-    filterData.options.category_slug || [],
+    filterData.options.category_slug || []
   );
+  const isNewFilter = useMemo(() => !filter.name, [filter.name]);
 
-  const onSubmitForm = event => {
-    const formData = parseOutputFormData(event.target.form);
-    const isNewFilter = !filterData.name;
-    const hasName = formData.name.trim() !== '';
-    const valuesHaveChanged = !isEqual(formData, filterData);
+  const onSubmitForm = useCallback(
+    event => {
+      const formData = parseOutputFormData(formRef.current);
+      const hasName = formData.name.trim() !== '';
+      const valuesHaveChanged = !isEqual(formData, filterData);
 
-    /* istanbul ignore else */
-    if (typeof onSaveFilter === 'function' && isNewFilter && hasName) {
-      onSaveFilter(formData);
-    }
-
-    /* istanbul ignore else */
-    if (
-      typeof onUpdateFilter === 'function' &&
-      !isNewFilter &&
-      valuesHaveChanged
-    ) {
-      if (formData.name.trim() === '') {
-        event.preventDefault();
-        global.window.alert('Filter naam mag niet leeg zijn');
-        return;
+      /* istanbul ignore else */
+      if (typeof onSaveFilter === 'function' && isNewFilter && hasName) {
+        onSaveFilter(formData);
       }
-      onUpdateFilter(formData);
-    }
 
-    /* istanbul ignore else */
-    if (typeof onSubmit === 'function') {
-      onSubmit(event, formData);
-    }
-  };
+      /* istanbul ignore else */
+      if (
+        typeof onUpdateFilter === 'function' &&
+        !isNewFilter &&
+        valuesHaveChanged
+      ) {
+        if (formData.name.trim() === '') {
+          event.preventDefault();
+          global.window.alert('Filter naam mag niet leeg zijn');
+          return;
+        }
+        onUpdateFilter(formData);
+      }
+
+      /* istanbul ignore else */
+      if (typeof onSubmit === 'function') {
+        onSubmit(event, formData);
+      }
+    },
+    [filterData, isNewFilter, onSaveFilter, onSubmit, onUpdateFilter]
+  );
 
   /**
    * Form reset handler
    *
    * Clears filterData state by setting values for controlled fields
    */
-  const onResetForm = () => {
+  const onResetForm = useCallback(() => {
     setFilterData({
       name: '',
       refresh: false,
@@ -94,17 +98,15 @@ const FilterForm = ({
     if (typeof onClearFilter === 'function') {
       onClearFilter();
     }
-  };
+  }, [onClearFilter]);
 
-  const onChangeForm = event => {
-    const isNewFilter = !filterData.name;
-
+  const onChangeForm = useCallback(() => {
     /* istanbul ignore else */
     if (isNewFilter) {
       return;
     }
 
-    const formData = parseOutputFormData(event.currentTarget);
+    const formData = parseOutputFormData(formRef.current);
     const valuesHaveChanged = !isEqual(formData, filterData);
     const btnHasSaveLabel = submitBtnLabel === saveSubmitBtnLabel;
 
@@ -123,34 +125,41 @@ const FilterForm = ({
     }
 
     setSubmitBtnLabel(defaultSubmitBtnLabel);
-  };
+  }, [filterData, isNewFilter, submitBtnLabel]);
 
-  const onNameChange = event => {
-    const { value } = event.target;
-    const nameHasChanged =
-      typeof value === 'string' && value.trim() !== filterData.name;
+  const onNameChange = useCallback(
+    event => {
+      const { value } = event.target;
+      const nameHasChanged = typeof value === 'string' && value !== filter.name;
 
-    if (nameHasChanged) {
-      setSubmitBtnLabel(saveSubmitBtnLabel);
-    } else {
-      setSubmitBtnLabel(defaultSubmitBtnLabel);
-    }
-  };
+      if (nameHasChanged) {
+        setSubmitBtnLabel(saveSubmitBtnLabel);
+      } else {
+        setSubmitBtnLabel(defaultSubmitBtnLabel);
+      }
 
-  const onRefreshChange = event => {
+      setFilterData(state => ({
+        ...state,
+        name: value,
+      }));
+    },
+    [filter.name]
+  );
+
+  const onRefreshChange = useCallback(event => {
     event.persist();
     const {
       currentTarget: { checked },
     } = event;
 
-    setFilterData({
-      ...filterData,
+    setFilterData(state => ({
+      ...state,
       refresh: checked,
-    });
-  };
+    }));
+  }, []);
 
   return (
-    <Form action="" novalidate onChange={onChangeForm}>
+    <Form action="" novalidate onChange={onChangeForm} ref={formRef}>
       <ControlsWrapper>
         {filterData.id && (
           <input type="hidden" name="id" value={filterData.id} />
@@ -158,10 +167,12 @@ const FilterForm = ({
         <Fieldset isSection>
           <legend className="hiddenvisually">Naam van het filter</legend>
 
-          <Label htmlFor="filter_name" isGroupHeader>Filternaam</Label>
+          <Label htmlFor="filter_name" isGroupHeader>
+            Filternaam
+          </Label>
           <div className="invoer">
             <input
-              defaultValue={filterData.name}
+              value={filterData.name}
               id="filter_name"
               name="name"
               onChange={onNameChange}
@@ -170,7 +181,9 @@ const FilterForm = ({
             />
           </div>
 
-          <Label htmlFor="filter_refresh" isGroupHeader>Automatisch verversen</Label>
+          <Label htmlFor="filter_refresh" isGroupHeader>
+            Automatisch verversen
+          </Label>
           <div className="antwoord">
             <input
               id="filter_refresh"
@@ -190,7 +203,9 @@ const FilterForm = ({
 
           {Array.isArray(status) && status.length > 0 && (
             <FilterGroup data-testid="statusFilterGroup">
-              <Label htmlFor={`status_${status[0].key}`} isGroupHeader>Status</Label>
+              <Label htmlFor={`status_${status[0].key}`} isGroupHeader>
+                Status
+              </Label>
               <CheckboxList
                 defaultValue={filterData.options && filterData.options.status}
                 groupName="status"
@@ -202,7 +217,9 @@ const FilterForm = ({
 
           {Array.isArray(stadsdeel) && stadsdeel.length > 0 && (
             <FilterGroup data-testid="stadsdeelFilterGroup">
-              <Label htmlFor={`status_${stadsdeel[0].key}`} isGroupHeader>Stadsdeel</Label>
+              <Label htmlFor={`status_${stadsdeel[0].key}`} isGroupHeader>
+                Stadsdeel
+              </Label>
               <CheckboxList
                 defaultValue={
                   filterData.options && filterData.options.stadsdeel
@@ -216,7 +233,9 @@ const FilterForm = ({
 
           {Array.isArray(priority) && priority.length > 0 && (
             <FilterGroup data-testid="priorityFilterGroup">
-              <Label htmlFor={`status_${priority[0].key}`} isGroupHeader>Urgentie</Label>
+              <Label htmlFor={`status_${priority[0].key}`} isGroupHeader>
+                Urgentie
+              </Label>
               <RadioButtonList
                 defaultValue={filterData.options && filterData.options.priority}
                 groupName="priority"
@@ -227,7 +246,9 @@ const FilterForm = ({
 
           {Array.isArray(feedback) && feedback.length > 0 && (
             <FilterGroup data-testid="feedbackFilterGroup">
-              <Label htmlFor={`feedback_${feedback[0].key}`} isGroupHeader>Feedback</Label>
+              <Label htmlFor={`feedback_${feedback[0].key}`} isGroupHeader>
+                Feedback
+              </Label>
               <RadioButtonList
                 defaultValue={filterData.options && filterData.options.feedback}
                 groupName="feedback"
@@ -237,7 +258,9 @@ const FilterForm = ({
           )}
 
           <FilterGroup>
-            <Label htmlFor="filter_date" isGroupHeader>Datum</Label>
+            <Label htmlFor="filter_date" isGroupHeader>
+              Datum
+            </Label>
             <div className="invoer">
               <DatePicker
                 autoComplete="off"
@@ -279,7 +302,9 @@ const FilterForm = ({
           </FilterGroup>
 
           <FilterGroup>
-            <Label htmlFor="filter_address" isGroupHeader>Adres</Label>
+            <Label htmlFor="filter_address" isGroupHeader>
+              Adres
+            </Label>
             <div className="invoer">
               <input
                 type="text"
@@ -292,7 +317,9 @@ const FilterForm = ({
 
           {Array.isArray(source) && source.length > 0 && (
             <FilterGroup data-testid="sourceFilterGroup">
-              <Label htmlFor={`source_${source[0].key}`} isGroupHeader>Bron</Label>
+              <Label htmlFor={`source_${source[0].key}`} isGroupHeader>
+                Bron
+              </Label>
               <CheckboxList
                 defaultValue={filterData.options && filterData.options.source}
                 groupName="source"

--- a/src/signals/incident-management/reducer.js
+++ b/src/signals/incident-management/reducer.js
@@ -88,7 +88,7 @@ export default (state = initialState, action) => {
 
     case CLEAR_FILTER:
       return state
-        .set('editFilter', state.get('editFilter'))
+        .set('editFilter', initialState.get('editFilter'))
         .set('error', false)
         .set('errorMessage', undefined)
         .set('loading', false);


### PR DESCRIPTION
This PR fixes an issue where, when the filter form was reset, the global store wasn't properly updated and, as a result, rendered the `FilterForm` component with the wrong data.

In addition, this PR:
- contains fixes for tests for the `FilterForm` component
- wraps functions with `useCallback`
- fixes another issue with the `name` field where its contents couldn't be altered after resetting the form (replacing `defaultValue` with `value`)
- makes specific props required instead of leaving them optional