### PR TITLE
(Chore) Remove redirect

### DIFF
--- a/src/signals/incident-management/__tests__/saga.test.js
+++ b/src/signals/incident-management/__tests__/saga.test.js
@@ -206,24 +206,6 @@ describe('signals/incident-management/saga', () => {
         .run();
     });
 
-    it('should redirect when search query is set', () => {
-      const q = 'Here be dragons';
-      const action = { type: SET_SEARCH_QUERY };
-
-      return expectSaga(searchIncidents, action)
-        .provide([
-          [select(makeSelectSearchQuery), q],
-          [matchers.call.fn(authCall), incidentsJSON],
-        ])
-        .select(makeSelectSearchQuery)
-        .put(applyFilterRefreshStop())
-        .select(makeSelectFilterParams)
-        .call.like(authCall, CONFIGURATION.SEARCH_ENDPOINT, { q })
-        .put(searchIncidentsSuccess(incidentsJSON))
-        .put(push('/manage/incidents'))
-        .run();
-    });
-
     it('should dispatch success in case of a 500 error status', () => {
       const q = 'Here be dragons';
       const message = 'Internal server error';

--- a/src/signals/incident-management/saga.js
+++ b/src/signals/incident-management/saga.js
@@ -100,7 +100,7 @@ export function* fetchIncidents() {
   }
 }
 
-export function* searchIncidents(action) {
+export function* searchIncidents() {
   try {
     const q = yield select(makeSelectSearchQuery);
 
@@ -116,10 +116,6 @@ export function* searchIncidents(action) {
     });
 
     yield put(searchIncidentsSuccess(incidents));
-
-    if (action.type === SET_SEARCH_QUERY) {
-      yield put(push('/manage/incidents'));
-    }
   } catch (error) {
     if (error.response && error.response.status === 500) {
       // Getting an error response with status code 500 from the search endpoint


### PR DESCRIPTION
This PR removes a push to `/manage/incidents` after a search incidents request has been performed since this push is duplicate. There is another push performed in `src/containers/App/saga.js`.