### PR TITLE
[SIG-2540] Remove marker on input clear

### DIFF
--- a/src/components/AutoSuggest/index.js
+++ b/src/components/AutoSuggest/index.js
@@ -33,7 +33,16 @@ const AbsoluteList = styled(SuggestList)`
  * - Home key focuses the input field at the first character
  * - End key focuses the input field at the last character
  */
-const AutoSuggest = ({ className, formatResponse, numOptionsDeterminer, onSelect, placeholder, url, value }) => {
+const AutoSuggest = ({
+  className,
+  formatResponse,
+  numOptionsDeterminer,
+  onClear,
+  onSelect,
+  placeholder,
+  url,
+  value,
+}) => {
   const { get, data } = useFetch();
   const [initialRender, setInitialRender] = useState(false);
   const [showList, setShowList] = useState(false);
@@ -80,6 +89,7 @@ const AutoSuggest = ({ className, formatResponse, numOptionsDeterminer, onSelect
           inputRef.current.value = '';
           setActiveIndex(-1);
           setShowList(false);
+          onClear();
           break;
 
         case 'Home':
@@ -103,7 +113,7 @@ const AutoSuggest = ({ className, formatResponse, numOptionsDeterminer, onSelect
           break;
       }
     },
-    [data, numOptionsDeterminer, showList]
+    [data, numOptionsDeterminer, showList, onClear]
   );
 
   useEffect(() => {
@@ -174,9 +184,13 @@ const AutoSuggest = ({ className, formatResponse, numOptionsDeterminer, onSelect
         get(`${url}${encodeURIComponent(inputValue)}`);
       } else {
         setShowList(false);
+
+        if (inputValue.length === 0) {
+          onClear();
+        }
       }
     },
-    [get, url]
+    [get, onClear, url]
   );
 
   const onSelectOption = useCallback(
@@ -242,6 +256,8 @@ AutoSuggest.propTypes = {
    * @return {Number} The amount of options returned from the request
    */
   numOptionsDeterminer: PropTypes.func.isRequired,
+  /** Callback function that is called whenever the input field */
+  onClear: PropTypes.func,
   /**
    * Option select callback
    * @param {Object} option - The selected option

--- a/src/components/MapInput/__tests__/MapInput.test.js
+++ b/src/components/MapInput/__tests__/MapInput.test.js
@@ -227,7 +227,7 @@ describe('components/MapInput', () => {
     expect(container.querySelector(`.${markerIcon.options.className}`)).toBeInTheDocument();
   });
 
-  it.only('should clear location and not render marker', async () => {
+  it('should clear location and not render marker', async () => {
     const location = {
       lat: 52.36058599633851,
       lng: 4.894292258032637,

--- a/src/components/MapInput/__tests__/MapInput.test.js
+++ b/src/components/MapInput/__tests__/MapInput.test.js
@@ -1,9 +1,10 @@
 import React from 'react';
-import { render, fireEvent, act } from '@testing-library/react';
+import { render, fireEvent, act, wait } from '@testing-library/react';
+
 import MapContext from 'containers/MapContext';
 import context from 'containers/MapContext/context';
-
-import { withAppContext } from 'test/utils';
+import { INPUT_DELAY } from 'components/AutoSuggest';
+import { withAppContext, resolveAfterMs } from 'test/utils';
 import MAP_OPTIONS from 'shared/services/configuration/map-options';
 import { markerIcon } from 'shared/services/configuration/map-markers';
 import * as actions from 'containers/MapContext/actions';
@@ -224,5 +225,42 @@ describe('components/MapInput', () => {
     await findByTestId('map-input');
 
     expect(container.querySelector(`.${markerIcon.options.className}`)).toBeInTheDocument();
+  });
+
+  it.only('should clear location and not render marker', async () => {
+    const location = {
+      lat: 52.36058599633851,
+      lng: 4.894292258032637,
+    };
+    const addressText = 'Foo bar street 10';
+
+    const { findByTestId } = render(
+      withAppContext(
+        <context.Provider value={{ state: { location, addressText }, dispatch: () => {} }}>
+          <MapInput mapOptions={MAP_OPTIONS} value={testLocation} />
+        </context.Provider>
+      )
+    );
+
+    const autoSuggest = await findByTestId('autoSuggest');
+    const input = autoSuggest.querySelector('input');
+
+    expect(setLocationSpy).not.toHaveBeenCalled();
+
+    act(() => {
+      fireEvent.change(input, { target: { value: addressText } });
+    });
+
+    await wait(() => resolveAfterMs(INPUT_DELAY));
+
+    expect(setLocationSpy).not.toHaveBeenCalled();
+
+    act(() => {
+      fireEvent.change(input, { target: { value: '' } });
+    });
+
+    await wait(() => resolveAfterMs(INPUT_DELAY));
+
+    expect(setLocationSpy).toHaveBeenCalledWith();
   });
 });

--- a/src/components/MapInput/index.js
+++ b/src/components/MapInput/index.js
@@ -111,6 +111,10 @@ const MapInput = ({ className, value, onChange, mapOptions, ...otherProps }) => 
     [map, dispatch, onChange]
   );
 
+  const onClear = useCallback(() => {
+    dispatch(setLocationAction());
+  }, [dispatch]);
+
   useEffect(() => {
     if (!marker || !hasLocation) return;
 
@@ -131,11 +135,12 @@ const MapInput = ({ className, value, onChange, mapOptions, ...otherProps }) => 
         <StyledViewerContainer
           topLeft={
             <StyledAutosuggest
-              value={addressValue}
-              onSelect={onSelect}
-              gemeentenaam="amsterdam"
-              placeholder="Zoek adres"
               formatResponse={formatPDOKResponse}
+              gemeentenaam="amsterdam"
+              onClear={onClear}
+              onSelect={onSelect}
+              placeholder="Zoek adres"
+              value={addressValue}
             />
           }
         />

--- a/src/test/utils.js
+++ b/src/test/utils.js
@@ -104,3 +104,5 @@ export const userObjects = (users = usersJSON) =>
         return obj;
       }, {})
   );
+
+export const resolveAfterMs = timeMs => new Promise(resolve => setTimeout(resolve, timeMs));


### PR DESCRIPTION
This PR applies changes to the `AutoSuggest` and `MapInput` components so that the marker can be removed from the map whenever the auto suggest input field is emptied.