### PR TITLE
[SIG-2263] Inactive categories throw exception in Mijn Filters

### DIFF
--- a/src/signals/shared/filter/__tests__/parse.test.js
+++ b/src/signals/shared/filter/__tests__/parse.test.js
@@ -155,6 +155,18 @@ describe('signals/shared/parse', () => {
       });
     });
 
+    it('should skip slugs that do not have a match in the list of categories', () => {
+      // Categories can be made inactive; those are filtered out when the full list is
+      // retrieved from the API. However, there can still be stored filters with those
+      // inactive categories.
+      const inactiveSlug = 'autom-verzinkbare-palen';
+      const category_slug = dataLists.category_slug.filter(({ slug }) => slug !== inactiveSlug);
+      const parsedInput = parseInputFormData(input, { ...dataLists, category_slug });
+      const outputSlugs = parsedInput.options.category_slug.map(({ slug }) => slug);
+
+      expect(outputSlugs).not.toContain(inactiveSlug);
+    });
+
     describe('parseToAPIData', () => {
       it('should return an object', () => {
         const filterData = { id: 123, name: 'foo' };

--- a/src/signals/shared/filter/parse.js
+++ b/src/signals/shared/filter/parse.js
@@ -81,11 +81,13 @@ export const parseInputFormData = (filterData, dataLists) => {
     Object.keys(options)
       .filter(fieldName => arrayFields.includes(fieldName))
       .forEach(fieldName => {
-        options[fieldName] = options[fieldName].map(value =>
-          dataLists[fieldName].find(
-            ({ key, slug }) => key === value || slug === value
+        options[fieldName] = options[fieldName]
+          .map(value =>
+            dataLists[fieldName].find(
+              ({ key, slug }) => key === value || slug === value
+            )
           )
-        );
+          .filter(Boolean);
       });
   }
 


### PR DESCRIPTION
### Issue
Some users complained about not being able to access their stored filters.

### Cause
The problem was caused by filtered out, inactive, categories.

### Background
The list of categories is retrieved from the public categories endpoint. In the JSON output, some categories are marked as inactive (`is_active: false`). Those inactive categories are filtered out by the `App` container saga after the list has been retrieved.
Prior to deactivating certain categories, there were users that stored a filter that contained the, previously active, filter.
The parse function that converts incoming data into an application readably format, didn't take into account that there could also be no match between the values coming from stored filters and the full of categories.

### The fix
Pretty straightforward: filtering out empty values after the data conversion has taken place.