### PR TITLE
(Chore) Include handling message in pre-POST data

### DIFF
--- a/src/signals/incident/containers/IncidentContainer/saga.js
+++ b/src/signals/incident/containers/IncidentContainer/saga.js
@@ -114,6 +114,7 @@ export function* getPostData(action) {
   const validFields = [
     'category',
     'extra_properties',
+    'handling_message',
     'incident_date_end',
     'incident_date_start',
     'location',

--- a/src/signals/incident/containers/IncidentContainer/saga.test.js
+++ b/src/signals/incident/containers/IncidentContainer/saga.test.js
@@ -156,6 +156,7 @@ describe('IncidentContainer saga', () => {
 
       const postData = {
         text: payloadIncident.text,
+        handling_message,
         category: {
           sub_category,
         },
@@ -189,6 +190,7 @@ describe('IncidentContainer saga', () => {
 
       const postData = {
         text: payloadIncident.text,
+        handling_message,
         category: {
           sub_category,
         },
@@ -220,6 +222,7 @@ describe('IncidentContainer saga', () => {
         category: {
           sub_category,
         },
+        handling_message,
         priority: {
           priority: payloadIncident.priority.id,
         },


### PR DESCRIPTION
A previous PR removed the `handling_message` prop from the pre-POST data in the `IncidentContainer` saga. This PR corrects that error.