### PR TITLE
[SIG-2012] Replace auth v0 endpoint

### DIFF
--- a/src/components/SiteHeader/__tests__/SiteHeader.test.js
+++ b/src/components/SiteHeader/__tests__/SiteHeader.test.js
@@ -28,7 +28,7 @@ describe('components/SiteHeader', () => {
     history.push('/');
 
     const { container, rerender, queryByText } = render(
-      withAppContext(<SiteHeader permissions={[]} />)
+      withAppContext(<SiteHeader />)
     );
 
     // menu items
@@ -51,7 +51,7 @@ describe('components/SiteHeader', () => {
 
     history.push('/manage');
 
-    rerender(withAppContext(<SiteHeader permissions={[]} />));
+    rerender(withAppContext(<SiteHeader />));
 
     expect(queryByText('Melden')).toBeNull();
   });
@@ -61,9 +61,7 @@ describe('components/SiteHeader', () => {
 
     history.push('/');
 
-    const { container, queryByText } = render(
-      withAppContext(<SiteHeader permissions={[]} />)
-    );
+    const { container, queryByText } = render(withAppContext(<SiteHeader showItems={{ settings: true, users: true, groups: true }} />));
 
     // menu items
     expect(queryByText('Melden')).not.toBeNull();
@@ -80,7 +78,7 @@ describe('components/SiteHeader', () => {
 
     history.push('/manage');
 
-    render(withAppContext(<SiteHeader permissions={[]} />));
+    render(withAppContext(<SiteHeader showItems={{ settings: true, users: true, groups: true }} />));
 
     // toggle menu should be visible
     expect(document.querySelectorAll('ul[aria-hidden="true"]')).toHaveLength(2);
@@ -91,9 +89,7 @@ describe('components/SiteHeader', () => {
 
     history.push('/');
 
-    const { queryByText } = render(
-      withAppContext(<SiteHeader permissions={[]} />)
-    );
+    const { queryByText } = render(withAppContext(<SiteHeader />));
 
     const title = 'SIA';
 
@@ -106,7 +102,7 @@ describe('components/SiteHeader', () => {
 
     history.push('/');
 
-    render(withAppContext(<SiteHeader permissions={[]} />));
+    render(withAppContext(<SiteHeader />));
 
     // do show title in front office when authenticated
     expect(queryByText(title)).not.toBeNull();
@@ -117,7 +113,7 @@ describe('components/SiteHeader', () => {
 
     history.push('/manage');
 
-    render(withAppContext(<SiteHeader permissions={[]} />));
+    render(withAppContext(<SiteHeader />));
 
     // don't show title in back office when not authenticated
     expect(queryByText(title)).toBeNull();
@@ -126,7 +122,7 @@ describe('components/SiteHeader', () => {
 
     jest.spyOn(auth, 'isAuthenticated').mockImplementation(() => true);
 
-    render(withAppContext(<SiteHeader permissions={[]} />));
+    render(withAppContext(<SiteHeader />));
 
     // do show title in back office when authenticated
     expect(queryByText(title)).not.toBeNull();
@@ -138,9 +134,7 @@ describe('components/SiteHeader', () => {
     history.push('/');
 
     const { container, rerender } = render(
-      withAppContext(
-        <SiteHeader permissions={[]} location={{ pathname: '/' }} />
-      )
+      withAppContext(<SiteHeader location={{ pathname: '/' }} />)
     );
 
     expect(
@@ -151,7 +145,7 @@ describe('components/SiteHeader', () => {
 
     jest.spyOn(auth, 'isAuthenticated').mockImplementation(() => true);
 
-    rerender(withAppContext(<SiteHeader permissions={[]} />));
+    rerender(withAppContext(<SiteHeader />));
 
     expect(
       container.querySelector('.siteHeader').classList.contains('isShort')
@@ -163,7 +157,7 @@ describe('components/SiteHeader', () => {
 
     jest.spyOn(auth, 'isAuthenticated').mockImplementation(() => false);
 
-    rerender(withAppContext(<SiteHeader permissions={[]} />));
+    rerender(withAppContext(<SiteHeader />));
 
     expect(
       container.querySelector('.siteHeader').classList.contains('isTall')
@@ -173,7 +167,7 @@ describe('components/SiteHeader', () => {
 
     jest.spyOn(auth, 'isAuthenticated').mockImplementation(() => true);
 
-    rerender(withAppContext(<SiteHeader permissions={[]} />));
+    rerender(withAppContext(<SiteHeader />));
 
     expect(
       container.querySelector('.siteHeader').classList.contains('isShort')
@@ -184,8 +178,7 @@ describe('components/SiteHeader', () => {
     const { queryByText } = render(
       withAppContext(
         <SiteHeader
-          permissions={['signals.sia_statusmessagetemplate_write']}
-          isAuthenticated
+          showItems={{ defaultTexts: true }}
           location={{ pathname: '/incident/beschrijf' }}
         />
       )
@@ -196,13 +189,7 @@ describe('components/SiteHeader', () => {
 
   it('should render correctly when logged in', () => {
     const { container, queryByText } = render(
-      withAppContext(
-        <SiteHeader
-          isAuthenticated
-          permissions={[]}
-          location={{ pathname: '/' }}
-        />
-      )
+      withAppContext(<SiteHeader location={{ pathname: '/' }} />)
     );
 
     // afhandelen menu item
@@ -223,7 +210,7 @@ describe('components/SiteHeader', () => {
     const onLogOut = jest.fn();
 
     const { getByText } = render(
-      withAppContext(<SiteHeader permissions={[]} onLogOut={onLogOut} />)
+      withAppContext(<SiteHeader onLogOut={onLogOut} />)
     );
 
     const logOutButton = getByText('Uitloggen');

--- a/src/components/SiteHeader/index.js
+++ b/src/components/SiteHeader/index.js
@@ -179,7 +179,7 @@ const HeaderWrapper = styled.div`
     `}
 `;
 
-const MenuItems = ({ onLogOut, show }) => {
+const MenuItems = ({ onLogOut, showItems }) => {
   const showLogout = isAuthenticated();
 
   return (
@@ -203,7 +203,7 @@ const MenuItems = ({ onLogOut, show }) => {
         </StyledMenuButton>
       </MenuItem>
 
-      {show.defaultTexts && (
+      {showItems.defaultTexts && (
         <MenuItem element="span">
           <StyledMenuButton $as={NavLink} to="/manage/standaard/teksten">
             Standaard teksten
@@ -211,15 +211,15 @@ const MenuItems = ({ onLogOut, show }) => {
         </MenuItem>
       )}
 
-      {show.settings && (
+      {showItems.settings && (showItems.users || showItems.groups) && (
         <StyledMenuFlyout label="Instellingen">
-          {show.users && (
+          {showItems.users && (
             <StyledMenuButton $as={NavLink} to="/instellingen/gebruikers">
               Gebruikers
             </StyledMenuButton>
           )}
 
-          {show.groups && (
+          {showItems.groups && (
             <StyledMenuButton $as={NavLink} to="/instellingen/rollen">
               Rollen
             </StyledMenuButton>
@@ -295,11 +295,12 @@ export const SiteHeader = props => {
 
 SiteHeader.defaultProps = {
   onLogOut: undefined,
+  showItems: {},
 };
 
 SiteHeader.propTypes = {
   onLogOut: PropTypes.func,
-  show: PropTypes.shape({}),
+  showItems: PropTypes.shape({}),
 };
 
 MenuItems.propTypes = SiteHeader.propTypes;

--- a/src/components/SiteHeader/index.js
+++ b/src/components/SiteHeader/index.js
@@ -179,7 +179,7 @@ const HeaderWrapper = styled.div`
     `}
 `;
 
-const MenuItems = ({ onLogOut, permissions }) => {
+const MenuItems = ({ onLogOut, show }) => {
   const showLogout = isAuthenticated();
 
   return (
@@ -202,23 +202,31 @@ const MenuItems = ({ onLogOut, permissions }) => {
           Melden
         </StyledMenuButton>
       </MenuItem>
-      {permissions.includes('signals.sia_statusmessagetemplate_write') && (
+
+      {show.defaultTexts && (
         <MenuItem element="span">
           <StyledMenuButton $as={NavLink} to="/manage/standaard/teksten">
             Standaard teksten
           </StyledMenuButton>
         </MenuItem>
       )}
-      {isAuthenticated() && (
+
+      {show.settings && (
         <StyledMenuFlyout label="Instellingen">
-          <StyledMenuButton $as={NavLink} to="/instellingen/gebruikers">
-            Gebruikers
-          </StyledMenuButton>
-          <StyledMenuButton $as={NavLink} to="/instellingen/rollen">
-            Rollen
-          </StyledMenuButton>
+          {show.users && (
+            <StyledMenuButton $as={NavLink} to="/instellingen/gebruikers">
+              Gebruikers
+            </StyledMenuButton>
+          )}
+
+          {show.groups && (
+            <StyledMenuButton $as={NavLink} to="/instellingen/rollen">
+              Rollen
+            </StyledMenuButton>
+          )}
         </StyledMenuFlyout>
       )}
+
       {showLogout && (
         <MenuItem
           element="button"
@@ -291,7 +299,7 @@ SiteHeader.defaultProps = {
 
 SiteHeader.propTypes = {
   onLogOut: PropTypes.func,
-  permissions: PropTypes.arrayOf(PropTypes.string).isRequired,
+  show: PropTypes.shape({}),
 };
 
 MenuItems.propTypes = SiteHeader.propTypes;

--- a/src/containers/App/actions.js
+++ b/src/containers/App/actions.js
@@ -1,18 +1,14 @@
 import {
   AUTHENTICATE_USER,
   AUTHORIZE_USER,
-
   SHOW_GLOBAL_NOTIFICATION,
   RESET_GLOBAL_NOTIFICATION,
-
   LOGIN,
   LOGIN_FAILED,
   LOGOUT,
   LOGOUT_FAILED,
-
   REQUEST_CATEGORIES,
   REQUEST_CATEGORIES_SUCCESS,
-
   UPLOAD_REQUEST,
   UPLOAD_PROGRESS,
   UPLOAD_SUCCESS,
@@ -29,82 +25,58 @@ export const logoutFailed = payload => ({
   payload,
 });
 
-export function authenticateUser(credentials) {
-  return {
-    type: AUTHENTICATE_USER,
-    payload: credentials,
-  };
-}
+export const authenticateUser = credentials => ({
+  type: AUTHENTICATE_USER,
+  payload: credentials,
+});
 
-export function authorizeUser(credentials) {
-  return {
-    type: AUTHORIZE_USER,
-    payload: credentials,
-  };
-}
+export const authorizeUser = payload => ({
+  type: AUTHORIZE_USER,
+  payload,
+});
 
-export function showGlobalNotification(payload) {
-  return {
-    type: SHOW_GLOBAL_NOTIFICATION,
-    payload,
-  };
-}
+export const showGlobalNotification = payload => ({
+  type: SHOW_GLOBAL_NOTIFICATION,
+  payload,
+});
 
-export function resetGlobalNotification() {
-  return {
-    type: RESET_GLOBAL_NOTIFICATION,
-  };
-}
+export const resetGlobalNotification = () => ({
+  type: RESET_GLOBAL_NOTIFICATION,
+});
 
-export function doLogin(domain) {
-  return {
-    type: LOGIN,
-    payload: domain,
-  };
-}
+export const doLogin = domain => ({
+  type: LOGIN,
+  payload: domain,
+});
 
-export function doLogout() {
-  return {
-    type: LOGOUT,
-    payload: null,
-  };
-}
+export const doLogout = () => ({
+  type: LOGOUT,
+  payload: null,
+});
 
-export function requestCategories() {
-  return {
-    type: REQUEST_CATEGORIES,
-  };
-}
+export const requestCategories = () => ({
+  type: REQUEST_CATEGORIES,
+});
 
-export function requestCategoriesSuccess(categories) {
-  return {
-    type: REQUEST_CATEGORIES_SUCCESS,
-    payload: categories,
-  };
-}
+export const requestCategoriesSuccess = categories => ({
+  type: REQUEST_CATEGORIES_SUCCESS,
+  payload: categories,
+});
 
-export function uploadRequest({ file, id }) {
-  return {
-    type: UPLOAD_REQUEST,
-    payload: { file, id },
-  };
-}
+export const uploadRequest = ({ file, id }) => ({
+  type: UPLOAD_REQUEST,
+  payload: { file, id },
+});
 
-export function uploadProgress(progress) {
-  return {
-    type: UPLOAD_PROGRESS,
-    payload: progress,
-  };
-}
+export const uploadProgress = progress => ({
+  type: UPLOAD_PROGRESS,
+  payload: progress,
+});
 
-export function uploadSuccess() {
-  return {
-    type: UPLOAD_SUCCESS,
-  };
-}
+export const uploadSuccess = () => ({
+  type: UPLOAD_SUCCESS,
+});
 
-export function uploadFailure() {
-  return {
-    type: UPLOAD_FAILURE,
-  };
-}
+export const uploadFailure = () => ({
+  type: UPLOAD_FAILURE,
+});

--- a/src/containers/App/actions.test.js
+++ b/src/containers/App/actions.test.js
@@ -1,4 +1,5 @@
 import { testActionCreator } from 'test/utils';
+import userJson from 'utils/__tests__/fixtures/user.json';
 
 import {
   AUTHENTICATE_USER,
@@ -39,29 +40,13 @@ import {
 } from './actions';
 
 
-describe('App actions', () => {
+describe('containers/App/actions', () => {
   it('should dispatch authenticate user action', () => {
-    const userName = 'name';
-    const userScopes = 'scopes';
-    const accessToken = 'token';
-    const payload = {
-      userName,
-      userScopes,
-      accessToken,
-    };
-    testActionCreator(authenticateUser, AUTHENTICATE_USER, payload);
+    testActionCreator(authenticateUser, AUTHENTICATE_USER, userJson);
   });
 
   it('should dispatch authorize user, action', () => {
-    const userName = 'name';
-    const userScopes = 'scopes';
-    const accessToken = 'token';
-    const payload = {
-      userName,
-      userScopes,
-      accessToken,
-    };
-    testActionCreator(authorizeUser, AUTHORIZE_USER, payload);
+    testActionCreator(authorizeUser, AUTHORIZE_USER, userJson);
   });
 
   it('should dispatch show global error action', () => {

--- a/src/containers/App/reducer.js
+++ b/src/containers/App/reducer.js
@@ -1,18 +1,5 @@
-/*
- * AppReducer
- *
- * The reducer takes care of our data. Using actions, we can change our
- * application state.
- * To add a new action, add it to the switch statement in the reducer function
- *
- * Example:
- * case YOUR_ACTION_CONSTANT:
- *   return state.set('yourStateVariable', true);
- */
-
 import { fromJS } from 'immutable';
 
-import { ACCESS_TOKEN } from 'shared/services/auth/auth';
 import {
   VARIANT_DEFAULT,
   TYPE_DEFAULT,
@@ -37,10 +24,11 @@ export const initialState = fromJS({
   loading: false,
   error: false,
   upload: {},
-  userPermissions: [],
-  userName: undefined,
-  userScopes: undefined,
-  accessToken: undefined,
+  user: {
+    permissions: [],
+    roles: [],
+    profile: null,
+  },
   categories: {
     main: [],
     sub: [],
@@ -57,19 +45,11 @@ export const initialState = fromJS({
 function appReducer(state = initialState, action) {
   switch (action.type) {
     case AUTHORIZE_USER:
-      global.localStorage.setItem(ACCESS_TOKEN, action.payload.accessToken);
-
-      return state
-        .set('userName', action.payload.userName)
-        .set('userScopes', fromJS(action.payload.userScopes))
-        .set('userPermissions', fromJS(action.payload.userPermissions))
-        .set('accessToken', action.payload.accessToken);
+      return state.set('user', fromJS(action.payload));
 
     case LOGIN_FAILED:
     case LOGOUT_FAILED:
-      return state
-        .set('error', Boolean(action.payload))
-        .set('loading', false);
+      return state.set('error', Boolean(action.payload)).set('loading', false);
 
     case SHOW_GLOBAL_NOTIFICATION:
       return state.set('notification', fromJS({ ...action.payload }));

--- a/src/containers/App/reducer.test.js
+++ b/src/containers/App/reducer.test.js
@@ -1,8 +1,7 @@
 import { fromJS } from 'immutable';
 
-import { ACCESS_TOKEN } from 'shared/services/auth/auth';
+import userJson from 'utils/__tests__/fixtures/user.json';
 import appReducer, { initialState } from './reducer';
-
 import {
   AUTHORIZE_USER,
   LOGIN_FAILED,
@@ -17,7 +16,7 @@ import {
   UPLOAD_SUCCESS,
 } from './constants';
 
-describe('appReducer', () => {
+describe('containers/App/reducer', () => {
   it('should return the initial state', () => {
     expect(appReducer(undefined, {})).toEqual(fromJS(initialState));
   });
@@ -27,36 +26,9 @@ describe('appReducer', () => {
       expect(
         appReducer(fromJS({}), {
           type: AUTHORIZE_USER,
-          payload: {
-            userName: 'Diabolo',
-            userScopes: ['SCOPE'],
-            accessToken: 'DFGHJGFDSDFGHJKJH',
-          },
+          payload: userJson,
         }).toJS(),
-      ).toEqual({
-        userName: 'Diabolo',
-        userScopes: ['SCOPE'],
-        accessToken: 'DFGHJGFDSDFGHJKJH',
-      });
-    });
-
-    it('should set the access token in session storage', () => {
-      const accessToken = 'DFGHJGFDSDFGHJKJH';
-      const action = {
-        type: AUTHORIZE_USER,
-        payload: {
-          userName: 'Diabolo',
-          userScopes: ['SCOPE'],
-          accessToken,
-        },
-      };
-
-      appReducer(fromJS({}), action);
-
-      expect(global.localStorage.setItem).toHaveBeenCalledWith(
-        ACCESS_TOKEN,
-        accessToken,
-      );
+      ).toEqual({ user: userJson });
     });
   });
 

--- a/src/containers/App/saga.js
+++ b/src/containers/App/saga.js
@@ -87,13 +87,7 @@ export function* callAuthorize(action) {
         accessToken
       );
 
-      const credentials = {
-        ...action.payload,
-        userScopes: user.groups,
-        userPermissions: user.permissions,
-      };
-
-      yield put(authorizeUser(credentials));
+      yield put(authorizeUser(user));
     }
   } catch (error) {
     const { response } = error;

--- a/src/containers/App/saga.test.js
+++ b/src/containers/App/saga.test.js
@@ -13,6 +13,7 @@ import mapCategories from 'shared/services/map-categories';
 import fileUploadChannel from 'shared/services/file-upload-channel';
 import stateTokenGenerator from 'shared/services/auth/services/state-token-generator/state-token-generator';
 import { VARIANT_ERROR, TYPE_GLOBAL } from 'containers/Notification/constants';
+import userJson from 'utils/__tests__/fixtures/user.json';
 
 import watchAppSaga, {
   callLogin,
@@ -47,7 +48,7 @@ jest.mock('shared/services/api/api');
 jest.mock('shared/services/map-categories');
 jest.mock('shared/services/file-upload-channel');
 
-describe('App saga', () => {
+describe('containers/App/saga', () => {
   let origSessionStorage;
 
   beforeEach(() => {
@@ -187,31 +188,20 @@ describe('App saga', () => {
 
     const payload = {
       accessToken: 'akjgrff',
-      userName: 'foo@bar.com',
-      userScopes: ['SIG/ALL'],
     };
 
     it('should dispatch success', () => {
-      const mockResponse = {
-        groups: ['SIG/ALL'],
-        permissions: ['foo', 'bar'],
-      };
-      const mockCredentials = {
-        ...payload,
-        userScopes: mockResponse.groups,
-        userPermissions: mockResponse.permissions,
-      };
       const action = { payload };
 
       return expectSaga(callAuthorize, action)
-        .provide([[matchers.call.fn(authCall), mockResponse]])
+        .provide([[matchers.call.fn(authCall), userJson]])
         .call(
           authCall,
           CONFIGURATION.AUTH_ME_ENDPOINT,
           null,
           payload.accessToken
         )
-        .put(authorizeUser(mockCredentials))
+        .put(authorizeUser(userJson))
         .run();
     });
 

--- a/src/containers/App/selectors.js
+++ b/src/containers/App/selectors.js
@@ -51,11 +51,7 @@ const makeSelectUserCan = createSelector(
         return true;
       }
 
-      const hasPermission = permissions.find(
-        codename => codename === capability
-      );
-
-      return Boolean(hasPermission);
+      return Boolean(permissions.find(codename => codename === capability));
     }
 );
 
@@ -88,12 +84,10 @@ const makeSelectUserCanAccess = createSelector(
       }
 
       // require all sets of permissions
-      const hasRequiredPerms = requiredPerms[section].every(sectionPerms =>
+      return requiredPerms[section].every(sectionPerms =>
         // from each set, require at least one permission
         sectionPerms.some(perm => permissions.includes(perm))
       );
-
-      return hasRequiredPerms;
     }
 );
 

--- a/src/containers/App/selectors.js
+++ b/src/containers/App/selectors.js
@@ -46,13 +46,9 @@ const makeSelectUserCan = createSelector(
     /**
      * @param {String} capability - The permission to check for
      */
-    capability => {
-      if (is_superuser) {
-        return true;
-      }
-
-      return Boolean(permissions.find(codename => codename === capability));
-    }
+    capability =>
+      is_superuser ||
+      Boolean(permissions.find(codename => codename === capability))
 );
 
 /**

--- a/src/containers/App/selectors.test.js
+++ b/src/containers/App/selectors.test.js
@@ -3,13 +3,9 @@ import { initialState } from './reducer';
 
 import {
   selectGlobal,
-  makeSelectUserName,
-  makeSelectAccessToken,
   makeSelectLoading,
   makeSelectError,
   makeSelectNotification,
-  makeSelectLocation,
-  makeSelectIsAuthenticated,
   makeSelectCategories,
 } from './selectors';
 
@@ -24,32 +20,6 @@ describe('selectGlobal', () => {
       global: globalState,
     });
     expect(selectGlobal(mockedState)).toEqual(globalState);
-  });
-});
-
-describe('makeSelectUserName', () => {
-  const userNameSelector = makeSelectUserName();
-  it('should select the current user', () => {
-    const username = 'loggedInUser';
-    const mockedState = fromJS({
-      global: {
-        userName: username,
-      },
-    });
-    expect(userNameSelector(mockedState)).toEqual(username);
-  });
-});
-
-describe('makeSelectAccessToken', () => {
-  const selector = makeSelectAccessToken();
-  it('should select the token', () => {
-    const accessToken = 'thisistheaccesstoken';
-    const mockedState = fromJS({
-      global: {
-        accessToken,
-      },
-    });
-    expect(selector(mockedState)).toEqual(accessToken);
   });
 });
 
@@ -97,32 +67,6 @@ describe('makeSelectNotification', () => {
     });
 
     expect(notificationSelector(mockedState)).toEqual(notification);
-  });
-});
-
-describe('makeSelectLocation', () => {
-  const locationStateSelector = makeSelectLocation();
-  it('should select the location', () => {
-    const route = fromJS({
-      location: { pathname: '/foo' },
-    });
-    const mockedState = fromJS({
-      route,
-    });
-    expect(locationStateSelector(mockedState)).toEqual(route.get('location').toJS());
-  });
-});
-
-describe('makeSelectIsAuthenticated', () => {
-  const isAuthenticatedStateSelector = makeSelectIsAuthenticated();
-  it('should select the login state', () => {
-    const accessToken = 'thisistheaccesstoken';
-    const mockedState = fromJS({
-      global: {
-        accessToken,
-      },
-    });
-    expect(isAuthenticatedStateSelector(mockedState)).toEqual(true);
   });
 });
 

--- a/src/containers/App/selectors.test.js
+++ b/src/containers/App/selectors.test.js
@@ -1,87 +1,354 @@
 import { fromJS } from 'immutable';
-import { initialState } from './reducer';
+import cloneDeep from 'lodash.clonedeep';
 
+import userJson from 'utils/__tests__/fixtures/user.json';
+
+import { initialState } from './reducer';
 import {
-  selectGlobal,
-  makeSelectLoading,
-  makeSelectError,
-  makeSelectNotification,
   makeSelectCategories,
+  makeSelectError,
+  makeSelectLoading,
+  makeSelectNotification,
+  makeSelectUserCan,
+  makeSelectUserCanAccess,
+  makeSelectUserPermissions,
+  makeSelectUserPermissionCodeNames,
+  selectGlobal,
 } from './selectors';
 
-describe('selectGlobal', () => {
-  it('should return the initialState', () => {
-    expect(selectGlobal()).toEqual(initialState);
-  });
+const getPermissionCount = userData => {
+  const numberOfPermissionsForRoles = userData.roles.reduce((acc, val) => {
+    const count = acc + val.permissions.length;
+    return count;
+  }, 0);
 
-  it('should select the global state', () => {
-    const globalState = fromJS({});
-    const mockedState = fromJS({
-      global: globalState,
+  return numberOfPermissionsForRoles + userData.permissions.length;
+};
+
+describe('containers/App/selectors', () => {
+  describe('selectGlobal', () => {
+    it('should return the initialState', () => {
+      expect(selectGlobal()).toEqual(initialState);
     });
-    expect(selectGlobal(mockedState)).toEqual(globalState);
-  });
-});
 
-describe('makeSelectLoading', () => {
-  const loadingSelector = makeSelectLoading();
-  it('should select the loading', () => {
-    const loading = false;
-    const mockedState = fromJS({
+    it('should select the global state', () => {
+      const globalState = fromJS({});
+      const mockedState = fromJS({
+        global: globalState,
+      });
+      expect(selectGlobal(mockedState)).toEqual(globalState);
+    });
+  });
+
+  describe('makeSelectLoading', () => {
+    const loadingSelector = makeSelectLoading();
+    it('should select the loading', () => {
+      const loading = false;
+      const mockedState = fromJS({
+        global: {
+          loading,
+        },
+      });
+      expect(loadingSelector(mockedState)).toEqual(loading);
+    });
+  });
+
+  describe('makeSelectError', () => {
+    const errorSelector = makeSelectError();
+    it('should select the error', () => {
+      const error = true;
+      const mockedState = fromJS({
+        global: {
+          error,
+        },
+      });
+      expect(errorSelector(mockedState)).toEqual(error);
+    });
+  });
+
+  describe('makeSelectNotification', () => {
+    const notificationSelector = makeSelectNotification();
+
+    it('should select the notification', () => {
+      const notification = {
+        title: 'Foo bar',
+        message: 'Qux',
+        type: 'error',
+        variant: 'global',
+      };
+
+      const mockedState = fromJS({
+        global: {
+          notification,
+        },
+      });
+
+      expect(notificationSelector(mockedState)).toEqual(notification);
+    });
+  });
+
+  describe('makeSelectCategories', () => {
+    const selector = makeSelectCategories();
+    it('should select the login state', () => {
+      const categories = {
+        main: [1, 2],
+        sub: [3, 4],
+      };
+      const mockedState = fromJS({
+        global: {
+          categories,
+        },
+      });
+      expect(selector(mockedState)).toEqual(categories);
+    });
+  });
+
+  describe('permissions', () => {
+    const state = fromJS({
       global: {
-        loading,
+        ...initialState.toJS(),
+        user: userJson,
       },
     });
-    expect(loadingSelector(mockedState)).toEqual(loading);
-  });
-});
 
-describe('makeSelectError', () => {
-  const errorSelector = makeSelectError();
-  it('should select the error', () => {
-    const error = true;
-    const mockedState = fromJS({
+    const regularUserState = fromJS({
       global: {
-        error,
-      },
-    });
-    expect(errorSelector(mockedState)).toEqual(error);
-  });
-});
-
-describe('makeSelectNotification', () => {
-  const notificationSelector = makeSelectNotification();
-
-  it('should select the notification', () => {
-    const notification = {
-      title: 'Foo bar',
-      message: 'Qux',
-      type: 'error',
-      variant: 'global',
-    };
-
-    const mockedState = fromJS({
-      global: {
-        notification,
+        ...initialState.toJS(),
+        user: {
+          ...userJson,
+          is_superuser: false,
+        },
       },
     });
 
-    expect(notificationSelector(mockedState)).toEqual(notification);
-  });
-});
+    describe('makeSelectUserPermissions', () => {
+      it('should return an empty list', () => {
+        expect(makeSelectUserPermissions(initialState)).toEqual([]);
+      });
 
-describe('makeSelectCategories', () => {
-  const selector = makeSelectCategories();
-  it('should select the login state', () => {
-    const categories = {
-      main: [1, 2],
-      sub: [3, 4],
-    };
-    const mockedState = fromJS({
-      global: {
-        categories,
-      },
+      it("should return a list of a user's permissions", () => {
+        expect(makeSelectUserPermissions(state)).toHaveLength(
+          getPermissionCount(userJson)
+        );
+      });
+
+      it('should return a list of unique permissions', () => {
+        const userJsonWithDuplicatePerms = cloneDeep(userJson);
+        // add another role with all duplicate permissions
+        userJsonWithDuplicatePerms.roles.push(
+          userJsonWithDuplicatePerms.roles[0]
+        );
+
+        // add a duplicate permission to a role
+        userJsonWithDuplicatePerms.roles[0].permissions.push(
+          userJsonWithDuplicatePerms.permissions[0]
+        );
+
+        const duplicatePermsState = fromJS({
+          global: {
+            ...initialState.toJS(),
+            user: userJsonWithDuplicatePerms,
+          },
+        });
+
+        const permissionCount = getPermissionCount(userJson);
+        const dupePermissionCount = getPermissionCount(
+          userJsonWithDuplicatePerms
+        );
+
+        expect(permissionCount).not.toEqual(dupePermissionCount);
+
+        expect(makeSelectUserPermissions(duplicatePermsState)).not.toHaveLength(
+          dupePermissionCount
+        );
+
+        expect(makeSelectUserPermissions(duplicatePermsState)).toHaveLength(
+          getPermissionCount(userJson)
+        );
+      });
     });
-    expect(selector(mockedState)).toEqual(categories);
+
+    describe('makeSelectUserPermissionCodeNames', () => {
+      it('should return a list of strings', () => {
+        const codenames = makeSelectUserPermissionCodeNames(state);
+
+        userJson.roles
+          .flatMap(role => role.permissions)
+          .concat(userJson.permissions)
+          .forEach(({ codename }) => {
+            expect(codenames.includes(codename)).toEqual(true);
+          });
+      });
+    });
+
+    describe('makeSelectUserCan', () => {
+      const doSomething = userJson.permissions[0].codename;
+      const cannotDoSomething = `${userJson.permissions[0].codename}97ysadfysd87f`;
+
+      it('should always allow for superuser', () => {
+        const superUserCan = makeSelectUserCan(state);
+
+        expect(superUserCan(doSomething)).toEqual(true);
+        expect(superUserCan(cannotDoSomething)).toEqual(true);
+      });
+
+      it('should return a boolean', () => {
+        const regularUserCan = makeSelectUserCan(regularUserState);
+
+        expect(regularUserCan(doSomething)).toEqual(true);
+        expect(regularUserCan(cannotDoSomething)).toEqual(false);
+      });
+    });
+
+    describe('makeSelectUserCanAccess', () => {
+      const settings = 'settings';
+      const groups = 'groups';
+      const users = 'users';
+      const someOtherSection = 'some_other_section';
+      const userSectionPermissions = ['view_user', 'add_user', 'change_user'];
+      const groupSectionPermissions = [
+        'view_group',
+        'change_group',
+        'add_group',
+      ];
+
+      const superUserCanAccess = makeSelectUserCanAccess(state);
+      const regularUserCanAccess = makeSelectUserCanAccess(regularUserState);
+
+      it('should always allow for superuser', () => {
+        expect(superUserCanAccess(settings)).toEqual(true);
+        expect(superUserCanAccess(someOtherSection)).toEqual(true);
+      });
+
+      it('should disallow for invalid section', () => {
+        expect(regularUserCanAccess(settings)).toEqual(true);
+        expect(regularUserCanAccess(groups)).toEqual(true);
+        expect(regularUserCanAccess(users)).toEqual(true);
+        expect(regularUserCanAccess(someOtherSection)).toEqual(false);
+      });
+
+      it('should require at least one permission per section', () => {
+        const userWithLimitedPermissions = cloneDeep(userJson);
+        const limitedUserState = fromJS({
+          global: {
+            ...initialState.toJS(),
+            user: {
+              ...userWithLimitedPermissions,
+              is_superuser: false,
+            },
+          },
+        });
+
+        expect(makeSelectUserCanAccess(limitedUserState)(users)).toEqual(true);
+
+        // remove one of the requires permissions to have access to the user section
+        userWithLimitedPermissions.permissions.splice(
+          userWithLimitedPermissions.permissions.findIndex(
+            ({ codename }) => codename === userSectionPermissions[0]
+          ),
+          1
+        );
+
+        const limitedUserState2 = fromJS({
+          global: {
+            ...initialState.toJS(),
+            user: {
+              ...userWithLimitedPermissions,
+              is_superuser: false,
+            },
+          },
+        });
+
+        expect(makeSelectUserCanAccess(limitedUserState2)(users)).toEqual(true);
+
+        // remove another one
+        userWithLimitedPermissions.permissions.splice(
+          userWithLimitedPermissions.permissions.findIndex(
+            ({ codename }) => codename === userSectionPermissions[1]
+          ),
+          1
+        );
+
+        const limitedUserState3 = fromJS({
+          global: {
+            ...initialState.toJS(),
+            user: {
+              ...userWithLimitedPermissions,
+              is_superuser: false,
+            },
+          },
+        });
+
+        expect(makeSelectUserCanAccess(limitedUserState3)(users)).toEqual(true);
+
+        // remove the last one
+        userWithLimitedPermissions.permissions.splice(
+          userWithLimitedPermissions.permissions.findIndex(
+            ({ codename }) => codename === userSectionPermissions[1]
+          ),
+          1
+        );
+
+        const limitedUserState4 = fromJS({
+          global: {
+            ...initialState.toJS(),
+            user: {
+              ...userWithLimitedPermissions,
+              is_superuser: false,
+            },
+          },
+        });
+
+        expect(makeSelectUserCanAccess(limitedUserState4)(users)).toEqual(
+          false
+        );
+      });
+
+      it('should require at least one permission per section category', () => {
+        // The 'settings' section contains more than one overpage and detail page and thus requires
+        // permissions fromt both 'groups' and 'users'. To be able to access 'settings', a user
+        // needs at least one permission in both 'groups' and 'users'.
+
+        const userWithLimitedPermissions = cloneDeep(userJson);
+
+        // remove all required permissions but one
+        userWithLimitedPermissions.permissions = userWithLimitedPermissions.permissions.filter(
+          ({ codename }) => codename === userSectionPermissions[0] || codename === groupSectionPermissions[0]
+        );
+
+        const limitedUserState = fromJS({
+          global: {
+            ...initialState.toJS(),
+            user: {
+              ...userWithLimitedPermissions,
+              is_superuser: false,
+            },
+          },
+        });
+
+        expect(makeSelectUserCanAccess(limitedUserState)(settings)).toEqual(
+          true
+        );
+
+        // remove last required permission
+        userWithLimitedPermissions.permissions = userWithLimitedPermissions.permissions.filter(
+          ({ codename }) => codename === groupSectionPermissions[0]
+        );
+
+        const limitedUserState2 = fromJS({
+          global: {
+            ...initialState.toJS(),
+            user: {
+              ...userWithLimitedPermissions,
+              is_superuser: false,
+            },
+          },
+        });
+
+        expect(makeSelectUserCanAccess(limitedUserState2)(settings)).toEqual(
+          false
+        );
+      });
+    });
   });
 });

--- a/src/containers/SiteHeader/__tests__/SiteHeader.test.js
+++ b/src/containers/SiteHeader/__tests__/SiteHeader.test.js
@@ -12,4 +12,13 @@ describe('containers/SiteHeader', () => {
     expect(containerProps.onLogOut).not.toBeUndefined();
     expect(typeof containerProps.onLogOut).toEqual('function');
   });
+
+  it('should have props from structured selector', () => {
+    const tree = mount(withAppContext(<SiteHeader />));
+
+    const props = tree.find(SiteHeaderContainer).props();
+
+    expect(props.userCan).not.toBeUndefined();
+    expect(props.userCanAccess).not.toBeUndefined();
+  });
 });

--- a/src/containers/SiteHeader/__tests__/SiteHeader.test.js
+++ b/src/containers/SiteHeader/__tests__/SiteHeader.test.js
@@ -9,7 +9,7 @@ describe('containers/SiteHeader', () => {
 
     const containerProps = tree.find(SiteHeaderContainer).props();
 
-    expect(containerProps.onLogOut).not.toBeUndefined();
+    expect(containerProps.onLogOut).toBeDefined();
     expect(typeof containerProps.onLogOut).toEqual('function');
   });
 
@@ -18,7 +18,7 @@ describe('containers/SiteHeader', () => {
 
     const props = tree.find(SiteHeaderContainer).props();
 
-    expect(props.userCan).not.toBeUndefined();
-    expect(props.userCanAccess).not.toBeUndefined();
+    expect(props.userCan).toBeDefined();
+    expect(props.userCanAccess).toBeDefined();
   });
 });

--- a/src/containers/SiteHeader/index.js
+++ b/src/containers/SiteHeader/index.js
@@ -14,7 +14,7 @@ import { doLogout } from '../App/actions';
 export const SiteHeaderContainer = ({ onLogOut, userCan, userCanAccess }) => (
   <SiteHeader
     onLogOut={onLogOut}
-    show={{
+    showItems={{
       defaultTexts: userCan('sia_statusmessagetemplate_write'),
       groups: userCanAccess('groups'),
       settings: userCanAccess('settings'),

--- a/src/containers/SiteHeader/index.js
+++ b/src/containers/SiteHeader/index.js
@@ -3,22 +3,35 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { compose, bindActionCreators } from 'redux';
 import { createStructuredSelector } from 'reselect';
-import { makeSelectUserPermissions } from 'containers/App/selectors';
+import {
+  makeSelectUserCan,
+  makeSelectUserCanAccess,
+} from 'containers/App/selectors';
 import SiteHeader from 'components/SiteHeader';
 
 import { doLogout } from '../App/actions';
 
-export const SiteHeaderContainer = ({ onLogOut, permissions }) => (
-  <SiteHeader onLogOut={onLogOut} permissions={permissions} />
+export const SiteHeaderContainer = ({ onLogOut, userCan, userCanAccess }) => (
+  <SiteHeader
+    onLogOut={onLogOut}
+    show={{
+      defaultTexts: userCan('sia_statusmessagetemplate_write'),
+      groups: userCanAccess('groups'),
+      settings: userCanAccess('settings'),
+      users: userCanAccess('users'),
+    }}
+  />
 );
 
 SiteHeaderContainer.propTypes = {
   onLogOut: PropTypes.func,
-  permissions: PropTypes.arrayOf(PropTypes.string).isRequired,
+  userCan: PropTypes.func,
+  userCanAccess: PropTypes.func,
 };
 
 const mapStateToProps = createStructuredSelector({
-  permissions: makeSelectUserPermissions(),
+  userCan: makeSelectUserCan,
+  userCanAccess: makeSelectUserCanAccess,
 });
 
 export const mapDispatchToProps = dispatch =>

--- a/src/shared/services/auth/auth.js
+++ b/src/shared/services/auth/auth.js
@@ -136,12 +136,15 @@ function getAccessTokenFromParams(params) {
 function handleCallback() {
   const params = queryStringParser(global.location.hash);
   const accessToken = getAccessTokenFromParams(params);
+
   if (accessToken) {
     tokenData = accessTokenParser(accessToken);
     localStorage.setItem(ACCESS_TOKEN, accessToken);
     returnPath = localStorage.getItem(RETURN_PATH);
     localStorage.removeItem(RETURN_PATH);
     localStorage.removeItem(STATE_TOKEN);
+
+    global.localStorage.setItem(ACCESS_TOKEN, accessToken);
 
     // Clean up URL; remove query and hash
     // https://stackoverflow.com/questions/4508574/remove-hash-from-url

--- a/src/shared/services/auth/auth.js
+++ b/src/shared/services/auth/auth.js
@@ -58,7 +58,7 @@ const RETURN_PATH = 'returnPath';
 const STATE_TOKEN = 'stateToken';
 // The access token returned by the OAuth2 authorization service
 // containing user userScopes and name
-export const ACCESS_TOKEN = 'accessToken';
+const ACCESS_TOKEN = 'accessToken';
 
 const OAUTH_DOMAIN = 'oauthDomain';
 
@@ -143,8 +143,6 @@ function handleCallback() {
     returnPath = localStorage.getItem(RETURN_PATH);
     localStorage.removeItem(RETURN_PATH);
     localStorage.removeItem(STATE_TOKEN);
-
-    global.localStorage.setItem(ACCESS_TOKEN, accessToken);
 
     // Clean up URL; remove query and hash
     // https://stackoverflow.com/questions/4508574/remove-hash-from-url

--- a/src/shared/services/configuration/configuration.js
+++ b/src/shared/services/configuration/configuration.js
@@ -125,7 +125,7 @@ export class Configuration {
   }
 
   get AUTH_ME_ENDPOINT() {
-    return `${this.API_ROOT}signals/user/auth/me/`;
+    return `${this.API_ROOT}signals/v1/private/me/`;
   }
 
   get CATEGORIES_ENDPOINT() {

--- a/src/shared/types/index.js
+++ b/src/shared/types/index.js
@@ -204,3 +204,9 @@ export const overviewPageType = PropTypes.shape({
   page: PropTypes.number,
   sort: PropTypes.string,
 });
+
+export const permissionsType = PropTypes.arrayOf(PropTypes.shape({
+  id: PropTypes.number.isRequired,
+  name: PropTypes.string.isRequired,
+  codename: PropTypes.string.isRequired,
+}));

--- a/src/utils/__tests__/fixtures/user.json
+++ b/src/utils/__tests__/fixtures/user.json
@@ -1,46 +1,169 @@
 {
   "_links": {
     "self": {
-      "href": "https://acc.api.data.amsterdam.nl/signals/v1/private/users/45"
+      "href": "https://acc.api.data.amsterdam.nl/signals/v1/private/users/255657600"
     }
   },
   "_display": "initial.lastname@amsterdam.nl",
-  "id": 45,
+  "id": 255657600,
   "username": "initial.lastname@amsterdam.nl",
   "email": "initial.lastname@amsterdam.nl",
-  "first_name": "First Name",
-  "last_name": "Last Name",
+  "first_name": "Firstname",
+  "last_name": "Lastname",
   "is_active": true,
-  "is_staff": true,
-  "is_superuser": false,
-  "roles": [],
+  "is_staff": false,
+  "is_superuser": true,
+  "roles": [
+    {
+      "_links": {
+        "self": {
+          "href": "https://acc.api.data.amsterdam.nl/signals/v1/private/roles/1576886400"
+        }
+      },
+      "_display": "monitors",
+      "id": 1576886400,
+      "name": "monitors",
+      "permissions": [
+        {
+          "_links": {
+            "self": {
+              "href": "https://acc.api.data.amsterdam.nl/signals/v1/private/permissions/331257600"
+            }
+          },
+          "_display": "signals | category | View all categories (this will override the category permission based on the user/department relation)",
+          "id": 331257600,
+          "name": "View all categories (this will override the category permission based on the user/department relation)",
+          "codename": "sia_can_view_all_categories"
+        },
+        {
+          "_links": {
+            "self": {
+              "href": "https://acc.api.data.amsterdam.nl/signals/v1/private/permissions/331257601"
+            }
+          },
+          "_display": "signals | priority | Can add priority",
+          "id": 331257601,
+          "name": "Can add priority",
+          "codename": "add_priority"
+        },
+        {
+          "_links": {
+            "self": {
+              "href": "https://acc.api.data.amsterdam.nl/signals/v1/private/permissions/331257602"
+            }
+          },
+          "_display": "signals | signal | Can read from SIA",
+          "id": 331257602,
+          "name": "Can read from SIA",
+          "codename": "sia_read"
+        },
+        {
+          "_links": {
+            "self": {
+              "href": "https://acc.api.data.amsterdam.nl/signals/v1/private/permissions/331257603"
+            }
+          },
+          "_display": "signals | signal | Can create notes for signals",
+          "id": 331257603,
+          "name": "Can create notes for signals",
+          "codename": "sia_signal_create_note"
+        },
+        {
+          "_links": {
+            "self": {
+              "href": "https://acc.api.data.amsterdam.nl/signals/v1/private/permissions/331257604"
+            }
+          },
+          "_display": "signals | signal | Can write to SIA",
+          "id": 331257604,
+          "name": "Can write to SIA",
+          "codename": "sia_write"
+        }
+      ]
+    }
+  ],
   "permissions": [
     {
       "_links": {
         "self": {
-          "href": "https://acc.api.data.amsterdam.nl/signals/v1/private/permissions/110"
+          "href": "https://acc.api.data.amsterdam.nl/signals/v1/private/permissions/1571875200"
         }
       },
-      "_display": "signals | signal | Can read from SIA",
-      "id": 110,
-      "name": "Can read from SIA",
-      "codename": "sia_read"
+      "_display": "auth | groep | Can add group",
+      "id": 1571875200,
+      "name": "Can add group",
+      "codename": "add_group"
     },
     {
       "_links": {
         "self": {
-          "href": "https://acc.api.data.amsterdam.nl/signals/v1/private/permissions/111"
+          "href": "https://acc.api.data.amsterdam.nl/signals/v1/private/permissions/1571875210"
         }
       },
-      "_display": "signals | signal | Can write to SIA",
-      "id": 111,
-      "name": "Can write to SIA",
-      "codename": "sia_write"
+      "_display": "auth | groep | Can change group",
+      "id": 1571875210,
+      "name": "Can change group",
+      "codename": "change_group"
+    },
+    {
+      "_links": {
+        "self": {
+          "href": "https://acc.api.data.amsterdam.nl/signals/v1/private/permissions/1571875220"
+        }
+      },
+      "_display": "auth | groep | Can view group",
+      "id": 1571875220,
+      "name": "Can view group",
+      "codename": "view_group"
+    },
+    {
+      "_links": {
+        "self": {
+          "href": "https://acc.api.data.amsterdam.nl/signals/v1/private/permissions/1571875230"
+        }
+      },
+      "_display": "auth | recht | Can view permission",
+      "id": 1571875230,
+      "name": "Can view permission",
+      "codename": "view_permission"
+    },
+    {
+      "_links": {
+        "self": {
+          "href": "https://acc.api.data.amsterdam.nl/signals/v1/private/permissions/1571875240"
+        }
+      },
+      "_display": "auth | gebruiker | Can add user",
+      "id": 1571875240,
+      "name": "Can add user",
+      "codename": "add_user"
+    },
+    {
+      "_links": {
+        "self": {
+          "href": "https://acc.api.data.amsterdam.nl/signals/v1/private/permissions/1571875250"
+        }
+      },
+      "_display": "auth | gebruiker | Can change user",
+      "id": 1571875250,
+      "name": "Can change user",
+      "codename": "change_user"
+    },
+    {
+      "_links": {
+        "self": {
+          "href": "https://acc.api.data.amsterdam.nl/signals/v1/private/permissions/1571875260"
+        }
+      },
+      "_display": "auth | gebruiker | Can view user",
+      "id": 1571875260,
+      "name": "Can view user",
+      "codename": "view_user"
     }
   ],
   "profile": {
     "departments": [],
-    "created_at": "2019-10-24T10:25:48.873796+02:00",
-    "updated_at": "2019-10-24T10:25:48.873809+02:00"
+    "created_at": "2019-10-24T10:25:48.874301+02:00",
+    "updated_at": "2019-10-24T10:25:48.874315+02:00"
   }
 }


### PR DESCRIPTION
This PR replaces the `v0` user endpoint with the `v1` endpoint. The former returned a list of permission identifiers as string. The latter returns multiple lists of objects that need to be parsed and computed. 

Therefore, this PR:
- changes the `AUTH_ME_ENDPOINT` property of the `Configuration` class
- adds a `permissionsType` type
- updates the `user` fixture
- changes the `global` state signature by removing `userName`, `userScopes` and `accessToken` in favour of a single `user` entry
- adds new selectors:
  - `makeSelectUserPermissions`: returns the permission objects aggregated from user roles and individual permissions
  - `makeSelectUserPermissionCodeNames`: returns a list similar to what the `v0` returns
  - `makeSelectUserCan`: returns a boolean indicating the presence of an individual permission
  - `makeSelectUserCanAccess`: returns a boolean indicating the ability to access a particular part of the application. For instance `settings`, which requires at least one permission from `groups` or `users`
- has the `SiteHeader` container use the new selectors instead of passing on the list of permissions to the `SiteHeader` component
- adds a `showItems` prop to the `SiteHeader` component that should contain a list of accessible items that need to be rendered.

In addition:
- removes the `localStorage.setItem` call in the `App` reducer, since setting the access token is already done by the `auth` service on login
- removes unused selectors from `App` selectors
