### PR TITLE
[SIG-2551] Fix for alert shown for logged out users

### DIFF
--- a/src/containers/App/index.js
+++ b/src/containers/App/index.js
@@ -4,7 +4,7 @@ import { Switch, Route, Redirect, useHistory } from 'react-router-dom';
 import { compose, bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 
-import { authenticate, isAuthenticated } from 'shared/services/auth/auth';
+import { isAuthenticated } from 'shared/services/auth/auth';
 import ThemeProvider from 'components/ThemeProvider';
 import injectSaga from 'utils/injectSaga';
 import injectReducer from 'utils/injectReducer';
@@ -24,8 +24,6 @@ import reducer from './reducer';
 import saga from './saga';
 
 export const AppContainer = ({ resetIncidentAction }) => {
-  // on each component render, see if the current session is authenticated
-  authenticate();
   const history = useHistory();
   const location = useLocationReferrer();
 

--- a/src/shared/services/auth/auth.js
+++ b/src/shared/services/auth/auth.js
@@ -226,9 +226,19 @@ export function getReturnPath() {
   return returnPath;
 }
 
-export function isAuthenticated() {
-  return Boolean(getAccessToken());
-}
+export const isAuthenticated = () => {
+  try {
+    const decoded = accessTokenParser(getAccessToken());
+
+    if (!decoded.expiresAt) return false;
+
+    const hasExpired = decoded.expiresAt * 1000 < Date.now();
+
+    return !hasExpired;
+  } catch (exception) {
+    return false;
+  }
+};
 
 export function getScopes() {
   return tokenData.scopes || [];

--- a/src/shared/services/auth/auth.js
+++ b/src/shared/services/auth/auth.js
@@ -227,17 +227,13 @@ export function getReturnPath() {
 }
 
 export const isAuthenticated = () => {
-  try {
-    const decoded = accessTokenParser(getAccessToken());
+  const decoded = accessTokenParser(getAccessToken());
 
-    if (!decoded.expiresAt) return false;
+  if (!decoded?.expiresAt) return false;
 
-    const hasExpired = decoded.expiresAt * 1000 < Date.now();
+  const hasExpired = decoded.expiresAt * 1000 < Date.now();
 
-    return !hasExpired;
-  } catch (exception) {
-    return false;
-  }
+  return !hasExpired;
 };
 
 export function getScopes() {


### PR DESCRIPTION
This PR contains a fix for the following scenario:
- user logs in
- access token expires (after a set time in the future)
- user tries to access `/manage/incidents`
- data is requested from a private API endpoint
- endpoint responds with `401` (unauthorized) status code
- error notification is shown about not being able to load resources

The issue was caused by a faulty check on the presence of the acces token that is present in localstorage. The `isAuthenticated()` function only checked if there was an access token and not if the access token was actually a valid token or hadn't expired yet.