### PR TITLE
[SIG-2610] Persistent incident state fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15002,9 +15002,9 @@
       }
     },
     "immutable": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
-      "integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM="
+      "version": "4.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.0.0-rc.12.tgz",
+      "integrity": "sha512-0M2XxkZLx/mi3t8NVwIm1g8nHoEmM9p9UBl/G9k4+hm0kBgOVdMV/B3CY5dQ8qG8qc80NN4gDV4HQv6FTJ5q7A=="
     },
     "import-fresh": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "connected-react-router": "^6.8.0",
     "history": "^4.10.1",
     "hoist-non-react-statics": "^3.3.2",
-    "immutable": "^3.8.2",
+    "immutable": "^4.0.0-rc.12",
     "invariant": "^2.2.4",
     "leaflet": "^1.6.0",
     "leaflet.markercluster": "^1.4.1",

--- a/src/signals/incident/containers/IncidentContainer/reducer.js
+++ b/src/signals/incident/containers/IncidentContainer/reducer.js
@@ -43,8 +43,7 @@ export const initialState = fromJS({
 const getIncidentWithoutExtraProps = incident =>
   fromJS(
     Object.entries(incident.toJS()).reduce((acc, [key, val]) => {
-      const keyVal = { [key]: val };
-      const value = key.startsWith('extra') ? {} : keyVal;
+      const value = key.startsWith('extra') ? {} : { [key]: val };
       return { ...acc, ...value };
     }, {})
   );

--- a/src/signals/incident/containers/IncidentContainer/reducer.js
+++ b/src/signals/incident/containers/IncidentContainer/reducer.js
@@ -12,23 +12,42 @@ import {
 
 export const initialState = fromJS({
   incident: {
+    custom_text: '',
+    datetime: undefined,
     incident_date: 'Vandaag',
     incident_time_hours: 9,
     incident_time_minutes: 0,
+    category: '',
+    description: '',
+    email: '',
+    handling_message: '',
+    images_errors: [],
+    images_previews: [],
+    images: [],
+    location: undefined,
+    phone: undefined,
     priority: {
       id: 'normal',
       label: 'Normaal',
     },
+    source: undefined,
+    subcategory: '',
     type: {
       id: 'SIG',
       label: 'Melding',
     },
-    category: '',
-    subcategory: '',
-    handling_message: '',
   },
   loadingClassification: false,
 });
+
+const getIncidentWithoutExtraProps = incident =>
+  fromJS(
+    Object.entries(incident.toJS()).reduce((acc, [key, val]) => {
+      const keyVal = { [key]: val };
+      const value = key.startsWith('extra') ? {} : keyVal;
+      return { ...acc, ...value };
+    }, {})
+  );
 
 export default (state = initialState, action) => {
   switch (action.type) {
@@ -60,6 +79,13 @@ export default (state = initialState, action) => {
       return state.set('loadingClassification', true);
 
     case GET_CLASSIFICATION_SUCCESS:
+      return state.set('loadingClassification', false).set(
+        'incident',
+        getIncidentWithoutExtraProps(state.get('incident'))
+          .set('category', action.payload.category)
+          .set('subcategory', action.payload.subcategory)
+      );
+
     case GET_CLASSIFICATION_ERROR:
       return state.set('loadingClassification', false).set(
         'incident',

--- a/src/signals/incident/containers/IncidentContainer/reducer.test.js
+++ b/src/signals/incident/containers/IncidentContainer/reducer.test.js
@@ -1,4 +1,4 @@
-import { fromJS } from 'immutable';
+import { has, fromJS } from 'immutable';
 import incidentContainerReducer, { initialState } from './reducer';
 
 import {
@@ -20,8 +20,8 @@ describe('signals/incident/containers/IncidentContainer/reducer', () => {
   });
 
   it('default wizard state should contain date, time, and priority', () => {
-    expect(initialState.get('incident')).toEqual(
-      fromJS({
+    expect(initialState.get('incident').toJS()).toEqual(
+      expect.objectContaining({
         incident_date: 'Vandaag',
         incident_time_hours: 9,
         incident_time_minutes: 0,
@@ -177,6 +177,21 @@ describe('signals/incident/containers/IncidentContainer/reducer', () => {
         },
         loadingClassification: false,
       });
+    });
+
+    it('removes all extra_ props', () => {
+      const intermediateState = initialState.set('incident', initialState.get('incident').set('extra_something', 'foo bar').set('extra_something_else', 'baz qux'));
+
+      const newState = incidentContainerReducer(intermediateState, {
+        type: GET_CLASSIFICATION_SUCCESS,
+        payload: {
+          category: 'Overlast in de openbare ruimte',
+          subcategory: 'Honden(poep)',
+        },
+      });
+
+      expect(has(newState.get('incident'), 'extra_something')).toEqual(false);
+      expect(has(newState.get('incident'), 'extra_something_else')).toEqual(false);
     });
   });
 

--- a/src/signals/incident/containers/IncidentContainer/reducer.test.js
+++ b/src/signals/incident/containers/IncidentContainer/reducer.test.js
@@ -156,6 +156,8 @@ describe('signals/incident/containers/IncidentContainer/reducer', () => {
   });
 
   describe('GET_CLASSIFICATION_SUCCESS', () => {
+    const intermediateState = initialState.set('incident', initialState.get('incident').set('extra_something', 'foo bar').set('extra_something_else', 'baz qux'));
+
     it('sets category and subcategory', () => {
       expect(
         incidentContainerReducer(
@@ -180,8 +182,6 @@ describe('signals/incident/containers/IncidentContainer/reducer', () => {
     });
 
     it('removes all extra_ props', () => {
-      const intermediateState = initialState.set('incident', initialState.get('incident').set('extra_something', 'foo bar').set('extra_something_else', 'baz qux'));
-
       const newState = incidentContainerReducer(intermediateState, {
         type: GET_CLASSIFICATION_SUCCESS,
         payload: {
@@ -192,6 +192,54 @@ describe('signals/incident/containers/IncidentContainer/reducer', () => {
 
       expect(has(newState.get('incident'), 'extra_something')).toEqual(false);
       expect(has(newState.get('incident'), 'extra_something_else')).toEqual(false);
+    });
+
+    it('only removes all extra_ props when category has changed', () => {
+      const type = GET_CLASSIFICATION_SUCCESS;
+      const payload = {
+        category: 'foo',
+        subcategory: 'bar',
+      };
+
+      const newState = incidentContainerReducer(intermediateState, { type, payload }).toJS();
+      newState.incident.extra_something = 'qux';
+
+      const updatedState = incidentContainerReducer(fromJS(newState), { type, payload });
+
+      expect(has(updatedState.get('incident'), 'extra_something')).toEqual(true);
+
+      const changedPayload = {
+        category: 'zork',
+        subcategory: 'bar',
+      };
+
+      const updatedStateDiff = incidentContainerReducer(updatedState, { type, payload: changedPayload });
+
+      expect(has(updatedStateDiff.get('incident'), 'extra_something')).toEqual(false);
+    });
+
+    it('only removes all extra_ props when subcategory has changed', () => {
+      const type = GET_CLASSIFICATION_SUCCESS;
+      const payload = {
+        category: 'foo',
+        subcategory: 'bar',
+      };
+
+      const newState = incidentContainerReducer(intermediateState, { type, payload }).toJS();
+      newState.incident.extra_something = 'qux';
+
+      const updatedState = incidentContainerReducer(fromJS(newState), { type, payload });
+
+      expect(has(updatedState.get('incident'), 'extra_something')).toEqual(true);
+
+      const changedPayload = {
+        category: 'foo',
+        subcategory: 'bazzz',
+      };
+
+      const updatedStateDiff = incidentContainerReducer(updatedState, { type, payload: changedPayload });
+
+      expect(has(updatedStateDiff.get('incident'), 'extra_something')).toEqual(false);
     });
   });
 


### PR DESCRIPTION
This pull request contains a fix for the following scenario:
- user fills in incident form
- prediction service returns with a category that sends the user through a specific workflow
- user clicks edit details button in submission summary page
- prediction service returns with a different category than before
- user completes filling in form
- summary page shows values for both workflows

The cause of this was that the state wasn't properly cleared whenever a determining factor in the state (in this case `category` and/or `subcategory`) changed.

The solution was to clear all values for which the prop name was prefixed with `extra` when the prediction service returned with a category.