### PR TITLE
(Fix) Date/time string

### DIFF
--- a/src/signals/incident-management/containers/IncidentOverviewPage/components/Map/index.js
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/components/Map/index.js
@@ -89,10 +89,10 @@ const OverviewMap = ({ ...rest }) => {
     () =>
       moment()
         .subtract(1, 'days')
-        .format('YYYY-MM-DDTkk:mm:ss'),
+        .format('YYYY-MM-DDTHH:mm:ss'),
     []
   );
-  params.created_before = useMemo(() => moment().format('YYYY-MM-DDTkk:mm:ss'), []);
+  params.created_before = useMemo(() => moment().format('YYYY-MM-DDTHH:mm:ss'), []);
   // fixed page size (default is 50; 4000 is 2.5 times the highest daily average)
   params.page_size = 4000;
 

--- a/src/signals/shared/filter/parse.js
+++ b/src/signals/shared/filter/parse.js
@@ -54,7 +54,7 @@ export const parseOutputFormData = options =>
         ) {
           entryValue = moment(options.created_before)
             .set({ hours: 23, minutes: 59, seconds: 59 })
-            .format('YYYY-MM-DDTkk:mm:ss');
+            .format('YYYY-MM-DDTHH:mm:ss');
         }
         break;
 


### PR DESCRIPTION
This PR contains a fix for the date/time string formats that are used as parameters for the API. The format used was faulty, because it sent hours as `24` instead of `00`.