### PR TITLE
[SIG-2546] Map double click

### DIFF
--- a/src/components/MapInput/__tests__/MapInput.test.js
+++ b/src/components/MapInput/__tests__/MapInput.test.js
@@ -9,10 +9,10 @@ import { withAppContext, resolveAfterMs } from 'test/utils';
 import MAP_OPTIONS from 'shared/services/configuration/map-options';
 import { markerIcon } from 'shared/services/configuration/map-markers';
 import * as actions from 'containers/MapContext/actions';
+import { DOUBLE_CLICK_TIMEOUT } from 'hooks/useDelayedDoubleClick';
 
 import { findFeatureByType } from '../services/reverseGeocoderService';
-import MapInput, { DOUBLE_CLICK_TIMEOUT } from '..';
-
+import MapInput from '..';
 jest.mock('containers/MapContext/actions', () => ({
   __esModule: true,
   ...jest.requireActual('containers/MapContext/actions'),
@@ -207,40 +207,6 @@ describe('components/MapInput', () => {
       geometrie: expect.any(Object),
       stadsdeel: bagResponse.features[0].properties.code,
     });
-  });
-
-  it('should handle double click', async () => {
-    const onChange = jest.fn();
-    const { getByTestId, findByTestId } = render(
-      withMapContext(<MapInput mapOptions={MAP_OPTIONS} value={testLocation} onChange={onChange} />)
-    );
-    const map = getByTestId('map-input');
-
-    expect(setValuesSpy).toHaveBeenCalledTimes(1);
-    expect(onChange).not.toHaveBeenCalled();
-
-    act(() => {
-      fireEvent.doubleClick(map, { clientX: 100, clientY: 100 });
-    });
-
-    await findByTestId('map-input');
-
-    expect(setValuesSpy).toHaveBeenCalledTimes(1);
-    expect(onChange).not.toHaveBeenCalled();
-
-    act(() => {
-      fireEvent.click(map, { clientX: 100, clientY: 100 });
-    });
-
-    await wait(() => resolveAfterMs(DOUBLE_CLICK_TIMEOUT));
-
-    expect(setValuesSpy).toHaveBeenCalledTimes(1);
-    expect(onChange).not.toHaveBeenCalled();
-
-    await wait(() => resolveAfterMs(DOUBLE_CLICK_TIMEOUT));
-
-    expect(setValuesSpy).toHaveBeenCalledTimes(1);
-    expect(onChange).not.toHaveBeenCalled();
   });
 
   it('should render marker', async () => {

--- a/src/components/MapInput/__tests__/MapInput.test.js
+++ b/src/components/MapInput/__tests__/MapInput.test.js
@@ -1,14 +1,17 @@
 import React from 'react';
-import { render, fireEvent, act } from '@testing-library/react';
+import { render, fireEvent, act, wait } from '@testing-library/react';
+
 import MapContext from 'containers/MapContext';
 import context from 'containers/MapContext/context';
 
-import { withAppContext } from 'test/utils';
+import geoSearchJSON from 'utils/__tests__/fixtures/geosearch.json';
+import { withAppContext, resolveAfterMs } from 'test/utils';
 import MAP_OPTIONS from 'shared/services/configuration/map-options';
 import { markerIcon } from 'shared/services/configuration/map-markers';
 import * as actions from 'containers/MapContext/actions';
 
-import MapInput from '..';
+import { findFeatureByType } from '../services/reverseGeocoderService';
+import MapInput, { DOUBLE_CLICK_TIMEOUT } from '..';
 
 jest.mock('containers/MapContext/actions', () => ({
   __esModule: true,
@@ -134,6 +137,12 @@ describe('components/MapInput', () => {
 
     await findByTestId('map-input');
 
+    expect(setLocationSpy).not.toHaveBeenCalled();
+    expect(onChange).not.toHaveBeenCalled();
+    expect(setValuesSpy).toHaveBeenCalledTimes(1);
+
+    await wait(() => resolveAfterMs(DOUBLE_CLICK_TIMEOUT));
+
     expect(setLocationSpy).toHaveBeenCalledTimes(1);
     expect(setLocationSpy).toHaveBeenCalledWith({
       lat: expect.any(Number),
@@ -181,6 +190,11 @@ describe('components/MapInput', () => {
 
     await findByTestId('map-input');
 
+    expect(setValuesSpy).toHaveBeenCalledTimes(1);
+    expect(onChange).not.toHaveBeenCalled();
+
+    await wait(() => resolveAfterMs(DOUBLE_CLICK_TIMEOUT));
+
     expect(setValuesSpy).toHaveBeenCalledTimes(2);
     expect(setValuesSpy).toHaveBeenLastCalledWith({
       addressText: '',
@@ -193,6 +207,40 @@ describe('components/MapInput', () => {
       geometrie: expect.any(Object),
       stadsdeel: bagResponse.features[0].properties.code,
     });
+  });
+
+  it('should handle double click', async () => {
+    const onChange = jest.fn();
+    const { getByTestId, findByTestId } = render(
+      withMapContext(<MapInput mapOptions={MAP_OPTIONS} value={testLocation} onChange={onChange} />)
+    );
+    const map = getByTestId('map-input');
+
+    expect(setValuesSpy).toHaveBeenCalledTimes(1);
+    expect(onChange).not.toHaveBeenCalled();
+
+    act(() => {
+      fireEvent.doubleClick(map, { clientX: 100, clientY: 100 });
+    });
+
+    await findByTestId('map-input');
+
+    expect(setValuesSpy).toHaveBeenCalledTimes(1);
+    expect(onChange).not.toHaveBeenCalled();
+
+    act(() => {
+      fireEvent.click(map, { clientX: 100, clientY: 100 });
+    });
+
+    await wait(() => resolveAfterMs(DOUBLE_CLICK_TIMEOUT));
+
+    expect(setValuesSpy).toHaveBeenCalledTimes(1);
+    expect(onChange).not.toHaveBeenCalled();
+
+    await wait(() => resolveAfterMs(DOUBLE_CLICK_TIMEOUT));
+
+    expect(setValuesSpy).toHaveBeenCalledTimes(1);
+    expect(onChange).not.toHaveBeenCalled();
   });
 
   it('should render marker', async () => {
@@ -224,5 +272,76 @@ describe('components/MapInput', () => {
     await findByTestId('map-input');
 
     expect(container.querySelector(`.${markerIcon.options.className}`)).toBeInTheDocument();
+  });
+
+  it('should handle onSelect', async () => {
+    const onChange = jest.fn();
+    const { container, getByTestId, findByTestId } = render(
+      withAppContext(
+        <context.Provider
+          value={{
+            state: {
+              lat: 52.36058599633851,
+              lng: 4.894292258032637,
+            },
+            dispatch: () => {},
+          }}
+        >
+          <MapInput mapOptions={MAP_OPTIONS} value={testLocation} onChange={onChange} />
+        </context.Provider>
+      )
+    );
+
+    const firstTileSrc = container.querySelector('.leaflet-tile').getAttribute('src');
+
+    // provide input with value
+    const input = getByTestId('autoSuggest').querySelector('input');
+    const value = 'Midden';
+
+    input.focus();
+
+    act(() => {
+      fireEvent.change(input, { target: { value } });
+    });
+
+    const suggestList = await findByTestId('suggestList');
+    const firstElement = suggestList.querySelector('li:nth-of-type(1)');
+
+    expect(setValuesSpy).toHaveBeenCalledTimes(1);
+    expect(onChange).not.toHaveBeenCalled();
+
+    // mock the geosearch response
+    fetch.mockResponse(JSON.stringify(geoSearchJSON));
+
+    // click option in list
+    act(() => {
+      fireEvent.click(firstElement);
+    });
+
+    await findByTestId('map-input');
+
+    expect(setValuesSpy).toHaveBeenCalledTimes(2);
+    expect(setValuesSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        location: expect.any(Object),
+        address: expect.any(Object),
+        addressText: input.value,
+      })
+    );
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        geometrie: expect.any(Object),
+        address: expect.any(Object),
+        stadsdeel: findFeatureByType(geoSearchJSON.features, 'gebieden/stadsdeel').code,
+      })
+    );
+
+    // the map should have panned to a different location; we can assert that by comparing the src attribute of the
+    // first tile in the DOM with the first tile of the previous render
+    const pannedFirstTileSrc = container.querySelector('.leaflet-tile').getAttribute('src');
+
+    expect(firstTileSrc).not.toEqual(pannedFirstTileSrc);
   });
 });

--- a/src/hooks/__tests__/useDelayedDoubleClick.test.js
+++ b/src/hooks/__tests__/useDelayedDoubleClick.test.js
@@ -1,0 +1,61 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+
+import { resolveAfterMs } from 'test/utils';
+
+import useDelayedDoubleClick, { DOUBLE_CLICK_TIMEOUT } from '../useDelayedDoubleClick';
+
+describe('hooks/useDelayedDoubleClick', () => {
+  it('should execute clickFunc', async () => {
+    const clickFunc = jest.fn();
+
+    const { result } = renderHook(() => useDelayedDoubleClick(clickFunc));
+
+    const event = { preventDefault: jest.fn() };
+
+    act(() => {
+      result.current.click(event);
+    });
+
+    expect(clickFunc).not.toHaveBeenCalled();
+
+    await resolveAfterMs(DOUBLE_CLICK_TIMEOUT);
+
+    expect(clickFunc).toHaveBeenCalledWith(event);
+  });
+
+  it('should not execute clickFunc when double clicking', async () => {
+    const clickFunc = jest.fn();
+
+    const { result } = renderHook(() => useDelayedDoubleClick(clickFunc));
+
+    const event = { preventDefault: jest.fn() };
+
+    act(() => {
+      result.current.click(event);
+    });
+
+    expect(clickFunc).not.toHaveBeenCalled();
+
+    act(() => {
+      result.current.doubleClick();
+    });
+
+    await resolveAfterMs(DOUBLE_CLICK_TIMEOUT);
+
+    expect(clickFunc).not.toHaveBeenCalled();
+
+    act(() => {
+      result.current.click(event);
+    });
+
+    expect(clickFunc).not.toHaveBeenCalled();
+
+    await resolveAfterMs(DOUBLE_CLICK_TIMEOUT);
+
+    act(() => {
+      result.current.click(event);
+    });
+
+    expect(clickFunc).toHaveBeenCalledWith(event);
+  });
+});

--- a/src/hooks/useDelayedDoubleClick.js
+++ b/src/hooks/useDelayedDoubleClick.js
@@ -1,0 +1,45 @@
+import { useCallback, useRef } from 'react';
+import debounce from 'lodash/debounce';
+
+/**
+ * Timeout by which clicks on the map are delayed so that potential double click can be captured
+ * Increasing the value lead to a perceivable delay between click and the placement of the marker. Decreasing the value
+ * could lead to a double click never being captured, because of the limited time to have both click registered.
+ */
+export const DOUBLE_CLICK_TIMEOUT = 200;
+
+const useDelayedDoubleClick = clickFunc => {
+  const doubleClicking = useRef(false);
+
+  /**
+   * Capture doubleClick event
+   *
+   * Will prevent click events from being fired until the timeout has expired
+   */
+  const doubleClick = useCallback(() => {
+    doubleClicking.current = true;
+
+    const dblClickTimeout = setTimeout(() => {
+      doubleClicking.current = false;
+      clearTimeout(dblClickTimeout);
+    }, DOUBLE_CLICK_TIMEOUT * 2);
+  }, []);
+
+  const debouncedClick = useCallback(
+    event => {
+      if (doubleClicking.current) return;
+
+      clickFunc(event);
+    },
+    [clickFunc]
+  );
+
+  const click = useCallback(debounce(debouncedClick, DOUBLE_CLICK_TIMEOUT), [debouncedClick]);
+
+  return {
+    doubleClick,
+    click,
+  };
+};
+
+export default useDelayedDoubleClick;

--- a/src/signals/settings/users/Overview/__tests__/Overview.test.js
+++ b/src/signals/settings/users/Overview/__tests__/Overview.test.js
@@ -8,7 +8,7 @@ import {
   act,
   cleanup,
 } from '@testing-library/react';
-import { history as memoryHistory, withCustomAppContext } from 'test/utils';
+import { history as memoryHistory, withCustomAppContext, resolveAfterMs } from 'test/utils';
 
 import usersJSON from 'utils/__tests__/fixtures/users.json';
 import inputRolesSelectorJSON from 'utils/__tests__/fixtures/inputRolesSelector.json';
@@ -68,8 +68,6 @@ const usersOverviewWithAppContext = (
     ...overrideCfg,
   });
 };
-const resolveAfterMs = timeMs =>
-  new Promise(resolve => setTimeout(resolve, timeMs));
 
 describe('signals/settings/users/containers/Overview', () => {
   beforeEach(() => {

--- a/src/test/utils.js
+++ b/src/test/utils.js
@@ -60,11 +60,7 @@ export const withAppContext = Component => (
 );
 
 // eslint-disable-next-line
-export const withCustomAppContext = Component => ({
-  themeCfg = {},
-  storeCfg = {},
-  routerCfg = {},
-}) => (
+export const withCustomAppContext = Component => ({ themeCfg = {}, storeCfg = {}, routerCfg = {} }) => (
   <ThemeProvider {...themeCfg}>
     <Provider store={store} {...storeCfg}>
       <ConnectedRouter history={history} {...routerCfg}>
@@ -104,3 +100,13 @@ export const userObjects = (users = usersJSON) =>
         return obj;
       }, {})
   );
+
+/**
+ * Timeboxed promise resolver
+ *
+ * Particularly useful when when functionality that is debounced with lodash.debounce
+ *
+ * @param {Number} timeMs
+ * @returns {Promise} Resolved promise
+ */
+export const resolveAfterMs = timeMs => new Promise(resolve => setTimeout(resolve, timeMs));

--- a/src/utils/__tests__/fixtures/geosearch.json
+++ b/src/utils/__tests__/fixtures/geosearch.json
@@ -1,0 +1,93 @@
+{
+  "features": [
+    {
+      "properties": {
+        "display": "Leidekkerssteeg",
+        "distance": 22.6973668384394,
+        "id": "0363300000004152",
+        "opr_type": "Weg",
+        "type": "bag/openbareruimte",
+        "uri": "https://api.data.amsterdam.nl/bag/v1.1/openbareruimte/0363300000004152/"
+      }
+    },
+    {
+      "properties": {
+        "display": "0363100012178924",
+        "distance": 6.32067934271216,
+        "id": "0363100012178924",
+        "type": "bag/pand",
+        "uri": "https://api.data.amsterdam.nl/bag/v1.1/pand/0363100012178924/"
+      }
+    },
+    {
+      "properties": {
+        "code": "A",
+        "display": "Centrum",
+        "distance": 261.707170210429,
+        "id": "03630000000018",
+        "type": "gebieden/stadsdeel",
+        "uri": "https://api.data.amsterdam.nl/gebieden/stadsdeel/03630000000018/"
+      }
+    },
+    {
+      "properties": {
+        "code": "00b",
+        "display": "Oude Kerk e.o.",
+        "distance": 95.7293216586015,
+        "id": "03630000000079",
+        "type": "gebieden/buurt",
+        "uri": "https://api.data.amsterdam.nl/gebieden/buurt/03630000000079/",
+        "vollcode": "A00b"
+      }
+    },
+    {
+      "properties": {
+        "display": "Burgwallen-Oude Zijde",
+        "distance": 51.9661128841278,
+        "id": "3630012052036",
+        "type": "gebieden/buurtcombinatie",
+        "uri": "https://api.data.amsterdam.nl/gebieden/buurtcombinatie/3630012052036/",
+        "vollcode": "A00"
+      }
+    },
+    {
+      "properties": {
+        "code": "YA21",
+        "display": "YA21",
+        "distance": 45.2687066448361,
+        "id": "03630012100637",
+        "type": "gebieden/bouwblok",
+        "uri": "https://api.data.amsterdam.nl/gebieden/bouwblok/03630012100637/"
+      }
+    },
+    {
+      "properties": {
+        "code": "DX01",
+        "display": "Centrum-West",
+        "distance": 662.943971929809,
+        "id": "DX01",
+        "type": "gebieden/gebiedsgerichtwerken",
+        "uri": "https://api.data.amsterdam.nl/gebieden/gebiedsgerichtwerken/DX01/"
+      }
+    },
+    {
+      "properties": {
+        "display": "Bufferzone",
+        "distance": 211.309033609669,
+        "id": "bufferzone",
+        "type": "gebieden/unesco",
+        "uri": "https://api.data.amsterdam.nl/gebieden/unesco/bufferzone/"
+      }
+    },
+    {
+      "properties": {
+        "display": "ASD05 G 08630 G 0000",
+        "distance": 5.35227918177308,
+        "id": "NL.KAD.OnroerendeZaak.11460863070000",
+        "type": "kadaster/kadastraal_object",
+        "uri": "https://api.data.amsterdam.nl/brk/object/NL.KAD.OnroerendeZaak.11460863070000/"
+      }
+    }
+  ],
+  "type": "FeatureCollection"
+}


### PR DESCRIPTION
This PR enables double click zoom by delaying clicks. The functionality is handled by a custom hook.

Note that tests have been added to increase test coverage on the `MapInput` component.