### PR TITLE
[SIG-2177] Sort categories by name

### DIFF
--- a/src/models/categories/__tests__/saga.test.js
+++ b/src/models/categories/__tests__/saga.test.js
@@ -23,10 +23,12 @@ describe('models/categories/saga', () => {
   });
 
   describe('fetchCategories', () => {
+    const requestUrl = CONFIGURATION.CATEGORIES_PRIVATE_ENDPOINT;
+
     it('should call endpoint and dispatch success', () => {
       testSaga(fetchCategories)
         .next()
-        .call(authCall, CONFIGURATION.CATEGORIES_PRIVATE_ENDPOINT)
+        .call(authCall, `${requestUrl}?page_size=1000`)
         .next(categoriesJson)
         .put(fetchCategoriesSuccess(categoriesJson))
         .next()
@@ -39,7 +41,7 @@ describe('models/categories/saga', () => {
 
       testSaga(fetchCategories)
         .next()
-        .call(authCall, CONFIGURATION.CATEGORIES_PRIVATE_ENDPOINT)
+        .call(authCall, `${requestUrl}?page_size=1000`)
         .throw(error)
         .put(fetchCategoriesFailed(error))
         .next()

--- a/src/models/categories/__tests__/selectors.test.js
+++ b/src/models/categories/__tests__/selectors.test.js
@@ -81,10 +81,11 @@ describe('models/categories/selectors', () => {
     const subCategories = makeSelectSubCategories.resultFunc(
       makeSelectCategories.resultFunc(state)
     );
-    const slugs = subCategories.map(({ slug }) => slug);
+    const slugs = subCategories.map(({ slug }) => slug).sort();
     const keys = categoriesJson.results
       .filter(filterForSub)
-      .map(({ slug }) => slug);
+      .map(({ slug }) => slug)
+      .sort();
 
     expect(slugs).toEqual(keys);
   });

--- a/src/models/categories/saga.js
+++ b/src/models/categories/saga.js
@@ -13,7 +13,7 @@ export function* fetchCategories() {
   const requestURL = CONFIGURATION.CATEGORIES_PRIVATE_ENDPOINT;
 
   try {
-    const categories = yield call(authCall, requestURL);
+    const categories = yield call(authCall, `${requestURL}?page_size=1000`);
 
     yield put(fetchCategoriesSuccess(categories));
   } catch (error) {

--- a/src/signals/incident-management/components/FilterForm/components/CategoryGroups.js
+++ b/src/signals/incident-management/components/FilterForm/components/CategoryGroups.js
@@ -6,33 +6,31 @@ import Label from 'components/Label';
 import CheckboxList from '../../CheckboxList';
 
 const CategoryGroups = ({ categories, filterSlugs, onChange, onToggle }) =>
-  Object.keys(categories.mainToSub)
-    .sort()
-    .map(mainCategory => {
-      const mainCatObj = categories.main.find(
-        ({ slug }) => slug === mainCategory
-      );
-      const options = categories.mainToSub[mainCategory];
-      const defaultValue = filterSlugs.filter(({ key, id }) =>
-        new RegExp(`/terms/categories/${mainCatObj.slug}`).test(key || id)
-      );
+  Object.keys(categories.mainToSub).map(mainCategory => {
+    const mainCatObj = categories.main.find(
+      ({ slug }) => slug === mainCategory
+    );
+    const options = categories.mainToSub[mainCategory];
+    const defaultValue = filterSlugs.filter(({ key, id }) =>
+      new RegExp(`/terms/categories/${mainCatObj.slug}`).test(key || id)
+    );
 
-      return (
-        <CheckboxList
-          defaultValue={defaultValue}
-          groupId={mainCatObj.key}
-          groupName="maincategory_slug"
-          groupValue={mainCatObj.slug}
-          hasToggle
-          key={mainCategory}
-          name={`${mainCatObj.slug}_category_slug`}
-          onChange={onChange}
-          onToggle={onToggle}
-          options={options}
-          title={<Label as="span">{mainCatObj.value}</Label>}
-        />
-      );
-    });
+    return (
+      <CheckboxList
+        defaultValue={defaultValue}
+        groupId={mainCatObj.key}
+        groupName="maincategory_slug"
+        groupValue={mainCatObj.slug}
+        hasToggle
+        key={mainCategory}
+        name={`${mainCatObj.slug}_category_slug`}
+        onChange={onChange}
+        onToggle={onToggle}
+        options={options}
+        title={<Label as="span">{mainCatObj.value}</Label>}
+      />
+    );
+  });
 
 CategoryGroups.defaultProps = {
   filterSlugs: [],


### PR DESCRIPTION
This PR contains a change that makes sure that all categories are returned from their selectors, sorted by name.
Next to that, the endpoint request has been given a query parameter that ensures that all categories will be retrieved, since the default response limit is capped to `100`.