### PR TITLE
Run tests using GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+on: [push, pull_request]
+
+env:
+  TZ: "Europe/Amsterdam"
+  CI: "true"
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        job: [lint, test, build]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Cache .npm
+        uses: actions/cache@v1
+        env:
+          cache-name: cache-dot-npm
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}
+
+      - name: Install libgif-dev
+        run: sudo apt install libgif-dev
+
+      - name: Setup Node 11.15
+        uses: actions/setup-node@v1
+        with:
+          node-version: 11.15
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run ${{ matrix.job }}
+        run: npm run ${{ matrix.job }}
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v1
+        if: matrix.job == 'test'
+        with:
+          name: coverage-report
+          path: coverage/


### PR DESCRIPTION
This PR introduces continuous integration using GitHub Actions. This allows pull requests from external contributors to be tested securely.

- The [GitHub Actions](https://help.github.com/en/actions/language-and-framework-guides/using-nodejs-with-github-actions) manual served as template of this setup.
- NPM modules are cached between builds.
- Code coverage report is uploaded using [artifacts](https://help.github.com/en/actions/configuring-and-managing-workflows/persisting-workflow-data-using-artifacts).

This setup is easily extendible for testing against multiple Node versions with the [build matrix feature](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix).

We could optimize this setup further by caching the apt install step and the binaries that are built with npm install, but this could be premature optimization.

## Todo

- [ ] Remove the continuous-integration/jenkins/branch check for pull requests from external contributors (help required from Amsterdam)
- [x] Decide if we want to run GitHub Actions for both internal and external pull requests (`on: [push, pull_request]`) or only for external pull requests  (`on: pull_request`)

Closes Signalen/backend#18