### PR TITLE
[SIG-2165] fix for fetching incidents when and split was successful

### DIFF
--- a/src/signals/incident-management/__tests__/saga.test.js
+++ b/src/signals/incident-management/__tests__/saga.test.js
@@ -25,6 +25,7 @@ import watchIncidentManagementSaga, {
   fetchIncidents,
   searchIncidents,
 } from '../saga';
+import { SPLIT_INCIDENT_SUCCESS } from '../containers/IncidentSplitContainer/constants';
 import {
   APPLY_FILTER_REFRESH_STOP,
   APPLY_FILTER_REFRESH,
@@ -86,6 +87,7 @@ describe('signals/incident-management/saga', () => {
             PAGE_CHANGED,
             ORDERING_CHANGED,
             PATCH_INCIDENT_SUCCESS,
+            SPLIT_INCIDENT_SUCCESS,
           ],
           fetchProxy
         ),

--- a/src/signals/incident-management/saga.js
+++ b/src/signals/incident-management/saga.js
@@ -57,6 +57,8 @@ import {
   UPDATE_FILTER,
 } from './constants';
 
+import { SPLIT_INCIDENT_SUCCESS } from './containers/IncidentSplitContainer/constants';
+
 import {
   makeSelectActiveFilter,
   makeSelectFilterParams,
@@ -252,6 +254,7 @@ export default function* watchIncidentManagementSaga() {
         PAGE_CHANGED,
         ORDERING_CHANGED,
         PATCH_INCIDENT_SUCCESS,
+        SPLIT_INCIDENT_SUCCESS,
       ],
       fetchProxy
     ),


### PR DESCRIPTION
added SPLIT_INCIDENT_SUCCESS to incident-management saga watch