### PR TITLE
(fix) Change in form values

### DIFF
--- a/src/signals/incident-management/components/FilterForm/__tests__/FilterForm.test.js
+++ b/src/signals/incident-management/components/FilterForm/__tests__/FilterForm.test.js
@@ -581,7 +581,7 @@ describe('signals/incident-management/components/FilterForm', () => {
       expect(handlers.onSaveFilter).toHaveBeenCalledTimes(1);
     });
 
-    it('should handle submit for existing filter', () => {
+    it('should handle submit for existing filter', async () => {
       jest.spyOn(window, 'alert').mockImplementation(() => {});
       const handlers = {
         onUpdateFilter: jest.fn(),
@@ -607,13 +607,12 @@ describe('signals/incident-management/components/FilterForm', () => {
         fireEvent.click(container.querySelector('button[type="submit"]'));
       });
 
-      expect(handlers.onUpdateFilter).toHaveBeenCalled();
+      // values haven't changed, update should not be called
+      expect(handlers.onUpdateFilter).not.toHaveBeenCalled();
 
       const nameField = container.querySelector(
         'input[type="text"][name="name"]'
       );
-
-      handlers.onUpdateFilter.mockReset();
 
       act(() => {
         fireEvent.change(nameField, { target: { value: ' ' } });
@@ -623,8 +622,19 @@ describe('signals/incident-management/components/FilterForm', () => {
         fireEvent.click(container.querySelector('button[type="submit"]'));
       });
 
+      // trimmed field value is empty, update should not be called
       expect(handlers.onUpdateFilter).not.toHaveBeenCalled();
       expect(window.alert).toHaveBeenCalled();
+
+      act(() => {
+        fireEvent.change(nameField, { target: { value: 'My changed filter' } });
+      });
+
+      act(() => {
+        fireEvent.click(container.querySelector('button[type="submit"]'));
+      });
+
+      expect(handlers.onUpdateFilter).toHaveBeenCalled();
 
       window.alert.mockRestore();
     });

--- a/src/signals/incident-management/components/FilterForm/__tests__/FilterForm.test.js
+++ b/src/signals/incident-management/components/FilterForm/__tests__/FilterForm.test.js
@@ -581,7 +581,7 @@ describe('signals/incident-management/components/FilterForm', () => {
       expect(handlers.onSaveFilter).toHaveBeenCalledTimes(1);
     });
 
-    it('should handle submit for existing filter', async () => {
+    it('should handle submit for existing filter', () => {
       jest.spyOn(window, 'alert').mockImplementation(() => {});
       const handlers = {
         onUpdateFilter: jest.fn(),

--- a/src/signals/incident-management/components/FilterForm/index.js
+++ b/src/signals/incident-management/components/FilterForm/index.js
@@ -1,4 +1,9 @@
-import React, { useEffect, useMemo, useCallback, useReducer } from 'react';
+import React, {
+  useLayoutEffect,
+  useMemo,
+  useCallback,
+  useReducer,
+} from 'react';
 import PropTypes from 'prop-types';
 import isEqual from 'lodash.isequal';
 import moment from 'moment';
@@ -50,37 +55,40 @@ const FilterForm = ({
   categories,
 }) => {
   const { feedback, priority, stadsdeel, status, source } = dataLists;
+
   const [state, dispatch] = useReducer(reducer, filter, init);
+
   const isNewFilter = useMemo(() => !filter.name, [filter.name]);
+
+  const initialFormState = useMemo(() => cloneDeep(init(filter)), [filter]);
+
+  const valuesHaveChanged = useMemo(() => {
+    const currentState = {
+      ...state.filter,
+      options: parseOutputFormData(state.options),
+    };
+    const initialState = {
+      ...initialFormState.filter,
+      options: parseOutputFormData(initialFormState.options),
+    };
+    const statesAreEqual = isEqual(currentState, initialState);
+
+    return (
+      (!isNewFilter && !statesAreEqual) || (isNewFilter && state.filter.name)
+    );
+  }, [state.filter, state.options, initialFormState, isNewFilter]);
 
   // state update handler; if the form values have changed compared with
   // the initial state, the form's submit button label will change accordingly
-  useEffect(() => {
-    if (isNewFilter) {
-      return;
-    }
-
-    const valuesHaveChanged = !isEqual(
-      {
-        ...state.filter,
-        options: parseOutputFormData(state.options),
-      },
-      {
-        ...initialFormState,
-        options: parseOutputFormData(initialFormState.options),
-      }
-    );
-
+  useLayoutEffect(() => {
     dispatch(setSaveButtonLabel(valuesHaveChanged));
-  }, [state.filter, state.options, initialFormState, isNewFilter]);
+  }, [state.filter.name, valuesHaveChanged, isNewFilter]);
 
   // collection of category objects that is used to set form field values with
   const filterSlugs = useMemo(
     () => state.options.maincategory_slug.concat(state.options.category_slug),
     [state.options.category_slug, state.options.maincategory_slug]
   );
-
-  const initialFormState = useMemo(() => cloneDeep(filter), [filter]);
 
   const dateFrom = useMemo(
     () => state.options.created_after && moment(state.options.created_after),
@@ -98,7 +106,6 @@ const FilterForm = ({
       const options = parseOutputFormData(state.options);
       const formData = { ...state.filter, options };
       const hasName = formData.name.trim() !== '';
-      const valuesHaveChanged = !isEqual(formData, initialFormState);
 
       if (isNewFilter && hasName) {
         onSaveFilter(formData);
@@ -116,7 +123,7 @@ const FilterForm = ({
       onSubmit(event, formData);
     },
     [
-      initialFormState,
+      valuesHaveChanged,
       isNewFilter,
       onSaveFilter,
       onSubmit,


### PR DESCRIPTION
This PR contains a fix for the `FilterForm` component where a change in the form's values was incorrectly derived. The form's update handler didn't take into account if a filter was a new filter or an existing one.