### PR TITLE
[SIG-2126] AbortController polyfill

### DIFF
--- a/internals/webpack/webpack.base.babel.js
+++ b/internals/webpack/webpack.base.babel.js
@@ -12,7 +12,6 @@ module.exports = options => ({
     '@babel/polyfill',
     'formdata-polyfill',
     'url-polyfill',
-    'abortcontroller-polyfill/dist/abortcontroller-polyfill-only',
     require.resolve('react-app-polyfill/ie11'),
   ].concat(options.entry),
   // eslint-disable-next-line prefer-object-spread

--- a/src/signals/settings/users/containers/Detail/hooks/useFetchUser.js
+++ b/src/signals/settings/users/containers/Detail/hooks/useFetchUser.js
@@ -1,3 +1,4 @@
+import 'abortcontroller-polyfill/dist/abortcontroller-polyfill-only';
 import { useState, useEffect } from 'react';
 import { getAuthHeaders } from 'shared/services/auth/auth';
 import { getErrorMessage } from 'shared/services/api/api';

--- a/src/signals/settings/users/containers/Overview/hooks/useFetchUsers.js
+++ b/src/signals/settings/users/containers/Overview/hooks/useFetchUsers.js
@@ -1,3 +1,4 @@
+import 'abortcontroller-polyfill/dist/abortcontroller-polyfill-only';
 import { useState, useEffect } from 'react';
 
 import { getAuthHeaders } from 'shared/services/auth/auth';


### PR DESCRIPTION
This PR fixes an issue in IE11 where the application stopped working when an overview page component was unmounted while it was loading. The cause of this was that the `abortcontroller-polyfill` wasn't applied.