### PR TITLE
[SIG-2308] Fix for not showing extra properties

### DIFF
--- a/src/signals/incident/containers/IncidentContainer/saga.js
+++ b/src/signals/incident/containers/IncidentContainer/saga.js
@@ -49,9 +49,11 @@ export function* createIncident(action) {
       `${CONFIGURATION.CATEGORIES_ENDPOINT}${category}/sub_categories/${subcategory}`
     );
 
+    const controlsToParams = mapControlsToParams(action.payload.incident, action.payload.wizard);
+
     const postData = {
       ...action.payload.incident,
-      handling_message,
+      ...controlsToParams,
       category: {
         sub_category,
       },
@@ -60,7 +62,7 @@ export function* createIncident(action) {
     const postResult = yield call(
       postCall,
       CONFIGURATION.INCIDENT_ENDPOINT,
-      mapControlsToParams(postData, action.payload.wizard)
+      postData
     );
 
     const incident = { ...postResult, handling_message };

--- a/src/signals/incident/services/map-values/index.js
+++ b/src/signals/incident/services/map-values/index.js
@@ -1,15 +1,14 @@
-import forEach from 'lodash.foreach';
 import set from 'lodash.set';
 import isObject from 'lodash.isobject';
 
 import getStepControls from '../get-step-controls';
 import convertValue from '../convert-value';
 
-const mapValues = (params, incident, wizard) => {
-  forEach(wizard, step => {
+const mapValues = (params, incident = {}, wizard = {}) => {
+  Object.values(wizard).forEach(step => {
     const controls = getStepControls(step, incident);
 
-    forEach(controls, (control, name) => {
+    Object.entries(controls).forEach(([name, control]) => {
       const value = incident[name];
       const meta = control.meta;
 
@@ -25,6 +24,7 @@ const mapValues = (params, incident, wizard) => {
       }
     });
   });
+
   return params || {};
 };
 


### PR DESCRIPTION
# Fix for not showing extra properties

This PR contains a fix for an issue that was introduced by the categories public endpoint removal.

## Background

Submitting an incident can have a payload that contains the `extra_properties` prop. This prop contains all the extra questions (aanvullende vragen/uitvraagpagina's) that a specific incident category dictates.

The contents of that payload are shown on the incident detail page below the location map.

## Cause

In a previous refactor, the call to the `mapControlsToParams` function contained an object with a wrong set of properties. This caused the result of the function to not contain the extra properties that were added to the incident on creation.

## The Fix

The previous refactor of the incident container saga has been partially reverted and tests have been adapted so that the correct procedure is asserted.