### PR TITLE
[SIG-1816] - Error handling for corrupted elastic index

### DIFF
--- a/src/signals/incident-management/containers/IncidentOverviewPage/saga.js
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/saga.js
@@ -74,6 +74,16 @@ export function* searchIncidents(action) {
 
     yield put(requestIncidentsSuccess(incidents));
   } catch (error) {
+    if (
+      error.response &&
+      error.response.status === 500
+    ) {
+      // Getting an error response with status code 500 from the search endpoint
+      // means that the Elasticsearch index is very likely corrupted. In that
+      // case we simulate a success response without results.
+      yield put(requestIncidentsSuccess({ count: 0, results: [] }));
+    }
+
     yield put(requestIncidentsError(error.message));
   }
 }

--- a/src/signals/incident-management/containers/IncidentOverviewPage/saga.test.js
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/saga.test.js
@@ -144,10 +144,30 @@ describe('signals/incident-management/containers/IncidentOverviewPage/saga', () 
         .run();
     });
 
+    it('should dispatch success in case of a 500 error status', () => {
+      const q = 'Here be dragons';
+      const message = 'Internal server error';
+      const error = new Error(message);
+      error.response = {
+        status: 500,
+      };
+
+      return expectSaga(searchIncidents, q)
+        .provide([
+          [matchers.call.fn(authCall), throwError(error)],
+        ])
+        .call.like(authCall)
+        .put(requestIncidentsSuccess({ count: 0, results: [] }))
+        .run();
+    });
+
     it('should dispatch fetchIncidents error', () => {
       const q = 'Here be dragons';
       const message = '404 Not Found';
       const error = new Error(message);
+      error.response = {
+        status: 404,
+      };
 
       return expectSaga(searchIncidents, q)
         .provide([


### PR DESCRIPTION
This PR contains changes that, despite receiving a response with a `500` status code, make sure that `requestIncidentsSuccess` is dispatched. In the case of the search endpoint, a `500` status code means that the Elasticsearch index is corrupt, for whatever reason. Since there is no other endpoint to fall back to and we still need to show feedback to the user, showing a search result with `0 meldingen` is considered to be better than showing an error notification.