### PR TITLE
[SIG-2122] Vrij zoeken fix

### DIFF
--- a/src/signals/incident-management/index.js
+++ b/src/signals/incident-management/index.js
@@ -41,12 +41,9 @@ export const IncidentManagementModuleComponent = ({
     }
 
     getFiltersAction();
-  }, [
-    getFiltersAction,
-    requestIncidentsAction,
-    searchIncidentsAction,
-    searchQuery,
-  ]);
+    // disabling linter; no deps needed, only execute on mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   if (!isAuthenticated()) {
     return <Route component={LoginPage} />;


### PR DESCRIPTION
This PR fixes an issue where no search request was dispatched after submitting the search form. The problem was caused by an incorrectly defined set of dependencies for the `IncidentManagement` module `useEffect` hook.