### PR TITLE
[SIG-2575] Checkboxlist state bug

### DIFF
--- a/src/signals/incident-management/components/FilterForm/__tests__/FilterForm.test.js
+++ b/src/signals/incident-management/components/FilterForm/__tests__/FilterForm.test.js
@@ -122,6 +122,23 @@ describe('signals/incident-management/components/FilterForm', () => {
     });
   });
 
+  it('should not rerender checkbox list group when state changes', () => {
+    const { rerender, queryByTestId } = render(withAppContext(<FilterForm {...formProps} dataLists={dataLists} />));
+
+    const firstRenderId = queryByTestId('priorityCheckboxGroup').dataset.renderId;
+
+    rerender(withAppContext(<FilterForm {...formProps} dataLists={dataLists} />));
+
+    const secondRenderId = queryByTestId('priorityCheckboxGroup').dataset.renderId;
+
+    rerender(withAppContext(<FilterForm {...formProps} dataLists={dataLists} />));
+
+    const thirdRenderId = queryByTestId('priorityCheckboxGroup').dataset.renderId;
+
+    expect(firstRenderId).toEqual(secondRenderId);
+    expect(secondRenderId).toEqual(thirdRenderId);
+  });
+
   it('should render a list of priority options', () => {
     const dataListsWithEmptyPriorityList = { ...dataLists };
     dataListsWithEmptyPriorityList.priority = [];

--- a/src/signals/incident-management/components/FilterForm/components/CheckboxGroup.js
+++ b/src/signals/incident-management/components/FilterForm/components/CheckboxGroup.js
@@ -6,18 +6,12 @@ import Label from 'components/Label';
 import CheckboxList from '../../CheckboxList';
 import { FilterGroup } from '../styled';
 
-const CheckboxGroup = ({
-  defaultValue,
-  label,
-  name,
-  hasToggle,
-  onChange,
-  onToggle,
-  options,
-}) =>
+const renderId = 0;
+
+const CheckboxGroup = ({ defaultValue, label, name, hasToggle, onChange, onToggle, options }) =>
   Array.isArray(options) &&
   options.length > 0 && (
-    <FilterGroup data-testid={`${name}CheckboxGroup`}>
+    <FilterGroup data-testid={`${name}CheckboxGroup`} data-render-id={renderId + 1}>
       <CheckboxList
         defaultValue={defaultValue}
         hasToggle={hasToggle}

--- a/src/signals/incident-management/components/FilterForm/index.js
+++ b/src/signals/incident-management/components/FilterForm/index.js
@@ -228,8 +228,8 @@ const FilterForm = ({
   return (
     <Form action="" novalidate>
       <ControlsWrapper>
-        {state.filter.id && (
-          <input type="hidden" name="id" value={state.filter.id} />
+        {filter.id && (
+          <input type="hidden" name="id" value={filter.id} />
         )}
         <Fieldset isSection>
           <legend className="hiddenvisually">Naam van het filter</legend>
@@ -239,7 +239,7 @@ const FilterForm = ({
           </Label>
           <div className="invoer">
             <input
-              value={state.filter.name}
+              value={initialFormState.name}
               id="filter_name"
               name="name"
               onChange={onNameChange}
@@ -253,7 +253,7 @@ const FilterForm = ({
           </Label>
           <div className="antwoord">
             <input
-              defaultChecked={state.filter.refresh}
+              defaultChecked={initialFormState.refresh}
               id="filter_refresh"
               name="refresh"
               onClick={onRefreshChange}
@@ -270,7 +270,7 @@ const FilterForm = ({
 
           {status && (
             <CheckboxGroup
-              defaultValue={state.options.status}
+              defaultValue={initialFormState.options.status}
               label="Status"
               name="status"
               onChange={onGroupChange}
@@ -281,7 +281,7 @@ const FilterForm = ({
 
           {stadsdeel && (
             <CheckboxGroup
-              defaultValue={state.options.stadsdeel}
+              defaultValue={initialFormState.options.stadsdeel}
               label="Stadsdeel"
               name="stadsdeel"
               onChange={onGroupChange}
@@ -291,7 +291,7 @@ const FilterForm = ({
           )}
 
           <CheckboxGroup
-            defaultValue={state.options.priority}
+            defaultValue={initialFormState.options.priority}
             hasToggle={false}
             label="Urgentie"
             name="priority"
@@ -301,7 +301,7 @@ const FilterForm = ({
           />
 
           <CheckboxGroup
-            defaultValue={state.options.contact_details}
+            defaultValue={initialFormState.options.contact_details}
             hasToggle={false}
             label="Contact"
             name="contact_details"
@@ -312,7 +312,7 @@ const FilterForm = ({
 
           {feedback && (
             <RadioGroup
-              defaultValue={state.options.feedback}
+              defaultValue={initialFormState.options.feedback}
               label="Feedback"
               name="feedback"
               onChange={onRadioChange}
@@ -362,14 +362,14 @@ const FilterForm = ({
               name="address_text"
               id="filter_address"
               onBlur={onAddressChange}
-              defaultValue={state.options.address_text}
+              defaultValue={initialFormState.options.address_text}
               type="text"
             />
           </FilterGroup>
 
           {source && (
             <CheckboxGroup
-              defaultValue={state.options.source}
+              defaultValue={initialFormState.options.source}
               label="Bron"
               name="source"
               onChange={onGroupChange}


### PR DESCRIPTION
# Checkboxlist state bug
This PR fixes a warning that was thrown in the `FilterForm` component after updating React from `16.13.0` to `16.13.1`:
> Warning: Cannot update a component (`FilterForm`) while rendering a different component (`CheckboxList`). To locate the bad setState() call inside `CheckboxList`, follow the stack trace as described in https://fb.me/setstate-in-render

## The problem
Both the `CheckboxList` component as well as the `FilterForm` component updated the state of the `CheckboxList` component. What happened:
1. Click on checkbox updates internal state of `CheckboxList`
2. Internal state update calls callback prop in `FilterForm`
3. `FilterForm` updates its internal state
4. Updated internal `FilterForm` state is propagated to the `CheckboxList` component through its `defaultValue` prop
5. `CheckboxList` internal state is updated based on value of `defaultValue` prop
6. Warning is shown

## The fix
Fixing the problem involved only setting the `defaultValue` prop once per `CheckboxList` instance and let both components `FilterForm` and `CheckboxList` handle their individual states.