### PR TITLE
(Chore) Remove Pingdom script

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -19,7 +19,6 @@
 
   <link rel="icon" href="/favicon.png" />
   <title>SIA - Signalen Informatievoorziening Amsterdam</title>
-  <script src="//rum-static.pingdom.net/pa-5de788aa3a7031000800098c.js" async></script>
 </head>
 
 <body class="with-sidebars">


### PR DESCRIPTION
Pingdom was a temporary measure for monitoring the site's performance. Since it has been discontinued, the script tag in the public HTML can also go.