### PR TITLE
[SIG-2048] allow for disabled checkboxes

### DIFF
--- a/src/signals/incident-management/components/CheckboxList/__tests__/CheckboxList.test.js
+++ b/src/signals/incident-management/components/CheckboxList/__tests__/CheckboxList.test.js
@@ -432,4 +432,59 @@ describe('signals/incident-management/components/CheckboxList', () => {
       expect(keys.includes(element.value));
     });
   });
+
+  it('should apply boxWrapperKeyPrefix prop value', () => {
+    const boxWrapperKeyPrefix = 'FooBar';
+    const options = categories.mainToSub.afval;
+    const { container } = render(
+      withAppContext(
+        <CheckboxList
+          boxWrapperKeyPrefix={boxWrapperKeyPrefix}
+          defaultValue={options.slice(0, 2)}
+          name="afval"
+          options={options}
+        />
+      )
+    );
+
+    const prefixedElements = container.querySelectorAll(`[id^="${boxWrapperKeyPrefix}"]`);
+
+    expect(prefixedElements.length).toBeGreaterThan(1);
+  });
+
+  it('should render checkboxes as disabled elements', () => {
+    const groupId = 'zoek';
+
+    const { container, rerender } = render(
+      withAppContext(
+        <CheckboxList
+          defaultValue={statuses}
+          groupId={groupId}
+          groupName="statuses"
+          hasToggle
+          name="status"
+          options={statuses}
+        />
+      )
+    );
+
+    expect(container.querySelectorAll('input[type=checkbox][disabled]')).toHaveLength(0);
+
+    const disabledValues = statuses.map(status => ({ ...status, disabled: true }));
+
+    rerender(
+      withAppContext(
+        <CheckboxList
+          defaultValue={disabledValues}
+          groupId={groupId}
+          groupName="statuses"
+          hasToggle
+          name="status"
+          options={statuses}
+        />
+      )
+    );
+
+    expect(container.querySelectorAll('input[type=checkbox][disabled]')).toHaveLength(statuses.length);
+  });
 });

--- a/src/signals/incident-management/components/CheckboxList/index.js
+++ b/src/signals/incident-management/components/CheckboxList/index.js
@@ -1,6 +1,6 @@
 import React, { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import { Checkbox, themeSpacing } from '@datapunt/asc-ui';
 import * as types from 'shared/types';
 
@@ -40,10 +40,23 @@ const StyledCheckbox = styled(Checkbox)`
   padding-right: ${themeSpacing(2)};
 `;
 
+const Wrapper = styled.div`
+  ${({ disabled }) =>
+    disabled &&
+    css`
+      opacity: 0.2;
+
+      * {
+        pointer-events: none;
+      }
+    `}
+`;
+
 const setsAreEqual = (a, b) =>
   a.size === b.size && [...a].every(value => b.has(value));
 
 const CheckboxList = ({
+  boxWrapperKeyPrefix,
   className,
   defaultValue,
   groupId,
@@ -234,18 +247,23 @@ const CheckboxList = ({
 
       {options.map(({ id, key, slug, value: label }) => {
         const uid = id || key;
-        const optionId = [name, uid].filter(Boolean).join('_');
+        const optionId = [boxWrapperKeyPrefix, name, uid]
+          .filter(Boolean)
+          .join('_');
         const value = slug || key;
+        const defaultOption =
+          defaultValue.find(option => option.id === id) || {};
 
         if (!uid) {
           return null;
         }
 
         return (
-          <div key={optionId}>
+          <Wrapper disabled={defaultOption.disabled} key={optionId}>
             <StyledCheckbox
               checked={isChecked(groupId) || isChecked(uid)}
               data-id={uid}
+              disabled={defaultOption.disabled}
               id={optionId}
               name={name}
               onChange={handleIndividualCheck}
@@ -253,7 +271,7 @@ const CheckboxList = ({
               value={value}
             />
             <label htmlFor={optionId}>{label}</label>
-          </div>
+          </Wrapper>
         );
       })}
     </FilterGroup>
@@ -261,6 +279,7 @@ const CheckboxList = ({
 };
 
 CheckboxList.defaultProps = {
+  boxWrapperKeyPrefix: '',
   className: '',
   defaultValue: [],
   groupId: undefined,
@@ -275,6 +294,7 @@ CheckboxList.defaultProps = {
 };
 
 CheckboxList.propTypes = {
+  boxWrapperKeyPrefix: PropTypes.string,
   /** @ignore */
   className: PropTypes.string,
   /** List of keys for elements that need to be checked by default */


### PR DESCRIPTION
This PR contains changes to the `CheckboxList` component that allow rendering disabled checkboxes. 

In addition, to indicate that boxes have been disabled, a box' wrapper has been given an opacity of `0.2` which looks like this:

![Screenshot 2020-02-21 at 16 09 30](https://user-images.githubusercontent.com/1062191/75045984-93e80100-54c4-11ea-90f0-cd91da631813.png)
