### PR TITLE
[SIG-2281] Form configuration for incident type

### DIFF
--- a/src/signals/incident/containers/IncidentContainer/index.test.js
+++ b/src/signals/incident/containers/IncidentContainer/index.test.js
@@ -59,7 +59,7 @@ describe('<IncidentContainer />', () => {
 
       expect(getAllByText('Volgende')).not.toBeNull(); // navigation
       expect(document.querySelectorAll('input[type="file"]')).toHaveLength(1); // image upload
-      expect(document.querySelectorAll('input[type="radio"].kenmerkradio')).toHaveLength(5); // 2 time indicator radio buttons and 3 priority
+      expect(document.querySelectorAll('input[type="radio"].kenmerkradio')).toHaveLength(10);
     });
   });
 

--- a/src/signals/incident/containers/IncidentContainer/reducer.js
+++ b/src/signals/incident/containers/IncidentContainer/reducer.js
@@ -19,6 +19,10 @@ export const initialState = fromJS({
       id: 'normal',
       label: 'Normaal',
     },
+    type: {
+      id: 'SIG',
+      label: 'Melding',
+    },
     category: '',
     subcategory: '',
     handling_message: '',

--- a/src/signals/incident/containers/IncidentContainer/reducer.test.js
+++ b/src/signals/incident/containers/IncidentContainer/reducer.test.js
@@ -29,6 +29,10 @@ describe('signals/incident/containers/IncidentContainer/reducer', () => {
           id: 'normal',
           label: 'Normaal',
         },
+        type: {
+          id: 'SIG',
+          label: 'Melding',
+        },
         category: '',
         subcategory: '',
         handling_message: '',

--- a/src/signals/incident/containers/IncidentContainer/saga.js
+++ b/src/signals/incident/containers/IncidentContainer/saga.js
@@ -105,11 +105,17 @@ export function* getPostData(action) {
     priority: {
       priority: action.payload.incident.priority.id,
     },
+    type: {
+      code: action.payload.incident.type.id,
+    },
     handling_message,
   };
 
+  const authenticatedOnlyFields = ['priority', 'source', 'type'];
+
   // function to filter out values that are not supported by the public API endpoint
-  const filterSupportedFields = ([key]) => isAuthenticated() || (!isAuthenticated() && key !== 'priority');
+  const filterSupportedFields = ([key]) =>
+    isAuthenticated() || (!isAuthenticated() && !authenticatedOnlyFields.includes(key));
 
   // return the filtered post data
   return Object.entries(primedPostData)

--- a/src/signals/incident/containers/IncidentContainer/saga.test.js
+++ b/src/signals/incident/containers/IncidentContainer/saga.test.js
@@ -63,6 +63,9 @@ const payloadIncident = {
   priority: {
     id: 'low',
   },
+  type: {
+    id: 'SIG',
+  },
   category,
   subcategory,
 };
@@ -190,6 +193,9 @@ describe('IncidentContainer saga', () => {
         handling_message,
         priority: {
           priority: payloadIncident.priority.id,
+        },
+        type: {
+          code: payloadIncident.type.id,
         },
       };
 

--- a/src/signals/incident/definitions/wizard-step-1-beschrijf.js
+++ b/src/signals/incident/definitions/wizard-step-1-beschrijf.js
@@ -1,35 +1,26 @@
 import some from 'lodash.some';
 import { Validators } from 'react-reactive-form';
-import { sourceList, priorityList } from 'signals/incident-management/definitions';
+import { sourceList, priorityList, typesList } from 'signals/incident-management/definitions';
 import IncidentNavigation from '../components/IncidentNavigation';
 import FormComponents from '../components/form';
 import checkVisibility from '../services/check-visibility';
 import getStepControls from '../services/get-step-controls';
 
-const sourceValuesObj = {
-  '': 'Vul bron in',
-};
-sourceList.forEach(({ key, value }) => {
-  sourceValuesObj[key] = value;
-});
-
-const priorityValuesList = {};
-priorityList.forEach(({ key, value, info }) => {
-  priorityValuesList[key] = {
-    value,
-    info,
-  };
-});
+const sourceValuesObj = sourceList.reduce((acc, { key, value }) => ({ ...acc, [key]: value }), { '': 'Vul bron in' });
+const priorityValuesList = priorityList.reduce((acc, { key, value, info }) => ({ ...acc, [key]: { value, info } }), {});
+const typesValuesList = typesList.reduce((acc, { key, value }) => ({ ...acc, [key]: { value } }), {});
 
 export default {
   label: 'Beschrijf uw melding',
   getNextStep: (wizard, incident) => {
-    if (!some(getStepControls(wizard.vulaan, incident), control => {
-      if (control.meta && !control.meta.ignoreVisibility) {
-        return checkVisibility(control, incident);
-      }
-      return false;
-    })) {
+    if (
+      !some(getStepControls(wizard.vulaan, incident), control => {
+        if (control.meta && !control.meta.ignoreVisibility) {
+          return checkVisibility(control, incident);
+        }
+        return false;
+      })
+    ) {
       return 'incident/telefoon';
     }
     return false;
@@ -71,10 +62,7 @@ export default {
           maxLength: 1000,
         },
         options: {
-          validators: [
-            Validators.required,
-            Validators.maxLength(1000),
-          ],
+          validators: [Validators.required, Validators.maxLength(1000)],
         },
         render: FormComponents.DescriptionWithClassificationInput,
       },
@@ -150,6 +138,16 @@ export default {
         authenticated: true,
         render: FormComponents.RadioInput,
       },
+      type: {
+        meta: {
+          className: 'col-sm-12 col-md-6',
+          label: 'Type',
+          path: 'type',
+          values: typesValuesList,
+        },
+        authenticated: true,
+        render: FormComponents.RadioInput,
+      },
       images_previews: {
         meta: {
           label: 'images_previews',
@@ -164,7 +162,7 @@ export default {
       },
       images: {
         meta: {
-          label: 'Foto\'s toevoegen',
+          label: "Foto's toevoegen",
           subtitle: 'Voeg een foto toe om de situatie te verduidelijken',
           minFileSize: 30 * 2 ** 10, // 30 KiB.
           maxFileSize: 8 * 2 ** 20, // 8 MiB.

--- a/src/utils/__tests__/fixtures/incident.json
+++ b/src/utils/__tests__/fixtures/incident.json
@@ -79,6 +79,12 @@
   "priority": {
     "priority": "normal"
   },
+  "notes": [],
+  "type": {
+    "code": "QUE",
+    "created_at": "2020-03-13T11:23:17.932429+01:00",
+    "created_by": "me@email.com"
+  },
   "created_at": "2020-02-06T08:50:15.634692+01:00",
   "updated_at": "2020-02-06T08:50:15.667022+01:00",
   "incident_date_start": "2020-02-06T08:50:15+01:00",


### PR DESCRIPTION
This PR applies changes to the incident submission form configuration so that the `type` property can be passed on incident POST.

In order to do so, this PR:
- changes the default values for an incident in the `IncidentContainer` reducer,
- adds an option to the `wizard-step-1-beschrijf` form configuration
- alters the `IncidentContainer` saga so that the fields 'priority', 'source' and 'type' can only be set by an authenticated user
- updates the incident JSON fixture so that its contents reflect the API's output