### PR TITLE
[SIG-2450] Limit params in incident POST payload

### DIFF
--- a/src/signals/incident/containers/IncidentContainer/saga.js
+++ b/src/signals/incident/containers/IncidentContainer/saga.js
@@ -111,24 +111,31 @@ export function* getPostData(action) {
     handling_message,
   };
 
-  const invalidFields = ['incident_date', 'incident_time_minutes', 'subcategory', 'datetime', 'incident_time_hours', 'description', 'status'];
+  const validFields = [
+    'category',
+    'extra_properties',
+    'incident_date_end',
+    'incident_date_start',
+    'location',
+    'priority',
+    'reporter',
+    'source',
+    'text_extra',
+    'text',
+    'type',
+  ];
   const authenticatedOnlyFields = ['priority', 'source', 'type'];
 
   // function to filter out values that are not supported by the public API endpoint
   const filterSupportedFields = ([key]) =>
     isAuthenticated() || (!isAuthenticated() && !authenticatedOnlyFields.includes(key));
 
-  const filterInvalidFields = ([key]) => {
-    const isInvalid = invalidFields.includes(key);
-    const isExtraProp = key !== 'extra_properties' && key.startsWith('extra_');
-
-    return !isInvalid && !isExtraProp;
-  };
+  const filterValidFields = ([key]) => validFields.includes(key);
 
   // return the filtered post data
   return Object.entries(primedPostData)
+    .filter(filterValidFields)
     .filter(filterSupportedFields)
-    .filter(filterInvalidFields)
     .reduce((acc, [key, value]) => ({ ...acc, [key]: value }), {});
 }
 

--- a/src/signals/incident/containers/IncidentContainer/saga.test.js
+++ b/src/signals/incident/containers/IncidentContainer/saga.test.js
@@ -159,7 +159,6 @@ describe('IncidentContainer saga', () => {
         category: {
           sub_category,
         },
-        handling_message,
       };
 
       const mapControlsToParamsResponse = {
@@ -193,7 +192,6 @@ describe('IncidentContainer saga', () => {
         category: {
           sub_category,
         },
-        handling_message,
       };
 
       return expectSaga(getPostData, action)
@@ -222,7 +220,6 @@ describe('IncidentContainer saga', () => {
         category: {
           sub_category,
         },
-        handling_message,
         priority: {
           priority: payloadIncident.priority.id,
         },


### PR DESCRIPTION
This PR contains a change that filters out fields that are not allowed by the `POST` API endpoint for incidents.
Previously, the responsible saga contained a blacklist. That list has been turned into a whitelist.