### PR TITLE
[SIG-2447] Incident reset on page navigation

### DIFF
--- a/src/containers/App/index.js
+++ b/src/containers/App/index.js
@@ -1,12 +1,8 @@
 import React, { Fragment, useEffect } from 'react';
-import {
-  Switch,
-  Route,
-  Redirect,
-  withRouter,
-  useHistory,
-} from 'react-router-dom';
-import { compose } from 'redux';
+import PropTypes from 'prop-types';
+import { Switch, Route, Redirect, useHistory } from 'react-router-dom';
+import { compose, bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
 
 import { authenticate, isAuthenticated } from 'shared/services/auth/auth';
 import ThemeProvider from 'components/ThemeProvider';
@@ -20,15 +16,26 @@ import SiteHeaderContainer from 'containers/SiteHeader';
 import IncidentManagementModule from 'signals/incident-management';
 import SettingsModule from 'signals/settings';
 import IncidentContainer from 'signals/incident/containers/IncidentContainer';
+import { resetIncident } from 'signals/incident/containers/IncidentContainer/actions';
 import KtoContainer from 'signals/incident/containers/KtoContainer';
+import useLocationReferrer from 'hooks/useLocationReferrer';
 
 import reducer from './reducer';
 import saga from './saga';
 
-const App = () => {
+export const AppContainer = ({ resetIncidentAction }) => {
   // on each component render, see if the current session is authenticated
   authenticate();
   const history = useHistory();
+  const location = useLocationReferrer();
+
+  useEffect(() => {
+    const { referrer } = location;
+
+    if (referrer === '/incident/bedankt') {
+      resetIncidentAction();
+    }
+  }, [location, resetIncidentAction]);
 
   useEffect(() => {
     const unlisten = history.listen(() => {
@@ -64,7 +71,20 @@ const App = () => {
   );
 };
 
+AppContainer.propTypes = {
+  resetIncidentAction: PropTypes.func.isRequired,
+};
+
+const mapDispatchToProps = dispatch =>
+  bindActionCreators(
+    {
+      resetIncidentAction: resetIncident,
+    },
+    dispatch
+  );
+
+const withConnect = connect(null, mapDispatchToProps);
 const withReducer = injectReducer({ key: 'global', reducer });
 const withSaga = injectSaga({ key: 'global', saga });
 
-export default compose(withReducer, withSaga, withRouter)(App);
+export default compose(withReducer, withSaga, withConnect)(AppContainer);

--- a/src/containers/App/index.test.js
+++ b/src/containers/App/index.test.js
@@ -2,9 +2,9 @@ import React from 'react';
 import { render, cleanup, act } from '@testing-library/react';
 import { withAppContext, history } from 'test/utils';
 import * as auth from 'shared/services/auth/auth';
-import App from './index';
+import App, { AppContainer } from './index';
 
-jest.mock('components/MapInteractive');
+jest.mock('signals/incident/components/IncidentWizard', () => () => <span />);
 jest.mock('shared/services/auth/auth', () => ({
   __esModule: true,
   ...jest.requireActual('shared/services/auth/auth'),
@@ -40,6 +40,33 @@ describe('<App />', () => {
     expect(spyScrollTo).toHaveBeenCalledWith(0, 0);
   });
 
+  it('should reset incident on page unload', () => {
+    act(() => {
+      history.push('/');
+    });
+
+    const resetIncidentAction = jest.fn();
+
+    const { rerender } = render(withAppContext(<AppContainer resetIncidentAction={resetIncidentAction} />));
+
+    expect(resetIncidentAction).not.toHaveBeenCalled();
+
+    act(() => {
+      history.push('/incident/bedankt');
+    });
+
+    rerender(withAppContext(<AppContainer resetIncidentAction={resetIncidentAction} />));
+
+    expect(resetIncidentAction).not.toHaveBeenCalled();
+
+    act(() => {
+      history.push('/');
+    });
+
+    rerender(withAppContext(<AppContainer resetIncidentAction={resetIncidentAction} />));
+
+    expect(resetIncidentAction).toHaveBeenCalled();
+  });
 
   it('should render correctly', () => {
     jest.spyOn(auth, 'isAuthenticated').mockImplementationOnce(() => false);

--- a/src/signals/incident/containers/IncidentContainer/index.js
+++ b/src/signals/incident/containers/IncidentContainer/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { connect } from 'react-redux';
@@ -9,10 +9,9 @@ import { Row, Column, themeColor, themeSpacing } from '@datapunt/asc-ui';
 import { isAuthenticated } from 'shared/services/auth/auth';
 import injectSaga from 'utils/injectSaga';
 import injectReducer from 'utils/injectReducer';
-import useLocationReferrer from 'hooks/useLocationReferrer';
 
 import wizardDefinition from '../../definitions/wizard';
-import { getClassification, updateIncident, createIncident, resetIncident } from './actions';
+import { getClassification, updateIncident, createIncident } from './actions';
 import { makeSelectIncidentContainer } from './selectors';
 import reducer from './reducer';
 import saga from './saga';
@@ -31,47 +30,34 @@ export const IncidentContainerComponent = ({
   createIncidentAction,
   getClassificationAction,
   incidentContainer,
-  resetIncidentAction,
   updateIncidentAction,
-}) => {
-  const location = useLocationReferrer();
+}) => (
+  <Row>
+    <Alert>
+      We pakken op dit moment alleen urgente meldingen op. De afhandeling van uw melding kan daarom tijdelijk langer
+      duren dan de standaard afhandeltermijn die wordt vermeld in de bevestiging die u ontvangt na registratie van uw
+      melding. Dank voor uw begrip.
+    </Alert>
 
-  useEffect(() => {
-    if (location?.referrer === '/incident/bedankt') {
-      resetIncidentAction();
-    }
-  }, [location, resetIncidentAction]);
+    <br />
 
-  return (
-    <Row>
-      <Alert>
-        We pakken op dit moment alleen urgente meldingen op. De afhandeling van
-        uw melding kan daarom tijdelijk langer duren dan de standaard
-        afhandeltermijn die wordt vermeld in de bevestiging die u ontvangt na
-        registratie van uw melding. Dank voor uw begrip.
-      </Alert>
-
-      <br />
-
-      <Column span={12}>
-        <IncidentWizard
-          wizardDefinition={wizardDefinition}
-          getClassification={getClassificationAction}
-          updateIncident={updateIncidentAction}
-          createIncident={createIncidentAction}
-          incidentContainer={incidentContainer}
-          isAuthenticated={isAuthenticated()}
-        />
-      </Column>
-    </Row>
-  );
-};
+    <Column span={12}>
+      <IncidentWizard
+        wizardDefinition={wizardDefinition}
+        getClassification={getClassificationAction}
+        updateIncident={updateIncidentAction}
+        createIncident={createIncidentAction}
+        incidentContainer={incidentContainer}
+        isAuthenticated={isAuthenticated()}
+      />
+    </Column>
+  </Row>
+);
 
 IncidentContainerComponent.propTypes = {
   createIncidentAction: PropTypes.func.isRequired,
   getClassificationAction: PropTypes.func.isRequired,
   incidentContainer: PropTypes.object.isRequired,
-  resetIncidentAction: PropTypes.func.isRequired,
   updateIncidentAction: PropTypes.func.isRequired,
 };
 
@@ -84,7 +70,6 @@ const mapDispatchToProps = dispatch =>
     {
       createIncidentAction: createIncident,
       getClassificationAction: getClassification,
-      resetIncidentAction: resetIncident,
       updateIncidentAction: updateIncident,
     },
     dispatch

--- a/src/signals/incident/containers/IncidentContainer/index.test.js
+++ b/src/signals/incident/containers/IncidentContainer/index.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import { render, act } from '@testing-library/react';
+import { render } from '@testing-library/react';
 
-import { history, withAppContext } from 'test/utils';
+import { withAppContext } from 'test/utils';
 import { IncidentContainerComponent } from '.';
 
 jest.mock('shared/services/auth/auth', () => ({
@@ -9,41 +9,19 @@ jest.mock('shared/services/auth/auth', () => ({
   ...jest.requireActual('shared/services/auth/auth'),
   isAuthenticated: () => true,
 }));
-jest.mock('signals/incident/components/IncidentWizard', () => () => <span />);
+jest.mock('signals/incident/components/IncidentWizard', () => () => <span data-testid="incidentWizard" />);
 
 describe('signals/incident/containers/IncidentContainer', () => {
-  const resetIncidentAction = jest.fn();
   const props = {
     incidentContainer: { incident: {} },
     getClassificationAction: jest.fn(),
     updateIncidentAction: jest.fn(),
     createIncidentAction: jest.fn(),
-    resetIncidentAction,
   };
 
-  it('should reset incident on page unload', () => {
-    act(() => {
-      history.push('/');
-    });
+  it('should render correctly', () => {
+    const { getByTestId } = render(withAppContext(<IncidentContainerComponent {...props} />));
 
-    const { rerender } = render(withAppContext(<IncidentContainerComponent {...props} />));
-
-    expect(resetIncidentAction).not.toHaveBeenCalled();
-
-    act(() => {
-      history.push('/incident/bedankt');
-    });
-
-    rerender(withAppContext(<IncidentContainerComponent {...props} />));
-
-    expect(resetIncidentAction).not.toHaveBeenCalled();
-
-    act(() => {
-      history.push('/');
-    });
-
-    rerender(withAppContext(<IncidentContainerComponent {...props} />));
-
-    expect(resetIncidentAction).toHaveBeenCalled();
+    expect(getByTestId('incidentWizard')).toBeInTheDocument();
   });
 });

--- a/src/signals/incident/containers/IncidentContainer/saga.js
+++ b/src/signals/incident/containers/IncidentContainer/saga.js
@@ -111,15 +111,24 @@ export function* getPostData(action) {
     handling_message,
   };
 
+  const invalidFields = ['incident_date', 'incident_time_minutes', 'subcategory', 'datetime', 'incident_time_hours', 'description', 'status'];
   const authenticatedOnlyFields = ['priority', 'source', 'type'];
 
   // function to filter out values that are not supported by the public API endpoint
   const filterSupportedFields = ([key]) =>
     isAuthenticated() || (!isAuthenticated() && !authenticatedOnlyFields.includes(key));
 
+  const filterInvalidFields = ([key]) => {
+    const isInvalid = invalidFields.includes(key);
+    const isExtraProp = key !== 'extra_properties' && key.startsWith('extra_');
+
+    return !isInvalid && !isExtraProp;
+  };
+
   // return the filtered post data
   return Object.entries(primedPostData)
     .filter(filterSupportedFields)
+    .filter(filterInvalidFields)
     .reduce((acc, [key, value]) => ({ ...acc, [key]: value }), {});
 }
 

--- a/src/signals/incident/containers/IncidentContainer/saga.test.js
+++ b/src/signals/incident/containers/IncidentContainer/saga.test.js
@@ -145,6 +145,40 @@ describe('IncidentContainer saga', () => {
   });
 
   describe('getPostData', () => {
+    it('returns data that is valid', () => {
+      jest.spyOn(auth, 'isAuthenticated').mockImplementation(() => false);
+
+      const description = 'description';
+      const datetime = 'datetime';
+
+      const invalidPostData = { ...payloadIncident, description, datetime };
+      const invalidAction = { ...action, payload: { ...action.payload, incident: invalidPostData } };
+
+      const postData = {
+        text: payloadIncident.text,
+        category: {
+          sub_category,
+        },
+        handling_message,
+      };
+
+      const mapControlsToParamsResponse = {
+        text: payloadIncident.text,
+        category: payloadIncident.category,
+        subcategory: payloadIncident.subcategory,
+      };
+
+      return expectSaga(getPostData, invalidAction)
+        .provide([
+          [matchers.call.fn(request), categoryResponse],
+          [matchers.call.fn(mapControlsToParams), mapControlsToParamsResponse],
+        ])
+        .call(request, `${configuration.CATEGORIES_ENDPOINT}${category}/sub_categories/${subcategory}`)
+        .call(mapControlsToParams, invalidAction.payload.incident, invalidAction.payload.wizard)
+        .returns(postData)
+        .run(false);
+    });
+
     it('returns data for unauthenticated users', () => {
       jest.spyOn(auth, 'isAuthenticated').mockImplementation(() => false);
 
@@ -159,7 +193,6 @@ describe('IncidentContainer saga', () => {
         category: {
           sub_category,
         },
-        subcategory: payloadIncident.subcategory,
         handling_message,
       };
 
@@ -189,7 +222,6 @@ describe('IncidentContainer saga', () => {
         category: {
           sub_category,
         },
-        subcategory: payloadIncident.subcategory,
         handling_message,
         priority: {
           priority: payloadIncident.priority.id,


### PR DESCRIPTION
# Incident reset on page navigation

This PR contains changes that fixes an issue where, after an incident had been submitted, the state that held the incident's data, was not cleared.

The `IncidentContainer` contained a listener for changes to the browser's location, but a crucial change was not picked up properly and that was the navigation away from the last page in the incident submission process.

By moving the listener to the `App` container this problem was solved.