### PR TITLE
Sig 2119 view rechten op gebruikers tonen en dan doorklikken geeft wit scherm

### DIFF
--- a/src/signals/settings/roles/containers/RolesListContainer/index.js
+++ b/src/signals/settings/roles/containers/RolesListContainer/index.js
@@ -41,7 +41,7 @@ export const RolesListContainer = ({
           <RolesList
             list={list}
             linksEnabled={Boolean(
-              userCan('view_group') || userCan('change_group')
+              userCan('change_group')
             )}
           />
         )}

--- a/src/signals/settings/users/containers/Overview/index.js
+++ b/src/signals/settings/users/containers/Overview/index.js
@@ -93,7 +93,7 @@ export const UsersOverviewContainer = ({ pageSize, userCan }) => {
 
   const onItemClick = useCallback(
     e => {
-      if (userCan('view_user') === false) {
+      if (userCan('change_user') === false) {
         e.preventDefault();
         return;
       }


### PR DESCRIPTION
In this PR:
- it is no longer possible to click a user detail when you no not have change_user permission
- it is no longer possible to click a role detail when you no not have change_group permission
- there is no test in the PR because all useCans are mocked with implementation false, so the change to  change_group and change_user will not trigger an error