### PR TITLE
[SIG-2333] v0 ⇨ v1 replace

### DIFF
--- a/src/shared/services/configuration/configuration.js
+++ b/src/shared/services/configuration/configuration.js
@@ -108,8 +108,12 @@ export class Configuration {
     return `${this.API_ROOT}signals/category/prediction`;
   }
 
-  get INCIDENT_ENDPOINT() {
-    return `${this.API_ROOT}signals/signal/`;
+  get INCIDENT_PUBLIC_ENDPOINT() {
+    return `${this.API_ROOT}signals/v1/public/signals/`;
+  }
+
+  get INCIDENT_PRIVATE_ENDPOINT() {
+    return `${this.API_ROOT}signals/v1/private/signals/`;
   }
 
   get INCIDENTS_ENDPOINT() {

--- a/src/shared/services/file-upload-channel/index.js
+++ b/src/shared/services/file-upload-channel/index.js
@@ -1,11 +1,7 @@
-import {
-  buffers,
-  eventChannel,
-  END,
-} from 'redux-saga';
+import { buffers, eventChannel, END } from 'redux-saga';
 
-function fileUploadChannel(endpoint, file, id) {
-  return eventChannel(emitter => {
+export default (endpoint, file, id) =>
+  eventChannel(emitter => {
     const formData = new window.FormData();
     formData.append('signal_id', id);
     formData.append('image', file);
@@ -52,6 +48,3 @@ function fileUploadChannel(endpoint, file, id) {
       xhr.abort();
     };
   }, buffers.sliding(2));
-}
-
-export default fileUploadChannel;

--- a/src/signals/incident/components/form/RadioInput/index.js
+++ b/src/signals/incident/components/form/RadioInput/index.js
@@ -24,7 +24,7 @@ const RadioInput = ({
   let info;
   let label;
 
-  if (currentSelected &&  meta.values) {
+  if (currentSelected && meta?.values[currentSelected.id]) {
     ({ info, value: label } = meta.values[currentSelected.id]);
   }
 

--- a/src/signals/incident/containers/IncidentContainer/actions.js
+++ b/src/signals/incident/containers/IncidentContainer/actions.js
@@ -1,9 +1,3 @@
-/*
- *
- * IncidentContainer actions
- *
- */
-
 import {
   UPDATE_INCIDENT,
   RESET_INCIDENT,
@@ -13,9 +7,6 @@ import {
   GET_CLASSIFICATION,
   GET_CLASSIFICATION_SUCCESS,
   GET_CLASSIFICATION_ERROR,
-  SET_PRIORITY,
-  SET_PRIORITY_SUCCESS,
-  SET_PRIORITY_ERROR,
 } from './constants';
 
 export const updateIncident = payload => ({
@@ -54,17 +45,4 @@ export const getClassificationSuccess = payload => ({
 export const getClassificationError = payload => ({
   type: GET_CLASSIFICATION_ERROR,
   payload,
-});
-
-export const setPriority = payload => ({
-  type: SET_PRIORITY,
-  payload,
-});
-
-export const setPrioritySuccess = () => ({
-  type: SET_PRIORITY_SUCCESS,
-});
-
-export const setPriorityError = () => ({
-  type: SET_PRIORITY_ERROR,
 });

--- a/src/signals/incident/containers/IncidentContainer/actions.test.js
+++ b/src/signals/incident/containers/IncidentContainer/actions.test.js
@@ -3,35 +3,23 @@ import { testActionCreator } from 'test/utils';
 import {
   UPDATE_INCIDENT,
   RESET_INCIDENT,
-
   CREATE_INCIDENT,
   CREATE_INCIDENT_SUCCESS,
   CREATE_INCIDENT_ERROR,
-
   GET_CLASSIFICATION,
   GET_CLASSIFICATION_SUCCESS,
   GET_CLASSIFICATION_ERROR,
-
-  SET_PRIORITY,
-  SET_PRIORITY_SUCCESS,
-  SET_PRIORITY_ERROR,
 } from './constants';
 
 import {
   updateIncident,
   resetIncident,
-
   createIncident,
   createIncidentSuccess,
   createIncidentError,
-
   getClassification,
   getClassificationSuccess,
   getClassificationError,
-
-  setPriority,
-  setPrioritySuccess,
-  setPriorityError,
 } from './actions';
 
 describe('Incident container actions', () => {
@@ -76,20 +64,5 @@ describe('Incident container actions', () => {
 
   it('should dispatch classification error action', () => {
     testActionCreator(getClassificationError, GET_CLASSIFICATION_ERROR);
-  });
-
-  it('should dispatch set priority action', () => {
-    testActionCreator(setPriority, SET_PRIORITY, {
-      priority: 'normal',
-      _signal: 666,
-    });
-  });
-
-  it('should dispatch set priority success action', () => {
-    testActionCreator(setPrioritySuccess, SET_PRIORITY_SUCCESS);
-  });
-
-  it('should dispatch set priority error action', () => {
-    testActionCreator(setPriorityError, SET_PRIORITY_ERROR);
   });
 });

--- a/src/signals/incident/containers/IncidentContainer/constants.js
+++ b/src/signals/incident/containers/IncidentContainer/constants.js
@@ -1,9 +1,3 @@
-/*
- *
- * IncidentContainer constants
- *
- */
-
 export const UPDATE_INCIDENT = 'sia/IncidentContainer/UPDATE_INCIDENT';
 export const RESET_INCIDENT = 'sia/IncidentContainer/RESET_INCIDENT';
 
@@ -14,7 +8,3 @@ export const CREATE_INCIDENT_ERROR = 'sia/IncidentContainer/CREATE_INCIDENT_ERRO
 export const GET_CLASSIFICATION = 'sia/IncidentContainer/GET_CLASSIFICATION';
 export const GET_CLASSIFICATION_SUCCESS = 'sia/IncidentContainer/GET_CLASSIFICATION_SUCCESS';
 export const GET_CLASSIFICATION_ERROR = 'sia/IncidentContainer/GET_CLASSIFICATION_ERROR';
-
-export const SET_PRIORITY = 'sia/IncidentContainer/SET_PRIORITY';
-export const SET_PRIORITY_SUCCESS = 'sia/IncidentContainer/SET_PRIORITY_SUCCESS';
-export const SET_PRIORITY_ERROR = 'sia/IncidentContainer/SET_PRIORITY_ERROR';

--- a/src/signals/incident/containers/IncidentContainer/reducer.js
+++ b/src/signals/incident/containers/IncidentContainer/reducer.js
@@ -8,16 +8,10 @@ import {
   GET_CLASSIFICATION,
   GET_CLASSIFICATION_SUCCESS,
   GET_CLASSIFICATION_ERROR,
-  SET_PRIORITY,
-  SET_PRIORITY_SUCCESS,
-  SET_PRIORITY_ERROR,
 } from './constants';
-// eslint-disable-next-line no-unused-vars
-import debugInitialState from './debug/initialState';
 
 export const initialState = fromJS({
   incident: {
-    // ...debugInitialState,
     incident_date: 'Vandaag',
     incident_time_hours: 9,
     incident_time_minutes: 0,
@@ -33,7 +27,7 @@ export const initialState = fromJS({
   priority: {},
 });
 
-function incidentContainerReducer(state = initialState, action) {
+export default (state = initialState, action) => {
   switch (action.type) {
     case UPDATE_INCIDENT:
       return state.set(
@@ -54,9 +48,7 @@ function incidentContainerReducer(state = initialState, action) {
         .set('incident', state.get('incident').set('id', null));
 
     case CREATE_INCIDENT_SUCCESS:
-      return state
-        .set('loading', false)
-        .set('incident', fromJS(action.payload));
+      return state.set('loading', false).set('incident', fromJS(action.payload));
 
     case CREATE_INCIDENT_ERROR:
       return state.set('error', true).set('loading', false);
@@ -74,16 +66,7 @@ function incidentContainerReducer(state = initialState, action) {
           .set('subcategory', action.payload.subcategory)
       );
 
-    case SET_PRIORITY:
-      return state.set('priority', fromJS(action.payload));
-
-    case SET_PRIORITY_SUCCESS:
-    case SET_PRIORITY_ERROR:
-      return state.set('priority', fromJS({}));
-
     default:
       return state;
   }
-}
-
-export default incidentContainerReducer;
+};

--- a/src/signals/incident/containers/IncidentContainer/reducer.test.js
+++ b/src/signals/incident/containers/IncidentContainer/reducer.test.js
@@ -10,9 +10,6 @@ import {
   GET_CLASSIFICATION,
   GET_CLASSIFICATION_SUCCESS,
   GET_CLASSIFICATION_ERROR,
-  SET_PRIORITY,
-  SET_PRIORITY_SUCCESS,
-  SET_PRIORITY_ERROR,
 } from './constants';
 
 describe('signals/incident/containers/IncidentContainer/reducer', () => {
@@ -200,49 +197,6 @@ describe('signals/incident/containers/IncidentContainer/reducer', () => {
           subcategory: 'overig(poep)',
         },
         loadingClassification: false,
-      });
-    });
-  });
-
-  describe('SET_PRIORITY', () => {
-    it('sets priority', () => {
-      expect(
-        incidentContainerReducer(fromJS({}), {
-          type: SET_PRIORITY,
-          payload: {
-            _signal: 666,
-            priority: 'normal',
-          },
-        }).toJS()
-      ).toEqual({
-        priority: {
-          _signal: 666,
-          priority: 'normal',
-        },
-      });
-    });
-  });
-
-  describe('SET_PRIORITY_SUCCESS', () => {
-    it('sets priority', () => {
-      expect(
-        incidentContainerReducer(fromJS({}), {
-          type: SET_PRIORITY_SUCCESS,
-        }).toJS()
-      ).toEqual({
-        priority: {},
-      });
-    });
-  });
-
-  describe('SET_PRIORITY_ERROR', () => {
-    it('sets priority', () => {
-      expect(
-        incidentContainerReducer(fromJS({}), {
-          type: SET_PRIORITY_ERROR,
-        }).toJS()
-      ).toEqual({
-        priority: {},
       });
     });
   });

--- a/src/signals/incident/containers/IncidentContainer/saga.js
+++ b/src/signals/incident/containers/IncidentContainer/saga.js
@@ -2,26 +2,23 @@ import { all, call, put, takeLatest } from 'redux-saga/effects';
 import { replace } from 'connected-react-router/immutable';
 
 import request from 'utils/request';
-import { authPostCall, postCall } from 'shared/services/api/api';
-import CONFIGURATION from 'shared/services/configuration/configuration';
-import { uploadRequest, showGlobalNotification } from 'containers/App/actions';
-import { VARIANT_ERROR } from 'containers/Notification/constants';
+import { postCall, authPostCall } from 'shared/services/api/api';
+import configuration from 'shared/services/configuration/configuration';
+import { uploadFile } from 'containers/App/saga';
 import resolveClassification from 'shared/services/resolveClassification';
-import { CREATE_INCIDENT, GET_CLASSIFICATION, SET_PRIORITY } from './constants';
+import mapControlsToParams from 'signals/incident/services/map-controls-to-params';
+import { isAuthenticated } from 'shared/services/auth/auth';
+import { CREATE_INCIDENT, GET_CLASSIFICATION } from './constants';
 import {
   createIncidentSuccess,
   createIncidentError,
   getClassificationSuccess,
   getClassificationError,
-  setPriority,
-  setPrioritySuccess,
-  setPriorityError,
 } from './actions';
-import mapControlsToParams from '../../services/map-controls-to-params';
 
 export function* getClassification(action) {
   try {
-    const result = yield call(postCall, CONFIGURATION.PREDICTION_ENDPOINT, {
+    const result = yield call(postCall, configuration.PREDICTION_ENDPOINT, {
       text: action.payload,
     });
 
@@ -37,59 +34,24 @@ export function* getClassification(action) {
 
 export function* createIncident(action) {
   try {
-    const { category, subcategory } = action.payload.incident;
+    const { handling_message, ...postData } = yield call(getPostData, action);
 
-    const {
-      handling_message,
-      _links: {
-        self: { href: sub_category },
-      },
-    } = yield call(
-      request,
-      `${CONFIGURATION.CATEGORIES_ENDPOINT}${category}/sub_categories/${subcategory}`
-    );
-
-    const controlsToParams = mapControlsToParams(action.payload.incident, action.payload.wizard);
-
-    const postData = {
-      ...action.payload.incident,
-      ...controlsToParams,
-      category: {
-        sub_category,
-      },
-    };
-
-    const postResult = yield call(
-      postCall,
-      CONFIGURATION.INCIDENT_ENDPOINT,
-      postData
-    );
+    const postResult = yield call(postIncident, postData);
 
     const incident = { ...postResult, handling_message };
 
-    if (
-      action.payload.isAuthenticated &&
-      action.payload.incident.priority.id !== 'normal'
-    ) {
-      yield put(
-        setPriority({
-          priority: action.payload.incident.priority.id,
-          _signal: incident.id,
-        })
-      );
-    }
-
     if (action.payload.incident.images) {
-      yield all(
-        action.payload.incident.images.map(image =>
-          put(
-            uploadRequest({
+      // perform blocking requests for image uploads
+      yield all([
+        ...action.payload.incident.images.map(image =>
+          call(uploadFile, {
+            payload: {
               file: image,
               id: incident.signal_id,
-            })
-          )
-        )
-      );
+            },
+          })
+        ),
+      ]);
     }
 
     yield put(createIncidentSuccess(incident));
@@ -99,29 +61,63 @@ export function* createIncident(action) {
   }
 }
 
-export function* setPriorityHandler(action) {
-  try {
-    const result = yield call(
-      authPostCall,
-      CONFIGURATION.PRIORITY_ENDPOINT,
-      action.payload
-    );
-    yield put(setPrioritySuccess(result));
-  } catch (error) {
-    yield put(setPriorityError());
-    yield put(
-      showGlobalNotification({
-        variant: VARIANT_ERROR,
-        title: 'Het zetten van de urgentie van deze melding is niet gelukt',
-      })
-    );
+/**
+ * Perform a POST request to either the public or the private endpoint
+ *
+ * @param {Object} postData
+ * @returns {Object} The post response, containing the newly created incident
+ */
+export function* postIncident(postData) {
+  if (isAuthenticated()) {
+    return yield call(authPostCall, configuration.INCIDENT_PRIVATE_ENDPOINT, postData);
   }
+
+  return yield call(postCall, configuration.INCIDENT_PUBLIC_ENDPOINT, postData);
+}
+
+/**
+ * Return data that has been collected by the incident form, enriched with information that the API
+ * requires (subcategory), potentially filtered based by the condition if the current user has been
+ * authenticated.
+ *
+ * @param {Object} action - Action object passed on by the createIncident saga
+ * @returns {Object}
+ */
+export function* getPostData(action) {
+  const { category, subcategory } = action.payload.incident;
+
+  const {
+    handling_message,
+    _links: {
+      self: { href: sub_category },
+    },
+  } = yield call(request, `${configuration.CATEGORIES_ENDPOINT}${category}/sub_categories/${subcategory}`);
+
+  const controlsToParams = yield call(mapControlsToParams, action.payload.incident, action.payload.wizard);
+
+  const primedPostData = {
+    ...action.payload.incident,
+    ...controlsToParams,
+    category: {
+      sub_category,
+    },
+    // the priority prop needs to be a nested value 🤷
+    priority: {
+      priority: action.payload.incident.priority.id,
+    },
+    handling_message,
+  };
+
+  // function to filter out values that are not supported by the public API endpoint when the submitting user
+  // has not been authenticated
+  const filterSupportedFields = ([key]) => isAuthenticated() || (!isAuthenticated() && key !== 'priority');
+
+  // return the filtered post data
+  return Object.entries(primedPostData)
+    .filter(filterSupportedFields)
+    .reduce((acc, [key, value]) => ({ ...acc, [key]: value }), {});
 }
 
 export default function* watchIncidentContainerSaga() {
-  yield all([
-    takeLatest(GET_CLASSIFICATION, getClassification),
-    takeLatest(CREATE_INCIDENT, createIncident),
-    takeLatest(SET_PRIORITY, setPriorityHandler),
-  ]);
+  yield all([takeLatest(GET_CLASSIFICATION, getClassification), takeLatest(CREATE_INCIDENT, createIncident)]);
 }

--- a/src/signals/incident/containers/IncidentContainer/saga.js
+++ b/src/signals/incident/containers/IncidentContainer/saga.js
@@ -108,8 +108,7 @@ export function* getPostData(action) {
     handling_message,
   };
 
-  // function to filter out values that are not supported by the public API endpoint when the submitting user
-  // has not been authenticated
+  // function to filter out values that are not supported by the public API endpoint
   const filterSupportedFields = ([key]) => isAuthenticated() || (!isAuthenticated() && key !== 'priority');
 
   // return the filtered post data

--- a/src/signals/incident/containers/IncidentContainer/saga.test.js
+++ b/src/signals/incident/containers/IncidentContainer/saga.test.js
@@ -5,297 +5,268 @@ import * as matchers from 'redux-saga-test-plan/matchers';
 import { throwError } from 'redux-saga-test-plan/providers';
 
 import request from 'utils/request';
-import CONFIGURATION from 'shared/services/configuration/configuration';
-import { authPostCall, postCall } from 'shared/services/api/api';
-import incident from 'utils/__tests__/fixtures/incident.json';
-import postIncident from 'utils/__tests__/fixtures/postIncident.json';
-import priority from 'utils/__tests__/fixtures/priority.json';
-import { showGlobalNotification } from 'containers/App/actions';
-import { UPLOAD_REQUEST } from 'containers/App/constants';
-import { VARIANT_ERROR } from 'containers/Notification/constants';
+import incidentJSON from 'utils/__tests__/fixtures/incident.json';
+import postIncidentJSON from 'utils/__tests__/fixtures/postIncident.json';
+
+import configuration from 'shared/services/configuration/configuration';
 import resolveClassification from 'shared/services/resolveClassification';
+import * as auth from 'shared/services/auth/auth';
+import { authPostCall, postCall } from 'shared/services/api/api';
+
+import { uploadFile } from 'containers/App/saga';
+
 import mapControlsToParams from '../../services/map-controls-to-params';
 
-import {
-  GET_CLASSIFICATION_SUCCESS,
-  GET_CLASSIFICATION_ERROR,
-  CREATE_INCIDENT,
-  GET_CLASSIFICATION,
-  SET_PRIORITY,
-} from './constants';
+import * as constants from './constants';
 import watchIncidentContainerSaga, {
   getClassification,
   createIncident,
-  setPriorityHandler,
+  postIncident as postIncidentSaga,
+  getPostData,
 } from './saga';
-import {
-  createIncidentSuccess,
-  createIncidentError,
-  setPriority,
-  setPriorityError,
-  setPrioritySuccess,
-} from './actions';
+import { createIncidentSuccess, createIncidentError } from './actions';
+
+jest.mock('shared/services/auth/auth', () => ({
+  __esModule: true,
+  ...jest.requireActual('shared/services/auth/auth'),
+}));
+
+// POST incident API response
+const incident = JSON.stringify(incidentJSON);
+
+// POST incident request body
+const postIncident = JSON.stringify(postIncidentJSON);
+
+const category = 'afval';
+const subcategory = 'veeg-zwerfvuil';
+
+const predictionResponse = {
+  hoofdrubriek: [
+    [`https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/${category}`],
+    [0.810301985712628],
+  ],
+  subrubriek: [
+    [`https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/${subcategory}`],
+    [0.5757328735244648],
+  ],
+};
+
+const wizard = {
+  label: 'foo bar',
+  form: {
+    controls: {},
+  },
+};
+
+const payloadIncident = {
+  text: 'Foo Baz',
+  priority: {
+    id: 'low',
+  },
+  category,
+  subcategory,
+};
+
+const action = {
+  type: 'CREATE_INCIDENT',
+  payload: {
+    incident: payloadIncident,
+    wizard,
+  },
+};
+
+const sub_category = predictionResponse.subrubriek[0][0];
+const handling_message = 'zork';
+const categoryResponse = {
+  handling_message,
+  _links: {
+    self: { href: sub_category },
+  },
+};
 
 describe('IncidentContainer saga', () => {
-  const predictionResponse = {
-    hoofdrubriek: [
-      [
-        'https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/afval',
-      ],
-      [0.810301985712628],
-    ],
-    subrubriek: [
-      [
-        'https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/veeg-zwerfvuil',
-      ],
-      [0.5757328735244648],
-    ],
-  };
   it('should watchAppSaga', () => {
     testSaga(watchIncidentContainerSaga)
       .next()
       .all([
-        takeLatest(GET_CLASSIFICATION, getClassification),
-        takeLatest(CREATE_INCIDENT, createIncident),
-        takeLatest(SET_PRIORITY, setPriorityHandler),
+        takeLatest(constants.GET_CLASSIFICATION, getClassification),
+        takeLatest(constants.CREATE_INCIDENT, createIncident),
       ]);
   });
 
   describe('getClassification', () => {
     const payload = 'Grof vuil op straat';
-    const action = { payload };
 
     it('should dispatch success', () =>
-      expectSaga(getClassification, action)
+      expectSaga(getClassification, { payload })
         .provide([[matchers.call.fn(postCall), predictionResponse]])
         .call(resolveClassification, predictionResponse)
-        .put.like({ action: { type: GET_CLASSIFICATION_SUCCESS } })
+        .put.like({ action: { type: constants.GET_CLASSIFICATION_SUCCESS } })
         .run());
 
     it('should dispatch error', () => {
       const errorResponse = { foo: 'bar' };
 
-      return expectSaga(getClassification, action)
+      return expectSaga(getClassification, { payload })
         .provide([
           [matchers.call.fn(resolveClassification), errorResponse],
           [matchers.call.fn(postCall), throwError(new Error('whoops!!!1!'))],
         ])
-        .call(postCall, CONFIGURATION.PREDICTION_ENDPOINT, { text: payload })
+        .call(postCall, configuration.PREDICTION_ENDPOINT, { text: payload })
         .call(resolveClassification)
-        .put({ type: GET_CLASSIFICATION_ERROR, payload: errorResponse })
+        .put({ type: constants.GET_CLASSIFICATION_ERROR, payload: errorResponse })
+        .run();
+    });
+  });
+
+  describe('postIncident', () => {
+    it('should perform postCall', () => {
+      jest.spyOn(auth, 'isAuthenticated').mockImplementation(() => false);
+
+      return expectSaga(postIncidentSaga, postIncident)
+        .provide([[matchers.call.fn(postCall), incident]])
+        .call(postCall, configuration.INCIDENT_PUBLIC_ENDPOINT, postIncident)
+        .returns(incident)
+        .run();
+    });
+
+    it('should perform authPostCall', () => {
+      jest.spyOn(auth, 'isAuthenticated').mockImplementation(() => true);
+
+      return expectSaga(postIncidentSaga, postIncident)
+        .provide([[matchers.call.fn(authPostCall), incident]])
+        .call(authPostCall, configuration.INCIDENT_PRIVATE_ENDPOINT, postIncident)
+        .returns(incident)
+        .run();
+    });
+  });
+
+  describe('getPostData', () => {
+    it('returns data for unauthenticated users', () => {
+      jest.spyOn(auth, 'isAuthenticated').mockImplementation(() => false);
+
+      const mapControlsToParamsResponse = {
+        text: payloadIncident.text,
+        category: payloadIncident.category,
+        subcategory: payloadIncident.subcategory,
+      };
+
+      const postData = {
+        text: payloadIncident.text,
+        category: {
+          sub_category,
+        },
+        subcategory: payloadIncident.subcategory,
+        handling_message,
+      };
+
+      return expectSaga(getPostData, action)
+        .provide([
+          [matchers.call.fn(request), categoryResponse],
+          [matchers.call.fn(mapControlsToParams), mapControlsToParamsResponse],
+        ])
+        .call(request, `${configuration.CATEGORIES_ENDPOINT}${category}/sub_categories/${subcategory}`)
+        .call(mapControlsToParams, action.payload.incident, action.payload.wizard)
+        .returns(postData)
+        .run();
+    });
+
+    it('returns data for authenticated users', () => {
+      jest.spyOn(auth, 'isAuthenticated').mockImplementation(() => true);
+
+      const mapControlsToParamsResponse = {
+        text: payloadIncident.text,
+        priority: payloadIncident.priority.id,
+        category: payloadIncident.category,
+        subcategory: payloadIncident.subcategory,
+      };
+
+      const postData = {
+        text: payloadIncident.text,
+        category: {
+          sub_category,
+        },
+        subcategory: payloadIncident.subcategory,
+        handling_message,
+        priority: {
+          priority: payloadIncident.priority.id,
+        },
+      };
+
+      return expectSaga(getPostData, action)
+        .provide([
+          [matchers.call.fn(request), categoryResponse],
+          [matchers.call.fn(mapControlsToParams), mapControlsToParamsResponse],
+        ])
+        .call(request, `${configuration.CATEGORIES_ENDPOINT}${category}/sub_categories/${subcategory}`)
+        .call(mapControlsToParams, action.payload.incident, action.payload.wizard)
+        .returns(postData)
         .run();
     });
   });
 
   describe('createIncident', () => {
-    const category = 'afval';
-    const subcategory = 'some-afval-subcategory';
-    const payload = {
-      incident: {
-        ...postIncident,
-        category,
-        subcategory,
-      },
-      wizard: {},
-    };
-    const handling_message = 'Here be a message';
-    const subCatResponse = {
-      handling_message,
-      _links: {
-        self: { href: 'https://this-is-a-url' },
-      },
-    };
-    const enrichedPostData = {
+    const postData = {
+      text: payloadIncident.text,
       category: {
-        sub_category: subCatResponse._links.self.href,
+        sub_category,
       },
+      subcategory: payloadIncident.subcategory,
     };
-    const incidentWithHandlingMessage = { ...incident, handling_message };
 
-    it('should dispatch success', () => {
-      const action = { payload };
-      const mappedControls = mapControlsToParams(
-        postIncident,
-        action.payload.wizard
-      );
-      const postData = {
-        ...action.payload.incident,
-        ...mappedControls,
-        ...enrichedPostData,
-      };
-
-      return expectSaga(createIncident, action)
+    it('should POST incident', () =>
+      expectSaga(createIncident, action)
         .provide([
-          [matchers.call.fn(request), subCatResponse],
-          [matchers.call.fn(postCall), incident],
+          [matchers.call.fn(getPostData), { handling_message, ...postData }],
+          [matchers.call.fn(postIncidentSaga), incident],
         ])
-        .call(
-          request,
-          `${CONFIGURATION.CATEGORIES_ENDPOINT}${category}/sub_categories/${subcategory}`
-        )
-        .call(postCall, CONFIGURATION.INCIDENT_ENDPOINT, postData)
-        .put(createIncidentSuccess(incidentWithHandlingMessage))
-        .run();
-    });
+        .call(getPostData, action)
+        .call(postIncidentSaga, postData)
+        .put(createIncidentSuccess({ handling_message, ...incident }))
+        .run());
 
-    it('should success with file upload', () => {
-      const action = {
-        payload: {
-          incident: {
-            ...postIncident,
-            images: [{ name: 'some-file' }, { name: 'some-other-file' }],
-            category,
-            subcategory,
-          },
-          wizard: {},
-        },
-      };
-      const mappedControls = mapControlsToParams(
-        action.payload.incident,
-        action.payload.wizard
-      );
-      const postData = {
-        ...action.payload.incident,
-        ...mappedControls,
-        ...enrichedPostData,
-      };
-
-      return expectSaga(createIncident, action)
+    it('should dispatch error', () =>
+      expectSaga(createIncident, action)
         .provide([
-          [matchers.call.fn(request), subCatResponse],
-          [matchers.call.fn(postCall), incident],
+          [matchers.call.fn(getPostData), { handling_message, ...postData }],
+          [matchers.call.fn(postIncidentSaga), throwError(new Error('whoops!!!1!'))],
         ])
-        .call(
-          request,
-          `${CONFIGURATION.CATEGORIES_ENDPOINT}${category}/sub_categories/${subcategory}`
-        )
-        .call(postCall, CONFIGURATION.INCIDENT_ENDPOINT, postData)
-        .put.like({ action: { type: UPLOAD_REQUEST } })
-        .put.like({ action: { type: UPLOAD_REQUEST } })
-        .put(createIncidentSuccess(incidentWithHandlingMessage))
-        .run();
-    });
-
-    it('should success when logged in and setting normal priority', () => {
-      const priorityId = 'normal';
-      const action = {
-        payload: {
-          isAuthenticated: true,
-          incident: {
-            ...postIncident,
-            priority: { id: priorityId },
-            category,
-            subcategory,
-          },
-          wizard: {},
-        },
-      };
-      const mappedControls = mapControlsToParams(
-        action.payload.incident,
-        action.payload.wizard
-      );
-      const postData = {
-        ...action.payload.incident,
-        ...mappedControls,
-        ...enrichedPostData,
-      };
-
-      return expectSaga(createIncident, action)
-        .provide([
-          [matchers.call.fn(request), subCatResponse],
-          [matchers.call.fn(postCall), incident],
-        ])
-        .call(
-          request,
-          `${CONFIGURATION.CATEGORIES_ENDPOINT}${category}/sub_categories/${subcategory}`
-        )
-        .call(postCall, CONFIGURATION.INCIDENT_ENDPOINT, postData)
-        .not.put(setPriority({ priority: priorityId, _signal: incident.id }))
-        .put(createIncidentSuccess(incidentWithHandlingMessage))
-        .run();
-    });
-
-    it('should success when logged in and setting high priority', () => {
-      const priorityId = 'high';
-      const action = {
-        payload: {
-          ...payload,
-          isAuthenticated: true,
-          incident: {
-            ...postIncident,
-            priority: { id: priorityId },
-            category,
-            subcategory,
-          },
-        },
-      };
-      const mappedControls = mapControlsToParams(
-        action.payload.incident,
-        action.payload.wizard
-      );
-      const postData = {
-        ...action.payload.incident,
-        ...mappedControls,
-        ...enrichedPostData,
-      };
-
-      return expectSaga(createIncident, action)
-        .provide([
-          [matchers.call.fn(request), subCatResponse],
-          [matchers.call.fn(postCall), incident],
-        ])
-        .call(
-          request,
-          `${CONFIGURATION.CATEGORIES_ENDPOINT}${category}/sub_categories/${subcategory}`
-        )
-        .call(postCall, CONFIGURATION.INCIDENT_ENDPOINT, postData)
-        .put(setPriority({ priority: priorityId, _signal: incident.id }))
-        .put(createIncidentSuccess(incidentWithHandlingMessage))
-        .run();
-    });
-
-    it('should dispatch error', () => {
-      const action = { payload };
-
-      return expectSaga(createIncident, action)
-        .provide([
-          [matchers.call.fn(request), subCatResponse],
-          [matchers.call.fn(postCall), throwError(new Error('whoops!!!1!'))],
-        ])
-        .call.like({ fn: postCall })
+        .call(getPostData, action)
         .put(createIncidentError())
         .put(replace('/incident/fout'))
+        .run());
+
+    it('should run blocking file upload calls', () => {
+      const actionWithFiles = {
+        ...action,
+      };
+
+      const image1 = {
+        name: 'foobarbaz.jpg',
+        lastModified: 1579597089586,
+        size: 4718960,
+        type: 'image/jpeg',
+      };
+
+      const image2 = {
+        name: 'omgwtfbbq.jpg',
+        lastModified: 1579597057799,
+        size: 2886977,
+        type: 'image/jpeg',
+      };
+
+      actionWithFiles.payload.incident.images = [image1, image2];
+
+      return expectSaga(createIncident, action)
+        .provide([
+          [matchers.call.fn(getPostData), { handling_message, ...postData }],
+          [matchers.call.fn(postIncidentSaga), incident],
+        ])
+        .call(getPostData, action)
+        .call(postIncidentSaga, postData)
+        .call(uploadFile, { payload: { file: image1, id: incident.signal_id } })
+        .call(uploadFile, { payload: { file: image2, id: incident.signal_id } })
         .run();
     });
   });
-});
-
-describe('setPriorityHandler', () => {
-  const payload = { priority: { id: 'normal', label: 'Normaal' } };
-  const action = { payload };
-
-  it('should dispatch success', () =>
-    expectSaga(setPriorityHandler, action)
-      .provide([[matchers.call.fn(authPostCall), priority]])
-      .call(authPostCall, CONFIGURATION.PRIORITY_ENDPOINT, payload)
-      .put(setPrioritySuccess(priority))
-      .run());
-
-  it('should dispatch error', () =>
-    expectSaga(setPriorityHandler, action)
-      .provide([
-        [
-          matchers.call.fn(authPostCall),
-          throwError(new Error('Nope. Not possible')),
-        ],
-      ])
-      .call(authPostCall, CONFIGURATION.PRIORITY_ENDPOINT, payload)
-      .put(setPriorityError())
-      .put(
-        showGlobalNotification({
-          variant: VARIANT_ERROR,
-          title: 'Het zetten van de urgentie van deze melding is niet gelukt',
-        })
-      )
-      .run());
 });

--- a/src/signals/incident/services/map-controls-to-params/index.js
+++ b/src/signals/incident/services/map-controls-to-params/index.js
@@ -16,10 +16,6 @@ const mapControlsToParams = (incident, wizard) => {
 
   let params = {
     reporter: {},
-    status: {
-      state: 'm',
-      extra_properties: {},
-    },
   };
 
   if (datetime) {

--- a/src/signals/incident/services/map-controls-to-params/index.js
+++ b/src/signals/incident/services/map-controls-to-params/index.js
@@ -3,20 +3,27 @@ import moment from 'moment';
 import mapValues from '../map-values';
 import mapPaths from '../map-paths';
 
-const mapControlsToParams = (incident, wizard) => {
+export const defaultParams = {
+  reporter: {},
+};
+
+export default (incident, wizard) => {
   let datetime;
 
   if (incident.datetime && incident.datetime.id === 'Nu') {
     datetime = moment();
   } else if (incident.incident_date) {
-    const date = incident.incident_date && incident.incident_date === 'Vandaag' ? moment().format('YYYY-MM-DD') : incident.incident_date;
+    const date =
+      incident.incident_date && incident.incident_date === 'Vandaag'
+        ? moment().format('YYYY-MM-DD')
+        : incident.incident_date;
+
     const time = `${incident.incident_time_hours}:${incident.incident_time_minutes}`;
+
     datetime = moment(`${date} ${time}`, 'YYYY-MM-DD HH:mm');
   }
 
-  let params = {
-    reporter: {},
-  };
+  let params = defaultParams;
 
   if (datetime) {
     params.incident_date_start = datetime.format();
@@ -27,5 +34,3 @@ const mapControlsToParams = (incident, wizard) => {
 
   return params;
 };
-
-export default mapControlsToParams;

--- a/src/signals/incident/services/map-controls-to-params/index.test.js
+++ b/src/signals/incident/services/map-controls-to-params/index.test.js
@@ -3,28 +3,20 @@ import moment from 'moment';
 import mapValues from '../map-values';
 import mapPaths from '../map-paths';
 
-import mapControlsToParams from './index';
+import mapControlsToParams, { defaultParams } from './index';
 
 jest.mock('moment');
 jest.mock('../map-values');
 jest.mock('../map-paths');
 
 describe('The map controls to params service', () => {
-  const defaultValues = {
-    reporter: {},
-    status: {
-      state: 'm',
-      extra_properties: {},
-    },
-  };
-
   beforeEach(() => {
     mapValues.mockImplementation(params => params);
     mapPaths.mockImplementation(params => params);
   });
 
   it('should map status by default', () => {
-    expect(mapControlsToParams({}, {})).toEqual(defaultValues);
+    expect(mapControlsToParams({}, {})).toEqual(defaultParams);
   });
 
   it('should map date: Nu', () => {
@@ -32,15 +24,20 @@ describe('The map controls to params service', () => {
       format: () => '2018-07-21T12:34:00+02:00',
     }));
 
-    expect(mapControlsToParams({
-      incident_time_hours: 12,
-      incident_time_minutes: 34,
-      datetime: {
-        id: 'Nu',
-        label: 'Nu',
-      },
-    }, {})).toEqual({
-      ...defaultValues,
+    expect(
+      mapControlsToParams(
+        {
+          incident_time_hours: 12,
+          incident_time_minutes: 34,
+          datetime: {
+            id: 'Nu',
+            label: 'Nu',
+          },
+        },
+        {}
+      )
+    ).toEqual({
+      ...defaultParams,
       incident_date_start: '2018-07-21T12:34:00+02:00',
     });
   });
@@ -50,12 +47,17 @@ describe('The map controls to params service', () => {
       format: () => '2018-07-21T10:21:00+02:00',
     }));
 
-    expect(mapControlsToParams({
-      incident_time_hours: 10,
-      incident_time_minutes: 21,
-      incident_date: 'Vandaag',
-    }, {})).toEqual({
-      ...defaultValues,
+    expect(
+      mapControlsToParams(
+        {
+          incident_time_hours: 10,
+          incident_time_minutes: 21,
+          incident_date: 'Vandaag',
+        },
+        {}
+      )
+    ).toEqual({
+      ...defaultParams,
       incident_date_start: '2018-07-21T10:21:00+02:00',
     });
   });
@@ -65,12 +67,17 @@ describe('The map controls to params service', () => {
       format: () => '2018-07-02T09:05:00+02:00',
     }));
 
-    expect(mapControlsToParams({
-      incident_time_hours: 9,
-      incident_time_minutes: 5,
-      incident_date: '2018-04-02',
-    }, {})).toEqual({
-      ...defaultValues,
+    expect(
+      mapControlsToParams(
+        {
+          incident_time_hours: 9,
+          incident_time_minutes: 5,
+          incident_date: '2018-04-02',
+        },
+        {}
+      )
+    ).toEqual({
+      ...defaultParams,
       incident_date_start: '2018-07-02T09:05:00+02:00',
     });
   });
@@ -80,7 +87,7 @@ describe('The map controls to params service', () => {
     mapPaths.mockImplementation(params => ({ ...params, varFromMapPaths: 'bar' }));
 
     expect(mapControlsToParams({}, {})).toEqual({
-      ...defaultValues,
+      ...defaultParams,
       varFromMapValues: 'foo',
       varFromMapPaths: 'bar',
     });


### PR DESCRIPTION
# v0 ⇨ v1 replace

This PR contains changes that effectively phase out the use of the v0 signals creation endpoint.

## Changes

- Renames `INCIDENT_ENDPOINT` constant in the configuration class to `INCIDENT_PUBLIC_ENDPOINT` and alters the URL to match the v1 endpoint
- `IncidentContainer` saga has been rewritten so that:
  + an incident can be created both as authorized and unauthorized user; the public endpoint doesn't allow setting `priority`
  + image uploads are blocking (previously, those were non-blocking and lead to file uploads not being completed)

## Additions

- `INCIDENT_PRIVATE_ENDPOINT` constant to the configuration class

## Fixes

- Every now and then error popped up in Sentry saying `Unable to get property 'info' of undefined or null reference`. A minor change to one of the `RadioInput` components fixed that issue. Included in this PR because I came across it while making changes.

## Removals

- Setting the `priority` separately is not necessary anymore; the v1 endpoint supports it. Corresponding actions, saga, reducer cases and constants have been removed.