### PR TITLE
[SIG-1421] Summary page section header width

### DIFF
--- a/src/signals/incident/components/IncidentPreview/index.js
+++ b/src/signals/incident/components/IncidentPreview/index.js
@@ -30,7 +30,11 @@ const Header = styled.header`
   display: grid;
   position: relative;
   column-gap: ${themeSpacing(5)};
-  grid-template-columns: 4fr 6fr;
+  grid-template-columns: 7fr 3fr;
+
+  @media (min-width: ${({ theme }) => theme.layouts.medium.min}px) {
+    grid-template-columns: 4fr 6fr;
+  }
 
   ${() =>
     isAuthenticated() &&

--- a/src/signals/incident/components/IncidentPreview/index.js
+++ b/src/signals/incident/components/IncidentPreview/index.js
@@ -30,11 +30,7 @@ const Header = styled.header`
   display: grid;
   position: relative;
   column-gap: ${themeSpacing(5)};
-  grid-template-columns: 7fr 3fr;
-
-  @media (min-width: ${({ theme }) => theme.layouts.medium.min}px) {
-    grid-template-columns: 4fr 6fr;
-  }
+  grid-template-columns: 10fr 2fr;
 
   ${() =>
     isAuthenticated() &&

--- a/src/signals/incident/components/IncidentPreview/index.test.js
+++ b/src/signals/incident/components/IncidentPreview/index.test.js
@@ -116,7 +116,7 @@ describe('<IncidentPreview />', () => {
     await findByTestId('incidentPreview');
 
     container.querySelectorAll('header').forEach(element => {
-      expect(element).toHaveStyleRule('grid-template-columns', '4fr 6fr');
+      expect(element).toHaveStyleRule('grid-template-columns', '10fr 2fr');
     });
 
     isAuthenticated.mockImplementation(() => true);


### PR DESCRIPTION
This PR contains a minor change to the incident preview section header width to ensure that the contents of the section header are shown on one line on as many screen widths as possible.