### PR TITLE
Chore remove connect from contacts overview

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -69,6 +69,7 @@ module.exports = {
     'no-console': 1,
     'no-unused-vars': 2,
     'no-use-before-define': 0,
+    'object-curly-spacing': [1, 'always'],
     'prefer-template': 2,
     'react/destructuring-assignment': 0,
     'react-hooks/exhaustive-deps': 'warn',

--- a/src/signals/settings/users/containers/Overview/__tests__/Overview.test.js
+++ b/src/signals/settings/users/containers/Overview/__tests__/Overview.test.js
@@ -7,7 +7,7 @@ import { USER_URL, USERS_PAGED_URL } from 'signals/settings/routes';
 import configuration from 'shared/services/configuration/configuration';
 import * as constants from 'containers/App/constants';
 import * as appSelectors from 'containers/App/selectors';
-import { UsersOverviewContainer } from '..';
+import UsersOverviewContainer from '..';
 
 jest.mock('containers/App/constants', () => ({
   __esModule: true,

--- a/src/signals/settings/users/containers/Overview/__tests__/Overview.test.js
+++ b/src/signals/settings/users/containers/Overview/__tests__/Overview.test.js
@@ -18,11 +18,8 @@ constants.PAGE_SIZE = 50;
 
 let testContext = {};
 const usersOverviewWithAppContext = (overrideProps = {}, overrideCfg = {}) => {
-  const { userCan, history } = testContext;
-  const props = {
-    userCan,
-    ...overrideProps,
-  };
+  const { history } = testContext;
+  const props = { ...overrideProps };
 
   return withCustomAppContext(<UsersOverviewContainer {...props} />)({
     routerCfg: { history },
@@ -35,7 +32,6 @@ describe('signals/settings/users/containers/Overview', () => {
   beforeEach(() => {
     const push = jest.fn();
     const scrollTo = jest.fn();
-    const userCan = () => true;
     const apiHeaders = {
       headers: {
         Accept: 'application/json',
@@ -57,7 +53,6 @@ describe('signals/settings/users/containers/Overview', () => {
       history,
       push,
       scrollTo,
-      userCan,
     };
   });
 

--- a/src/signals/settings/users/containers/Overview/index.js
+++ b/src/signals/settings/users/containers/Overview/index.js
@@ -5,22 +5,20 @@ import React, {
   useMemo,
   useCallback, useReducer,
 } from 'react';
-import PropTypes from 'prop-types';
 import { useParams, useHistory, useLocation, Link } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+
 import { Row, Column, themeSpacing, Button, SearchBar } from '@datapunt/asc-ui';
 import styled from 'styled-components';
-import { createStructuredSelector } from 'reselect';
-import { connect } from 'react-redux';
-import { compose } from 'redux';
 import debounce from 'lodash/debounce';
 
 import { PAGE_SIZE } from 'containers/App/constants';
-import { makeSelectUserCan } from 'containers/App/selectors';
 import LoadingIndicator from 'shared/components/LoadingIndicator';
 import Pagination from 'components/Pagination';
 import PageHeader from 'signals/settings/components/PageHeader';
 import DataView from 'components/DataView';
 import { USERS_PAGED_URL, USER_URL } from 'signals/settings/routes';
+import { makeSelectUserCan } from 'containers/App/selectors';
 import useFetchUsers from './hooks/useFetchUsers';
 
 const StyledPagination = styled(Pagination)`
@@ -39,7 +37,7 @@ const StyledSearchbar = styled(SearchBar)`
   }
 `;
 
-const filtersReducer = (state, action) => {
+const filtersReducer = (_, action) => {
   switch (action.type) {
     case 'username':
       return { username: action.payload };
@@ -54,7 +52,7 @@ const StyledDataView = styled(DataView)`
   }
 `;
 
-export const UsersOverviewContainer = ({ userCan }) => {
+export const UsersOverviewContainer = () => {
   const history = useHistory();
   const location = useLocation();
   const filtersInitialState = location.state && location.state.filters || {};
@@ -62,6 +60,7 @@ export const UsersOverviewContainer = ({ userCan }) => {
   const [page, setPage] = useState(1);
   const [filters, dispatchFiltersChange] = useReducer(filtersReducer, filtersInitialState);
   const { isLoading, users: { list: data }, users } = useFetchUsers({ page, filters });
+  const userCan = useSelector(makeSelectUserCan);
 
   /**
    * Get page number value from URL query string
@@ -178,14 +177,4 @@ export const UsersOverviewContainer = ({ userCan }) => {
   );
 };
 
-UsersOverviewContainer.propTypes = {
-  userCan: PropTypes.func.isRequired,
-};
-
-const mapStateToProps = createStructuredSelector({
-  userCan: makeSelectUserCan,
-});
-
-const withConnect = connect(mapStateToProps);
-
-export default compose(withConnect)(UsersOverviewContainer);
+export default UsersOverviewContainer;

--- a/src/signals/settings/users/containers/Overview/index.js
+++ b/src/signals/settings/users/containers/Overview/index.js
@@ -37,10 +37,10 @@ const StyledSearchbar = styled(SearchBar)`
   }
 `;
 
-const filtersReducer = (_, action) => {
+const filtersReducer = (state, action) => {
   switch (action.type) {
     case 'username':
-      return { username: action.payload };
+      return { ...state, username: action.payload };
     default:
       throw new Error();
   }
@@ -52,7 +52,7 @@ const StyledDataView = styled(DataView)`
   }
 `;
 
-export const UsersOverviewContainer = () => {
+const UsersOverviewContainer = () => {
   const history = useHistory();
   const location = useLocation();
   const filtersInitialState = location.state && location.state.filters || {};


### PR DESCRIPTION
This PR contains changes that remove react-redux's `connect` function, making the `users overview container` a lot cleaner.

Test have been rewritten to cover the changes in the component.

(Text has been borrowed from Jan Jaap ;)