### PR TITLE
(Chore) Exception message assignment

### DIFF
--- a/src/hooks/__tests__/useFetch.test.js
+++ b/src/hooks/__tests__/useFetch.test.js
@@ -4,7 +4,7 @@ import { getErrorMessage } from 'shared/services/api/api';
 
 import useFetch from '../useFetch';
 
-jest.mock('shared/services/api/api');
+// jest.mock('shared/services/api/api');
 
 const URL = 'https://here-is-my.api/someId/6';
 
@@ -88,6 +88,7 @@ describe('hooks/useFetch', () => {
 
     it('should return errors that are thrown during fetch', async () => {
       const error = new Error();
+      const message = getErrorMessage(error);
       fetch.mockRejectOnce(error);
 
       const { result, waitForNextUpdate } = renderHook(() => useFetch());
@@ -102,6 +103,7 @@ describe('hooks/useFetch', () => {
       await waitForNextUpdate();
 
       expect(result.current.error).toEqual(error);
+      expect(result.current.error.message).toEqual(message);
       expect(result.current.isLoading).toEqual(false);
     });
 

--- a/src/hooks/__tests__/useFetch.test.js
+++ b/src/hooks/__tests__/useFetch.test.js
@@ -4,8 +4,6 @@ import { getErrorMessage } from 'shared/services/api/api';
 
 import useFetch from '../useFetch';
 
-// jest.mock('shared/services/api/api');
-
 const URL = 'https://here-is-my.api/someId/6';
 
 describe('hooks/useFetch', () => {

--- a/src/hooks/__tests__/useFetch.test.js
+++ b/src/hooks/__tests__/useFetch.test.js
@@ -127,6 +127,7 @@ describe('hooks/useFetch', () => {
 
     it('should throw on error response', async () => {
       const response = { status: 401, ok: false, statusText: 'Unauthorized' };
+      const message = getErrorMessage(response);
 
       fetch.mockImplementation(() => response);
 
@@ -141,8 +142,8 @@ describe('hooks/useFetch', () => {
 
       await waitForNextUpdate();
 
-      expect(getErrorMessage).toHaveBeenCalledWith(response);
       expect(result.current.error).toEqual(response);
+      expect(result.current.error.message).toEqual(message);
       expect(result.current.isLoading).toEqual(false);
     });
 
@@ -204,6 +205,7 @@ describe('hooks/useFetch', () => {
 
     it('should throw on error response', async () => {
       const response = { status: 401, ok: false, statusText: 'Unauthorized' };
+      const message = getErrorMessage(response);
       const formData = { ...JSONresponse, is_active: false };
       const { result, waitForNextUpdate } = renderHook(() => useFetch());
 
@@ -222,6 +224,7 @@ describe('hooks/useFetch', () => {
       await waitForNextUpdate();
 
       expect(result.current.error).toEqual(response);
+      expect(result.current.error.message).toEqual(message);
       expect(result.current.isSuccess).toEqual(false);
       expect(result.current.isLoading).toEqual(false);
     });
@@ -286,6 +289,7 @@ describe('hooks/useFetch', () => {
 
     it('should throw on error response', async () => {
       const response = { status: 401, ok: false, statusText: 'Unauthorized' };
+      const message = getErrorMessage(response);
       const formData = { ...JSONresponse, is_active: false };
       const { result, waitForNextUpdate } = renderHook(() => useFetch());
 
@@ -303,6 +307,7 @@ describe('hooks/useFetch', () => {
       await waitForNextUpdate();
 
       expect(result.current.error).toEqual(response);
+      expect(result.current.error.message).toEqual(message);
       expect(result.current.isSuccess).toEqual(false);
       expect(result.current.isLoading).toEqual(false);
     });

--- a/src/hooks/useFetch.js
+++ b/src/hooks/useFetch.js
@@ -70,9 +70,13 @@ export default () => {
       }
 
       setData(responseData);
-    } catch (e) {
-      e.message = getErrorMessage(e);
-      setError(e);
+    } catch (exception) {
+      Object.defineProperty(exception, 'message', {
+        value: getErrorMessage(exception),
+        writable: false,
+      });
+
+      setError(exception);
     } finally {
       setLoading(false);
     }
@@ -105,10 +109,13 @@ export default () => {
 
       setData(responseData);
       setSuccess(true);
-    } catch (e) {
-      e.message = getErrorMessage(e);
+    } catch (exception) {
+      Object.defineProperty(exception, 'message', {
+        value: getErrorMessage(exception),
+        writable: false,
+      });
 
-      setError(e);
+      setError(exception);
       setSuccess(false);
     } finally {
       setLoading(false);


### PR DESCRIPTION
This PR fixes an issue where the application would throw error unrelated to pending actions. This was due to the fact that in the `useFetch` custom hook, the error message was set on a freezed object.