### PR TITLE
[SIG-2219] - (Fix) Main menu visibility IE11

### DIFF
--- a/src/components/SiteHeader/index.js
+++ b/src/components/SiteHeader/index.js
@@ -86,6 +86,7 @@ const StyledSearchBar = styled(SearchBar)`
 
 const HeaderWrapper = styled.div`
   z-index: 1;
+  position: relative;
 
   ${({ tall }) =>
     !tall &&


### PR DESCRIPTION
This PR fixes a z-index issue in IE11 where the site header menu wasn't visible after the previous release.