### PR TITLE
[SIG-2238] Incompatible filter data

### DIFF
--- a/src/signals/incident-management/__tests__/selectors.test.js
+++ b/src/signals/incident-management/__tests__/selectors.test.js
@@ -175,6 +175,7 @@ describe('signals/incident-management/selectors', () => {
         ordering: '-created_at',
         page: 1,
         page_size: FILTER_PAGE_SIZE,
+        priority: [],
       });
 
       const state = fromJS({
@@ -198,6 +199,7 @@ describe('signals/incident-management/selectors', () => {
         ordering: '-created_at',
         page: 1,
         page_size: FILTER_PAGE_SIZE,
+        priority: [],
       });
 
       const state2 = fromJS({
@@ -208,6 +210,7 @@ describe('signals/incident-management/selectors', () => {
         ordering: 'created_at',
         page: 1,
         page_size: FILTER_PAGE_SIZE,
+        priority: [],
       });
     });
   });

--- a/src/signals/incident-management/containers/FilterTagList/index.js
+++ b/src/signals/incident-management/containers/FilterTagList/index.js
@@ -47,6 +47,7 @@ const renderGroup = (tag, main, list, tagKey) => {
   if (tag.length === list.length) {
     return renderItem(`${mapKeys(tagKey)}${allLabelAppend}`, tagKey);
   }
+
   return tag.map(item => renderTag(item.key, main, list));
 };
 

--- a/src/signals/incident-management/reducer.js
+++ b/src/signals/incident-management/reducer.js
@@ -33,12 +33,16 @@ export const initialState = fromJS({
   activeFilter: {
     // filter settings for the list of incidents
     name: '',
-    options: {},
+    options: {
+      priority: [],
+    },
   },
   editFilter: {
     // settings selected for editing
     name: '',
-    options: {},
+    options: {
+      priority: [],
+    },
   },
   feedback,
   filters: [],

--- a/src/signals/incident-management/selectors.js
+++ b/src/signals/incident-management/selectors.js
@@ -46,7 +46,7 @@ export const makeSelectAllFilters = createSelector(
         ...filter,
         options: {
           ...filter.options,
-          priority: converted,
+          priority: converted.filter(Boolean),
         },
       };
 
@@ -66,7 +66,17 @@ export const makeSelectActiveFilter = createSelector(
   (stateMap, dataLists, categories) => {
     const state = stateMap.toJS();
 
-    return parseInputFormData(state.activeFilter, {
+    const { priority } = state.activeFilter.options;
+    const converted = Array.isArray(priority) ? priority : [priority];
+    const filter = {
+      ...state.activeFilter,
+      options: {
+        ...state.activeFilter.options,
+        priority: converted.filter(Boolean),
+      },
+    };
+
+    return parseInputFormData(filter, {
       ...dataLists,
       maincategory_slug: categories.main,
       category_slug: categories.sub,

--- a/src/signals/incident-management/selectors.js
+++ b/src/signals/incident-management/selectors.js
@@ -39,13 +39,23 @@ export const makeSelectAllFilters = createSelector(
   (stateMap, dataLists, categories) => {
     const filters = stateMap.get('filters').toJS();
 
-    return filters.map(filter =>
-      parseInputFormData(filter, {
+    return filters.map(filter => {
+      const { priority } = filter.options;
+      const converted = Array.isArray(priority) ? priority : [priority];
+      const fltr = {
+        ...filter,
+        options: {
+          ...filter.options,
+          priority: converted,
+        },
+      };
+
+      return parseInputFormData(fltr, {
         ...dataLists,
         maincategory_slug: categories.main,
         category_slug: categories.sub,
-      })
-    );
+      });
+    });
   }
 );
 
@@ -145,7 +155,10 @@ export const makeSelectIncidents = createSelector(
 export const makeSelectIncidentsCount = createSelector(
   selectIncidentManagementDomain,
   state => {
-    const { incidents: { count } } = state.toJS();
+    const {
+      incidents: { count },
+    } = state.toJS();
 
     return count;
-  });
+  }
+);

--- a/src/signals/incident-management/selectors.js
+++ b/src/signals/incident-management/selectors.js
@@ -41,12 +41,15 @@ export const makeSelectAllFilters = createSelector(
 
     return filters.map(filter => {
       const { priority } = filter.options;
-      const converted = Array.isArray(priority) ? priority : [priority];
+      const converted = (Array.isArray(priority)
+        ? priority
+        : [priority]
+      ).filter(Boolean);
       const fltr = {
         ...filter,
         options: {
           ...filter.options,
-          priority: converted.filter(Boolean),
+          priority: converted,
         },
       };
 
@@ -67,12 +70,14 @@ export const makeSelectActiveFilter = createSelector(
     const state = stateMap.toJS();
 
     const { priority } = state.activeFilter.options;
-    const converted = Array.isArray(priority) ? priority : [priority];
+    const converted = (Array.isArray(priority) ? priority : [priority]).filter(
+      Boolean
+    );
     const filter = {
       ...state.activeFilter,
       options: {
         ...state.activeFilter.options,
-        priority: converted.filter(Boolean),
+        priority: converted,
       },
     };
 


### PR DESCRIPTION
### The issue
An exception is thrown when the filters list is rendered in the filter modal

### The cause
The `priority` field was recently changed from a single string to a list of strings. Storing filters after that change goes as expected. However, previously stored filters do not contain the values that the application expects and therefore runs into unparsable data.

### The solution
The incoming data is converted before it is sent to the parser function.