### PR TITLE
(Chore) Fix fetch GET

### DIFF
--- a/src/hooks/__tests__/useFetch.test.js
+++ b/src/hooks/__tests__/useFetch.test.js
@@ -2,13 +2,17 @@ import { renderHook, act } from '@testing-library/react-hooks';
 import JSONresponse from 'utils/__tests__/fixtures/user.json';
 import { getErrorMessage } from 'shared/services/api/api';
 
-import useFetch, { headers } from '../useFetch';
+import useFetch from '../useFetch';
 
 jest.mock('shared/services/api/api');
 
 const URL = 'https://here-is-my.api/someId/6';
 
 describe('hooks/useFetch', () => {
+  afterEach(() => {
+    fetch.resetMocks();
+  });
+
   describe('get', () => {
     it('should request from URL on mount', async () => {
       fetch.mockResponseOnce(JSON.stringify(JSONresponse));
@@ -26,7 +30,9 @@ describe('hooks/useFetch', () => {
 
       expect(fetch).toHaveBeenCalledWith(
         URL,
-        expect.objectContaining({ headers })
+        expect.objectContaining({
+          method: 'GET',
+        })
       );
 
       await waitForNextUpdate();
@@ -51,7 +57,9 @@ describe('hooks/useFetch', () => {
 
       expect(fetch).toHaveBeenCalledWith(
         `${URL}?foo=bar&qux=zork`,
-        expect.objectContaining({ headers })
+        expect.objectContaining({
+          method: 'GET',
+        })
       );
     });
 
@@ -76,10 +84,7 @@ describe('hooks/useFetch', () => {
 
     it('should abort request on unmount', () => {
       fetch.mockResponseOnce(
-        () =>
-          new Promise(resolve =>
-            setTimeout(() => resolve(JSON.stringify(JSONresponse)), 100)
-          )
+        () => new Promise(resolve => setTimeout(() => resolve(JSON.stringify(JSONresponse)), 100))
       );
 
       const abortSpy = jest.spyOn(global.AbortController.prototype, 'abort');
@@ -132,7 +137,6 @@ describe('hooks/useFetch', () => {
       const expectRequest = [
         URL,
         expect.objectContaining({
-          headers,
           body: JSON.stringify(formData),
           method: 'PATCH',
         }),
@@ -196,7 +200,6 @@ describe('hooks/useFetch', () => {
       const expectRequest = [
         URL,
         expect.objectContaining({
-          headers,
           body: JSON.stringify(formData),
           method: 'POST',
         }),

--- a/src/hooks/useFetch.js
+++ b/src/hooks/useFetch.js
@@ -3,12 +3,6 @@ import { useState, useEffect } from 'react';
 import { getAuthHeaders } from 'shared/services/auth/auth';
 import { getErrorMessage } from 'shared/services/api/api';
 
-export const headers = {
-  ...getAuthHeaders(),
-  'Content-Type': 'application/json',
-  Accept: 'application/json',
-};
-
 /**
  * Custom hook useFetch
  *
@@ -26,6 +20,11 @@ export default () => {
 
   const controller = new AbortController();
   const { signal } = controller;
+  const requestHeaders = {
+    ...getAuthHeaders(),
+    'Content-Type': 'application/json',
+    Accept: 'application/json',
+  };
 
   useEffect(() => () => {
     controller.abort();
@@ -44,7 +43,8 @@ export default () => {
 
     try {
       const response = await fetch(requestURL, {
-        headers,
+        headers: requestHeaders,
+        method: 'GET',
         signal,
       });
       /* istanbul ignore else */
@@ -68,7 +68,7 @@ export default () => {
 
     try {
       const response = await fetch(url, {
-        headers,
+        headers: requestHeaders,
         method,
         signal,
         body: JSON.stringify(modifiedData),


### PR DESCRIPTION
This PR fixes a bug where resources could not be loaded and returned a `401` response from the API until the page was reloaded.

The problem came from the request headers being defined outside the `useFetch` hook. When a user enters the site and the session is expired, the request headers are set without the bearer token.
When that same user authenticates without reloading the site, the request headers still have the bearer token missing. This is only solved by reloading the page so that the bearer token is included in the request headers.

By placing the initialisation of the request headers inside the `useFetch` hook function, the issue is resolved.