### PR TITLE
Sig 2519 map zoom controls

### DIFF
--- a/src/components/Map/index.js
+++ b/src/components/Map/index.js
@@ -11,16 +11,17 @@ const StyledViewerContainer = styled(ViewerContainer)`
 
 const Map = ({ mapOptions, hasZoomControls, isInteractive, children, ...otherProps }) => {
   const hasTouchCapabilities = 'ontouchstart' in window;
+  const showZoom = hasZoomControls && isInteractive && !hasTouchCapabilities;
   const options = {
     ...mapOptions,
     dragging: isInteractive && !hasTouchCapabilities,
-    tap: isInteractive && !hasTouchCapabilities,
+    tap: false,
     scrollWheelZoom: false,
   };
 
   return (
     <MapComponent data-testid="map-base" options={options} {...otherProps}>
-      {hasZoomControls && <StyledViewerContainer bottomRight={<Zoom />} />}
+      {showZoom && <StyledViewerContainer bottomRight={<Zoom />} />}
 
       {children}
 

--- a/src/components/Map/index.js
+++ b/src/components/Map/index.js
@@ -15,7 +15,7 @@ const Map = ({ mapOptions, hasZoomControls, isInteractive, children, ...otherPro
     ...mapOptions,
     dragging: isInteractive && !hasTouchCapabilities,
     tap: isInteractive && !hasTouchCapabilities,
-    scrollWheelZoom: isInteractive && !hasTouchCapabilities,
+    scrollWheelZoom: false,
   };
 
   return (

--- a/src/components/MapInput/index.js
+++ b/src/components/MapInput/index.js
@@ -116,8 +116,9 @@ const MapInput = ({ className, value, onChange, mapOptions, ...otherProps }) => 
       <StyledMap
         className={className}
         data-testid="map-input"
-        mapOptions={mapOptions}
         events={{ click: clickHandler }}
+        hasZoomControls
+        mapOptions={mapOptions}
         setInstance={setMap}
         {...otherProps}
       >

--- a/src/components/MapSelect/index.js
+++ b/src/components/MapSelect/index.js
@@ -202,9 +202,9 @@ const MapSelect = ({
 
         layer.setIcon(icon);
       });
-      // only execute when value changes; disabling linter
-      // eslint-disable-next-line
     },
+    // only execute when value changes; disabling linter
+    // eslint-disable-next-line
     [value]
   );
 
@@ -212,6 +212,7 @@ const MapSelect = ({
     <StyledMap
       className={classNames('map-component', { write: onSelectionChange })}
       data-testid="mapSelect"
+      hasZoomControls
       mapOptions={mapOptions}
       setInstance={setMapInstance}
     />

--- a/src/signals/incident-management/components/MapInput/__snapshots__/index.test.js.snap
+++ b/src/signals/incident-management/components/MapInput/__snapshots__/index.test.js.snap
@@ -20,6 +20,7 @@ exports[`<MapInput /> should render correctly 1`] = `
     >
       <Memo(MapContext)>
         <MapInput
+          hasZoomControls={true}
           mapOptions={
             Object {
               "attributionControl": true,

--- a/src/signals/incident-management/components/MapInput/index.js
+++ b/src/signals/incident-management/components/MapInput/index.js
@@ -31,7 +31,7 @@ export const MapInput = props => {
 
           <div className="map-input__control invoer">
             <MapContext>
-              <MapInputComponent value={value} onChange={onLocationChange} mapOptions={mapOptions}/>
+              <MapInputComponent value={value} onChange={onLocationChange} mapOptions={mapOptions} hasZoomControls />
             </MapContext>
           </div>
         </div>

--- a/src/signals/incident-management/containers/IncidentOverviewPage/components/Map/index.js
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/components/Map/index.js
@@ -189,6 +189,7 @@ const OverviewMap = ({ ...rest }) => {
           minZoom: 8,
         }}
         setInstance={setMap}
+        hasZoomControls
       >
         {hasLocation && (
           <Marker

--- a/src/signals/incident-management/containers/IncidentOverviewPage/components/Map/index.js
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/components/Map/index.js
@@ -183,13 +183,13 @@ const OverviewMap = ({ ...rest }) => {
     <Wrapper {...rest}>
       <StyledMap
         data-testid="overviewMap"
+        hasZoomControls
         mapOptions={{
           ...MAP_OPTIONS,
           maxZoom: 16,
           minZoom: 8,
         }}
         setInstance={setMap}
-        hasZoomControls
       >
         {hasLocation && (
           <Marker


### PR DESCRIPTION
This PR:
- adds zoom controls to all interactive map instances
- disables scroll wheel zoom while maintaining the ability to pinch zoom and do a two-finger scroll on mobile