### PR TITLE
[SIG-2536] Fix for missing value in RadioInput component

### DIFF
--- a/src/signals/incident-management/components/RadioInput/index.js
+++ b/src/signals/incident-management/components/RadioInput/index.js
@@ -10,13 +10,14 @@ const Info = styled.span`
   color: ${themeColor('tint', 'level5')};
 `;
 
-export const RadioInput = ({ name, display, values }) => {
+const RadioInput = ({ name, display, values }) => {
   const Render = ({ handler, value: current }) => {
     let info;
     let label;
+    const currentValue = values?.find(({ key }) => key === current);
 
-    if (current && values) {
-      ({ info, value: label } = values.find(({ key }) => key === current));
+    if (currentValue) {
+      ({ info, value: label } = currentValue);
     }
 
     return (
@@ -25,18 +26,17 @@ export const RadioInput = ({ name, display, values }) => {
           {display && <Label htmlFor={`form${name}`}>{display}</Label>}
 
           <div className="radio-input__control invoer">
-            {values &&
-              values.map(({ key, value }) => (
-                <div className="antwoord" key={`${name}-${key}`}>
-                  <input
-                    id={`${name}-${key}`}
-                    data-testid={`${name}-${key}`}
-                    className="kenmerkradio"
-                    {...handler('radio', key)}
-                  />
-                  <label htmlFor={`${name}-${key}`}>{value}</label>
-                </div>
-              ))}
+            {values?.map(({ key, value }) => (
+              <div className="antwoord" key={`${name}-${key}`}>
+                <input
+                  id={`${name}-${key}`}
+                  data-testid={`${name}-${key}`}
+                  className="kenmerkradio"
+                  {...handler('radio', key)}
+                />
+                <label htmlFor={`${name}-${key}`}>{value}</label>
+              </div>
+            ))}
 
             <p>
               {info ? (

--- a/src/signals/incident-management/components/RadioInput/index.test.js
+++ b/src/signals/incident-management/components/RadioInput/index.test.js
@@ -35,6 +35,22 @@ describe('<RadioInput />', () => {
     expect(getByText(new RegExp(currentValue.info))).toBeInTheDocument();
   });
 
+  it('should not display info text', () => {
+    const currentValue = priorityList[0];
+    const RenderFunc = RadioInput({
+      name: 'priority',
+      display: 'Urgentie',
+    });
+
+    const { queryByText } = render(
+      withAppContext(
+        <RenderFunc handler={handler} value={currentValue.key} />
+      )
+    );
+
+    expect(queryByText(new RegExp(currentValue.info))).not.toBeInTheDocument();
+  });
+
   it('should display a label', () => {
     const { container, rerender } = render(
       withAppContext(<RadioInputRender handler={handler} />)


### PR DESCRIPTION
This PR contains a fix for a faulty assumption in the `RadioInput` component in the incident management module. The component assumed that all items in its `values` prop had an `info` prop present, which wasn't the case.