### PR TITLE
[SIG-2314] Fix for radio button list display

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/components/MetaList/components/ChangeValue/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/MetaList/components/ChangeValue/index.js
@@ -8,7 +8,7 @@ import { incidentType, dataListType } from 'shared/types';
 
 import { getListValueByKey } from 'shared/services/list-helper/list-helper';
 
-import RadioInput from 'signals/incident-management/components/RadioInput';
+import SelectInput from 'signals/incident-management/components/SelectInput';
 import FieldControlWrapper from 'signals/incident-management/components/FieldControlWrapper';
 
 import './style.scss';
@@ -59,7 +59,7 @@ class ChangeValue extends React.Component { // eslint-disable-line react/prefer-
 
   render() {
     const {
-      display, definitionClass, valueClass, list, incident, path, valuePath, sort, disabled,
+      component, display, definitionClass, valueClass, list, incident, path, valuePath, sort, disabled,
     } = this.props;
     const { formVisible } = this.state;
     return (
@@ -77,7 +77,7 @@ class ChangeValue extends React.Component { // eslint-disable-line react/prefer-
                 <form onSubmit={this.handleSubmit} className="change-value__form">
                   <Fragment>
                     <FieldControlWrapper
-                      render={RadioInput}
+                      render={component}
                       name="input"
                       values={list}
                       className="change-value__form-input"
@@ -121,12 +121,14 @@ class ChangeValue extends React.Component { // eslint-disable-line react/prefer-
 }
 
 ChangeValue.defaultProps = {
+  component: SelectInput,
   valuePath: '',
   patch: {},
   disabled: false,
 };
 
 ChangeValue.propTypes = {
+  component: PropTypes.func,
   incident: incidentType.isRequired,
   definitionClass: PropTypes.string.isRequired,
   valueClass: PropTypes.string.isRequired,

--- a/src/signals/incident-management/containers/IncidentDetail/components/MetaList/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/MetaList/index.js
@@ -9,6 +9,7 @@ import {
 } from 'shared/services/string-parser/string-parser';
 
 import { incidentType, dataListType } from 'shared/types';
+import RadioInput from 'signals/incident-management/components/RadioInput';
 
 import ChangeValue from './components/ChangeValue';
 import Highlight from '../Highlight';
@@ -80,6 +81,7 @@ const MetaList = ({
               path="priority.priority"
               type="priority"
               onPatchIncident={onPatchIncident}
+              component={RadioInput}
             />
           </Highlight>
         )}

--- a/src/signals/incident-management/containers/IncidentDetail/components/MetaList/index.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/MetaList/index.test.js
@@ -1,17 +1,24 @@
 import React from 'react';
 import {
+  fireEvent,
   render,
   cleanup,
+  act,
 } from '@testing-library/react';
 
 import { string2date, string2time } from 'shared/services/string-parser/string-parser';
 import { withAppContext } from 'test/utils';
+import categories from 'utils/__tests__/fixtures/categories_structured.json';
 
 import priorityList from '../../../../definitions/priorityList';
 
 import MetaList from './index';
 
 jest.mock('shared/services/string-parser/string-parser');
+
+const subcategories = Object.entries(categories).flatMap(
+  ([, { sub }]) => sub
+);
 
 describe('<MetaList />', () => {
   let props;
@@ -32,7 +39,7 @@ describe('<MetaList />', () => {
         },
         source: 'public-api',
         status: {
-          status: 'm',
+          state: 'm',
           state_display: 'Gemeld',
         },
         priority: {
@@ -40,10 +47,7 @@ describe('<MetaList />', () => {
         },
         _links: {},
       },
-      subcategories: [{
-        key: 'https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/overlast-bedrijven-en-horeca/sub_categories/overig-horecabedrijven',
-        value: 'Overig bedrijven / horeca',
-      }],
+      subcategories,
       priorityList,
       onPatchIncident: jest.fn(),
       onEditStatus: jest.fn(),
@@ -81,6 +85,56 @@ describe('<MetaList />', () => {
 
       expect(queryByTestId('meta-list-source-definition')).toHaveTextContent(/^Bron$/);
       expect(queryByTestId('meta-list-source-value')).toHaveTextContent(/^public-api$/);
+    });
+
+    it('should render the correct HTML elements for priority', () => {
+      const { getByText } = render(
+        <MetaList {...props} />
+      );
+
+      const showFormButton = getByText('Urgentie')
+        .closest('div')
+        .querySelector('.change-value__edit.incident-detail__button--edit');
+
+      expect(
+        getByText('Urgentie')
+          .closest('div')
+          .querySelectorAll('input[type="radio"]').length
+      ).toBe(0);
+
+      act(() => {
+        fireEvent.click(showFormButton);
+      });
+
+      expect(
+        getByText('Urgentie')
+          .closest('div')
+          .querySelectorAll('input[type="radio"]').length
+      ).toBeGreaterThan(0);
+    });
+
+    it.only('should render the correct HTML elements for subcategories', () => {
+      const { getByText } = render(<MetaList {...props} />);
+
+      const showFormButton = getByText('Subcategorie')
+        .closest('div')
+        .querySelector('.change-value__edit.incident-detail__button--edit');
+
+      expect(
+        getByText('Subcategorie')
+          .closest('div')
+          .querySelectorAll('form select').length
+      ).toBe(0);
+
+      act(() => {
+        fireEvent.click(showFormButton);
+      });
+
+      expect(
+        getByText('Subcategorie')
+          .closest('div')
+          .querySelectorAll('form select').length
+      ).toBeGreaterThan(0);
     });
 
     it('should render correctly with high priority', () => {


### PR DESCRIPTION
This PR contains a fix for a previously merged PR (#649). This change allow rendering different components in the incident detail's `MetaList` component by setting a default and setting a specific component where necessary.

Extra tests were added to assert the functional aspects of the change.