### PR TITLE
(Fix) Perpetuating state

### DIFF
--- a/src/components/SiteHeader/index.js
+++ b/src/components/SiteHeader/index.js
@@ -198,7 +198,7 @@ const MenuItems = ({ onLogOut, showItems }) => {
         </Fragment>
       )}
       <MenuItem element="span">
-        <StyledMenuButton forwardedAs={NavLink} to="/incident/beschrijf">
+        <StyledMenuButton forwardedAs="a" href="/incident/beschrijf">
           Melden
         </StyledMenuButton>
       </MenuItem>


### PR DESCRIPTION
This PR makes the 'Melden' link in the main menu an anchor that bypasses the react router logic so that, whenever the 'Melden' link is clicked, the page is fully reloaded.

This fixes an issue where the incident global state isn't properly purged after an incident has been submitted. This lead to data being submitted in incidents that was submitted in prior incidents.

Note that this is a quick fix and should be followed by a proper clean-up of the application's state.