### PR TITLE
[SIG-2004] Date fields

### DIFF
--- a/src/shared/types/index.js
+++ b/src/shared/types/index.js
@@ -49,8 +49,9 @@ export const apiFilterType = PropTypes.shape({
   options: PropTypes.shape({
     address_text: PropTypes.string,
     category_slug: PropTypes.arrayOf(PropTypes.string),
+    created_after: PropTypes.string,
+    created_before: PropTypes.string,
     feedback: PropTypes.string,
-    incident_date: PropTypes.string,
     maincategory_slug: PropTypes.arrayOf(PropTypes.string),
     priority: PropTypes.arrayOf(PropTypes.string),
     stadsdeel: PropTypes.arrayOf(PropTypes.string),
@@ -69,8 +70,9 @@ export const filterType = PropTypes.shape({
   options: PropTypes.shape({
     address_text: PropTypes.string,
     category_slug: PropTypes.arrayOf(dataItemType),
+    created_after: PropTypes.string,
+    created_before: PropTypes.string,
     feedback: PropTypes.string,
-    incident_date: PropTypes.string,
     maincategory_slug: PropTypes.arrayOf(dataItemType),
     priority: PropTypes.string,
     stadsdeel: PropTypes.arrayOf(dataItemType),

--- a/src/signals/incident-management/components/FilterForm/__test__/FilterForm.test.js
+++ b/src/signals/incident-management/components/FilterForm/__test__/FilterForm.test.js
@@ -528,8 +528,7 @@ describe('signals/incident-management/components/FilterForm', () => {
       const { container } = render(
         withAppContext(
           <FilterForm
-            {...formProps}
-            {...handlers}
+            {...{...formProps, ...handlers}}
             filter={{
               name: '',
               options: { incident_date: '1970-01-01' },
@@ -567,8 +566,7 @@ describe('signals/incident-management/components/FilterForm', () => {
       const { container } = render(
         withAppContext(
           <FilterForm
-            {...formProps}
-            {...handlers}
+            {...{...formProps, ...handlers}}
             filter={{
               name: 'My filter',
               options: {

--- a/src/signals/incident-management/components/FilterForm/__test__/FilterForm.test.js
+++ b/src/signals/incident-management/components/FilterForm/__test__/FilterForm.test.js
@@ -384,8 +384,8 @@ describe('signals/incident-management/components/FilterForm', () => {
     ).toHaveLength(dataLists.source.length);
   });
 
-  it('should render a datepicker', () => {
-    const { container, rerender } = render(
+  it('should render datepickers', () => {
+    render(
       withAppContext(
         <FilterForm
           {...formProps}
@@ -394,28 +394,50 @@ describe('signals/incident-management/components/FilterForm', () => {
       ),
     );
 
-    expect(
-      container.querySelectorAll('input[type="hidden"][name="incident_date"]'),
-    ).toHaveLength(0);
+    expect(document.getElementById('filter_created_before')).toBeInTheDocument();
+    expect(document.getElementById('filter_created_after')).toBeInTheDocument();
+  });
 
-    expect(document.getElementById('filter_date')).toBeTruthy();
-
-    cleanup();
-
-    // rerendering, because react-datepicker interaction isn't testable
-    rerender(
+  it('should update the state on created before date select', () => {
+    render(
       withAppContext(
         <FilterForm
           {...formProps}
-          filter={{ options: { incident_date: '1970-01-01' } }}
           dataLists={dataLists}
         />,
       ),
     );
 
-    expect(
-      container.querySelectorAll('input[type="hidden"][name="incident_date"]'),
-    ).toHaveLength(1);
+    const value = '18-12-2018';
+    const inputElement = document.getElementById('filter_created_before');
+
+    // selecting a date from the datepicker will render a hidden input
+    expect(document.querySelector('input[name=created_before]')).not.toBeInTheDocument();
+
+    fireEvent.change(inputElement, { target: { value } });
+
+    expect(document.querySelector('input[name=created_before]')).toBeInTheDocument();
+  });
+
+  it('should update the state on created after date select', () => {
+    render(
+      withAppContext(
+        <FilterForm
+          {...formProps}
+          dataLists={dataLists}
+        />,
+      ),
+    );
+
+    const value = '23-12-2018';
+    const inputElement = document.getElementById('filter_created_after');
+
+    // selecting a date from the datepicker will render a hidden input
+    expect(document.querySelector('input[name=created_after]')).not.toBeInTheDocument();
+
+    fireEvent.change(inputElement, { target: { value } });
+
+    expect(document.querySelector('input[name=created_after]')).toBeInTheDocument();
   });
 
   // Note that jsdom has a bug where `submit` and `reset` handlers are not called when those handlers
@@ -436,7 +458,7 @@ describe('signals/incident-management/components/FilterForm', () => {
     const nameField = container.querySelector(
       'input[type="text"][name="name"]',
     );
-    const dateField = container.querySelector('input[id="filter_date"]');
+    const dateField = container.querySelector('input[id="filter_created_before"]');
     const addressField = container.querySelector(
       'input[type="text"][name="address_text"]',
     );

--- a/src/signals/incident-management/components/FilterForm/__test__/FilterForm.test.js
+++ b/src/signals/incident-management/components/FilterForm/__test__/FilterForm.test.js
@@ -553,7 +553,7 @@ describe('signals/incident-management/components/FilterForm', () => {
       fireEvent.change(nameField, { target: { value: 'New name' }});
       fireEvent.click(container.querySelector('button[type="submit"]'));
 
-      expect(handlers.onSaveFilter).toHaveBeenCalled();
+      expect(handlers.onSaveFilter).toHaveBeenCalledTimes(1);
     });
 
     it('should handle submit for existing filter', () => {

--- a/src/signals/incident-management/components/FilterForm/styled.js
+++ b/src/signals/incident-management/components/FilterForm/styled.js
@@ -1,5 +1,5 @@
 import styled, { css } from 'styled-components';
-import { Button, Column, themeColor } from '@datapunt/asc-ui';
+import { Button, Column, themeColor, themeSpacing } from '@datapunt/asc-ui';
 
 export const Form = styled.form`
   column-count: 2;
@@ -95,4 +95,11 @@ export const Fieldset = styled.fieldset`
     background-color: #f5f5f5;
     padding: 15px 20px;
   `}
+`;
+
+export const DatesWrapper = styled.div`
+  display: flex;
+  & > * + * {
+    margin-left: ${themeSpacing(5)};
+  }
 `;

--- a/src/signals/incident-management/containers/FilterTagList/__tests__/FilterTagList.test.js
+++ b/src/signals/incident-management/containers/FilterTagList/__tests__/FilterTagList.test.js
@@ -43,20 +43,61 @@ describe('signals/incident-management/containers/FilterTagList', () => {
     expect(props.categories).not.toBeUndefined();
   });
 
-  it('formats a date value', () => {
-    const { queryByText } = render(
-      withIntlAppContext(
-        <FilterTagListComponent
-          dataLists={dataLists}
-          tags={tags}
-          categories={categories}
-        />,
-        translations,
-      ),
-    );
+  describe('date formatting', () => {
+    it('renders created before', () => {
+      const { queryByText } = render(
+        withIntlAppContext(
+          <FilterTagListComponent
+            dataLists={dataLists}
+            tags={{ ...tags, created_before: '2019-09-23' }}
+            categories={categories}
+          />,
+          translations
+        )
+      );
 
-    expect(queryByText(tags.incident_date)).not.toBeInTheDocument();
-    expect(queryByText('17-09-2019')).toBeInTheDocument();
+      const createdBeforeLabel = 'Datum: t/m 23-09-2019';
+
+      expect(queryByText(createdBeforeLabel)).toBeInTheDocument();
+    });
+
+    it('renders date after', () => {
+      const { queryByText } = render(
+        withIntlAppContext(
+          <FilterTagListComponent
+            dataLists={dataLists}
+            tags={{ ...tags, created_after: '2019-09-17' }}
+            categories={categories}
+          />,
+          translations
+        )
+      );
+
+      const createdAfterLabel = 'Datum: 17-09-2019 t/m nu';
+
+      expect(queryByText(createdAfterLabel)).toBeInTheDocument();
+    });
+
+    it('renders both date after and date before', () => {
+      const { queryByText } = render(
+        withIntlAppContext(
+          <FilterTagListComponent
+            dataLists={dataLists}
+            tags={{
+              ...tags,
+              created_before: '2019-09-23',
+              created_after: '2019-09-17',
+            }}
+            categories={categories}
+          />,
+          translations
+        )
+      );
+
+      const createdBeforeAfterLabel = 'Datum: 17-09-2019 t/m 23-09-2019';
+
+      expect(queryByText(createdBeforeAfterLabel)).toBeInTheDocument();
+    });
   });
 
   describe('tags list', () => {

--- a/src/signals/incident-management/containers/FilterTagList/index.js
+++ b/src/signals/incident-management/containers/FilterTagList/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo} from 'react';
 import { connect } from 'react-redux';
 import { createStructuredSelector } from 'reselect';
 import styled from 'styled-components';
@@ -29,18 +29,13 @@ const renderTag = (key, mainCategories, list) => {
   let display = (found && found.value) || key;
 
   if (!display) {
-    return;
-  }
-
-  if (moment(display, 'YYYY-MM-DD', true).isValid()) {
-    display = moment(display).format('DD-MM-YYYY');
+    return null;
   }
 
   const foundMain = mainCategories.find(i => i.key === key);
 
   display += foundMain ? allLabelAppend : '';
 
-  // eslint-disable-next-line consistent-return
   return (
     <StyledTag
       colorType="tint"
@@ -66,9 +61,34 @@ export const FilterTagListComponent = props => {
     category_slug: sub,
   };
 
+  const tagsList = { ...tags };
+
+  // piece together date strings into one tag
+  const dateRange = useMemo(() => {
+    if (!tagsList.created_after && !tagsList.created_before) return undefined;
+
+    return [
+      'Datum:',
+      tagsList.created_after && moment(tagsList.created_after).format('DD-MM-YYYY'),
+      't/m',
+      (tagsList.created_before &&
+        moment(tagsList.created_before).format('DD-MM-YYYY')) ||
+        'nu',
+    ]
+      .filter(Boolean)
+      .join(' ');
+  }, [tagsList.created_after, tagsList.created_before]);
+
+  if (dateRange) {
+    delete tagsList.created_after;
+    delete tagsList.created_before;
+
+    tagsList.dateRange = dateRange;
+  }
+
   return (
     <FilterWrapper className="incident-overview-page__filter-tag-list">
-      {Object.entries(tags).map(([tagKey, tag]) =>
+      {Object.entries(tagsList).map(([tagKey, tag]) =>
         Array.isArray(tag)
           ? tag.map(item => renderTag(item.key, main, map[tagKey]))
           : renderTag(tag, main, map[tagKey])

--- a/src/signals/incident-management/containers/IncidentOverviewPage/index.js
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/index.js
@@ -11,7 +11,6 @@ import MyFilters from 'signals/incident-management/containers/MyFilters';
 import PageHeader from 'containers/PageHeader';
 import injectSaga from 'utils/injectSaga';
 import injectReducer from 'utils/injectReducer';
-import { makeSelectCategories } from 'containers/App/selectors';
 import {
   makeSelectDataLists,
   makeSelectActiveFilter,
@@ -202,7 +201,6 @@ IncidentOverviewPageContainerComponent.defaultProps = {
 
 IncidentOverviewPageContainerComponent.propTypes = {
   activeFilter: types.filterType,
-  categories: types.categoriesType.isRequired,
   dataLists: types.dataListsType.isRequired,
   incidentsCount: PropTypes.number,
   onChangeOrdering: PropTypes.func.isRequired,
@@ -215,7 +213,6 @@ IncidentOverviewPageContainerComponent.propTypes = {
 
 const mapStateToProps = createStructuredSelector({
   activeFilter: makeSelectActiveFilter,
-  categories: makeSelectCategories(),
   dataLists: makeSelectDataLists,
   incidentsCount: makeSelectIncidentsCount,
   ordering: makeSelectOrdering,

--- a/src/signals/incident-management/containers/IncidentOverviewPage/index.test.js
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/index.test.js
@@ -24,8 +24,10 @@ jest.mock('scroll-lock');
 jest.mock('signals/incident-management/constants');
 jest.mock('signals/incident-management/actions', () => {
   const actual = jest.requireActual('signals/incident-management/actions');
-  // eslint-disable-next-line
-  const { PAGE_INCIDENTS_CHANGED } = require('signals/incident-management/constants');
+  const {
+    PAGE_INCIDENTS_CHANGED,
+    // eslint-disable-next-line
+  } = require('signals/incident-management/constants');
 
   return {
     __esModule: true,
@@ -117,8 +119,12 @@ describe('signals/incident-management/containers/IncidentOverviewPage', () => {
       .find(IncidentOverviewPageContainerComponent)
       .props();
 
+    expect(containerProps.activeFilter).not.toBeUndefined();
     expect(containerProps.overviewpage).not.toBeUndefined();
-    expect(containerProps.categories).not.toBeUndefined();
+    expect(containerProps.dataLists).not.toBeUndefined();
+    expect(containerProps.incidentsCount).not.toBeUndefined();
+    expect(containerProps.ordering).not.toBeUndefined();
+    expect(containerProps.page).not.toBeUndefined();
   });
 
   it('should have props from action creator', () => {
@@ -141,7 +147,7 @@ describe('signals/incident-management/containers/IncidentOverviewPage', () => {
   it('should scroll page to top after navigating with pagination', () => {
     constants.FILTER_PAGE_SIZE = 30;
     Object.defineProperty(window, 'scrollTo', {
-      value: () => { },
+      value: () => {},
       writable: true,
     });
     const scrollSpy = jest.spyOn(window, 'scrollTo');

--- a/src/signals/shared/filter/__tests__/parse.test.js
+++ b/src/signals/shared/filter/__tests__/parse.test.js
@@ -3,92 +3,136 @@ import statusList from 'signals/incident-management/definitions/statusList';
 import stadsdeelList from 'signals/incident-management/definitions/stadsdeelList';
 import categories from 'utils/__tests__/fixtures/categories.json';
 
-import { parseOutputFormData, parseInputFormData } from '../parse';
+import {
+  parseOutputFormData,
+  parseInputFormData,
+  parseFromAPIData,
+  parseToAPIData,
+} from '../parse';
 
 describe('signals/shared/parse', () => {
-  it('should parse output FormData', () => {
-    const form = document.createElement('form');
-    const nameField = document.createElement('input');
-    nameField.setAttribute('type', 'text');
-    nameField.setAttribute('name', 'name');
-    nameField.setAttribute('value', 'Afval in Westpoort');
-    nameField.checked = true;
-    form.appendChild(nameField);
+  const dataLists = {
+    stadsdeel: stadsdeelList,
+    maincategory_slug: categories.main,
+    priority: priorityList,
+    status: statusList,
+    category_slug: categories.sub,
+  };
 
-    const toggle = document.createElement('input');
-    toggle.setAttribute('type', 'checkbox');
-    toggle.setAttribute('name', 'maincategory_slug');
-    toggle.setAttribute('value', 'afval');
-    toggle.checked = true;
-    form.appendChild(toggle);
+  describe('parseOutputFormData', () => {
+    it('should parse output FormData', () => {
+      const form = document.createElement('form');
+      const nameField = document.createElement('input');
+      nameField.setAttribute('type', 'text');
+      nameField.setAttribute('name', 'name');
+      nameField.setAttribute('value', 'Afval in Westpoort');
+      nameField.checked = true;
+      form.appendChild(nameField);
 
-    const individualCheckbox1 = document.createElement('input');
-    individualCheckbox1.setAttribute('type', 'checkbox');
-    individualCheckbox1.setAttribute('name', 'drijfvuil_category_slug');
-    individualCheckbox1.setAttribute('value', 'drijfvuil');
-    individualCheckbox1.checked = true;
-    form.appendChild(individualCheckbox1);
+      const toggle = document.createElement('input');
+      toggle.setAttribute('type', 'checkbox');
+      toggle.setAttribute('name', 'maincategory_slug');
+      toggle.setAttribute('value', 'afval');
+      toggle.checked = true;
+      form.appendChild(toggle);
 
-    const expected1 = {
-      name: 'Afval in Westpoort',
-      refresh: false,
-      options: {
-        maincategory_slug: ['afval'],
-        category_slug: ['drijfvuil'],
-      },
-    };
+      const individualCheckbox1 = document.createElement('input');
+      individualCheckbox1.setAttribute('type', 'checkbox');
+      individualCheckbox1.setAttribute('name', 'drijfvuil_category_slug');
+      individualCheckbox1.setAttribute('value', 'drijfvuil');
+      individualCheckbox1.checked = true;
+      form.appendChild(individualCheckbox1);
 
-    const parsedOutput1 = parseOutputFormData(form);
+      const expected1 = {
+        name: 'Afval in Westpoort',
+        refresh: false,
+        options: {
+          maincategory_slug: ['afval'],
+          category_slug: ['drijfvuil'],
+        },
+      };
 
-    expect(parsedOutput1).toEqual(expected1);
+      const parsedOutput1 = parseOutputFormData(form);
 
-    const individualCheckbox2 = document.createElement('input');
-    individualCheckbox2.setAttribute('type', 'checkbox');
-    individualCheckbox2.setAttribute('name', 'maaien-snoeien_category_slug');
-    individualCheckbox2.setAttribute('value', 'maaien-snoeien');
-    individualCheckbox2.checked = true;
-    form.appendChild(individualCheckbox2);
+      expect(parsedOutput1).toEqual(expected1);
 
-    const individualCheckbox3 = document.createElement('input');
-    individualCheckbox3.setAttribute('type', 'checkbox');
-    individualCheckbox3.setAttribute('name', 'maaien-snoeien_category_slug');
-    individualCheckbox3.setAttribute('value', 'maaien-snoeien-2');
-    individualCheckbox3.checked = true;
-    form.appendChild(individualCheckbox3);
+      const individualCheckbox2 = document.createElement('input');
+      individualCheckbox2.setAttribute('type', 'checkbox');
+      individualCheckbox2.setAttribute('name', 'maaien-snoeien_category_slug');
+      individualCheckbox2.setAttribute('value', 'maaien-snoeien');
+      individualCheckbox2.checked = true;
+      form.appendChild(individualCheckbox2);
 
-    const toggle2 = document.createElement('input');
-    toggle2.setAttribute('type', 'checkbox');
-    toggle2.setAttribute('name', 'maincategory_slug');
-    toggle2.setAttribute('value', 'wegen-verkeer-straatmeubilair');
-    toggle2.checked = true;
-    form.appendChild(toggle2);
+      const individualCheckbox3 = document.createElement('input');
+      individualCheckbox3.setAttribute('type', 'checkbox');
+      individualCheckbox3.setAttribute('name', 'maaien-snoeien_category_slug');
+      individualCheckbox3.setAttribute('value', 'maaien-snoeien-2');
+      individualCheckbox3.checked = true;
+      form.appendChild(individualCheckbox3);
 
-    const expected2 = {
-      name: 'Afval in Westpoort',
-      refresh: false,
-      options: {
-        maincategory_slug: ['afval', 'wegen-verkeer-straatmeubilair'],
-        category_slug: ['drijfvuil', 'maaien-snoeien', 'maaien-snoeien-2'],
-      },
-    };
+      const toggle2 = document.createElement('input');
+      toggle2.setAttribute('type', 'checkbox');
+      toggle2.setAttribute('name', 'maincategory_slug');
+      toggle2.setAttribute('value', 'wegen-verkeer-straatmeubilair');
+      toggle2.checked = true;
+      form.appendChild(toggle2);
 
-    const parsedOutput2 = parseOutputFormData(form);
+      const expected2 = {
+        name: 'Afval in Westpoort',
+        refresh: false,
+        options: {
+          maincategory_slug: ['afval', 'wegen-verkeer-straatmeubilair'],
+          category_slug: ['drijfvuil', 'maaien-snoeien', 'maaien-snoeien-2'],
+        },
+      };
 
-    expect(parsedOutput2).toEqual(expected2);
+      const parsedOutput2 = parseOutputFormData(form);
+
+      expect(parsedOutput2).toEqual(expected2);
+    });
+
+    it('should format date values', () => {
+      const form = document.createElement('form');
+      const dateCreatedBefore = document.createElement('input');
+      dateCreatedBefore.name = 'created_before';
+      dateCreatedBefore.setAttribute('value', '2019-12-19');
+      form.appendChild(dateCreatedBefore);
+
+      const dateCreatedAfter = document.createElement('input');
+      dateCreatedAfter.name = 'created_after';
+      dateCreatedAfter.setAttribute('value', '2019-12-10');
+      form.appendChild(dateCreatedAfter);
+
+      const expected = {
+        refresh: false,
+        options: {
+          created_before: '2019-12-19T23:59:59',
+          created_after: '2019-12-10T00:00:00',
+        },
+      };
+
+      const parsedOutput = parseOutputFormData(form);
+
+      expect(parsedOutput).toEqual(expected);
+    });
   });
 
-  it('should parse input FormData', () => {
+  describe('parseInputFormData', () => {
     const input = {
       name: 'Afval in Westpoort',
       options: {
         stadsdeel: ['B'],
         address_text: '',
         maincategory_slug: ['afval'],
-        category_slug: ['maaien-snoeien', 'onkruid', 'autom-verzinkbare-palen'],
+        category_slug: [
+          'maaien-snoeien',
+          'onkruid',
+          'autom-verzinkbare-palen',
+        ],
       },
     };
 
-    const expected = {
+    const output = {
       name: 'Afval in Westpoort',
       stadsdeel: [
         {
@@ -99,7 +143,8 @@ describe('signals/shared/parse', () => {
       address_text: '',
       maincategory_slug: [
         {
-          key: 'https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/afval',
+          key:
+            'https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/afval',
           slug: 'afval',
           value: 'Afval',
         },
@@ -135,16 +180,49 @@ describe('signals/shared/parse', () => {
       ],
     };
 
-    const dataLists = {
-      stadsdeel: stadsdeelList,
-      maincategory_slug: categories.main,
-      priority: priorityList,
-      status: statusList,
-      category_slug: categories.sub,
-    };
+    it('should parse input FormData', () => {
+      const parsedInput = parseInputFormData(input, dataLists);
 
-    const parsedInput = parseInputFormData(input, dataLists);
+      expect(parsedInput).toEqual(output);
+    });
 
-    expect(parsedInput).toEqual(expected);
+    it('should return an empty object', () => {
+      expect(parseInputFormData({}, dataLists)).toEqual({});
+      expect(parseInputFormData({ options: {} }, dataLists)).toEqual({});
+    });
+
+    describe('parseFromAPIData', () => {
+      it('should return an object', () => {
+        // empty API data equals the default initial state value for activeFilter
+        const emptyAPIData = {
+          name: '',
+          options: {},
+        };
+
+        const undefinedValues = { id: undefined, refresh: undefined };
+
+        const expected = { ...undefinedValues, ...emptyAPIData };
+
+        expect(parseFromAPIData(emptyAPIData, dataLists)).toEqual(expected);
+
+        const expectedOutput = { options: output, name: input.name };
+        delete expectedOutput.options.name;
+
+        expect(parseFromAPIData(input, dataLists)).toEqual(expectedOutput);
+      });
+    });
+
+    describe('parseToAPIData', () => {
+      it('should return an object', () => {
+        const filterData = { id: 123, name: 'foo' };
+
+        expect(parseToAPIData(filterData)).toEqual({ options: {}, id: 123, name: 'foo' });
+
+        filterData.options = output;
+        delete filterData.options.name;
+
+        expect(parseToAPIData(filterData)).toEqual({ ...input, id: 123, name: 'foo' });
+      });
+    });
   });
 });

--- a/src/signals/shared/filter/parse.js
+++ b/src/signals/shared/filter/parse.js
@@ -86,6 +86,7 @@ export const parseOutputFormData = form => {
  * Turns scalar values into arrays where necessary and replaces keys and slugs with objects
  *
  * @param   {Object} filterData - Data to be passed on to the form
+ * @param   {Object} filterData.options - options key/value object
  * @param   {Object} dataLists - collection of fixtures that is used to enrich the filter data with
  * @returns {Object}
  */
@@ -95,18 +96,7 @@ export const parseInputFormData = (filterData, dataLists) => {
   parsed.id = filterData.id;
   parsed.refresh = filterData.refresh;
 
-  /* istanbul ignore else */
   if (Object.keys(filterData).length) {
-    // convert scalar values to arrays
-    Object.keys(filterData).forEach(fieldName => {
-      if (
-        arrayFields.includes(fieldName)
-        && !Array.isArray(filterData[fieldName])
-      ) {
-        parsed[fieldName] = [filterData[fieldName]];
-      }
-    });
-
     // replace string entries in filter data with objects from dataLists
     Object.keys(parsed)
       .filter(fieldName => arrayFields.includes(fieldName))
@@ -115,16 +105,6 @@ export const parseInputFormData = (filterData, dataLists) => {
           ({ key, slug }) => key === value || slug === value,
         ),);
       });
-  }
-
-  // before/after params include the time which we don't need in the filter form
-  // returning values that only have the date
-  if (moment(parsed.created_before, 'YYYY-MM-DD', true).toISOString() !== null) {
-    parsed.created_before = moment(parsed.created_before).format('YYYY-MM-DD');
-  }
-
-  if (moment(parsed.created_after, 'YYYY-MM-DD', true).toISOString() !== null) {
-    parsed.created_after = moment(parsed.created_after).format('YYYY-MM-DD');
   }
 
   return parsed;

--- a/src/signals/shared/filter/parse.js
+++ b/src/signals/shared/filter/parse.js
@@ -1,4 +1,5 @@
 import clonedeep from 'lodash.clonedeep';
+import moment from 'moment';
 
 const arrayFields = [
   'stadsdeel',
@@ -64,6 +65,16 @@ export const parseOutputFormData = form => {
     name, refresh, id, ...options
   } = parsed;
 
+  // before/after params require a specific format that includes the time
+  // since `created_before` means before and including, we add a day
+  if (moment(options.created_before, 'YYYY-MM-DD').toISOString() !== null) {
+    options.created_before = moment(options.created_before).set({ hours: 23, minutes: 59, seconds: 59 }).format('YYYY-MM-DDTkk:mm:ss');
+  }
+
+  if (moment(options.created_after, 'YYYY-MM-DD').toISOString() !== null) {
+    options.created_after = moment(options.created_after).format('YYYY-MM-DDT00:00:00');
+  }
+
   return {
     name, refresh: !!refresh, id, options,
   };
@@ -104,6 +115,16 @@ export const parseInputFormData = (filterData, dataLists) => {
           ({ key, slug }) => key === value || slug === value,
         ),);
       });
+  }
+
+  // before/after params include the time which we don't need in the filter form
+  // returning values that only have the date
+  if (moment(parsed.created_before, 'YYYY-MM-DD', true).toISOString() !== null) {
+    parsed.created_before = moment(parsed.created_before).format('YYYY-MM-DD');
+  }
+
+  if (moment(parsed.created_after, 'YYYY-MM-DD', true).toISOString() !== null) {
+    parsed.created_after = moment(parsed.created_after).format('YYYY-MM-DD');
   }
 
   return parsed;


### PR DESCRIPTION
This PR adds an extra date field to the `Filter` form component. The initial field, which was tied to `incident_date` has been replaced by `created_after` and `created_before` filter fields.
Since the date fields should only show dates (no times) and the API expects and returns a string that contains both date and time, incoming and outgoing data are converted to match those requirements.

The `FilterTagList` container needed to combine the possible selected dates into one tag element, so that it can display three different date range options, like so:
- `Datum: 09-12-2019 t/m nu`
- `Datum: 09-12-2019 t/m 24-12-2019`
- `Datum: t/m 24-12-2019`