### PR TITLE
[SIG-2038] Date field helper components

### DIFF
--- a/src/signals/incident-management/components/CalendarInput/CustomInput.js
+++ b/src/signals/incident-management/components/CalendarInput/CustomInput.js
@@ -1,0 +1,46 @@
+import React, { Fragment } from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { Calendar } from '@datapunt/asc-assets';
+import { styles } from '@datapunt/asc-ui';
+
+import Label from '../Label';
+
+const InputWrapper = styled.div`
+  position: relative;
+  svg {
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    right: 10px;
+    pointer-events: none;
+  }
+`;
+
+// Using explicit reference to defined styles for Input component; using the Input component itself
+// will throw warnings, because react-datepicker cannot get a ref to the HTMLElement that is rendered
+// by the Input component
+const Input = styled.input`
+  ${styles.InputStyle.componentStyle.rules}
+`;
+
+const CustomInput = React.forwardRef(({ id, label, ...props }, ref) => (
+  <Fragment>
+    <Label htmlFor={id}>{label}</Label>
+
+    <InputWrapper data-testid="calendarCustomInputElement">
+      <Input id={id} {...props} ref={ref} />
+      <Calendar width={24} height={24} />
+    </InputWrapper>
+  </Fragment>
+));
+
+CustomInput.propTypes = {
+  /** HTMLLabelElement text label */
+  label: PropTypes.string.isRequired,
+  /** HTMLInputElement id attribute; used for referencing with an HTMLLabelElement */
+  id: PropTypes.string.isRequired,
+  /** The rest of the props is passed by react-datepicker itself */
+};
+
+export default CustomInput;

--- a/src/signals/incident-management/components/CalendarInput/__tests__/CalendarInput.test.js
+++ b/src/signals/incident-management/components/CalendarInput/__tests__/CalendarInput.test.js
@@ -1,0 +1,74 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import moment from 'moment';
+
+import { withAppContext } from 'test/utils';
+
+import CalendarInput from '..';
+
+const calendarInputProps = {
+  id: 'foo',
+  label: 'Here be dragons',
+  name: 'my_date_field',
+  onSelect: () => {},
+};
+
+describe('signals/incident-management/components/CalendarInput', () => {
+  it('renders a datepicker component', () => {
+    render(withAppContext(<CalendarInput {...calendarInputProps} />));
+
+    expect(
+      document.querySelectorAll('[class*=react-datepicker]').length
+    ).toBeGreaterThan(0);
+  });
+
+  it('renders a CustomInput component', () => {
+    const { getByTestId } = render(
+      withAppContext(<CalendarInput {...calendarInputProps} />)
+    );
+
+    expect(getByTestId('calendarCustomInputElement')).toBeInTheDocument();
+  });
+
+  it('renders a hidden input field', () => {
+    const { rerender } = render(
+      withAppContext(<CalendarInput {...calendarInputProps} />)
+    );
+
+    expect(
+      document.querySelector('input[type=hidden]')
+    ).not.toBeInTheDocument();
+
+    const selectedDate = moment();
+
+    rerender(
+      withAppContext(
+        <CalendarInput {...calendarInputProps} selectedDate={selectedDate} />
+      )
+    );
+
+    expect(document.querySelector('input[type=hidden]')).toBeInTheDocument();
+  });
+
+  it('should call onSelect', () => {
+    const onSelect = jest.fn();
+    const id = 'qux';
+
+    render(
+      withAppContext(
+        <CalendarInput {...calendarInputProps} id={id} onSelect={onSelect} />
+      )
+    );
+
+    const inputElement = document.getElementById(id);
+
+    expect(onSelect).not.toHaveBeenCalled();
+
+    fireEvent.change(inputElement, { target: { value: '18-12-2018' } });
+
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.any(moment),
+      expect.any(Object)
+    );
+  });
+});

--- a/src/signals/incident-management/components/CalendarInput/__tests__/CustomInput.test.js
+++ b/src/signals/incident-management/components/CalendarInput/__tests__/CustomInput.test.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { withAppContext } from 'test/utils';
+
+import CustomInput from '../CustomInput';
+
+const label = 'Here be dragons';
+const id = 'input_date_created_before';
+
+describe('signals/incident-management/components/CalendarInput/CustomInput', () => {
+  it('renders correctly', () => {
+    const { getByLabelText } = render(withAppContext(
+      <CustomInput label={label} id={id} />
+    ));
+
+    expect(document.getElementById(id)).toBeInTheDocument();
+    expect(getByLabelText(label)).toBeInTheDocument();
+    expect(document.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('should accept extra props', () => {
+    const name = 'date_created_before';
+    render(withAppContext(
+      <CustomInput label={label} id={id} name={name} readOnly />
+    ));
+
+    expect(document.querySelector(`input[name=${name}]`)).toBeInTheDocument();
+    expect(document.querySelector(`input[readonly]`)).toBeInTheDocument();
+  });
+});

--- a/src/signals/incident-management/components/CalendarInput/index.js
+++ b/src/signals/incident-management/components/CalendarInput/index.js
@@ -1,0 +1,51 @@
+import React, { Fragment } from 'react';
+import PropTypes from 'prop-types';
+import DatePicker from 'react-datepicker';
+import moment from 'moment';
+import CustomInput from './CustomInput';
+
+const CalendarInput = ({ id, label, name, onSelect, selectedDate }) => (
+  <Fragment>
+    <DatePicker
+      autoComplete="off"
+      customInput={<CustomInput label={label} id={id} />}
+      dateFormat="DD-MM-YYYY"
+      id={id}
+      locale="nl"
+      onSelect={onSelect}
+      selected={selectedDate}
+    />
+
+    {selectedDate && (
+      <input
+        value={selectedDate.format('YYYY-MM-DD')}
+        name={name}
+        readOnly
+        type="hidden"
+      />
+    )}
+  </Fragment>
+);
+
+CalendarInput.defaultProps = {
+  selectedDate: null,
+};
+
+CalendarInput.propTypes = {
+  /** HTMLInputElement id attribute; used for referencing with an HTMLLabelElement */
+  id: PropTypes.string.isRequired,
+  /** HTMLLabelElement text label */
+  label: PropTypes.string.isRequired,
+  /** HTMLInputElement name attribute value */
+  name: PropTypes.string.isRequired,
+  /**
+   * Date selection callback function
+   * @param {String} dateValue - Date value formatted by Moment
+   * @param {Event} event - Object from the event that triggered the callback
+   */
+  onSelect: PropTypes.func.isRequired,
+  /** Date value */
+  selectedDate: PropTypes.instanceOf(moment),
+};
+
+export default CalendarInput;

--- a/src/signals/incident-management/components/CalendarInput/index.js
+++ b/src/signals/incident-management/components/CalendarInput/index.js
@@ -10,6 +10,7 @@ const CalendarInput = ({ id, label, name, onSelect, selectedDate }) => (
       autoComplete="off"
       customInput={<CustomInput label={label} id={id} />}
       dateFormat="DD-MM-YYYY"
+      id={id}
       locale="nl"
       onSelect={onSelect}
       selected={selectedDate}

--- a/src/signals/incident-management/components/CalendarInput/index.js
+++ b/src/signals/incident-management/components/CalendarInput/index.js
@@ -10,7 +10,6 @@ const CalendarInput = ({ id, label, name, onSelect, selectedDate }) => (
       autoComplete="off"
       customInput={<CustomInput label={label} id={id} />}
       dateFormat="DD-MM-YYYY"
-      id={id}
       locale="nl"
       onSelect={onSelect}
       selected={selectedDate}


### PR DESCRIPTION
This PR adds the `CalendarInput` and `CustomInput` components. They both are needed to render a date input field like so:
![Screenshot 2019-12-19 at 07 30 33](https://user-images.githubusercontent.com/1062191/71150430-bb56ef00-2231-11ea-9346-2fb961791ad1.png)
instead of:
![Screenshot 2019-12-19 at 07 31 00](https://user-images.githubusercontent.com/1062191/71150442-c27dfd00-2231-11ea-9e5f-89496a4b37b4.png)
