### PR TITLE
[SIG-2358] User overview page infinite loop on navigation

### DIFF
--- a/docs/adr/0001-fetching-incidents.md
+++ b/docs/adr/0001-fetching-incidents.md
@@ -1,5 +1,8 @@
 # Fetching incidents
 
+date: 2020-01-15
+
+## Context
 In the Signals frontend application, two different endpoints provide data that can be used to render an overview of incidents.
 
 The first one is the [private signals endpoint](https://api.data.amsterdam.nl/api/swagger/?url=/signals/swagger/openapi.yaml#/default/get_signals_v1_private_signals_), the second is the private search endpoint. Both return the same data structure, but expect/require different parameters.

--- a/docs/adr/0001-fetching-incidents.md
+++ b/docs/adr/0001-fetching-incidents.md
@@ -1,6 +1,4 @@
-# Architectural decision records
-
-## Fetching incidents
+# Fetching incidents
 
 In the Signals frontend application, two different endpoints provide data that can be used to render an overview of incidents.
 
@@ -27,7 +25,7 @@ In a number of occasions, a request is made to one of the private endpoints to r
    Every time the input for the `SearchBar` is submitted, the `SearchBar` container dispatches an action that trigger another fetch. The `submit` event triggers a redirect to the `IncidentManagement` module. See 1. for details.
 
    Component: `signals/containers/SearchBar`
-   
+
    Action: `setSearchQuery`
 
 4. **When a pagination item is clicked**
@@ -35,7 +33,7 @@ In a number of occasions, a request is made to one of the private endpoints to r
    If the incidents overview page renders a `Pagination` component, every click on a pagination item results in an action being dispatched. This action, in turn, triggers a fetch of results from either the `search` endpoint or the `signals` endpoint, depending on the presence of a search query.
 
    Component: `signals/IncidentManagement/containers/IncidentOverviewPage`
-   
+
    Action: `pageChanged`
 
 5. **When a column's order is changed**
@@ -43,7 +41,7 @@ In a number of occasions, a request is made to one of the private endpoints to r
    The incidents overview page shows a table with sortable columns. Clicking on a column header will dispatch an action. This action, similar to `pageChanged` will trigger a fetch of results from either the `search` endpoint or the `signals` endpoint.
 
    Component: `signals/IncidentManagement/containers/IncidentOverviewPage`
-   
+
    Action: `orderingChanged`
 
 6. **When an incident has been successfully patched**
@@ -51,5 +49,5 @@ In a number of occasions, a request is made to one of the private endpoints to r
    Individual incidents can be patched in the `IncidentDetail` container. Navigating back from the detail page to the overview page should show the changes that have been applied to the incident. Therefore, after the `patchIncidentSuccess` action has been dispatched, a new set of (updated) incidents is retrieved.
 
    Component: `signals/IncidentManagement/containers/IncidentDetail`
-   
+
    Action: `patchIncident`

--- a/docs/adr/0002-using-local-state-in-settings-module.md
+++ b/docs/adr/0002-using-local-state-in-settings-module.md
@@ -1,0 +1,21 @@
+# Using local state in settings module
+
+Date: 2020-03-11
+
+## Status
+
+Under consideration
+
+## Context
+
+Some of the data that is required by the application is only needed in specific modules. Till now, `redux` has been relied on heavily and most of times for good reason. Some data, however, is only needed in specific parts of the application, but is still stored in the global store or is kept in a reducer on a per-component basis.
+
+Different parts of the application have their own saga, reducer, actions and selectors which makes the application more difficult to understand, error prone and maintenance harder to keep up.
+
+Storing all data in the global store requires a lot of (duplicate) boilerplate code, tests and mocking.
+
+## Decision
+
+The structure of the application's state needs to reflect the data that is globally required. If specific data is only needed in specific parts of the application, that application's part should provide the data through a reducer and a context provider and not make use of the global (`redux`) store.
+
+Essentially, the entire application's state can be provided by a context provider, but for now we'll take the bottom-up approach and gradually refactor and introduce the reducer/context approach in favour of `redux` complexity.

--- a/docs/adr/0002-using-local-state-in-settings-module.md
+++ b/docs/adr/0002-using-local-state-in-settings-module.md
@@ -4,7 +4,7 @@ Date: 2020-03-11
 
 ## Status
 
-Under consideration
+Accepted
 
 ## Context
 

--- a/src/signals/settings/__tests__/actions.test.js
+++ b/src/signals/settings/__tests__/actions.test.js
@@ -1,0 +1,15 @@
+import { setUserFilters } from '../actions';
+import { SET_USER_FILTERS } from '../constants';
+
+describe('signals/settings/actions', () => {
+  test('setUserFilters', () => {
+    const payload = {
+      some: 'object',
+    };
+
+    expect(setUserFilters(payload)).toEqual({
+      type: SET_USER_FILTERS,
+      payload,
+    });
+  });
+});

--- a/src/signals/settings/__tests__/reducer.test.js
+++ b/src/signals/settings/__tests__/reducer.test.js
@@ -1,0 +1,40 @@
+import reducer, { initialState } from '../reducer';
+import { SET_USER_FILTERS } from '../constants';
+
+describe('signals/settings/reducer', () => {
+  it('should return the state', () => {
+    expect(reducer(initialState, {})).toEqual(initialState);
+  });
+
+  it('should handle setting user filters', () => {
+    const intermediateState = {
+      users: {
+        filters: {
+          someProp: 'foo',
+        },
+      },
+    };
+
+    const action = {
+      type: SET_USER_FILTERS,
+      payload: {
+        username: 'bar baz',
+      },
+    };
+
+    expect(reducer(initialState, action)).toEqual({
+      users: {
+        filters: action.payload,
+      },
+    });
+
+    expect(reducer(intermediateState, action)).toEqual({
+      users: {
+        filters: {
+          someProp: 'foo',
+          username: 'bar baz',
+        },
+      },
+    });
+  });
+});

--- a/src/signals/settings/actions.js
+++ b/src/signals/settings/actions.js
@@ -1,0 +1,6 @@
+import { SET_USER_FILTERS } from './constants';
+
+export const setUserFilters = payload => ({
+  type: SET_USER_FILTERS,
+  payload,
+});

--- a/src/signals/settings/constants.js
+++ b/src/signals/settings/constants.js
@@ -1,0 +1,1 @@
+export const SET_USER_FILTERS = 'signal/settings/SET_USER_FILTERS';

--- a/src/signals/settings/context.js
+++ b/src/signals/settings/context.js
@@ -1,0 +1,5 @@
+import React from 'react';
+
+import { initialState } from './reducer';
+
+export default React.createContext(initialState);

--- a/src/signals/settings/index.js
+++ b/src/signals/settings/index.js
@@ -1,4 +1,4 @@
-import React, { memo, Fragment, useEffect, useState } from 'react';
+import React, { memo, useEffect, useState, useReducer } from 'react';
 import PropTypes from 'prop-types';
 import { Route, Redirect, Switch, useLocation } from 'react-router-dom';
 import { createStructuredSelector } from 'reselect';
@@ -33,6 +33,9 @@ import DepartmentsDetailContainer from './departments/Detail';
 import CategoriesOverviewContainer from './categories/Overview';
 import CategoryDetailContainer from './categories/Detail';
 
+import SettingsContext from './context';
+import reducer, { initialState } from './reducer';
+
 export const SettingsModule = ({
   onFetchDepartments,
   onFetchPermissions,
@@ -43,6 +46,7 @@ export const SettingsModule = ({
 }) => {
   const moduleLocation = useLocation();
   const [location, setLocation] = useState(moduleLocation);
+  const [state, dispatch] = useReducer(reducer, initialState);
 
   useEffect(() => {
     if (!isAuthenticated()) {
@@ -81,7 +85,7 @@ export const SettingsModule = ({
   }
 
   return (
-    <Fragment>
+    <SettingsContext.Provider value={{ state, dispatch }}>
       {userCanAccess('groups') && (
         <Switch location={location}>
           <Route exact path={routes.roles} component={RolesListContainer} />
@@ -168,7 +172,7 @@ export const SettingsModule = ({
           )}
         </Switch>
       )}
-    </Fragment>
+    </SettingsContext.Provider>
   );
 };
 

--- a/src/signals/settings/reducer.js
+++ b/src/signals/settings/reducer.js
@@ -1,0 +1,23 @@
+import { SET_USER_FILTERS } from './constants';
+
+export const initialState = {
+  users: {
+    filters: {},
+  },
+};
+
+export default (state, action) => {
+  switch (action.type) {
+    case SET_USER_FILTERS:
+      return {
+        ...state,
+        users: {
+          ...state.users,
+          filters: { ...state.users.filters, ...action.payload },
+        },
+      };
+
+    default:
+      return state;
+  }
+};

--- a/src/signals/settings/users/containers/Detail/__tests__/Detail.test.js
+++ b/src/signals/settings/users/containers/Detail/__tests__/Detail.test.js
@@ -551,7 +551,6 @@ describe('signals/settings/users/containers/Detail', () => {
     expect(push).toHaveBeenCalledTimes(1);
     expect(push).toHaveBeenCalledWith(
       expect.stringContaining(routes.users),
-      expect.undefined,
     );
 
     expect(showGlobalNotification).toHaveBeenCalledTimes(1);
@@ -579,7 +578,6 @@ describe('signals/settings/users/containers/Detail', () => {
     expect(push).toHaveBeenCalledTimes(2);
     expect(push).toHaveBeenCalledWith(
       expect.stringContaining(routes.users),
-      expect.objectContaining(state),
     );
 
     expect(showGlobalNotification).toHaveBeenCalledTimes(2);
@@ -616,7 +614,6 @@ describe('signals/settings/users/containers/Detail', () => {
     expect(push).toHaveBeenCalledTimes(1);
     expect(push).toHaveBeenCalledWith(
       expect.stringContaining(routes.users),
-      expect.undefined,
     );
 
     jest.spyOn(reactRouterDom, 'useLocation').mockImplementationOnce(() => ({
@@ -640,7 +637,6 @@ describe('signals/settings/users/containers/Detail', () => {
     expect(push).toHaveBeenCalledTimes(2);
     expect(push).toHaveBeenCalledWith(
       expect.stringContaining(routes.users),
-      expect.objectContaining(state),
     );
   });
 
@@ -650,8 +646,7 @@ describe('signals/settings/users/containers/Detail', () => {
 
     global.window.confirm = jest.fn();
 
-    const state = { some: "random state" };
-    const { rerender, getByTestId } = render(
+    const { getByTestId } = render(
       withAppContext(
         <UserDetailContainerComponent
           showGlobalNotification={() => {}}
@@ -680,42 +675,11 @@ describe('signals/settings/users/containers/Detail', () => {
     expect(push).toHaveBeenCalledTimes(1);
     expect(push).toHaveBeenCalledWith(
       expect.stringContaining(routes.users),
-      expect.undefined,
-    );
-
-    jest.spyOn(reactRouterDom, 'useLocation').mockImplementationOnce(() => ({
-      state,
-    }));
-
-    rerender(
-      withAppContext(
-        <UserDetailContainerComponent
-          showGlobalNotification={() => {}}
-          userCan={userCan}
-        />
-      )
-    );
-
-    fireEvent.click(getByTestId('cancelBtn'));
-
-    expect(global.window.confirm).toHaveBeenCalledTimes(3);
-    expect(push).toHaveBeenCalledTimes(2);
-
-    global.window.confirm.mockReturnValue(true);
-
-    fireEvent.click(getByTestId('cancelBtn'));
-
-    expect(global.window.confirm).toHaveBeenCalledTimes(4);
-    expect(push).toHaveBeenCalledTimes(3);
-    expect(push).toHaveBeenCalledWith(
-      expect.stringContaining(routes.users),
-      expect.objectContaining(state),
     );
   });
 
   it('should push to correct URL when cancel button is clicked and form data is pristine', () => {
     const referrer = '/some-page-we-came-from';
-    const state = { some: "random state" };
     jest.spyOn(reactRouterDom, 'useLocation').mockImplementationOnce(() => ({
       referrer,
     }));
@@ -742,12 +706,10 @@ describe('signals/settings/users/containers/Detail', () => {
     expect(push).toHaveBeenCalledTimes(1);
     expect(push).toHaveBeenCalledWith(
       expect.stringContaining(referrer),
-      expect.undefined,
     );
 
     jest.spyOn(reactRouterDom, 'useLocation').mockImplementationOnce(() => ({
       referrer,
-      state,
     }));
 
     rerender(withAppContext(
@@ -764,7 +726,6 @@ describe('signals/settings/users/containers/Detail', () => {
     expect(push).toHaveBeenCalledTimes(2);
     expect(push).toHaveBeenCalledWith(
       expect.stringContaining(referrer),
-      expect.objectContaining(state),
     );
   });
 });

--- a/src/signals/settings/users/containers/Detail/index.js
+++ b/src/signals/settings/users/containers/Detail/index.js
@@ -1,4 +1,4 @@
-import React, { Fragment, useCallback, useEffect, useMemo } from 'react';
+import React, { Fragment, useCallback, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { compose, bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
@@ -35,21 +35,16 @@ export const UserDetailContainerComponent = ({
   const { userId } = useParams();
   const location = useLocation();
   const history = useHistory();
+
   const isExistingUser = userId !== undefined;
   const { isLoading, isSuccess, error, data, patch, post } = useFetchUser(
     userId
   );
   const shouldRenderForm = !isExistingUser || (isExistingUser && Boolean(data));
-  const redirectURL = {
-    pathname: location.referrer || routes.users,
-    state: location.state,
-  };
-  const userCanSubmitForm = useMemo(
-    () =>
-      (isExistingUser && userCan('change_user')) ||
-      (!isExistingUser && userCan('add_user')),
-    [isExistingUser, userCan]
-  );
+  const redirectURL = location.referrer || routes.users;
+  const userCanSubmitForm =
+    (isExistingUser && userCan('change_user')) ||
+    (!isExistingUser && userCan('add_user'));
 
   const getFormData = useCallback(
     e => {
@@ -98,7 +93,7 @@ export const UserDetailContainerComponent = ({
     });
 
     if (isSuccess) {
-      history.push(redirectURL.pathname, redirectURL.state);
+      history.push(redirectURL);
     }
   }, [
     error,
@@ -106,8 +101,7 @@ export const UserDetailContainerComponent = ({
     isExistingUser,
     isLoading,
     isSuccess,
-    redirectURL.pathname,
-    redirectURL.state,
+    redirectURL,
     showGlobalNotification,
   ]);
 
@@ -141,16 +135,13 @@ export const UserDetailContainerComponent = ({
         (!isEqual(data, formData) &&
           global.confirm('Niet opgeslagen gegevens gaan verloren. Doorgaan?'))
       ) {
-        history.push(redirectURL.pathname, redirectURL.state);
+        history.push(redirectURL);
       }
     },
     [data, getFormData, history, redirectURL]
   );
 
-  const title = useMemo(
-    () => `Gebruiker ${isExistingUser ? 'wijzigen' : 'toevoegen'}`,
-    [isExistingUser]
-  );
+  const title = `Gebruiker ${isExistingUser ? 'wijzigen' : 'toevoegen'}`;
 
   return (
     <Fragment>

--- a/src/signals/settings/users/containers/Overview/__tests__/Overview.test.js
+++ b/src/signals/settings/users/containers/Overview/__tests__/Overview.test.js
@@ -1,37 +1,84 @@
 import React from 'react';
-import { render, fireEvent, wait, waitForElement, within } from '@testing-library/react';
+import {
+  render,
+  fireEvent,
+  wait,
+  waitForElement,
+  within,
+  act,
+} from '@testing-library/react';
 import { history as memoryHistory, withCustomAppContext } from 'test/utils';
 
 import usersJSON from 'utils/__tests__/fixtures/users.json';
 import { USER_URL, USERS_PAGED_URL } from 'signals/settings/routes';
 import configuration from 'shared/services/configuration/configuration';
 import * as constants from 'containers/App/constants';
+import * as settingsActions from 'signals/settings/actions';
+import * as reactRouter from 'react-router-dom';
 import { UsersOverviewContainer as UsersOverview } from '..';
+
+import SettingsContext from '../../../../context';
 
 jest.mock('containers/App/constants', () => ({
   __esModule: true,
   ...jest.requireActual('containers/App/constants'),
 }));
 
+jest.mock('signals/settings/actions', () => ({
+  __esModule: true,
+  ...jest.requireActual('signals/settings/actions'),
+}));
+
+jest.mock('react-router-dom', () => ({
+  __esModule: true,
+  ...jest.requireActual('react-router-dom'),
+}));
+
+const setUserFilters = jest.fn();
+jest
+  .spyOn(settingsActions, 'setUserFilters')
+  .mockImplementation(setUserFilters);
+
 constants.PAGE_SIZE = 50;
 
+const state = {
+  users: {
+    filters: {},
+  },
+};
+
+const dispatch = jest.fn();
+
 let testContext = {};
-const usersOverviewWithAppContext = (overrideProps = {}, overrideCfg = {}) => {
+const usersOverviewWithAppContext = (
+  overrideProps = {},
+  overrideCfg = {},
+  stateCfg = state
+) => {
   const { userCan, history } = testContext;
   const props = {
     userCan,
     ...overrideProps,
   };
 
-  return withCustomAppContext(<UsersOverview {...props} />)({
+  return withCustomAppContext(
+    <SettingsContext.Provider value={{ state: stateCfg, dispatch }}>
+      <UsersOverview {...props} />
+    </SettingsContext.Provider>
+  )({
     routerCfg: { history },
     ...overrideCfg,
   });
 };
-const resolveAfterMs = timeMs => new Promise(resolve => setTimeout(resolve, timeMs));
+const resolveAfterMs = timeMs =>
+  new Promise(resolve => setTimeout(resolve, timeMs));
 
 describe('signals/settings/users/containers/Overview', () => {
   beforeEach(() => {
+    jest
+      .spyOn(reactRouter, 'useParams')
+      .mockImplementation(() => ({ pageNum: 1 }));
+
     const push = jest.fn();
     const scrollTo = jest.fn();
     const userCan = () => true;
@@ -47,6 +94,7 @@ describe('signals/settings/users/containers/Overview', () => {
 
     jest.useRealTimers();
     fetch.resetMocks();
+    dispatch.mockReset();
 
     fetch.mockResponse(JSON.stringify(usersJSON));
     global.window.scrollTo = scrollTo;
@@ -89,11 +137,18 @@ describe('signals/settings/users/containers/Overview', () => {
 
   it('should render title, data view with headers only and loading indicator when loading', async () => {
     jest.useFakeTimers();
-    fetch.mockResponse(() => new Promise((resolve => {
-      setTimeout(() => resolve({
-        body: JSON.stringify(usersJSON),
-      }) , 50);
-    })));
+    fetch.mockResponse(
+      () =>
+        new Promise(resolve => {
+          setTimeout(
+            () =>
+              resolve({
+                body: JSON.stringify(usersJSON),
+              }),
+            50
+          );
+        })
+    );
 
     const { getByText, queryByTestId } = render(usersOverviewWithAppContext());
 
@@ -125,7 +180,9 @@ describe('signals/settings/users/containers/Overview', () => {
   it('should render title and data view with headers only when no data', async () => {
     fetch.mockResponse(JSON.stringify({}));
 
-    const { getByText, queryByTestId, queryAllByTestId } = render(usersOverviewWithAppContext());
+    const { getByText, queryByTestId, queryAllByTestId } = render(
+      usersOverviewWithAppContext()
+    );
 
     await wait();
 
@@ -136,13 +193,22 @@ describe('signals/settings/users/containers/Overview', () => {
 
   it('should render data view with no data when loading', async () => {
     jest.useFakeTimers();
-    fetch.mockResponse(() => new Promise((resolve => {
-      setTimeout(() => resolve({
-        body: JSON.stringify(usersJSON),
-      }) , 50);
-    })));
+    fetch.mockResponse(
+      () =>
+        new Promise(resolve => {
+          setTimeout(
+            () =>
+              resolve({
+                body: JSON.stringify(usersJSON),
+              }),
+            50
+          );
+        })
+    );
 
-    const { queryByTestId, queryAllByTestId } = render(usersOverviewWithAppContext());
+    const { queryByTestId, queryAllByTestId } = render(
+      usersOverviewWithAppContext()
+    );
 
     await wait(() => queryByTestId('loadingIndicator'));
 
@@ -178,7 +244,25 @@ describe('signals/settings/users/containers/Overview', () => {
     await wait();
 
     expect(queryByTestId('pagination')).toBeInTheDocument();
-    expect(within(queryByTestId('pagination')).queryByText('2')).toBeInTheDocument();
+    expect(
+      within(queryByTestId('pagination')).queryByText('2')
+    ).toBeInTheDocument();
+
+    expect(
+      within(queryByTestId('pagination')).queryByText('2').nodeName
+    ).toEqual('BUTTON');
+
+    jest
+      .spyOn(reactRouter, 'useParams')
+      .mockImplementation(() => ({ pageNum: 2 }));
+
+    rerender(usersOverviewWithAppContext());
+
+    await wait();
+
+    expect(
+      within(queryByTestId('pagination')).queryByText('2').nodeName
+    ).not.toEqual('BUTTON');
 
     constants.PAGE_SIZE = usersJSON.count;
 
@@ -196,7 +280,9 @@ describe('signals/settings/users/containers/Overview', () => {
 
     await wait(() => getByText('2'));
 
-    fireEvent.click(getByText('2'));
+    act(() => {
+      fireEvent.click(getByText('2'));
+    });
 
     expect(scrollTo).toHaveBeenCalledWith(0, 0);
     expect(push).toHaveBeenCalled();
@@ -218,32 +304,37 @@ describe('signals/settings/users/containers/Overview', () => {
 
     expect(push).toHaveBeenCalledTimes(0);
 
-    fireEvent.click(username);
+    act(() => {
+      fireEvent.click(username);
+    });
 
     expect(push).toHaveBeenCalledTimes(1);
-    expect(push).toHaveBeenCalledWith(
-      expect.stringContaining(`${USER_URL}/${itemId}`),
-      expect.objectContaining({ filters: {} }),
-    );
+    expect(push).toHaveBeenCalledWith(`${USER_URL}/${itemId}`);
 
     // Remove 'itemId' and fire click event again.
     delete row.dataset.itemId;
 
-    fireEvent.click(username);
+    act(() => {
+      fireEvent.click(username);
+    });
 
     expect(push).toHaveBeenCalledTimes(1);
 
     // Set 'itemId' again and fire click event once more.
     row.dataset.itemId = itemId;
 
-    fireEvent.click(username);
+    act(() => {
+      fireEvent.click(username);
+    });
 
     expect(push).toHaveBeenCalledTimes(2);
   });
 
   it('should not push on list item click when permissions are insufficient', async () => {
     const { push } = testContext;
-    const { container } = render(usersOverviewWithAppContext({ userCan: () => false }));
+    const { container } = render(
+      usersOverviewWithAppContext({ userCan: () => false })
+    );
 
     const row = await waitForElement(
       () => container.querySelector('tbody tr:nth-child(42)'),
@@ -253,7 +344,9 @@ describe('signals/settings/users/containers/Overview', () => {
     // Explicitly set an 'itemId'.
     row.dataset.itemId = 666;
 
-    fireEvent.click(row.querySelector('td:first-of-type'));
+    act(() => {
+      fireEvent.click(row.querySelector('td:first-of-type'));
+    });
 
     expect(push).not.toHaveBeenCalled();
   });
@@ -266,89 +359,82 @@ describe('signals/settings/users/containers/Overview', () => {
     expect(getByTestId('filterUsersByUsername')).toBeInTheDocument();
   });
 
-  it('should make API call only after 250ms since last filter update', async () => {
-    const { apiHeaders } = testContext;
+  it('should dispatch filter values only after 250ms since last input change', async () => {
     const { getByTestId } = render(usersOverviewWithAppContext());
 
     await wait();
 
     const filterByUsername = getByTestId('filterUsersByUsername');
     const filterByUserNameInput = filterByUsername.querySelector('input');
-    let filterValue = 'test1';
+    const filterValue = 'test1';
 
-    expect(fetch).toHaveBeenCalledTimes(1);
-    expect(fetch).not.toHaveBeenCalledWith(
-      expect.stringContaining(`username=${filterValue}`),
-      expect.objectContaining(apiHeaders),
-    );
-
-    fireEvent.change(filterByUserNameInput, { target: { value: filterValue } });
+    act(() => {
+      fireEvent.change(filterByUserNameInput, {
+        target: { value: filterValue },
+      });
+    });
 
     await wait(() => resolveAfterMs(50));
 
-    expect(fetch).toHaveBeenCalledTimes(1);
-    expect(fetch).not.toHaveBeenCalledWith(
-      expect.stringContaining(`username=${filterValue}`),
-      expect.objectContaining(apiHeaders),
-    );
+    expect(dispatch).not.toHaveBeenCalled();
 
     await wait(() => resolveAfterMs(200));
 
-    expect(fetch).toHaveBeenCalledTimes(2);
-    expect(fetch).toHaveBeenCalledWith(
-      expect.stringContaining(`username=${filterValue}`),
-      expect.objectContaining(apiHeaders),
-    );
-
-    // Test that 'debounce' timer is reset on new input changes within 250ms.
-    filterValue = 'test2';
-
-    fireEvent.change(filterByUserNameInput, { target: { value: filterValue } });
-
-    await wait(() => resolveAfterMs(200));
-
-    expect(fetch).toHaveBeenCalledTimes(2);
-    expect(fetch).not.toHaveBeenCalledWith(
-      expect.stringContaining(`username=${filterValue}`),
-      expect.objectContaining(apiHeaders),
-    );
-
-    filterValue = 'test3';
-
-    fireEvent.change(filterByUserNameInput, { target: { value: filterValue } });
-
-    await wait(() => resolveAfterMs(200));
-
-    expect(fetch).toHaveBeenCalledTimes(2);
-    expect(fetch).not.toHaveBeenCalledWith(
-      expect.stringContaining(`username=${filterValue}`),
-      expect.objectContaining(apiHeaders),
-    );
-
-    filterValue = 'test4';
-
-    fireEvent.change(filterByUserNameInput, { target: { value: filterValue } });
-
-    await wait(() => resolveAfterMs(200));
-
-    expect(fetch).toHaveBeenCalledTimes(2);
-    expect(fetch).not.toHaveBeenCalledWith(
-      expect.stringContaining(`username=${filterValue}`),
-      expect.objectContaining(apiHeaders),
-    );
-
-    await wait(() => resolveAfterMs(50));
-
-    expect(fetch).toHaveBeenCalledTimes(3);
-    expect(fetch).toHaveBeenCalledWith(
-      expect.stringContaining(`username=${filterValue}`),
-      expect.objectContaining(apiHeaders),
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(dispatch).toHaveBeenCalledWith(
+      setUserFilters({ username: filterValue })
     );
   });
 
-  it(`should send 'filters' as state when navigating to details page.`, async () => {
+  it('should not dispatch filter values when input value has not changed', async () => {
+    const username = 'foo bar baz';
+    const stateCfg = {
+      users: {
+        filters: {
+          username,
+        },
+      },
+    };
+
+    const { getByTestId, rerender } = render(usersOverviewWithAppContext());
+
+    await wait();
+
+    expect(dispatch).not.toHaveBeenCalled();
+
+    const filterByUsername = getByTestId('filterUsersByUsername');
+    const filterByUserNameInput = filterByUsername.querySelector('input');
+
+    act(() => {
+      fireEvent.input(filterByUserNameInput, {
+        target: { value: username },
+      });
+    });
+
+    await wait(() => resolveAfterMs(250));
+
+    expect(dispatch).toHaveBeenCalledTimes(1);
+
+    rerender(usersOverviewWithAppContext({}, {}, stateCfg));
+
+    await wait();
+
+    act(() => {
+      fireEvent.input(filterByUserNameInput, {
+        target: { value: username },
+      });
+    });
+
+    await wait(() => resolveAfterMs(250));
+
+    expect(dispatch).toHaveBeenCalledTimes(1);
+  });
+
+  it(`should dispatch setUserFilters`, async () => {
     const { push } = testContext;
-    const { getByTestId, queryAllByTestId } = render(usersOverviewWithAppContext());
+    const { getByTestId, queryAllByTestId } = render(
+      usersOverviewWithAppContext()
+    );
 
     await wait();
 
@@ -361,66 +447,38 @@ describe('signals/settings/users/containers/Overview', () => {
 
     expect(push).not.toHaveBeenCalled();
 
-    fireEvent.click(firstRow);
+    act(() => {
+      fireEvent.click(firstRow);
+    });
 
     expect(push).toHaveBeenCalledTimes(1);
     expect(push).toHaveBeenCalledWith(
-      expect.stringContaining(`${USER_URL}/${firstRow.dataset.itemId}`),
-      expect.objectContaining({ filters: {} })
+      expect.stringContaining(`${USER_URL}/${firstRow.dataset.itemId}`)
     );
 
-    fireEvent.change(filterByUserNameInput, { target: { value: filterValue } });
+    act(() => {
+      fireEvent.change(filterByUserNameInput, {
+        target: { value: filterValue },
+      });
+    });
 
     await wait(() => resolveAfterMs(250));
 
     expect(push).toHaveBeenCalledTimes(2);
-    expect(push).toHaveBeenCalledWith(expect.stringContaining(`${USERS_PAGED_URL}/1`));
+    expect(push).toHaveBeenCalledWith(
+      expect.stringContaining(`${USERS_PAGED_URL}/1`)
+    );
 
     rows = queryAllByTestId('dataViewBodyRow');
     firstRow = Array.from(rows)[0];
 
-    fireEvent.click(firstRow);
+    act(() => {
+      fireEvent.click(firstRow);
+    });
 
     expect(push).toHaveBeenCalledTimes(3);
     expect(push).toHaveBeenCalledWith(
-      expect.stringContaining(`${USER_URL}/${firstRow.dataset.itemId}`),
-      expect.objectContaining({ filters: { username: filterValue } })
+      expect.stringContaining(`${USER_URL}/${firstRow.dataset.itemId}`)
     );
-  });
-
-  it(`should set 'filters' initial state to receiving history state`, async () => {
-    const { apiHeaders, history } = testContext;
-    const username = 'test';
-    const historyWithState = {
-      ...history,
-      location: {
-        ...history.location,
-        state: {
-          filters: {
-            username,
-          },
-        },
-      },
-    };
-    const { getByTestId } = render(usersOverviewWithAppContext(
-      {},
-      {
-        routerCfg: {
-          history: historyWithState,
-        },
-      }
-    ));
-
-    await wait();
-
-    const filterByUsername = getByTestId('filterUsersByUsername');
-    const filterByUserNameInput = filterByUsername.querySelector('input');
-
-    expect(fetch).toHaveBeenCalledTimes(1);
-    expect(fetch).toHaveBeenCalledWith(
-      expect.stringContaining(`username=${username}`),
-      expect.objectContaining(apiHeaders)
-    );
-    expect(filterByUserNameInput.value).toBe(username);
   });
 });


### PR DESCRIPTION
# User overview page infinite loop on navigation

## The Issue

Navigating from the users overview page to a user detail page, after a user's data was posted before that navigation occurred, lead the application into an endless loop, causing errors and freezing the page.

## The Problem

The cause was the state that was pushed onto the history stack. Removing it solved the problem. It is, however, unclear why providing a value for a history item's state lead to an endless loop. I looked into issues concerning `redux`, `react-router-dom` and `connected-react-router`, but I couldn't find the problem.

## The solution

The reason that a value for a history item's state was needed, was that the filter selection needed to be retained when navigating from the overview page to a detail page and back again.

In order to keep that functionality, the `settings` module has been changed so that it keeps state in a reducer and passes that state into its child component by using a context provider.

The values for the context are updated by the overview page through a `dispatch` function that is also provided by the context. This way, all underlying pages in the `settings` module can make use of the state and update it accordingly.