### PR TITLE
(Chore) Always retrieve stadsdeel

### DIFF
--- a/src/components/MapInput/__tests__/MapInput.test.js
+++ b/src/components/MapInput/__tests__/MapInput.test.js
@@ -46,6 +46,33 @@ const geocoderResponse = {
   },
 };
 
+const bagResponse = {
+  features: [
+    {
+      properties: {
+        code: 'N',
+        display: 'Noord',
+        distance: 4467.47982312323,
+        id: '03630000000019',
+        type: 'gebieden/stadsdeel',
+        uri: 'https://api.data.amsterdam.nl/gebieden/stadsdeel/03630000000019/',
+      },
+    },
+    {
+      properties: {
+        code: '61b',
+        display: 'Vogelbuurt Zuid',
+        distance: 109.145476159977,
+        id: '03630000000644',
+        type: 'gebieden/buurt',
+        uri: 'https://api.data.amsterdam.nl/gebieden/buurt/03630000000644/',
+        vollcode: 'N61b',
+      },
+    },
+  ],
+  type: 'FeatureCollection',
+};
+
 describe('components/MapInput', () => {
   beforeEach(() => {
     fetch.mockResponse(JSON.stringify(geocoderResponse));
@@ -89,33 +116,6 @@ describe('components/MapInput', () => {
   });
 
   it('should handle click', async () => {
-    const bagResponse = {
-      features: [
-        {
-          properties: {
-            code: 'N',
-            display: 'Noord',
-            distance: 4467.47982312323,
-            id: '03630000000019',
-            type: 'gebieden/stadsdeel',
-            uri: 'https://api.data.amsterdam.nl/gebieden/stadsdeel/03630000000019/',
-          },
-        },
-        {
-          properties: {
-            code: '61b',
-            display: 'Vogelbuurt Zuid',
-            distance: 109.145476159977,
-            id: '03630000000644',
-            type: 'gebieden/buurt',
-            uri: 'https://api.data.amsterdam.nl/gebieden/buurt/03630000000644/',
-            vollcode: 'N61b',
-          },
-        },
-      ],
-      type: 'FeatureCollection',
-    };
-
     fetch.mockResponseOnce(JSON.stringify(geocoderResponse)).mockResponseOnce(JSON.stringify(bagResponse));
 
     const onChange = jest.fn();
@@ -165,7 +165,7 @@ describe('components/MapInput', () => {
         docs: [],
       },
     };
-    fetch.mockResponse(JSON.stringify(noneFoundResponse));
+    fetch.mockResponseOnce(JSON.stringify(noneFoundResponse)).mockResponseOnce(JSON.stringify(bagResponse));
 
     const { getByTestId, findByTestId } = render(
       withMapContext(<MapInput mapOptions={MAP_OPTIONS} value={testLocation} onChange={onChange} />)
@@ -185,12 +185,13 @@ describe('components/MapInput', () => {
     expect(setValuesSpy).toHaveBeenLastCalledWith({
       addressText: '',
       address: '',
-      stadsdeel: '',
+      stadsdeel: bagResponse.features[0].properties.code,
     });
 
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(onChange).toHaveBeenCalledWith({
       geometrie: expect.any(Object),
+      stadsdeel: bagResponse.features[0].properties.code,
     });
   });
 

--- a/src/components/MapInput/__tests__/reverseGeocoderService.test.js
+++ b/src/components/MapInput/__tests__/reverseGeocoderService.test.js
@@ -132,7 +132,6 @@ describe('reverseGeocoderService', () => {
         postcode: serviceURLResponse.response.docs[0].postcode,
         woonplaats: serviceURLResponse.response.docs[0].woonplaatsnaam,
       },
-      stadsdeel: bagResponse.features[0].properties.code,
     },
   };
 
@@ -154,13 +153,13 @@ describe('reverseGeocoderService', () => {
 
   it('should return the correct location', async () => {
     fetch.resetMocks();
-    fetch.mockResponseOnce(JSON.stringify(serviceURLResponse)).mockResponseOnce(JSON.stringify(bagResponse));
+    fetch.mockResponseOnce(JSON.stringify(serviceURLResponse));
+
     const result = await reverseGeocoderService(testLocation);
 
-    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(fetch).toHaveBeenCalledTimes(1);
 
-    expect(fetch).toHaveBeenNthCalledWith(1, expect.stringContaining(serviceURL));
-    expect(fetch).toHaveBeenNthCalledWith(2, expect.stringContaining('https://api.data.amsterdam.nl/geosearch/bag/'));
+    expect(fetch).toHaveBeenCalledWith(expect.stringContaining(serviceURL));
 
     expect(result).toEqual(testResult);
   });

--- a/src/components/MapInput/index.js
+++ b/src/components/MapInput/index.js
@@ -64,18 +64,18 @@ const MapInput = ({ className, value, onChange, mapOptions, ...otherProps }) => 
       dispatch(setLocationAction(event.latlng));
 
       const response = await reverseGeocoderService(event.latlng);
+      const stadsdeel = await getStadsdeel(event.latlng);
 
       const onChangePayload = {
         geometrie: locationTofeature(event.latlng),
+        stadsdeel,
       };
 
       const addressText = response?.value || '';
       const address = response?.data?.address || '';
-      const stadsdeel = response?.data?.stadsdeel || '';
 
       if (response) {
         onChangePayload.address = response.data.address;
-        onChangePayload.stadsdeel = response.data.stadsdeel;
       }
 
       dispatch(

--- a/src/components/MapInput/services/reverseGeocoderService.js
+++ b/src/components/MapInput/services/reverseGeocoderService.js
@@ -32,10 +32,6 @@ const reverseGeocoderService = async location => {
   const result = await fetch(url).then(res => res.json());
   const formattedResponse = formatPDOKResponse(result)[0];
 
-  if (formattedResponse) {
-    formattedResponse.data.stadsdeel = await getStadsdeel(formattedResponse.data.location);
-  }
-
   return formattedResponse;
 };
 


### PR DESCRIPTION
This PR contains a fix for the geocoding service where it didn't retrieve the stadsdeel for locations that didn't have a resolved address.