### PR TITLE
(Chore) Fix checkboxlist state update warning

### DIFF
--- a/src/signals/incident-management/components/CheckboxList/__tests__/CheckboxList.test.js
+++ b/src/signals/incident-management/components/CheckboxList/__tests__/CheckboxList.test.js
@@ -498,6 +498,7 @@ describe('signals/incident-management/components/CheckboxList', () => {
   });
 
   it('should fire the right amount of events with onToggle set and unset', () => {
+    jest.useFakeTimers();
     const onChangeMock = jest.fn();
     const onToggleMock = jest.fn();
 
@@ -517,12 +518,16 @@ describe('signals/incident-management/components/CheckboxList', () => {
       )
     );
 
+    jest.runOnlyPendingTimers();
+
     expect(onChangeMock).not.toHaveBeenCalled();
     expect(onToggleMock).not.toHaveBeenCalled();
 
     for (const checkbox of container.querySelectorAll('input[type="checkbox"]').values()) {
       act(() => { fireEvent.click(checkbox); });
     }
+
+    jest.runOnlyPendingTimers();
 
     // since the onToggle prop has been defined it should call it
     // when all the checkboxes have been selected
@@ -550,6 +555,8 @@ describe('signals/incident-management/components/CheckboxList', () => {
     for (const checkbox of container.querySelectorAll('input[type="checkbox"]').values()) {
       act(() => { fireEvent.click(checkbox); });
     }
+
+    jest.runAllTimers();
 
     // since the onToggle prop has not been defined it should call the onChange event
     // on every checkbox selection

--- a/src/signals/incident-management/components/CheckboxList/index.js
+++ b/src/signals/incident-management/components/CheckboxList/index.js
@@ -204,7 +204,10 @@ const CheckboxList = ({
         if (onToggle && allOptionsChecked) {
           onToggle(groupValue || name, allOptionsChecked);
         } else {
-          onChange(groupValue || name, Array.from(modifiedState));
+          const onChangeTimeout = global.setTimeout(() => {
+            global.clearTimeout(onChangeTimeout);
+            onChange(groupValue || name, Array.from(modifiedState));
+          }, 0);
         }
 
         return modifiedState;

--- a/src/signals/incident-management/components/FilterForm/index.js
+++ b/src/signals/incident-management/components/FilterForm/index.js
@@ -200,9 +200,7 @@ const FilterForm = ({ filter, onCancel, onClearFilter, onSaveFilter, onSubmit, o
   return (
     <Form action="" novalidate>
       <ControlsWrapper>
-        {filter.id && (
-          <input type="hidden" name="id" value={filter.id} />
-        )}
+        {filter.id && <input type="hidden" name="id" value={filter.id} />}
         <Fieldset isSection>
           <legend className="hiddenvisually">Naam van het filter</legend>
 
@@ -356,12 +354,14 @@ const FilterForm = ({ filter, onCancel, onClearFilter, onSaveFilter, onSubmit, o
             Categorie
           </Label>
 
-          <CategoryGroups
-            categories={categories}
-            filterSlugs={filterSlugs}
-            onChange={onChangeCategories}
-            onToggle={onMainCategoryToggle}
-          />
+          {categories && (
+            <CategoryGroups
+              categories={categories}
+              filterSlugs={filterSlugs}
+              onChange={onChangeCategories}
+              onToggle={onMainCategoryToggle}
+            />
+          )}
         </Fieldset>
       </ControlsWrapper>
 

--- a/src/signals/settings/departments/Detail/components/CategoryLists/__tests__/CategoryLists.test.js
+++ b/src/signals/settings/departments/Detail/components/CategoryLists/__tests__/CategoryLists.test.js
@@ -38,7 +38,7 @@ const withContextProvider = Component =>
   );
 
 describe('signals/settings/departments/Detail/components/CategoryLists', () => {
-  beforeEach(() => {
+  afterEach(() => {
     jest.resetAllMocks();
   });
 
@@ -97,6 +97,8 @@ describe('signals/settings/departments/Detail/components/CategoryLists', () => {
   });
 
   it('should update the state on is_responsible checkbox tick', () => {
+    jest.useFakeTimers();
+
     const { container, getByText } = render(
       withContextProvider(<CategoryLists {...props} />)
     );
@@ -113,12 +115,18 @@ describe('signals/settings/departments/Detail/components/CategoryLists', () => {
       fireEvent.click(checkbox);
     });
 
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+
     expect(container.querySelectorAll('input:checked')).toHaveLength(
       totalChecked + 1
     );
   });
 
   it('should update the state on is_responsible toggle click', () => {
+    jest.useFakeTimers();
+
     const { container, getByText } = render(
       withContextProvider(<CategoryLists {...props} />)
     );
@@ -159,6 +167,10 @@ describe('signals/settings/departments/Detail/components/CategoryLists', () => {
       fireEvent.click(toggleIsResponsible);
     });
 
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+
     // ticking an is_responsible checkbox should also check its can_view counterpart
     const extraTicked =
       numBoxes - numTickedIsResponsible + (numBoxes - numTickedCanView);
@@ -171,12 +183,18 @@ describe('signals/settings/departments/Detail/components/CategoryLists', () => {
       fireEvent.click(toggleIsResponsible);
     });
 
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+
     expect(container.querySelectorAll('input:checked')).toHaveLength(
       totalChecked - (numTickedIsResponsible + numTickedCanView)
     );
   });
 
   it('should update the state on is_responsible checkbox tick', () => {
+    jest.useFakeTimers();
+
     const { container, getByText } = render(
       withContextProvider(<CategoryLists {...props} />)
     );
@@ -193,12 +211,18 @@ describe('signals/settings/departments/Detail/components/CategoryLists', () => {
       fireEvent.click(checkbox);
     });
 
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+
     expect(container.querySelectorAll('input:checked')).toHaveLength(
       totalChecked + 2
     );
   });
 
   it('should update the state on can_view toggle click', () => {
+    jest.useFakeTimers();
+
     const { container, getByText } = render(
       withContextProvider(<CategoryLists {...props} />)
     );
@@ -228,6 +252,10 @@ describe('signals/settings/departments/Detail/components/CategoryLists', () => {
       fireEvent.click(toggle);
     });
 
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+
     const extraTicked = numBoxes - numTicked;
 
     expect(container.querySelectorAll('input:checked')).toHaveLength(
@@ -236,6 +264,10 @@ describe('signals/settings/departments/Detail/components/CategoryLists', () => {
 
     act(() => {
       fireEvent.click(toggle);
+    });
+
+    act(() => {
+      jest.runOnlyPendingTimers();
     });
 
     expect(container.querySelectorAll('input:checked')).toHaveLength(

--- a/src/signals/settings/departments/Detail/components/CategoryLists/index.js
+++ b/src/signals/settings/departments/Detail/components/CategoryLists/index.js
@@ -4,11 +4,7 @@ import styled from 'styled-components';
 import { Row, themeSpacing } from '@datapunt/asc-ui';
 import isEqual from 'lodash.isequal';
 
-import {
-  ControlsWrapper,
-  Fieldset,
-  Form,
-} from 'signals/incident-management/components/FilterForm/styled';
+import { ControlsWrapper, Fieldset, Form } from 'signals/incident-management/components/FilterForm/styled';
 import Label from 'components/Label';
 import FormFooter from 'components/FormFooter';
 
@@ -28,24 +24,21 @@ const StyledFieldset = styled(Fieldset)`
 `;
 
 /**
- * Component that renders two columns of checkboxes from the value of the
- * `subCategories` prop. Categories are grouped by their parent category.
- * Checkboxes in the `is_responsible` column have a one-on-one relation with
- * the checkboxes in the `can_view` column, meaning that when a `is_responsible`
- * checkbox is ticked, the corresponding checkbox in the `can_view` column is
- * also ticked and disabled. This doesn't go the other way around.
+ * Component that renders two columns of checkboxes from the value of the `subCategories` prop. Categories are grouped
+ * by their parent category.
+ * Checkboxes in the `is_responsible` column have a one-on-one relation with the checkboxes in the `can_view` column,
+ * meaning that when a `is_responsible` checkbox is ticked, the corresponding checkbox in the `can_view` column is also
+ * ticked and disabled. This doesn't go the other way around.
  *
  * The tick logic is handled by the component's reducer function.
  */
 const CategoryLists = ({ onCancel, onSubmit }) => {
-  const { categories, department, subCategories } = useContext(
-    DepartmentDetailContext
-  );
+  const { categories, department, subCategories } = useContext(DepartmentDetailContext);
 
-  const categoriesMapped = useMemo(
-    () => incoming(department.categories, subCategories),
-    [department.categories, subCategories]
-  );
+  const categoriesMapped = useMemo(() => incoming(department.categories, subCategories), [
+    department.categories,
+    subCategories,
+  ]);
   const [state, dispatch] = useReducer(reducer, categoriesMapped);
 
   const onSubmitForm = useCallback(
@@ -73,9 +66,7 @@ const CategoryLists = ({ onCancel, onSubmit }) => {
 
   const onChangeIsResponsibleCategories = useCallback(
     (slug, selectedSubCategories) => {
-      dispatch(
-        setIsResponsible({ slug, subCategories: selectedSubCategories })
-      );
+      dispatch(setIsResponsible({ slug, subCategories: selectedSubCategories }));
     },
     [dispatch]
   );
@@ -91,9 +82,7 @@ const CategoryLists = ({ onCancel, onSubmit }) => {
   const onIsResponsibleMainCategoryToggle = useCallback(
     (slug, isToggled) => {
       const selectedSubCategories = isToggled ? categories[slug].sub : [];
-      dispatch(
-        setIsResponsible({ slug, subCategories: selectedSubCategories })
-      );
+      dispatch(setIsResponsible({ slug, subCategories: selectedSubCategories }));
     },
     [categories, dispatch]
   );


### PR DESCRIPTION
This PR fixes a warning that was shown when the `CheckboxList` component was updated by a parent component. The underlying issue was a matter of timing. What happened was:
1. a checkbox is checked
2. `CheckboxList` internal state is updated
3. the parent component's `onChange` handler is called
4. parent component updates its internal state and sends the updated state to the `CheckboxList` component
5. `CheckboxList` internal state is updated if the incoming values differ from the internal state

Steps 4 and 5 happen short after one another which renders the parent component while the child component is rerendering. This caused the warning to show up.

The solution was to move the `onChange` handler call from the call stack to the event loop.