### PR TITLE
[SIG-2307] Incident type patch

### DIFF
--- a/src/models/incident/reducer.js
+++ b/src/models/incident/reducer.js
@@ -1,7 +1,6 @@
 import { fromJS } from 'immutable';
 
-import stadsdeelList from 'signals/incident-management/definitions/stadsdeelList';
-import priorityList from 'signals/incident-management/definitions/priorityList';
+import { stadsdeelList, priorityList, typesList } from 'signals/incident-management/definitions';
 import statusList, {
   changeStatusOptionList,
   defaultTextsOptionList,
@@ -54,6 +53,7 @@ export const initialState = fromJS({
     [PATCH_TYPE_LOCATION]: false,
   },
   split: false,
+  typesList,
 });
 
 function incidentModelReducer(state = initialState, action) {

--- a/src/signals/incident-management/containers/IncidentDetail/components/MetaList/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/MetaList/index.js
@@ -22,10 +22,11 @@ function getId(item) {
 
 const MetaList = ({
   incident,
-  subcategories,
-  priorityList,
-  onPatchIncident,
   onEditStatus,
+  onPatchIncident,
+  priorityList,
+  subcategories,
+  typesList,
 }) => {
   const children = get(incident, '_links.sia:children');
   const parent = get(incident, '_links.sia:parent');
@@ -82,6 +83,24 @@ const MetaList = ({
               type="priority"
               onPatchIncident={onPatchIncident}
               component={RadioInput}
+            />
+          </Highlight>
+        )}
+
+        {incident.type && (
+          <Highlight
+            subscribeTo={incident.type.code}
+          >
+            <ChangeValue
+              component={RadioInput}
+              definitionClass="meta-list__definition"
+              display="Type"
+              incident={incident}
+              list={typesList}
+              onPatchIncident={onPatchIncident}
+              path="type.code"
+              type="type"
+              valueClass="meta-list__value"
             />
           </Highlight>
         )}
@@ -217,11 +236,11 @@ const MetaList = ({
 
 MetaList.propTypes = {
   incident: incidentType.isRequired,
+  onEditStatus: PropTypes.func.isRequired,
+  onPatchIncident: PropTypes.func.isRequired,
   priorityList: dataListType.isRequired,
   subcategories: PropTypes.array.isRequired,
-
-  onPatchIncident: PropTypes.func.isRequired,
-  onEditStatus: PropTypes.func.isRequired,
+  typesList: dataListType.isRequired,
 };
 
 export default MetaList;

--- a/src/signals/incident-management/containers/IncidentDetail/components/MetaList/index.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/MetaList/index.test.js
@@ -10,7 +10,7 @@ import { string2date, string2time } from 'shared/services/string-parser/string-p
 import { withAppContext } from 'test/utils';
 import categories from 'utils/__tests__/fixtures/categories_structured.json';
 
-import priorityList from '../../../../definitions/priorityList';
+import { priorityList, typesList } from 'signals/incident-management/definitions';
 
 import MetaList from './index';
 
@@ -45,10 +45,14 @@ describe('<MetaList />', () => {
         priority: {
           priority: 'normal',
         },
+        type: {
+          code: 'SIG',
+        },
         _links: {},
       },
       subcategories,
       priorityList,
+      typesList,
       onPatchIncident: jest.fn(),
       onEditStatus: jest.fn(),
       onShowAttachment: jest.fn(),
@@ -108,6 +112,32 @@ describe('<MetaList />', () => {
 
       expect(
         getByText('Urgentie')
+          .closest('div')
+          .querySelectorAll('input[type="radio"]').length
+      ).toBeGreaterThan(0);
+    });
+
+    it('should render the correct HTML elements for type', () => {
+      const { getByText } = render(
+        <MetaList {...props} />
+      );
+
+      const showFormButton = getByText('Type')
+        .closest('div')
+        .querySelector('.change-value__edit.incident-detail__button--edit');
+
+      expect(
+        getByText('Type')
+          .closest('div')
+          .querySelectorAll('input[type="radio"]').length
+      ).toBe(0);
+
+      act(() => {
+        fireEvent.click(showFormButton);
+      });
+
+      expect(
+        getByText('Type')
           .closest('div')
           .querySelectorAll('input[type="radio"]').length
       ).toBeGreaterThan(0);

--- a/src/signals/incident-management/containers/IncidentDetail/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/index.js
@@ -148,18 +148,19 @@ export class IncidentDetail extends React.Component {
     } = this.props;
     const { list } = this.props.historyModel;
     const {
-      incident,
       attachments,
+      changeStatusOptionList,
+      defaultTexts,
+      defaultTextsOptionList,
+      error,
+      incident,
       loading,
       patching,
-      error,
+      priorityList,
       split,
       stadsdeelList,
-      priorityList,
-      changeStatusOptionList,
-      defaultTextsOptionList,
       statusList,
-      defaultTexts,
+      typesList,
     } = this.props.incidentModel;
     const { previewState, attachmentHref } = this.state;
 
@@ -270,6 +271,7 @@ export class IncidentDetail extends React.Component {
                       <MetaList
                         incident={incident}
                         priorityList={priorityList}
+                        typesList={typesList}
                         subcategories={subCategories}
                         onPatchIncident={onPatchIncident}
                         onEditStatus={this.onEditStatus}
@@ -307,6 +309,7 @@ IncidentDetail.propTypes = {
     split: PropTypes.oneOfType([PropTypes.bool, PropTypes.object]),
     stadsdeelList: dataListType,
     priorityList: dataListType,
+    typesList: dataListType,
     changeStatusOptionList: dataListType,
     defaultTextsOptionList: dataListType,
     statusList: dataListType,

--- a/src/signals/incident-management/containers/IncidentDetail/index.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/index.test.js
@@ -21,6 +21,7 @@ import statusList, {
 } from '../../definitions/statusList';
 import stadsdeelList from '../../definitions/stadsdeelList';
 import priorityList from '../../definitions/priorityList';
+import typesList from '../../definitions/typesList';
 
 const subCategories = Object.entries(categories).flatMap(([, { sub }]) => sub);
 
@@ -166,6 +167,7 @@ describe('<IncidentDetail />', () => {
       changeStatusOptionList,
       statusList,
       defaultTextsOptionList: statusList,
+      typesList,
     },
     historyModel: {
       list: [


### PR DESCRIPTION
This PR adds a component to the incident detail page with which the incident type can be patched.

**Component in preview mode**
<img width="439" alt="Screenshot 2020-03-13 at 12 08 35" src="https://user-images.githubusercontent.com/1062191/76616019-6cb0ac80-6523-11ea-9baa-8f2f03f59a8d.png">

---

**Component in edit mode**
<img width="432" alt="Screenshot 2020-03-13 at 12 08 42" src="https://user-images.githubusercontent.com/1062191/76616021-6d494300-6523-11ea-947e-35b0a28fc460.png">
