### PR TITLE
[SIG-2531] Fix redirect from incident edit

### DIFF
--- a/src/signals/incident-management/__tests__/saga.test.js
+++ b/src/signals/incident-management/__tests__/saga.test.js
@@ -201,16 +201,33 @@ describe('signals/incident-management/saga', () => {
   });
 
   describe('search incidents', () => {
-    it('should fetchIncidents success', () => {
+    it('should dispatch search incidents success', () => {
       const q = 'Here be dragons';
+      const action = { type: ORDERING_CHANGED };
 
-      return expectSaga(searchIncidents, q)
-        .provide([[matchers.call.fn(authCall), incidentsJSON]])
+      return expectSaga(searchIncidents, action)
+        .provide([[select(makeSelectSearchQuery), q], [matchers.call.fn(authCall), incidentsJSON]])
+        .select(makeSelectSearchQuery)
         .put(applyFilterRefreshStop())
         .select(makeSelectFilterParams)
         .call.like(authCall, CONFIGURATION.SEARCH_ENDPOINT, { q })
-        .put(push('/manage/incidents'))
+        .not.put(push('/manage/incidents'))
         .put(searchIncidentsSuccess(incidentsJSON))
+        .run();
+    });
+
+    it('should redirect when search query is set', () => {
+      const q = 'Here be dragons';
+      const action = { type: SET_SEARCH_QUERY };
+
+      return expectSaga(searchIncidents, action)
+        .provide([[select(makeSelectSearchQuery), q], [matchers.call.fn(authCall), incidentsJSON]])
+        .select(makeSelectSearchQuery)
+        .put(applyFilterRefreshStop())
+        .select(makeSelectFilterParams)
+        .call.like(authCall, CONFIGURATION.SEARCH_ENDPOINT, { q })
+        .put(searchIncidentsSuccess(incidentsJSON))
+        .put(push('/manage/incidents'))
         .run();
     });
 

--- a/src/signals/incident-management/saga.js
+++ b/src/signals/incident-management/saga.js
@@ -101,7 +101,7 @@ export function* fetchIncidents() {
   }
 }
 
-export function* searchIncidents() {
+export function* searchIncidents(action) {
   try {
     const q = yield select(makeSelectSearchQuery);
 
@@ -116,8 +116,11 @@ export function* searchIncidents() {
       ordering,
     });
 
-    yield put(push('/manage/incidents'));
     yield put(searchIncidentsSuccess(incidents));
+
+    if (action.type === SET_SEARCH_QUERY) {
+      yield put(push('/manage/incidents'));
+    }
   } catch (error) {
     if (error.response && error.response.status === 500) {
       // Getting an error response with status code 500 from the search endpoint


### PR DESCRIPTION
This PR fixes a faulty redirect when editing an incident's details after having submitted the search form. The problem here was that the responsible saga always redirected the application back to the overview page when an incident was updated, regardless of which action triggered the saga.

The proposed change has the saga only redirect to the overview page when the search query is set, not when it has already been set.