### PR TITLE
(Chore) Fix https URL

### DIFF
--- a/src/components/MapInput/__tests__/reverseGeocoderService.test.js
+++ b/src/components/MapInput/__tests__/reverseGeocoderService.test.js
@@ -5,7 +5,7 @@ describe('formatRequest', () => {
     latitude: 42,
     longitude: 4,
   };
-  const result = 'httpd://base-url&X=39180.476027290264&Y=-667797.6751788945&distance=';
+  const result = 'https://base-url&X=39180.476027290264&Y=-667797.6751788945&distance=';
 
   it('should format correct without distance', () => {
     expect(formatRequest('https://base-url', testLocation)).toEqual(`${result}50`);

--- a/src/components/MapInput/__tests__/reverseGeocoderService.test.js
+++ b/src/components/MapInput/__tests__/reverseGeocoderService.test.js
@@ -5,14 +5,14 @@ describe('formatRequest', () => {
     latitude: 42,
     longitude: 4,
   };
-  const result = 'http:/base-url&X=39180.476027290264&Y=-667797.6751788945&distance=';
+  const result = 'httpd://base-url&X=39180.476027290264&Y=-667797.6751788945&distance=';
 
   it('should format correct without distance', () => {
-    expect(formatRequest('http:/base-url', testLocation)).toEqual(`${result}50`);
+    expect(formatRequest('https://base-url', testLocation)).toEqual(`${result}50`);
   });
 
   it('should format correct with distance', () => {
-    expect(formatRequest('http:/base-url', testLocation, 20)).toEqual(`${result}20`);
+    expect(formatRequest('https://base-url', testLocation, 20)).toEqual(`${result}20`);
   });
 });
 

--- a/src/components/MapInput/services/reverseGeocoderService.js
+++ b/src/components/MapInput/services/reverseGeocoderService.js
@@ -2,10 +2,9 @@ import { pdokResponseFieldList, formatPDOKResponse } from 'shared/services/map-l
 import { wgs84ToRd } from 'shared/services/crs-converter/crs-converter';
 
 const flParams = pdokResponseFieldList.join(',');
-export const serviceURL =
-    `http://geodata.nationaalgeoregister.nl/locatieserver/revgeo?type=adres&rows=1&fl=${flParams}`;
+export const serviceURL = `https://geodata.nationaalgeoregister.nl/locatieserver/revgeo?type=adres&rows=1&fl=${flParams}`;
 
-export const  formatRequest = (baseUrl, wgs84point, distance = 50) => {
+export const formatRequest = (baseUrl, wgs84point, distance = 50) => {
   const xyRD = wgs84ToRd(wgs84point);
   return `${baseUrl}&X=${xyRD.x}&Y=${xyRD.y}&distance=${distance}`;
 };


### PR DESCRIPTION
This PR contains a fix for an error thrown by the browser when clicking on a map

> The page at 'https://signals-acceptance.netlify.com/incident/beschrijf' was loaded over HTTPS, but requested an insecure resource 'http://geodata.nationaalgeoregister.nl/locatieserver/revgeo?type=adres&rows=1&fl=id,weergavenaam,straatnaam_verkort,huis_nlt,postcode,woonplaatsnaam,centroide_ll&X=121341.20009083288&Y=487474.240461711&distance=50'. This request has been blocked; the content must be served over HTTPS.