### PR TITLE
(Chore) Placeholder for AutoSuggest input element

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9264,7 +9264,7 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true,
           "optional": true

--- a/src/components/AutoSuggest/index.js
+++ b/src/components/AutoSuggest/index.js
@@ -33,7 +33,7 @@ const AbsoluteList = styled(SuggestList)`
  * - Home key focuses the input field at the first character
  * - End key focuses the input field at the last character
  */
-const AutoSuggest = ({ className, formatResponse, numOptionsDeterminer, onSelect, url, value }) => {
+const AutoSuggest = ({ className, formatResponse, numOptionsDeterminer, onSelect, placeholder, url, value }) => {
   const { get, data } = useFetch();
   const [initialRender, setInitialRender] = useState(false);
   const [showList, setShowList] = useState(false);
@@ -198,20 +198,21 @@ const AutoSuggest = ({ className, formatResponse, numOptionsDeterminer, onSelect
     <Wrapper className={className} ref={wrapperRef} data-testid="autoSuggest">
       <div role="combobox" aria-controls="as-listbox" aria-expanded={showList} aria-haspopup="listbox">
         <Input
-          defaultValue={value}
-          onChange={onChange}
           aria-activedescendant={activeId}
           aria-autocomplete="list"
+          defaultValue={value}
+          onChange={onChange}
+          placeholder={placeholder}
           ref={inputRef}
         />
       </div>
       {showList && (
         <AbsoluteList
-          options={options}
-          role="listbox"
+          activeIndex={activeIndex}
           id="as-listbox"
           onSelectOption={onSelectOption}
-          activeIndex={activeIndex}
+          options={options}
+          role="listbox"
         />
       )}
     </Wrapper>
@@ -220,6 +221,7 @@ const AutoSuggest = ({ className, formatResponse, numOptionsDeterminer, onSelect
 
 AutoSuggest.defaultProps = {
   className: '',
+  placeholder: '',
   value: '',
 };
 
@@ -247,6 +249,7 @@ AutoSuggest.propTypes = {
    * @param {String} option.value - Option text label
    */
   onSelect: PropTypes.func.isRequired,
+  placeholder: PropTypes.string,
   /**
    * Request URL from which options should be gotten and to which the search query should be appended
    * @example `//some-domain.com/api-endpoint?q=`

--- a/src/components/MapInput/index.js
+++ b/src/components/MapInput/index.js
@@ -111,7 +111,14 @@ const MapInput = ({ className, value, onChange, mapOptions, ...otherProps }) => 
         {...otherProps}
       >
         <StyledViewerContainer
-          topLeft={<StyledAutosuggest value={addressValue} onSelect={onSelect} gemeentenaam="amsterdam" />}
+          topLeft={
+            <StyledAutosuggest
+              value={addressValue}
+              onSelect={onSelect}
+              gemeentenaam="amsterdam"
+              placeholder="Zoek adres"
+            />
+          }
         />
         {hasLocation && (
           <Marker

--- a/src/components/PDOKAutoSuggest/__tests__/PDOKAutoSuggest.test.js
+++ b/src/components/PDOKAutoSuggest/__tests__/PDOKAutoSuggest.test.js
@@ -97,4 +97,11 @@ describe('components/PDOKAutoSuggest', () => {
     expect(onSelect).toHaveBeenCalledTimes(2);
     expect(onSelect).toHaveBeenLastCalledWith(formatPDOKResponse(JSONResponse)[0]);
   });
+
+  it('should pass on props to underlying component', () => {
+    const placeholder = 'Foo bar';
+    const { container } = render(withAppContext(<PDOKAutoSuggest onSelect={onSelect} placeholder={placeholder} />));
+
+    expect(container.querySelector(`[placeholder="${placeholder}"]`)).toBeInTheDocument();
+  });
 });

--- a/src/components/PDOKAutoSuggest/index.js
+++ b/src/components/PDOKAutoSuggest/index.js
@@ -20,7 +20,7 @@ export const formatResponseFunc = ({ response }) => response.docs.map(({ id, wee
  *
  * @see {@link https://www.pdok.nl/restful-api/-/article/pdok-locatieserver#/paths/~1suggest/get}
  */
-const PDOKAutoSuggest = ({ className, fieldList, gemeentenaam, onSelect, formatResponse, value }) => {
+const PDOKAutoSuggest = ({ className, fieldList, gemeentenaam, onSelect, formatResponse, value, ...rest }) => {
   const fq = gemeentenaam && [['fq', `gemeentenaam:${gemeentenaam}`]];
   const fl = [['fl', fieldList.concat(['id', 'weergavenaam']).join(',')]];
   const params = fq
@@ -38,6 +38,7 @@ const PDOKAutoSuggest = ({ className, fieldList, gemeentenaam, onSelect, formatR
       formatResponse={formatResponse}
       onSelect={onSelect}
       value={value}
+      {...rest}
     />
   );
 };


### PR DESCRIPTION
This PR contains changes that allow setting a `placeholder` attribute on the `AutoSuggest` component's input element.