### PR TITLE
[SIG-2049] useFetch hook

### DIFF
--- a/internals/testing/test-bundler.js
+++ b/internals/testing/test-bundler.js
@@ -8,8 +8,9 @@ import 'jest-localstorage-mock';
 
 import Enzyme from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
+import fetchMock from 'jest-fetch-mock';
 
-require('jest-fetch-mock').enableMocks();
+fetchMock.enableMocks();
 
 // React 16 Enzyme adapter
 Enzyme.configure({ adapter: new Adapter() });

--- a/internals/testing/test-bundler.js
+++ b/internals/testing/test-bundler.js
@@ -9,7 +9,7 @@ import 'jest-localstorage-mock';
 import Enzyme from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 
-global.fetch = require('jest-fetch-mock');
+require('jest-fetch-mock').enableMocks();
 
 // React 16 Enzyme adapter
 Enzyme.configure({ adapter: new Adapter() });

--- a/package-lock.json
+++ b/package-lock.json
@@ -8403,21 +8403,13 @@
       }
     },
     "cross-fetch": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-2.2.3.tgz",
-      "integrity": "sha512-PrWWNH3yL2NYIb/7WF/5vFG3DCQiXDOVf8k3ijatbrtnwNuhMWLC7YF7uqf53tbTFDzHIUD8oITw4Bxt8ST3Nw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.4.tgz",
+      "integrity": "sha512-MSHgpjQqgbT/94D4CyADeNoYh52zMkCX4pcJvPP5WqPsLFMKjr2TCMg381ox5qI0ii2dPwaLx/00477knXqXVw==",
       "dev": true,
       "requires": {
-        "node-fetch": "2.1.2",
-        "whatwg-fetch": "2.0.4"
-      },
-      "dependencies": {
-        "whatwg-fetch": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
-          "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
-          "dev": true
-        }
+        "node-fetch": "2.6.0",
+        "whatwg-fetch": "3.0.0"
       }
     },
     "cross-spawn": {
@@ -14221,13 +14213,13 @@
       }
     },
     "jest-fetch-mock": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-2.1.2.tgz",
-      "integrity": "sha512-tcSR4Lh2bWLe1+0w/IwvNxeDocMI/6yIA2bijZ0fyWxC4kQ18lckQ1n7Yd40NKuisGmcGBRFPandRXrW/ti/Bw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-3.0.1.tgz",
+      "integrity": "sha512-R5GVbQLVjk+PCfzf4vFoYDXt+oCEWuYigyaAnucdeVCXkElAgAYXDFFikHxLyCVjSNDc7TCYQZ1ItLNOE6OCrQ==",
       "dev": true,
       "requires": {
-        "cross-fetch": "^2.2.2",
-        "promise-polyfill": "^7.1.1"
+        "cross-fetch": "^3.0.4",
+        "promise-polyfill": "^8.1.3"
       }
     },
     "jest-get-type": {
@@ -16976,9 +16968,9 @@
       }
     },
     "node-fetch": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.2.tgz",
-      "integrity": "sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
       "dev": true
     },
     "node-gyp": {
@@ -19707,9 +19699,9 @@
       "dev": true
     },
     "promise-polyfill": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-7.1.2.tgz",
-      "integrity": "sha512-FuEc12/eKqqoRYIGBrUptCBRhobL19PS2U31vMNTfyck1FxPyMfgsXyW4Mav85y/ZN1hop3hOwRlUDok23oYfQ==",
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.3.tgz",
+      "integrity": "sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g==",
       "dev": true
     },
     "prompts": {

--- a/package.json
+++ b/package.json
@@ -172,7 +172,7 @@
     "ip": "1.1.5",
     "jest-cli": "^24.9.0",
     "jest-dom": "^4.0.0",
-    "jest-fetch-mock": "^2.1.2",
+    "jest-fetch-mock": "^3.0.1",
     "jest-localstorage-mock": "^2.4.0",
     "jest-styled-components": "^6.3.4",
     "leaflet-headless": "^0.2.6",

--- a/src/hooks/__tests__/useFetch.test.js
+++ b/src/hooks/__tests__/useFetch.test.js
@@ -1,0 +1,235 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import JSONresponse from 'utils/__tests__/fixtures/user.json';
+
+import useFetch, { headers } from '../useFetch';
+
+const URL = 'https://here-is-my.api/someId/6';
+
+describe('hooks/useFetch', () => {
+  describe('get', () => {
+    it('should request from URL on mount', async () => {
+      fetch.mockResponseOnce(JSON.stringify(JSONresponse));
+
+      const { result, waitForNextUpdate } = renderHook(() => useFetch(URL));
+
+      expect(result.current.isLoading).toEqual(true);
+      expect(result.current.data).toBeUndefined();
+
+      await waitForNextUpdate();
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        URL,
+        expect.objectContaining({ headers })
+      );
+
+      expect(result.current.isLoading).toEqual(false);
+      expect(result.current.data).toEqual(JSONresponse);
+    });
+
+    it('should construct a URL with query params', async () => {
+      const params = {
+        foo: 'bar',
+        qux: 'zork',
+      };
+
+      const { waitForNextUpdate } = renderHook(() => useFetch(URL, params));
+
+      await waitForNextUpdate();
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        `${URL}?foo=bar&qux=zork`,
+        expect.objectContaining({ headers })
+      );
+    });
+
+    it('should return errors that are thrown during fetch', async () => {
+      const error = new Error();
+      fetch.mockRejectOnce(error);
+
+      const { result, waitForNextUpdate } = renderHook(() => useFetch(URL));
+
+      expect(result.current.isLoading).toEqual(true);
+      expect(result.current.error).toEqual(false);
+
+      await waitForNextUpdate();
+
+      expect(result.current.error).toEqual(error);
+      expect(result.current.isLoading).toEqual(false);
+    });
+
+    it('should abort request on unmount', () => {
+      fetch.mockResponseOnce(
+        () =>
+          new Promise(resolve =>
+            setTimeout(() => resolve(JSON.stringify(JSONresponse)), 100)
+          )
+      );
+
+      const abortSpy = jest.spyOn(global.AbortController.prototype, 'abort');
+
+      const { unmount } = renderHook(async () => useFetch(URL));
+
+      expect(abortSpy).not.toHaveBeenCalled();
+
+      unmount();
+
+      expect(abortSpy).toHaveBeenCalled();
+    });
+
+    it('should throw on error response', async () => {
+      const response = { status: 401, ok: false, statusText: 'Unauthorized' };
+
+      fetch.mockImplementation(() => response);
+
+      const { result, waitForNextUpdate } = renderHook(() => useFetch(URL));
+
+      expect(result.current.isLoading).toEqual(true);
+      expect(result.current.error).toEqual(false);
+
+      await waitForNextUpdate();
+
+      expect(result.current.error).toEqual(response);
+      expect(result.current.isLoading).toEqual(false);
+    });
+  });
+
+  describe('patch', () => {
+    it('should send PATCH request', async () => {
+      fetch.mockResponse(JSON.stringify(JSONresponse));
+
+      const { result, waitForNextUpdate } = renderHook(() => useFetch(URL));
+
+      expect(result.current.isLoading).toEqual(true);
+
+      // make sure the side effects are all done
+      await waitForNextUpdate();
+
+      fetch.resetMocks();
+
+      const formData = { ...JSONresponse, is_active: false };
+
+      fetch.mockResponseOnce(JSON.stringify(formData));
+
+      const expectRequest = [
+        URL,
+        expect.objectContaining({
+          headers,
+          body: JSON.stringify(formData),
+          method: 'PATCH',
+        }),
+      ];
+
+      // value of isSuccess can be one of `undefined`, `false`, or `true`
+      expect(result.current.isSuccess).not.toEqual(true);
+
+      expect(global.fetch).not.toHaveBeenLastCalledWith(...expectRequest);
+
+      act(() => {
+        result.current.patch(formData);
+      });
+
+      await waitForNextUpdate();
+
+      expect(global.fetch).toHaveBeenLastCalledWith(...expectRequest);
+
+      expect(result.current.isSuccess).toEqual(true);
+      expect(result.current.isLoading).toEqual(false);
+    });
+
+    it('should throw on error response', async () => {
+      const response = { status: 401, ok: false, statusText: 'Unauthorized' };
+      const formData = { ...JSONresponse, is_active: false };
+      const { result, waitForNextUpdate } = renderHook(() => useFetch(URL));
+
+      expect(result.current.isLoading).toEqual(true);
+      expect(result.current.error).not.toEqual(response);
+      // value of isSuccess can be one of `undefined`, `false`, or `true`
+      expect(result.current.isSuccess).not.toEqual(false);
+
+      // make sure the side effects are all done
+      await waitForNextUpdate();
+
+      const { patch } = result.current;
+
+      // set the result for the patch response
+      fetch.mockImplementation(() => response);
+
+      act(() => {
+        patch(formData);
+      });
+
+      await waitForNextUpdate();
+
+      expect(result.current.error).toEqual(response);
+      expect(result.current.isSuccess).toEqual(false);
+      expect(result.current.isLoading).toEqual(false);
+    });
+  });
+
+  describe('post', () => {
+    it('should send POST request', async () => {
+      const { result, waitForNextUpdate } = renderHook(() => useFetch(URL));
+
+      const formData = {
+        first_name: JSONresponse.first_name,
+        last_name: JSONresponse.last_name,
+        username: JSONresponse.username,
+      };
+      delete formData.id;
+
+      fetch.mockResponseOnce(JSON.stringify(JSONresponse));
+
+      expect(result.current.isSuccess).not.toEqual(true);
+
+      const expectRequest = [
+        URL,
+        expect.objectContaining({
+          headers,
+          body: JSON.stringify(formData),
+          method: 'POST',
+        }),
+      ];
+
+      expect(global.fetch).not.toHaveBeenCalledWith(...expectRequest);
+
+      act(() => {
+        result.current.post(formData);
+      });
+
+      await waitForNextUpdate();
+
+      expect(global.fetch).toHaveBeenCalledWith(...expectRequest);
+
+      expect(result.current.isSuccess).toEqual(true);
+      expect(result.current.isLoading).toEqual(false);
+    });
+
+    it('should throw on error response', async () => {
+      const response = { status: 401, ok: false, statusText: 'Unauthorized' };
+      const formData = { ...JSONresponse, is_active: false };
+      const { result, waitForNextUpdate } = renderHook(() => useFetch(URL));
+
+      expect(result.current.isLoading).toEqual(true);
+      expect(result.current.error).not.toEqual(response);
+      expect(result.current.isSuccess).not.toEqual(false);
+
+      // make sure the side effects are all done
+      await waitForNextUpdate();
+
+      const { post } = result.current;
+
+      // set the result for the patch response
+      fetch.mockImplementation(() => response);
+
+      act(() => {
+        post(formData);
+      });
+
+      await waitForNextUpdate();
+
+      expect(result.current.error).toEqual(response);
+      expect(result.current.isSuccess).toEqual(false);
+      expect(result.current.isLoading).toEqual(false);
+    });
+  });
+});

--- a/src/hooks/useFetch.js
+++ b/src/hooks/useFetch.js
@@ -1,0 +1,122 @@
+import 'abortcontroller-polyfill/dist/abortcontroller-polyfill-only';
+import { useState, useEffect } from 'react';
+import { getAuthHeaders } from 'shared/services/auth/auth';
+import { getErrorMessage } from 'shared/services/api/api';
+
+export const headers = {
+  ...getAuthHeaders(),
+  'Content-Type': 'application/json',
+  Accept: 'application/json',
+};
+
+/**
+ * Custom hook useFetch
+ *
+ * Will take a URL and an optional object of parameters and use those to construct a request URL
+ * with, call fetch and return the response.
+ *
+ * @param {Object} params - key/value
+ * @returns {FetchResponse}
+ */
+export default (URL, params) => {
+  const [isLoading, setLoading] = useState();
+  const [data, setData] = useState();
+  const [error, setError] = useState(false);
+  const [isSuccess, setSuccess] = useState();
+
+  const queryParams = Object.entries(params || {})
+    .filter(([, value]) => Boolean(value))
+    .reduce((acc, [key, value]) => [...acc, `${key}=${value}`], [])
+    .join('&');
+
+  const url = [URL, queryParams].filter(Boolean).join('?');
+
+  const controller = new AbortController();
+  const { signal } = controller;
+
+  useEffect(() => {
+    async function fetchData() {
+      setLoading(true);
+
+      try {
+        const response = await fetch(url, {
+          headers,
+          signal,
+        });
+
+        /* istanbul ignore else */
+        if (response.ok === false) {
+          throw response;
+        }
+
+        const JSONResponse = await response.json();
+
+        setData(JSONResponse);
+      } catch (e) {
+        e.message = getErrorMessage(e);
+        setError(e);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    fetchData();
+
+    return () => {
+      controller.abort();
+    };
+    // linter complains about missing deps although using `controller` and `signal` will throw this component in an endless loop
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [url, params]);
+
+  const modify = method => async modifiedData => {
+    setLoading(true);
+
+    try {
+      const response = await fetch(url, {
+        headers,
+        method,
+        signal,
+        body: JSON.stringify(modifiedData),
+      });
+
+      /* istanbul ignore else */
+      if (response.ok === false) {
+        throw response;
+      }
+
+      const responseData = await response.json();
+
+      setData(responseData);
+      setSuccess(true);
+    } catch (e) {
+      e.message = getErrorMessage(e);
+
+      setError(e);
+      setSuccess(false);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const post = modify('POST');
+  const patch = modify('PATCH');
+
+  /**
+   * @typedef {Object} FetchResponse
+   * @property {Object} data - Fetch response
+   * @property {Error} error - Error object thrown during fetch and data parsing
+   * @property {Boolean} isLoading - Indicator of fetch request status
+   * @property {Boolean} isSuccess - Indicator of post or patch request status
+   * @property {Function} patch - Function that expects the user data object as parameter
+   * @property {Function} post - Function that expects the user data object as parameter
+   */
+  return {
+    data,
+    error,
+    isLoading,
+    isSuccess,
+    patch,
+    post,
+  };
+};


### PR DESCRIPTION
# Custom `useFetch` hook
This PR adds a generic `useFetch` hook. The hook contains asynchronous request handlers and can be used as follows

## GET

```jsx
const MyComponent = ({ id }) => {
  const { isLoading, error, data, get } = useFetch();

  useEffect(() => {
    const params = { foo: 'bar' };
    // method get can be given a query parameter object as its 
    // second function parameter
    get(`${ENDPOINT_URL}${id}`, params);
  }, []);

  return isLoading ? (
    <LoadingIndicator />
  ) : (
    // do something with data
  );
```

## PATCH

```jsx
const MyComponent = ({ id }) => {
  const { isLoading, isSuccess, error, data, patch } = useFetch();

  useEffect(() => {
    if (isSuccess) {
      global.alert('Success!!!1!);
    }
  }, [isSuccess]);

  const onSubmit = formData => {
    patch(`${ENDPOINT_URL}${id}`, formData);
  };

  return isLoading ? (
    <LoadingIndicator />
  ) : (
    <FormComponent onSubmit={onSubmit} />
  );
```

## POST

```jsx
const MyComponent = () => {
  const { isLoading, isSuccess, error, data, post } = useFetch();

  useEffect(() => {
    if (isSuccess) {
      // redirect to another page or whatever
    }
  }, [isSuccess]);

  const onSubmit = formData => {
    post(ENDPOINT_URL, formData);
  };

  return isLoading ? (
    <LoadingIndicator />
  ) : (
    <FormComponent onSubmit={onSubmit} />
  );
```