### PR TITLE
[TEST] Added test to trigger the notorious 'cannot update bug'

### DIFF
--- a/src/signals/incident-management/components/FilterForm/__tests__/FilterForm.test.js
+++ b/src/signals/incident-management/components/FilterForm/__tests__/FilterForm.test.js
@@ -76,6 +76,14 @@ describe('signals/incident-management/components/FilterForm', () => {
     });
   });
 
+  it('should check all checkboxes on the first group and not trigger an error', () => {
+    const { getAllByTestId } = render(withAppContext(<FilterForm {...formProps} />));
+
+    getAllByTestId('checkboxList')[0].querySelectorAll('input[type="checkbox"]').forEach(checkbox => {
+      act(() => { fireEvent.click(checkbox); });
+    });
+  });
+
   it('should not rerender checkbox list group when state changes', () => {
     const { rerender, queryByTestId } = render(withAppContext(<FilterForm {...formProps} dataLists={dataLists} />));
 


### PR DESCRIPTION
This test should trigger the following error:
- Cannot update a component (`FilterForm`) while rendering a different component (`CheckboxList`). To locate the bad setState() call inside `CheckboxList`, follow the stack trace as described in https://fb.me/setstate-in-render