### PR TITLE
(Chore) FF Instellingen fixes

### DIFF
--- a/src/containers/App/saga.js
+++ b/src/containers/App/saga.js
@@ -109,7 +109,9 @@ export function* callAuthorize(action) {
 
 export function* fetchCategories() {
   try {
-    const categories = yield call(request, CONFIGURATION.CATEGORIES_ENDPOINT);
+    const categories = yield call(request, CONFIGURATION.CATEGORIES_ENDPOINT, {
+      headers: { Accept: 'application/json' },
+    });
 
     yield put(requestCategoriesSuccess(mapCategories(categories)));
   } catch (err) {

--- a/src/containers/App/saga.test.js
+++ b/src/containers/App/saga.test.js
@@ -254,7 +254,9 @@ describe('containers/App/saga', () => {
 
       testSaga(fetchCategories)
         .next()
-        .call(request, CONFIGURATION.CATEGORIES_ENDPOINT)
+        .call(request, CONFIGURATION.CATEGORIES_ENDPOINT, {
+          headers: { Accept: 'application/json' },
+        })
         .next()
         .put(requestCategoriesSuccess(mapCategories(categories)))
         .next()
@@ -266,7 +268,9 @@ describe('containers/App/saga', () => {
 
       return expectSaga(fetchCategories)
         .provide([[matchers.call.fn(request), throwError(error)]])
-        .call(request, CONFIGURATION.CATEGORIES_ENDPOINT)
+        .call(request, CONFIGURATION.CATEGORIES_ENDPOINT, {
+          headers: { Accept: 'application/json' },
+        })
         .put(
           showGlobalNotification({
             variant: VARIANT_ERROR,

--- a/src/shared/services/api/api.js
+++ b/src/shared/services/api/api.js
@@ -37,6 +37,7 @@ export function* authCall(url, params, authorizationToken) {
 
 export function* authCallWithPayload(url, params, method) {
   const headers = {
+    accept: 'application/json',
     'Content-Type': 'application/json',
   };
 

--- a/src/shared/services/api/api.test.js
+++ b/src/shared/services/api/api.test.js
@@ -104,6 +104,7 @@ describe('api service', () => {
       const options = {
         method: 'METHOD',
         headers: {
+          accept: 'application/json',
           'Content-Type': 'application/json',
           Authorization: `Bearer ${token}`,
         },
@@ -118,6 +119,7 @@ describe('api service', () => {
       const options = {
         method: 'METHOD',
         headers: {
+          accept: 'application/json',
           'Content-Type': 'application/json',
         },
         body: JSON.stringify(params),
@@ -171,15 +173,21 @@ describe('api service', () => {
   describe('getErrorMessage', () => {
     it('returns a default error message', () => {
       expect(getErrorMessage({})).toEqual(errorMessageDictionary.default);
-      expect(getErrorMessage({ status: 415 })).toEqual(errorMessageDictionary.default);
-      expect(getErrorMessage({ status: 'foo bar' })).toEqual(errorMessageDictionary.default);
+      expect(getErrorMessage({ status: 415 })).toEqual(
+        errorMessageDictionary.default
+      );
+      expect(getErrorMessage({ status: 'foo bar' })).toEqual(
+        errorMessageDictionary.default
+      );
     });
 
     it('returns a specific error message', () => {
       const statuses = [401, 403, 408, 413, 429, 500, 503];
 
       statuses.forEach(status => {
-        expect(getErrorMessage({ status })).toEqual(errorMessageDictionary[status]);
+        expect(getErrorMessage({ status })).toEqual(
+          errorMessageDictionary[status]
+        );
       });
     });
   });

--- a/src/signals/settings/users/containers/Overview/__tests__/Overview.test.js
+++ b/src/signals/settings/users/containers/Overview/__tests__/Overview.test.js
@@ -40,24 +40,34 @@ describe('signals/settings/users/containers/Overview', () => {
     let queryByText;
 
     await reAct(async () => {
-      ({ queryByText, rerender } = await render(withAppContext(<UsersOverviewContainer userCan={userCan} />)));
+      ({ queryByText, rerender } = await render(
+        withAppContext(<UsersOverviewContainer userCan={userCan} />)
+      ));
     });
 
     expect(queryByText('Gebruiker toevoegen')).toBeInTheDocument();
 
-    await reAct(async () => rerender(withAppContext(<UsersOverviewContainer userCan={() => false} />)));
+    await reAct(async () =>
+      rerender(withAppContext(<UsersOverviewContainer userCan={() => false} />))
+    );
 
     expect(queryByText('Gebruiker toevoegen')).not.toBeInTheDocument();
   });
 
   it('should request users from API on mount', async () => {
     await act(async () => {
-      await render(withAppContext(<UsersOverviewContainer userCan={userCan} />));
+      await render(
+        withAppContext(<UsersOverviewContainer userCan={userCan} />)
+      );
 
       await wait(() =>
         expect(global.fetch).toHaveBeenCalledWith(
           expect.stringContaining(configuration.USERS_ENDPOINT),
-          expect.objectContaining({ headers: {} })
+          expect.objectContaining({
+            headers: {
+              Accept: 'application/json',
+            },
+          })
         )
       );
     });
@@ -75,7 +85,9 @@ describe('signals/settings/users/containers/Overview', () => {
 
     expect(getByText(`Gebruikers (${usersJSON.count})`)).toBeInTheDocument();
 
-    expect(container.querySelectorAll('tbody tr')).toHaveLength(usersJSON.count);
+    expect(container.querySelectorAll('tbody tr')).toHaveLength(
+      usersJSON.count
+    );
   });
 
   it('should render pagination controls', async () => {
@@ -94,7 +106,9 @@ describe('signals/settings/users/containers/Overview', () => {
 
     await reAct(async () => {
       await rerender(
-        withAppContext(<UsersOverviewContainer pageSize={100} userCan={userCan} />)
+        withAppContext(
+          <UsersOverviewContainer pageSize={100} userCan={userCan} />
+        )
       );
     });
 
@@ -127,7 +141,9 @@ describe('signals/settings/users/containers/Overview', () => {
     }));
 
     await reAct(async () => {
-      await render(withAppContext(<UsersOverviewContainer userCan={userCan} />));
+      await render(
+        withAppContext(<UsersOverviewContainer userCan={userCan} />)
+      );
     });
 
     expect(push).not.toHaveBeenCalled();
@@ -139,7 +155,9 @@ describe('signals/settings/users/containers/Overview', () => {
     }));
 
     await reAct(async () => {
-      await render(withAppContext(<UsersOverviewContainer userCan={userCan} />));
+      await render(
+        withAppContext(<UsersOverviewContainer userCan={userCan} />)
+      );
     });
 
     expect(push).not.toHaveBeenCalled();
@@ -160,9 +178,7 @@ describe('signals/settings/users/containers/Overview', () => {
 
     fireEvent.click(row.querySelector('td:first-of-type'), { bubbles: true });
 
-    expect(push).toHaveBeenCalledWith(
-      routes.user.replace(/:userId.*/, itemId)
-    );
+    expect(push).toHaveBeenCalledWith(routes.user.replace(/:userId.*/, itemId));
 
     push.mockReset();
 

--- a/src/signals/settings/users/containers/Overview/hooks/__tests__/useFetchUsers.test.js
+++ b/src/signals/settings/users/containers/Overview/hooks/__tests__/useFetchUsers.test.js
@@ -21,7 +21,11 @@ describe('signals/settings/users/containers/Overview/hooks/FetchUsers', () => {
 
     expect(global.fetch).toHaveBeenCalledWith(
       configuration.USERS_ENDPOINT,
-      expect.objectContaining({ headers: {} })
+      expect.objectContaining({
+        headers: {
+          Accept: 'application/json',
+        },
+      })
     );
 
     expect(result.current.isLoading).toEqual(false);
@@ -37,7 +41,7 @@ describe('signals/settings/users/containers/Overview/hooks/FetchUsers', () => {
 
     expect(global.fetch).toHaveBeenCalledWith(
       expect.stringMatching(new RegExp(`\\/?page=${page}$`)),
-      expect.objectContaining({ headers: {} })
+      expect.objectContaining({ headers: { Accept: 'application/json' } })
     );
   });
 
@@ -49,7 +53,7 @@ describe('signals/settings/users/containers/Overview/hooks/FetchUsers', () => {
 
     expect(global.fetch).toHaveBeenCalledWith(
       expect.stringMatching(new RegExp(`\\/?page_size=${pageSize}$`)),
-      expect.objectContaining({ headers: {} })
+      expect.objectContaining({ headers: { Accept: 'application/json' } })
     );
   });
 
@@ -57,7 +61,9 @@ describe('signals/settings/users/containers/Overview/hooks/FetchUsers', () => {
     const error = new Error('fake error message');
     fetch.mockRejectOnce(error);
 
-    const { result, waitForNextUpdate } = renderHook(() => useFetchUsers({ page: 1 }));
+    const { result, waitForNextUpdate } = renderHook(() =>
+      useFetchUsers({ page: 1 })
+    );
 
     expect(result.current.error).toEqual(false);
 

--- a/src/signals/settings/users/containers/Overview/hooks/useFetchUsers.js
+++ b/src/signals/settings/users/containers/Overview/hooks/useFetchUsers.js
@@ -35,9 +35,13 @@ const useFetchUsers = ({ page, pageSize } = {}) => {
           .filter(Boolean)
           .join('?');
         const response = await fetch(url, {
-          headers: getAuthHeaders(),
+          headers: {
+            ...getAuthHeaders(),
+            Accept: 'application/json',
+          },
           signal,
         });
+
         const userData = await response.json();
         const filteredUserData = filterData(userData.results);
 


### PR DESCRIPTION
This PR fixes an issue where, in Firefox 43, JSON responses from a RESTful API endpoint weren't parsed by the browser and resulted in empty pages or error notifications about content that could not be retrieved.
The solution was fairly simple; add `Accept: 'application/json'` to the request headers.