### PR TITLE
[SIG-2545] Fix for extra_properties object

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/components/Detail/components/ExtraProperties/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/Detail/components/ExtraProperties/index.js
@@ -7,7 +7,7 @@ import { extraPropertiesType } from 'shared/types';
 
 const getValue = answer => {
   if (isArray(answer)) {
-    return answer.map(item => isObject(item) ? item.label : item).join(', ');
+    return answer.map(item => (isObject(item) ? item.label : item)).join(', ');
   }
   if (isObject(answer)) {
     if (isBoolean(answer.value)) {
@@ -19,14 +19,18 @@ const getValue = answer => {
   return answer;
 };
 
-const ExtraProperties = ({ items }) =>
-  items &&
-  items.map(item => (
+const ExtraProperties = ({ items }) => {
+  // Some incidents have been stored with values for their extra properties that is incompatible with the current API
+  // We therefore need to check if we're getting an array or an object
+  const itemList = Array.isArray(items) ? items : Object.entries(items);
+
+  return itemList.map(item => (
     <Fragment key={item.id}>
       <dt data-testid="extra-properties-definition">{item.label}</dt>
       <dd data-testid="extra-properties-value">{getValue(item.answer)}</dd>
     </Fragment>
   ));
+};
 
 ExtraProperties.defaultProps = {
   items: [],

--- a/src/signals/incident-management/containers/IncidentDetail/components/Detail/components/ExtraProperties/index.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/Detail/components/ExtraProperties/index.test.js
@@ -9,7 +9,8 @@ describe('<ExtraProperties />', () => {
       {
         id: 'extra_straatverlichting',
         label: 'Gaat uw melding over één of over meer lampen?',
-        category_url: '/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/straatverlichting-openbare-klok',
+        category_url:
+          '/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/straatverlichting-openbare-klok',
         answer: {
           id: 'meer_lampen',
           label: 'Meer lampen',
@@ -18,31 +19,39 @@ describe('<ExtraProperties />', () => {
       {
         id: 'extra_straatverlichting_wat',
         label: 'Wat is er aan de hand met de lamp(en)?',
-        category_url: '/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/straatverlichting-openbare-klok',
-        answer: [{ id: 'brandt_niet', label: 'Brandt niet' }, { id: 'brandt_overdag', label: 'Brandt overdag' }],
+        category_url:
+          '/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/straatverlichting-openbare-klok',
+        answer: [
+          { id: 'brandt_niet', label: 'Brandt niet' },
+          { id: 'brandt_overdag', label: 'Brandt overdag' },
+        ],
       },
       {
         id: 'extra_straatverlichting_nummer',
         label: 'Hebt u een nummer van (één van) de lamp(en)?',
-        category_url: '/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/straatverlichting-openbare-klok',
+        category_url:
+          '/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/straatverlichting-openbare-klok',
         answer: '42',
       },
       {
         id: 'extra_bedrijven_vaker',
         label: 'Gebeurt het vaker?',
-        category_url: '/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/straatverlichting-openbare-klok',
+        category_url:
+          '/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/straatverlichting-openbare-klok',
         answer: { label: 'Ja, het gebeurt vaker', value: false },
       },
       {
         id: 'extra_bedrijven_gezien',
         label: 'Heeft u het gezien?',
-        category_url: '/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/straatverlichting-openbare-klok',
+        category_url:
+          '/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/straatverlichting-openbare-klok',
         answer: { label: 'Ja, het gebeurt vaker', value: true },
       },
       {
         id: 'lampen',
         label: 'Welke lampen?',
-        category_url: '/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/straatverlichting-openbare-klok',
+        category_url:
+          '/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/straatverlichting-openbare-klok',
         answer: ['126543', '87654'],
       },
     ],
@@ -51,18 +60,22 @@ describe('<ExtraProperties />', () => {
   afterEach(cleanup);
 
   it('should render correctly', () => {
-    const { queryAllByTestId } = render(
-      <ExtraProperties {...props} />
+    const { queryAllByTestId } = render(<ExtraProperties {...props} />);
+
+    expect(queryAllByTestId('extra-properties-definition')).toHaveLength(props.items.length);
+    expect(queryAllByTestId('extra-properties-value')).toHaveLength(props.items.length);
+
+    expect(queryAllByTestId('extra-properties-definition')[0]).toHaveTextContent(
+      /^Gaat uw melding over één of over meer lampen\?$/
     );
-
-    expect(queryAllByTestId('extra-properties-definition')).toHaveLength(6);
-    expect(queryAllByTestId('extra-properties-value')).toHaveLength(6);
-
-    expect(queryAllByTestId('extra-properties-definition')[0]).toHaveTextContent(/^Gaat uw melding over één of over meer lampen\?$/);
     expect(queryAllByTestId('extra-properties-value')[0]).toHaveTextContent(/^Meer lampen$/);
-    expect(queryAllByTestId('extra-properties-definition')[1]).toHaveTextContent(/^Wat is er aan de hand met de lamp\(en\)\?$/);
+    expect(queryAllByTestId('extra-properties-definition')[1]).toHaveTextContent(
+      /^Wat is er aan de hand met de lamp\(en\)\?$/
+    );
     expect(queryAllByTestId('extra-properties-value')[1]).toHaveTextContent(/^Brandt niet, Brandt overdag$/);
-    expect(queryAllByTestId('extra-properties-definition')[2]).toHaveTextContent(/^Hebt u een nummer van \(één van\) de lamp\(en\)\?$/);
+    expect(queryAllByTestId('extra-properties-definition')[2]).toHaveTextContent(
+      /^Hebt u een nummer van \(één van\) de lamp\(en\)\?$/
+    );
     expect(queryAllByTestId('extra-properties-value')[2]).toHaveTextContent(/^42$/);
     expect(queryAllByTestId('extra-properties-definition')[3]).toHaveTextContent(/^Gebeurt het vaker\?$/);
     expect(queryAllByTestId('extra-properties-value')[3]).toHaveTextContent(/^Nee$/);
@@ -73,11 +86,30 @@ describe('<ExtraProperties />', () => {
   });
 
   it('should render correctly without items', () => {
-    const { queryAllByTestId } = render(
-      <ExtraProperties />
-    );
+    const { queryAllByTestId } = render(<ExtraProperties />);
 
     expect(queryAllByTestId('extra-properties-definition')).toHaveLength(0);
     expect(queryAllByTestId('extra-properties-value')).toHaveLength(0);
+  });
+
+  it('should be able to deal with legacy format', () => {
+    global.console.error = jest.fn();
+
+    const items = {
+      'Gaat uw melding over één of over meer lampen?': {
+        id: 'meer_lampen',
+        label: 'Meer lampen',
+      },
+      'Wat is er aan de hand met de lamp(en)?': [
+        { id: 'brandt_niet', label: 'Brandt niet' },
+        { id: 'brandt_overdag', label: 'Brandt overdag' },
+      ],
+    };
+    const { queryAllByTestId } = render(<ExtraProperties items={items} />);
+
+    expect(queryAllByTestId('extra-properties-definition')).toHaveLength(Object.values(items).length);
+    expect(queryAllByTestId('extra-properties-value')).toHaveLength(Object.values(items).length);
+
+    global.console.error.mockRestore();
   });
 });


### PR DESCRIPTION
This PR fixes an issues where, for older incidents, the `ExtraProperties` component would throw an error. A while ago, the API expected a different structure for extra properties for incidents, namely an object where it's keys were the properties' labels and its values, well, the values. Currently, the API expects an array of objects. The current implementation of the `ExtraProperties` components expects an array which leads to the incidents that still have objects for values to throw an exception in the incident detail page.