### PR TITLE
[SIG-2498] Map component

### DIFF
--- a/src/components/PDOKAutoSuggest/index.js
+++ b/src/components/PDOKAutoSuggest/index.js
@@ -11,21 +11,26 @@ const serviceParams = [
 ];
 const serviceURL = 'https://geodata.nationaalgeoregister.nl/locatieserver/v3/suggest?';
 const numOptionsDeterminer = data => data?.response?.docs?.length || 0;
-const formatResponse = ({ response }) => response.docs.map(({ id, weergavenaam }) => ({ id, value: weergavenaam }));
+const formatResponseFunc = ({ response }) => response.docs.map(({ id, weergavenaam }) => ({ id, value: weergavenaam }));
 
 /**
  * Geocoder component that specifically uses the PDOK location service to request information from
  *
  * @see {@link https://www.pdok.nl/restful-api/-/article/pdok-locatieserver#/paths/~1suggest/get}
  */
-const PDOKAutoSuggest = ({ gemeentenaam, onSelect, value }) => {
+const PDOKAutoSuggest = ({ className, fieldList, gemeentenaam, onSelect, formatResponse, value }) => {
   const fq = gemeentenaam && [['fq', `gemeentenaam:${gemeentenaam}`]];
-  const params = fq.concat(serviceParams).filter(Boolean);
+  const fl = [['fl', fieldList.concat(['id', 'weergavenaam']).join(',')]];
+  const params = fq
+    .concat(fl)
+    .concat(serviceParams)
+    .filter(Boolean);
   const queryParams = params.flatMap(([key, val]) => `${key}=${val}`).join('&');
   const URL = `${serviceURL}`.concat(queryParams);
 
   return (
     <AutoSuggest
+      className={className}
       url={URL}
       numOptionsDeterminer={numOptionsDeterminer}
       formatResponse={formatResponse}
@@ -36,17 +41,23 @@ const PDOKAutoSuggest = ({ gemeentenaam, onSelect, value }) => {
 };
 
 PDOKAutoSuggest.defaultProps = {
+  className: '',
+  fieldList: [],
   gemeentenaam: 'amsterdam',
+  formatResponse: formatResponseFunc,
   value: '',
 };
 
 PDOKAutoSuggest.propTypes = {
+  className: PropTypes.string,
+  fieldList: PropTypes.arrayOf(PropTypes.string),
   /**
    * Value that determines to which municipality the search query should be applied
    * Can be a single name, like amsterdam, or a combination, like (amsterdam OR weesp)
    */
   gemeentenaam: PropTypes.string,
   onSelect: PropTypes.func.isRequired,
+  formatResponse: PropTypes.func,
   value: PropTypes.string,
 };
 

--- a/src/hooks/__tests__/useFetch.test.js
+++ b/src/hooks/__tests__/useFetch.test.js
@@ -63,6 +63,29 @@ describe('hooks/useFetch', () => {
       );
     });
 
+    it('should construct a URL with complex query params', async () => {
+      const params = {
+        foo: 'bar',
+        qux: 'zork',
+        category: ['a', 'b', 'c'],
+      };
+
+      const { result, waitForNextUpdate } = renderHook(() => useFetch());
+
+      act(() => {
+        result.current.get(URL, params);
+      });
+
+      await waitForNextUpdate();
+
+      expect(fetch).toHaveBeenCalledWith(
+        `${URL}?category=a&category=b&category=c&foo=bar&qux=zork`,
+        expect.objectContaining({
+          method: 'GET',
+        })
+      );
+    });
+
     it('should return errors that are thrown during fetch', async () => {
       const error = new Error();
       fetch.mockRejectOnce(error);

--- a/src/hooks/useFetch.js
+++ b/src/hooks/useFetch.js
@@ -26,19 +26,27 @@ export default () => {
     Accept: 'application/json',
   };
 
-  useEffect(() => () => {
-    controller.abort();
+  useEffect(
+    () => () => {
+      controller.abort();
+    },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+    []
+  );
 
   const get = async (url, params, requestOptions = {}) => {
     setLoading(true);
 
-    const queryParams = Object.entries(params || {})
-      .filter(([, value]) => Boolean(value))
-      .reduce((acc, [key, value]) => [...acc, `${key}=${value}`], [])
-      .join('&');
+    const arrayParams = Object.entries(params || {})
+      .filter(([key]) => Array.isArray(params[key]))
+      .flatMap(([key, value]) => value.flatMap(val => `${key}=${val}`));
 
+    const scalarParams = Object.entries(params || {})
+      .filter(([, value]) => Boolean(value))
+      .filter(([key]) => !Array.isArray(params[key]))
+      .reduce((acc, [key, value]) => [...acc, `${key}=${value}`], []);
+
+    const queryParams = arrayParams.concat(scalarParams).join('&');
     const requestURL = [url, queryParams].filter(Boolean).join('?');
 
     try {

--- a/src/shared/services/configuration/configuration.js
+++ b/src/shared/services/configuration/configuration.js
@@ -120,6 +120,10 @@ export class Configuration {
     return `${this.API_ROOT}signals/v1/private/signals/`;
   }
 
+  get GEOGRAPHY_ENDPOINT() {
+    return `${this.API_ROOT}signals/v1/private/signals/geography`;
+  }
+
   get PRIORITY_ENDPOINT() {
     return `${this.API_ROOT}signals/auth/priority/`;
   }

--- a/src/shared/services/map-location/index.js
+++ b/src/shared/services/map-location/index.js
@@ -13,9 +13,23 @@ export const address2pdok = address => {
     straatnaam: openbare_ruimte,
     huisnummer: `${huisnummer}`,
     huisletter: `${huisletter}` || '',
-    huisnummertoevoeging: huisnummer_toevoeging ?   `${huisnummer_toevoeging}` : '',
+    huisnummertoevoeging: huisnummer_toevoeging ? `${huisnummer_toevoeging}` : '',
     postcode,
     woonplaatsnaam: woonplaats,
+  };
+};
+
+export const centroideToLocation = centroide => {
+  if (!centroide.includes('POINT')) {
+    throw TypeError('Provided centroide geometry is not a point.');
+  }
+  const coordinate = centroide.split('(')[1].split(')')[0];
+  const lat = parseFloat(coordinate.split(' ')[1]);
+  const lng = parseFloat(coordinate.split(' ')[0]);
+
+  return {
+    lat,
+    lng,
   };
 };
 
@@ -39,10 +53,7 @@ const mapLocation = loc => {
   if (loc.query) {
     location.geometrie = {
       type: 'Point',
-      coordinates: [
-        loc.query.longitude,
-        loc.query.latitude,
-      ],
+      coordinates: [loc.query.longitude, loc.query.latitude],
     };
   }
 

--- a/src/signals/incident-management/__tests__/selectors.test.js
+++ b/src/signals/incident-management/__tests__/selectors.test.js
@@ -95,6 +95,9 @@ describe('signals/incident-management/selectors', () => {
   });
 
   it('should select active filter', () => {
+    const activeFilter = initialState.toJS().activeFilter;
+    activeFilter.options.priority = [];
+
     expect(
       makeSelectActiveFilter.resultFunc(
         initialState,
@@ -102,7 +105,7 @@ describe('signals/incident-management/selectors', () => {
         maincategory_slug,
         category_slug
       )
-    ).toEqual(initialState.toJS().activeFilter);
+    ).toEqual(activeFilter);
 
     const state = fromJS({ ...initialState.toJS(), activeFilter: filters[0] });
 
@@ -209,7 +212,6 @@ describe('signals/incident-management/selectors', () => {
         ordering: '-created_at',
         page: 1,
         page_size: FILTER_PAGE_SIZE,
-        priority: [],
       });
 
       const state = fromJS({
@@ -233,7 +235,6 @@ describe('signals/incident-management/selectors', () => {
         ordering: '-created_at',
         page: 1,
         page_size: FILTER_PAGE_SIZE,
-        priority: [],
       });
 
       const state2 = fromJS({
@@ -244,7 +245,6 @@ describe('signals/incident-management/selectors', () => {
         ordering: 'created_at',
         page: 1,
         page_size: FILTER_PAGE_SIZE,
-        priority: [],
       });
     });
   });

--- a/src/signals/incident-management/containers/IncidentOverviewPage/components/Map/index.js
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/components/Map/index.js
@@ -1,0 +1,118 @@
+import React, { memo, useContext, useState, useCallback, useEffect } from 'react';
+import styled from 'styled-components';
+import { useSelector } from 'react-redux';
+import isEqual from 'lodash.isequal';
+import moment from 'moment';
+
+import MapContext from 'containers/MapContext/context';
+import { setAddressAction } from 'containers/MapContext/actions';
+import Map from 'components/Map';
+import PDOKAutoSuggest from 'components/PDOKAutoSuggest';
+import MAP_OPTIONS from 'shared/services/configuration/map-options';
+import configuration from 'shared/services/configuration/configuration';
+import { centroideToLocation } from 'shared/services/map-location';
+import { makeSelectFilterParams, makeSelectActiveFilter } from 'signals/incident-management/selectors';
+import { initialState } from 'signals/incident-management/reducer';
+import useFetch from 'hooks/useFetch';
+
+const Wrapper = styled.div`
+  position: relative;
+  width: 100%;
+`;
+
+const StyledMap = styled(Map)`
+  height: 450px;
+  width: 100%;
+`;
+
+const Autosuggest = styled(PDOKAutoSuggest)`
+  position: absolute;
+  top: 30px;
+  left: 20px;
+  max-width: calc(100% - 40px);
+  z-index: 401; // 400 is the minimum elevation were elements are shown above the map
+`;
+
+const formatResponse = ({ response }) =>
+  response.docs.map(result => {
+    const { id, weergavenaam, centroide_ll } = result;
+    return {
+      id,
+      value: weergavenaam,
+      data: {
+        location: centroideToLocation(centroide_ll),
+      },
+    };
+  });
+
+const OverviewMap = ({ ...rest }) => {
+  const { dispatch } = useContext(MapContext);
+  const [map, setMap] = useState();
+  const { options } = useSelector(makeSelectActiveFilter);
+  const filterParams = useSelector(makeSelectFilterParams);
+  const { get, data, isLoading } = useFetch();
+  const createdAfter = moment()
+    .subtract(1, 'days')
+    .format('YYYY-MM-DDTkk:mm:ss');
+  const { ...params } = filterParams;
+  params.created_after = createdAfter;
+
+  const onSelect = useCallback(
+    option => {
+      dispatch(setAddressAction(option.value));
+
+      if (map) {
+        const currentZoom = map.getZoom();
+        map.flyTo(option.data.location, currentZoom < 11 ? 11 : currentZoom);
+      }
+    },
+    [map, dispatch]
+  );
+
+  useEffect(() => {
+    if (!options || isLoading) return;
+
+    const { name, ...initialActive } = initialState.get('activeFilter').toJS();
+
+    const theSame = isEqual(initialActive.options, options);
+
+    if (theSame) return;
+
+    get(`${configuration.GEOGRAPHY_ENDPOINT}`, params);
+    // eslint-disable-next-line
+  }, [filterParams]);
+
+  // request data on mount
+  useEffect(() => {
+    get(`${configuration.GEOGRAPHY_ENDPOINT}`, params);
+    // eslint-disable-next-line
+  }, []);
+
+  // temporaryli disabling linter till the function below has been implemented
+  // eslint-disable-next-line
+  useEffect(() => {
+    if (!data) return undefined;
+
+    // handle the data retrieval;
+  }, [data]);
+
+  return (
+    <Wrapper {...rest}>
+      <StyledMap
+        data-testid="overviewMap"
+        mapOptions={MAP_OPTIONS}
+        // events={{ click: clickHandler }}
+        setInstance={setMap}
+        // {...otherProps}
+      />
+      <Autosuggest
+        onSelect={onSelect}
+        gemeentenaam="amsterdam"
+        fieldList={['centroide_ll']}
+        formatResponse={formatResponse}
+      />
+    </Wrapper>
+  );
+};
+
+export default memo(OverviewMap);

--- a/src/signals/incident-management/containers/IncidentOverviewPage/components/Map/index.js
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/components/Map/index.js
@@ -47,15 +47,16 @@ const formatResponse = ({ response }) =>
 
 const OverviewMap = ({ ...rest }) => {
   const { dispatch } = useContext(MapContext);
+  const [initialMount, setInitialMount] = useState(false);
   const [map, setMap] = useState();
   const { options } = useSelector(makeSelectActiveFilter);
   const filterParams = useSelector(makeSelectFilterParams);
   const { get, data, isLoading } = useFetch();
-  const createdAfter = moment()
+
+  const { ...params } = filterParams;
+  params.created_after = moment()
     .subtract(1, 'days')
     .format('YYYY-MM-DDTkk:mm:ss');
-  const { ...params } = filterParams;
-  params.created_after = createdAfter;
 
   const onSelect = useCallback(
     option => {
@@ -70,25 +71,27 @@ const OverviewMap = ({ ...rest }) => {
   );
 
   useEffect(() => {
-    if (!options || isLoading) return;
+    if (!options || isLoading || !initialMount) return;
 
     const { name, ...initialActive } = initialState.get('activeFilter').toJS();
+    const paramsAreInitial = isEqual(initialActive.options, options);
 
-    const theSame = isEqual(initialActive.options, options);
-
-    if (theSame) return;
+    if (paramsAreInitial) return;
 
     get(`${configuration.GEOGRAPHY_ENDPOINT}`, params);
+    // Only execute when the value of filterParams changes; disabling linter
     // eslint-disable-next-line
   }, [filterParams]);
 
   // request data on mount
   useEffect(() => {
     get(`${configuration.GEOGRAPHY_ENDPOINT}`, params);
+    setInitialMount(true);
+
     // eslint-disable-next-line
   }, []);
 
-  // temporaryli disabling linter till the function below has been implemented
+  // temporarily disabling linter till the function below has been implemented
   // eslint-disable-next-line
   useEffect(() => {
     if (!data) return undefined;

--- a/src/signals/incident-management/containers/IncidentOverviewPage/index.js
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/index.js
@@ -17,6 +17,7 @@ import Modal from 'components/Modal';
 import * as types from 'shared/types';
 import Pagination from 'components/Pagination';
 import { FILTER_PAGE_SIZE } from 'signals/incident-management/constants';
+import MapContext from 'containers/MapContext';
 
 import {
   makeSelectActiveFilter,
@@ -28,6 +29,7 @@ import {
 import { MAP_URL, INCIDENTS_URL } from '../../routes';
 
 import ListComponent from './components/List';
+import OverviewMap from './components/Map';
 import FilterTagList from '../FilterTagList';
 
 import './style.scss';
@@ -153,7 +155,13 @@ export const IncidentOverviewPageContainerComponent = ({
       </PageHeader>
 
       <Row>
-        {showsMap && <span data-testid="24HourMap">Kaart</span>}
+        {showsMap && (
+          <Column span={12}>
+            <MapContext>
+              <OverviewMap data-testid="24HourMap" />
+            </MapContext>
+          </Column>
+        )}
 
         {!showsMap && (
           <Column span={12} wrap>

--- a/src/signals/incident-management/reducer.js
+++ b/src/signals/incident-management/reducer.js
@@ -35,14 +35,12 @@ export const initialState = fromJS({
     // filter settings for the list of incidents
     name: '',
     options: {
-      priority: [],
     },
   },
   editFilter: {
     // settings selected for editing
     name: '',
     options: {
-      priority: [],
     },
   },
   feedback,


### PR DESCRIPTION
This PR contains a skeleton Map component for the incident overview page. 

In order for the map to be functional, this PR:
- applies changes to the `PDOKAutoSuggest` component so that the list of fields, for which values should be retrieved from the geocoding service,is configurable. That also goes for the function that parsed the service's output. One doesn't go without the other in this case.
- applies changes to the `useFetch` hook so that its parameter values can both be scalar as well as array values
- requests data from the geography service on mount and update of the map component