### PR TITLE
SIG-2538 corrects the Avenir Next font name

### DIFF
--- a/src/components/MapSelect/index.js
+++ b/src/components/MapSelect/index.js
@@ -26,7 +26,7 @@ const Wrapper = styled.div`
 const StyledMap = styled(Map)`
   height: 450px;
   width: 100%;
-  font-family: Avenir Next LT W01, arial, sans-serif;
+  font-family: "AvenirNextLTW01-Regular", arial, sans-serif;
 `;
 
 const MapSelect = ({

--- a/src/components/Pagination/components/PaginationItem/index.js
+++ b/src/components/Pagination/components/PaginationItem/index.js
@@ -18,7 +18,7 @@ const StyledItem = styled(AscLink)`
   color: black;
   cursor: pointer;
   display: flex;
-  font-family: Avenir Next W01, arial, sans-serif;
+  font-family: "AvenirNextLTW01-Regular", arial, sans-serif;
   height: 100%;
   margin: 0;
   outline: none;


### PR DESCRIPTION
This PR corrects the Avenir Next Regular font name. Because the name didn't match the arial font was used in MapSelect and PaginationItem components

