### PR TITLE
[SIG-2048] Custom hooks

### DIFF
--- a/src/signals/settings/hooks/__tests__/useConfirmedCancel.test.js
+++ b/src/signals/settings/hooks/__tests__/useConfirmedCancel.test.js
@@ -1,0 +1,62 @@
+import { renderHook } from '@testing-library/react-hooks';
+import * as reactRouterDom from 'react-router-dom';
+
+import useConfirmedCancel, { confirmationMessage } from '../useConfirmedCancel';
+
+jest.mock('react-router-dom', () => ({
+  __esModule: true,
+  ...jest.requireActual('react-router-dom'),
+}));
+
+const push = jest.fn();
+jest.spyOn(reactRouterDom, 'useHistory').mockImplementation(() => ({
+  push,
+}));
+
+const redirectURL = 'https://redirect-me-here';
+
+global.window.confirm = jest.fn();
+
+describe('signals/settings/hooks/useConfirmedCancel', () => {
+  it('should redirect', () => {
+    const pristine = true;
+    const { result } = renderHook(() => useConfirmedCancel(redirectURL));
+
+    expect(push).not.toHaveBeenCalled();
+
+    result.current(pristine);
+
+    expect(push).toHaveBeenCalledWith(redirectURL);
+
+    expect(global.window.confirm).not.toHaveBeenCalled();
+  });
+
+  it('should show a confirm', () => {
+    const { result } = renderHook(() => useConfirmedCancel(redirectURL));
+
+    expect(global.window.confirm).not.toHaveBeenCalled();
+
+    result.current(true);
+
+    expect(global.window.confirm).not.toHaveBeenCalled();
+
+    expect(push).toHaveBeenCalled();
+
+    push.mockReset();
+
+    result.current(false);
+
+    expect(global.window.confirm).toHaveBeenCalledWith(confirmationMessage);
+
+    expect(push).not.toHaveBeenCalled();
+
+    global.window.confirm.mockReset();
+    global.window.confirm.mockReturnValue(true);
+
+    result.current(false);
+
+    expect(global.window.confirm).toHaveBeenCalledWith(confirmationMessage);
+
+    expect(push).toHaveBeenCalledWith(redirectURL);
+  });
+});

--- a/src/signals/settings/hooks/__tests__/useFetchResponseNotification.test.js
+++ b/src/signals/settings/hooks/__tests__/useFetchResponseNotification.test.js
@@ -1,0 +1,132 @@
+import { renderHook } from '@testing-library/react-hooks';
+import * as reactRouterDom from 'react-router-dom';
+import * as reactRedux from 'react-redux';
+import { withAppContext } from 'test/utils';
+import { showGlobalNotification } from 'containers/App/actions';
+import {
+  TYPE_LOCAL,
+  VARIANT_ERROR,
+  VARIANT_SUCCESS,
+} from 'containers/Notification/constants';
+
+import useFetchResponseNotification from '../useFetchResponseNotification';
+
+jest.mock('react-router-dom', () => ({
+  __esModule: true,
+  ...jest.requireActual('react-router-dom'),
+}));
+
+jest.mock('react-redux', () => ({
+  __esModule: true,
+  ...jest.requireActual('react-redux'),
+  dispatch: jest.fn(),
+}));
+
+const push = jest.fn();
+jest.spyOn(reactRouterDom, 'useHistory').mockImplementation(() => ({
+  push,
+}));
+
+const dispatch = jest.fn();
+jest.spyOn(reactRedux, 'useDispatch').mockImplementation(() => dispatch);
+
+describe('signals/settings/hooks/useFetchResponseNotification', () => {
+  afterEach(() => {
+    push.mockReset();
+    dispatch.mockReset();
+  });
+
+  it('should not do anything', () => {
+    renderHook(() =>
+      withAppContext(useFetchResponseNotification({ isLoading: true }))
+    );
+
+    renderHook(() =>
+      withAppContext(
+        useFetchResponseNotification({ isLoading: true, error: new Error() })
+      )
+    );
+
+    renderHook(() =>
+      withAppContext(
+        useFetchResponseNotification({
+          isLoading: true,
+          error: new Error(),
+          isSuccess: true,
+        })
+      )
+    );
+
+    renderHook(() =>
+      withAppContext(useFetchResponseNotification({ isLoading: false }))
+    );
+
+    expect(dispatch).not.toHaveBeenCalled();
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it('should dispatch error', () => {
+    const title = 'Keyboard not found. Press F1 to continue.';
+    const variant = VARIANT_ERROR;
+    const type = TYPE_LOCAL;
+
+    renderHook(() =>
+      withAppContext(useFetchResponseNotification({ error: new Error(title) }))
+    );
+
+    expect(dispatch).toHaveBeenCalledWith(
+      showGlobalNotification({ title, variant, type })
+    );
+
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it('should dispatch success', () => {
+    renderHook(() =>
+      withAppContext(useFetchResponseNotification({ isSuccess: true }))
+    );
+
+    const type = TYPE_LOCAL;
+    const variant = VARIANT_SUCCESS;
+
+    expect(dispatch).toHaveBeenCalledWith(
+      showGlobalNotification({ title: 'Gegevens toegevoegd', variant, type })
+    );
+
+    renderHook(() =>
+      withAppContext(useFetchResponseNotification({ isSuccess: true, entityName: 'Gebruiker' }))
+    );
+
+    expect(dispatch).toHaveBeenCalledWith(
+      showGlobalNotification({ title: 'Gebruiker toegevoegd', variant, type })
+    );
+
+    renderHook(() =>
+      withAppContext(useFetchResponseNotification({ isSuccess: true, isExisting: true }))
+    );
+
+    expect(dispatch).toHaveBeenLastCalledWith(
+      showGlobalNotification({ title: 'Gegevens bijgewerkt', variant, type })
+    );
+
+    renderHook(() =>
+      withAppContext(useFetchResponseNotification({ isSuccess: true, isExisting: true, entityName: 'Gebruiker' }))
+    );
+
+    expect(dispatch).toHaveBeenCalledWith(
+      showGlobalNotification({ title: 'Gebruiker bijgewerkt', variant, type })
+    );
+
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it('should redirect', () => {
+    const redirectURL = 'https://redirect-me-here';
+
+    renderHook(() =>
+      withAppContext(useFetchResponseNotification({ isSuccess: true, redirectURL }))
+    );
+
+    expect(push).toHaveBeenCalledWith(redirectURL);
+  });
+});

--- a/src/signals/settings/hooks/useConfirmedCancel.js
+++ b/src/signals/settings/hooks/useConfirmedCancel.js
@@ -1,0 +1,34 @@
+import { useHistory } from 'react-router-dom';
+
+export const confirmationMessage = 'Niet opgeslagen gegevens gaan verloren. Doorgaan?';
+
+/**
+ * Custom hook useConfirmedCancel
+ *
+ * Will take a URL and can be used as onCancel callback for forms
+ *
+ * @param {String} redirectURL - key/value
+ * @returns {Function}
+ */
+const useConfirmedCancel = redirectURL => {
+  const history = useHistory();
+
+  /**
+   * redirect function
+   *
+   * @param {Boolean} isPristine - Flag indicating if the form data has changed
+   */
+  const redirect = isPristine => {
+    if (
+      isPristine ||
+      (!isPristine &&
+        global.confirm(confirmationMessage))
+    ) {
+      history.push(redirectURL);
+    }
+  };
+
+  return redirect;
+};
+
+export default useConfirmedCancel;

--- a/src/signals/settings/hooks/useFetchResponseNotification.js
+++ b/src/signals/settings/hooks/useFetchResponseNotification.js
@@ -1,0 +1,83 @@
+import { useDispatch } from 'react-redux';
+import { useCallback, useEffect } from 'react';
+import { useHistory } from 'react-router-dom';
+
+import {
+  TYPE_LOCAL,
+  VARIANT_ERROR,
+  VARIANT_SUCCESS,
+} from 'containers/Notification/constants';
+import { showGlobalNotification } from 'containers/App/actions';
+
+/**
+ * Custom hook useConfirmedCancel
+ *
+ * Will take a URL and can be used as onCancel callback for forms
+ *
+ * @param {Object} options
+ * @param {String} options.entityName - Name by which the stored/patched data should be labeled (eg. 'Afdeling')
+ * @param {Error} options.error - Exception object
+ * @param {Boolean} options.isExisting - Flag indicating if notification should mention newly stored data
+ * @param {Boolean} options.isLoading - Flag indicating if data is still loading
+ * @param {Boolean} options.isSuccess - Flag indicating if data has been stored/patched successfully
+ * @param {String} options.redirectURL - URL to which the push should be directed when isSuccess is truthy
+ * @returns {void}
+ */
+const useFetchResponseNotification = ({
+  entityName,
+  error,
+  isExisting,
+  isLoading,
+  isSuccess,
+  redirectURL,
+}) => {
+  const dispatch = useDispatch();
+  const history = useHistory();
+  const showNotification = useCallback(
+    (variant, title) =>
+      dispatch(
+        showGlobalNotification({
+          variant,
+          title,
+          type: TYPE_LOCAL,
+        })
+      ),
+    [dispatch]
+  );
+
+  useEffect(() => {
+    if (isLoading || !(error || isSuccess)) return;
+
+    let message;
+    let variant = VARIANT_SUCCESS;
+
+    if (error) {
+      ({ message } = error);
+      variant = VARIANT_ERROR;
+    }
+
+    if (isSuccess) {
+      const entityLabel = entityName || 'Gegevens';
+      message = isExisting
+        ? `${entityLabel} bijgewerkt`
+        : `${entityLabel} toegevoegd`;
+    }
+
+    showNotification(variant, message);
+
+    if (isSuccess && redirectURL) {
+      history.push(redirectURL);
+    }
+  }, [
+    entityName,
+    error,
+    history,
+    isExisting,
+    isLoading,
+    isSuccess,
+    redirectURL,
+    showNotification,
+  ]);
+};
+
+export default useFetchResponseNotification;


### PR DESCRIPTION
# Custom hooks

This PR adds two custom hooks for the `settings` module:
- `useConfirmedCancel`
- `useFetchResponseNotification`

## useConfirmedCancel

This hook can be used to show a confirmation (`window.confirm`) message when a form's cancel button is clicked. It takes the URL to redirect to after cancel as parameter and returns a function that takes a single parameter: `isPristine` and is to be used as follows:

```jsx
const MyComponent = () => {
  const redirectOnCancelURL = '/some-overview-page';
  const [state, dispatch] = useReducer(reducer);
  const confirmedCancel = useConfirmedCancel(redirectOnCancelURL);

  const onFormCancel = () => {
    const formData = new FormData(document.forms[0]);
    // ...
    const isPristine = isEqual(formData, state);
    confirmedCancel(isPristine);
  };

  return (
    <form onCancel={onFormCancel}>
      ...
      <button type="button" onClick={onFormCancel}>Cancel</button>
    </form>
  );
};
```

## useFetchResponseNotification

This hook can be used to enhance a form's submit action by showing a global notification and, optionally, redirecting. The hook takes an options object as parameter with the following props:

| Prop        	| Type    	| Default     	| Note                                                                                              	|
|-------------	|---------	|-------------	|---------------------------------------------------------------------------------------------------	|
| entityName  	| String  	| `undefined` 	| Is prepended to the notification message                                                          	|
| error       	| Error   	| `undefined` 	| When not `undefined`, will show a red notification bar                                            	|
| isExisting  	| Boolean 	| `false`     	| Value will determine if the notification shows 'toegevoegd' or 'bijgewerkt'                       	|
| isLoading   	| Boolean 	| `false`     	| When `false` will not proceed showing anything (only when both `error` and `isSuccess` are falsy) 	|
| isSuccess   	| Boolean 	| `false`     	| Value will determine the type of notification and if the page should redirect                     	|
| redirectURL 	| String  	| `''`        	| When given a value and `isSuccess` is truthy, the page will redirect                              	|

The hook is to be used as follows:

```jsx
const MyComponent = () => {
  const { userId } = useParams();
  const isExistingUser = Boolean(userId);
  const { isLoading, isSuccess, data, error, get, patch } = useFetch();
  const entityName = 'Gebruiker';

  useFetchResponseNotification({
    entityName,
    error,
    isExisting: isExistingUser,
    isLoading,
    isSuccess,
    redirectURL: routes.users,
  });
};
```