### PR TITLE
(Chore) Fix type mismatch

### DIFF
--- a/src/signals/incident-management/components/CheckboxList/index.js
+++ b/src/signals/incident-management/components/CheckboxList/index.js
@@ -139,7 +139,9 @@ const CheckboxList = ({
    * @returns {(Object|undefined)}
    */
   const getOption = useCallback(
-    id => options.find(option => option.id === id || option.key === id),
+    // id is always a string, because it comes from an HTML data- attribute
+    // cast the comparing value to a string to make sure that we're comparing the same things
+    id => options.find(option => `${option.id}` === id || `${option.key}` === id),
     [options]
   );
 


### PR DESCRIPTION
This PR contains a fix for type check mismatch in the `CheckboxList` component. 

The problem arose when an option was unchecked, but that change wasn't reflected by the list of options returned by the component's `onChange` handler. This was caused by the fact that an option's id was compared to the value of the corresponding HTML element's `data-id` attribute. The latter is always a string and the former can be either a string or a number.

By casting the comparing values to a string the issue is resolved.