### PR TITLE
[SIG-1505] Map toggle buttons

### DIFF
--- a/src/components/AutoSuggest/index.js
+++ b/src/components/AutoSuggest/index.js
@@ -12,7 +12,6 @@ export const INPUT_DELAY = 350;
 const Wrapper = styled.div`
   position: relative;
   z-index: 1;
-  min-width: 350px;
 `;
 
 const AbsoluteList = styled(SuggestList)`

--- a/src/components/PageHeader/index.js
+++ b/src/components/PageHeader/index.js
@@ -2,19 +2,19 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
-import { Heading, Row, Paragraph } from '@datapunt/asc-ui';
+import { Heading, Row, Paragraph, themeSpacing } from '@datapunt/asc-ui';
 
 const StyledSection = styled.section`
   background-color: #f3f3f3;
-  padding-top: 24px;
-  padding-bottom: 10px;
-  margin-bottom: 40px;
+  padding-top: ${themeSpacing(6)};
+  padding-bottom: ${themeSpacing(2)};
+  margin-bottom: ${themeSpacing(5)};
 `;
 
 const StyledHeading = styled(Heading)`
   font-weight: 400;
   margin: 0;
-  line-height: 24px;
+  line-height: ${themeSpacing(6)};
 `;
 
 const SubTitle = styled(Paragraph)`

--- a/src/global.scss
+++ b/src/global.scss
@@ -14,6 +14,7 @@ body {
   @include avenirnext();
   font-size: 1rem;
   line-height: 22px;
+  overflow-y: scroll;
 }
 
 ul li {

--- a/src/signals/incident-management/containers/FilterTagList/index.js
+++ b/src/signals/incident-management/containers/FilterTagList/index.js
@@ -13,6 +13,7 @@ import * as types from 'shared/types';
 
 const FilterWrapper = styled.div`
   margin-top: 10px;
+  flex-basis: 100%;
 `;
 
 const StyledTag = styled(Tag)`
@@ -119,7 +120,7 @@ export const FilterTagListComponent = props => {
   }
 
   return mainCategories && subCategories ? (
-    <FilterWrapper className="incident-overview-page__filter-tag-list">
+    <FilterWrapper>
       {Object.entries(tagsList).map(([tagKey, tag]) =>
         Array.isArray(tag)
           ? renderGroup(tag, mainCategories, map[tagKey], tagKey)

--- a/src/signals/incident-management/containers/IncidentOverviewPage/components/Map/index.js
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/components/Map/index.js
@@ -31,6 +31,7 @@ const Autosuggest = styled(PDOKAutoSuggest)`
   left: 20px;
   max-width: calc(100% - 40px);
   z-index: 401; // 400 is the minimum elevation were elements are shown above the map
+  width: 350px;
 `;
 
 const formatResponse = ({ response }) =>

--- a/src/signals/incident-management/containers/IncidentOverviewPage/components/SubNav/__tests__/SubNav.test.js
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/components/SubNav/__tests__/SubNav.test.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { withAppContext } from 'test/utils';
+
+import SubNav from '..';
+
+describe('signals/incident-management/containers/IncidentOverviewPage/components/SubNav', () => {
+  it('should render tabbed links', () => {
+    const { queryByTestId, rerender } = render(withAppContext(<SubNav />));
+
+    expect(queryByTestId('subNavMapLink')).toBeInTheDocument();
+    expect(queryByTestId('subNavListLink')).not.toBeInTheDocument();
+
+    rerender(withAppContext(<SubNav showsMap />));
+
+    expect(queryByTestId('subNavMapLink')).not.toBeInTheDocument();
+    expect(queryByTestId('subNavListLink')).toBeInTheDocument();
+  });
+});

--- a/src/signals/incident-management/containers/IncidentOverviewPage/components/SubNav/index.js
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/components/SubNav/index.js
@@ -1,0 +1,100 @@
+import React, { Fragment } from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { Row, Column, themeSpacing, themeColor, Heading } from '@datapunt/asc-ui';
+import { Link } from 'react-router-dom';
+
+import { MAP_URL, INCIDENTS_URL } from '../../../../routes';
+
+export const Wrapper = styled(Row)`
+  margin-bottom: ${themeSpacing(5)};
+`;
+
+export const MapHeading = styled(Heading).attrs({
+  forwardedAs: 'h2',
+})`
+  margin: 0;
+  font-size: 16px;
+`;
+
+export const TabContainer = styled.div`
+  border-bottom: 2px solid ${themeColor('tint', 'level3')};
+  display: flex;
+  padding-bottom: ${themeSpacing(1)};
+
+  a {
+    text-decoration: none;
+  }
+`;
+
+export const Tab = styled.span`
+  line-height: 24px;
+  font-size: 18px;
+  font-family: Avenir Next LT W01 Demi, arial, sans-serif;
+  box-shadow: 0px 6px 0px 0px rgba(0, 0, 0, 0);
+  padding: 0 10px 6px;
+  color: ${themeColor('tint', 'level6')};
+
+  &.active {
+    pointer-events: none;
+    box-shadow: 0px 6px 0px 0px ${themeColor('secondary')};
+    color: ${themeColor('secondary')};
+  }
+
+  &:not(.active):hover {
+    box-shadow: 0px 6px 0px 0px rgba(0, 0, 0, 1);
+    color: ${themeColor('tint', 'level6')};
+  }
+
+  & + & {
+    margin-left: ${themeSpacing(7)};
+  }
+`;
+
+export const Toggle = styled(Column).attrs({
+  span: 6,
+})`
+  justify-content: flex-end;
+  align-items: center;
+  height: ${themeSpacing(8)};
+`;
+
+const SubNav = ({ showsMap }) => (
+  <Wrapper data-testid="subNav">
+    <Column span={6}>{showsMap && <MapHeading>Afgelopen 24 uur</MapHeading>}</Column>
+
+    <Toggle>
+      <TabContainer>
+        {showsMap ? (
+          <Fragment>
+            <Tab data-testid="subNavListLink" as={Link} to={INCIDENTS_URL}>
+              Lijst
+            </Tab>
+            <Tab className="active">
+              <span>Kaart</span>
+            </Tab>
+          </Fragment>
+        ) : (
+          <Fragment>
+            <Tab className="active">
+              <span>Lijst</span>
+            </Tab>
+            <Tab data-testid="subNavMapLink" as={Link} to={MAP_URL}>
+              Kaart
+            </Tab>
+          </Fragment>
+        )}
+      </TabContainer>
+    </Toggle>
+  </Wrapper>
+);
+
+SubNav.defaultProps = {
+  showsMap: false,
+};
+
+SubNav.propTypes = {
+  showsMap: PropTypes.bool,
+};
+
+export default SubNav;

--- a/src/signals/incident-management/containers/IncidentOverviewPage/components/SubNav/index.js
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/components/SubNav/index.js
@@ -51,9 +51,7 @@ export const Tab = styled.span`
   }
 `;
 
-export const Toggle = styled(Column).attrs({
-  span: 6,
-})`
+export const TabWrapper = styled(Column)`
   justify-content: flex-end;
   align-items: center;
   height: ${themeSpacing(8)};
@@ -61,9 +59,11 @@ export const Toggle = styled(Column).attrs({
 
 const SubNav = ({ showsMap }) => (
   <Wrapper data-testid="subNav">
-    <Column span={6}>{showsMap && <MapHeading>Afgelopen 24 uur</MapHeading>}</Column>
+    <Column span={{ small: 1, medium: 1, big: 3, large: 6, xLarge: 6 }}>
+      {showsMap && <MapHeading>Afgelopen 24 uur</MapHeading>}
+    </Column>
 
-    <Toggle>
+    <TabWrapper span={{ small: 1, medium: 1, big: 3, large: 6, xLarge: 6 }}>
       <TabContainer>
         {showsMap ? (
           <Fragment>
@@ -85,7 +85,7 @@ const SubNav = ({ showsMap }) => (
           </Fragment>
         )}
       </TabContainer>
-    </Toggle>
+    </TabWrapper>
   </Wrapper>
 );
 

--- a/src/signals/incident-management/containers/IncidentOverviewPage/index.test.js
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/index.test.js
@@ -4,7 +4,7 @@ import { fireEvent, render, act } from '@testing-library/react';
 import { disablePageScroll, enablePageScroll } from 'scroll-lock';
 import incidentJson from 'utils/__tests__/fixtures/incident.json';
 
-import { withAppContext, history } from 'test/utils';
+import { withAppContext } from 'test/utils';
 import {
   priorityList,
   statusList,
@@ -243,10 +243,10 @@ describe('signals/incident-management/containers/IncidentOverviewPage', () => {
     expect(props.pageChangedAction).toHaveBeenCalledWith(pagenum);
   });
 
-  it('should render a map', () => {
+  it('should render a map', async () => {
     const incidents = generateIncidents();
 
-    const { queryByTestId, getByTestId } = render(
+    const { queryByTestId, getByTestId, findByTestId } = render(
       withAppContext(
         <IncidentOverviewPageContainerComponent
           {...props}
@@ -259,15 +259,30 @@ describe('signals/incident-management/containers/IncidentOverviewPage', () => {
       )
     );
 
+    expect(getByTestId('subNav')).toBeInTheDocument();
+
     expect(getByTestId('incidentOverviewListComponent')).toBeInTheDocument();
     expect(queryByTestId('24HourMap')).not.toBeInTheDocument();
 
+    const subNavMapLink = await findByTestId('subNavMapLink');
+
     act(() => {
-      history.push('/manage/incidents/kaart');
+      fireEvent.click(subNavMapLink);
     });
+
+    const subNavListLink = await findByTestId('subNavListLink');
 
     expect(queryByTestId('incidentOverviewListComponent')).not.toBeInTheDocument();
     expect(getByTestId('24HourMap')).toBeInTheDocument();
+
+    act(() => {
+      fireEvent.click(subNavListLink);
+    });
+
+    await findByTestId('subNavMapLink');
+
+    expect(getByTestId('incidentOverviewListComponent')).toBeInTheDocument();
+    expect(queryByTestId('24HourMap')).not.toBeInTheDocument();
   });
 
   describe('filter modal', () => {

--- a/src/signals/incident-management/containers/IncidentOverviewPage/style.scss
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/style.scss
@@ -1,7 +1,0 @@
-@import "config.scss";
-
-.incident-overview-page {
-  &__filter-tag-list {
-    flex-basis: 100%;
-  }
-}

--- a/src/signals/incident-management/containers/IncidentOverviewPage/styled.js
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/styled.js
@@ -1,0 +1,24 @@
+import styled from 'styled-components';
+import { Column, Button, themeSpacing, Paragraph, themeColor } from '@datapunt/asc-ui';
+import Pagination from 'components/Pagination';
+
+export const StyledButton = styled(Button)`
+  margin-left: 10px;
+`;
+
+export const StyledPagination = styled(Pagination)`
+  margin-top: ${themeSpacing(12)};
+`;
+
+export const NoResults = styled(Paragraph)`
+  width: 100%;
+  text-align: center;
+  font-family: Avenir Next LT W01 Demi, arial, sans-serif;
+  color: ${themeColor('tint', 'level4')};
+`;
+
+export const MapWrapper = styled(Column).attrs({
+  span: 12,
+})`
+  flex-direction: column;
+`;


### PR DESCRIPTION
This PR adds a section to the incident overview page that has a tabbed list of links that can toggle the list and the map on that page.

<img width="1075" alt="Screenshot 2020-04-08 at 09 26 38" src="https://user-images.githubusercontent.com/1062191/78756428-1183a580-797b-11ea-9a0f-0b1077a243ae.png">

Next to that, this PR:
- adjusts the margins of the `PageHeader` component to make the tabbed list fit
- sets the overflow of the `body` to 'scroll' so that the page scrollbar is always visible and the page never jumps when navigating from a long page to a short page
- moves `IncidentOverview` styled components into their own file