### PR TITLE
[SIG-2447] AttachmentViewer keyboard nav

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/components/AttachmentViewer/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/AttachmentViewer/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
@@ -39,10 +39,44 @@ const Img = styled.img`
   margin: 0 auto;
 `;
 
-const AttachmentViewer = ({ href, attachments, onShowAttachment }) => {
-  const index = attachments.findIndex(item => item.location === href);
+const AttachmentViewer = ({ href, attachments }) => {
+  const [currentHref, setCurrentHref] = useState(href);
+  const index = attachments.findIndex(item => item.location === currentHref);
   const previous = index > 0 ? attachments[index - 1].location : false;
   const next = index < attachments.length - 1 ? attachments[index + 1].location : false;
+
+  const handleKeyDown = useCallback(
+    event => {
+      switch (event.key) {
+        case 'ArrowLeft':
+          if (previous) {
+            setCurrentHref(previous);
+          }
+          break;
+
+        case 'ArrowRight':
+          if (next) {
+            setCurrentHref(next);
+          }
+          break;
+
+        default:
+          break;
+      }
+    },
+    [next, previous]
+  );
+
+  /**
+   * Register and unregister listeners
+   */
+  useEffect(() => {
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [handleKeyDown]);
 
   return (
     <Wrapper>
@@ -50,7 +84,7 @@ const AttachmentViewer = ({ href, attachments, onShowAttachment }) => {
         <PreviousButton
           data-testid="attachment-viewer-button-previous"
           icon={<ChevronLeft />}
-          onClick={() => onShowAttachment(previous)}
+          onClick={() => setCurrentHref(previous)}
         />
       )}
 
@@ -58,20 +92,20 @@ const AttachmentViewer = ({ href, attachments, onShowAttachment }) => {
         <NextButton
           data-testid="attachment-viewer-button-next"
           icon={<ChevronRight />}
-          onClick={() => onShowAttachment(next)}
+          onClick={() => setCurrentHref(next)}
         />
       )}
 
-      <Img src={href} data-testid="attachment-viewer-image" alt="uploaded afbeelding" />
+      <Img src={currentHref} data-testid="attachment-viewer-image" alt={attachments[index]._display} />
     </Wrapper>
   );
 };
 
 AttachmentViewer.propTypes = {
+  /** Current image's href */
   href: PropTypes.string.isRequired,
+  /** List of attachments */
   attachments: attachmentsType.isRequired,
-
-  onShowAttachment: PropTypes.func.isRequired,
 };
 
 export default AttachmentViewer;

--- a/src/signals/incident-management/containers/IncidentDetail/components/AttachmentViewer/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/AttachmentViewer/index.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
@@ -40,6 +40,7 @@ const Img = styled.img`
 `;
 
 const AttachmentViewer = ({ href, attachments }) => {
+  const wrapperRef = useRef(null);
   const [currentHref, setCurrentHref] = useState(href);
   const index = attachments.findIndex(item => item.location === currentHref);
   const previous = index > 0 ? attachments[index - 1].location : false;
@@ -47,6 +48,12 @@ const AttachmentViewer = ({ href, attachments }) => {
 
   const handleKeyDown = useCallback(
     event => {
+      const refInTarget = event.target.contains(wrapperRef.current);
+
+      if (!refInTarget) {
+        return;
+      }
+
       switch (event.key) {
         case 'ArrowLeft':
           if (previous) {
@@ -79,7 +86,7 @@ const AttachmentViewer = ({ href, attachments }) => {
   }, [handleKeyDown]);
 
   return (
-    <Wrapper>
+    <Wrapper ref={wrapperRef}>
       {previous && (
         <PreviousButton
           data-testid="attachment-viewer-button-previous"

--- a/src/signals/incident-management/containers/IncidentDetail/components/AttachmentViewer/index.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/AttachmentViewer/index.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent, cleanup } from '@testing-library/react';
+import { render, fireEvent, act } from '@testing-library/react';
 
 import AttachmentViewer from './index';
 
@@ -8,42 +8,24 @@ describe('<AttachmentViewer />', () => {
     attachments: [
       {
         _display: 'Attachment object (678)',
-        _links: {
-          self: {
-            href: 'https://acc.api.data.amsterdam.nl/signals/v1/private/signals/3087/attachments',
-          },
-        },
         location: 'https://objectstore.eu/mock/image/1',
         is_image: true,
         created_at: '2019-08-05T08:19:16.372476+02:00',
       },
       {
         _display: 'Attachment object (679)',
-        _links: {
-          self: {
-            href: 'https://acc.api.data.amsterdam.nl/signals/v1/private/signals/3087/attachments',
-          },
-        },
         location: 'https://objectstore.eu/mock/image/2',
         is_image: true,
         created_at: '2019-08-05T08:19:17.205236+02:00',
       },
       {
         _display: 'Attachment object (680)',
-        _links: {
-          self: {
-            href: 'https://acc.api.data.amsterdam.nl/signals/v1/private/signals/3087/attachments',
-          },
-        },
         location: 'https://objectstore.eu/mock/image/3',
         is_image: true,
         created_at: '2019-08-05T08:19:18.389461+02:00',
       },
     ],
-    onShowAttachment: jest.fn(),
   };
-
-  afterEach(cleanup);
 
   describe('rendering', () => {
     it('on page 1 it should render the correct image and only next button', () => {
@@ -84,22 +66,72 @@ describe('<AttachmentViewer />', () => {
   });
 
   describe('events', () => {
-    it('should trigger opening previous image', () => {
+    it('should navigate on click', () => {
       const { queryByTestId } = render(
-        <AttachmentViewer {...props} href="https://objectstore.eu/mock/image/2" />
+        <AttachmentViewer {...props} href={props.attachments[1].location} />
       );
-      fireEvent.click(queryByTestId('attachment-viewer-button-previous'));
 
-      expect(props.onShowAttachment).toHaveBeenCalledWith('https://objectstore.eu/mock/image/1');
+      expect(queryByTestId('attachment-viewer-image')).toHaveAttribute('src', props.attachments[1].location);
+
+      act(() => {
+        fireEvent.click(queryByTestId('attachment-viewer-button-previous'));
+      });
+
+      expect(queryByTestId('attachment-viewer-image')).toHaveAttribute('src', props.attachments[0].location);
+
+      expect(queryByTestId('attachment-viewer-button-previous')).not.toBeInTheDocument();
+
+      act(() => {
+        fireEvent.click(queryByTestId('attachment-viewer-button-next'));
+      });
+
+      expect(queryByTestId('attachment-viewer-image')).toHaveAttribute('src', props.attachments[1].location);
+
+      act(() => {
+        fireEvent.click(queryByTestId('attachment-viewer-button-next'));
+      });
+
+      expect(queryByTestId('attachment-viewer-image')).toHaveAttribute('src', props.attachments[2].location);
+
+      expect(queryByTestId('attachment-viewer-button-next')).not.toBeInTheDocument();
     });
 
-    it('should trigger opening next image', () => {
+    it('should navigate on key press', () => {
       const { queryByTestId } = render(
-        <AttachmentViewer {...props} href="https://objectstore.eu/mock/image/2" />
+        <AttachmentViewer {...props} href={props.attachments[1].location} />
       );
-      fireEvent.click(queryByTestId('attachment-viewer-button-next'));
 
-      expect(props.onShowAttachment).toHaveBeenCalledWith('https://objectstore.eu/mock/image/3');
+      expect(queryByTestId('attachment-viewer-image')).toHaveAttribute('src', props.attachments[1].location);
+
+      act(() => {
+        fireEvent.keyDown(document, { key: 'ArrowLeft', code: 37, keyCode: 37 });
+      });
+
+      expect(queryByTestId('attachment-viewer-image')).toHaveAttribute('src', props.attachments[0].location);
+
+      act(() => {
+        fireEvent.keyDown(document, { key: 'ArrowLeft', code: 37, keyCode: 37 });
+      });
+
+      expect(queryByTestId('attachment-viewer-image')).toHaveAttribute('src', props.attachments[0].location);
+
+      act(() => {
+        fireEvent.keyDown(document, { key: 'ArrowRight', code: 39, keyCode: 39 });
+      });
+
+      expect(queryByTestId('attachment-viewer-image')).toHaveAttribute('src', props.attachments[1].location);
+
+      act(() => {
+        fireEvent.keyDown(document, { key: 'ArrowRight', code: 39, keyCode: 39 });
+      });
+
+      expect(queryByTestId('attachment-viewer-image')).toHaveAttribute('src', props.attachments[2].location);
+
+      act(() => {
+        fireEvent.keyDown(document, { key: 'ArrowRight', code: 39, keyCode: 39 });
+      });
+
+      expect(queryByTestId('attachment-viewer-image')).toHaveAttribute('src', props.attachments[2].location);
     });
   });
 });

--- a/src/signals/incident-management/containers/IncidentDetail/components/AttachmentViewer/index.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/AttachmentViewer/index.test.js
@@ -30,9 +30,7 @@ describe('<AttachmentViewer />', () => {
   describe('rendering', () => {
     it('on page 1 it should render the correct image and only next button', () => {
       const href = 'https://objectstore.eu/mock/image/1';
-      const { queryByTestId, queryAllByTestId } = render(
-        <AttachmentViewer {...props} href={href} />
-      );
+      const { queryByTestId, queryAllByTestId } = render(<AttachmentViewer {...props} href={href} />);
 
       expect(queryAllByTestId('attachment-viewer-button-previous')).toHaveLength(0);
       expect(queryAllByTestId('attachment-viewer-button-next')).toHaveLength(1);
@@ -42,9 +40,7 @@ describe('<AttachmentViewer />', () => {
 
     it('on page 2 it should render the correct image and both previous and next button', () => {
       const href = 'https://objectstore.eu/mock/image/2';
-      const { queryByTestId, queryAllByTestId } = render(
-        <AttachmentViewer {...props} href={href} />
-      );
+      const { queryByTestId, queryAllByTestId } = render(<AttachmentViewer {...props} href={href} />);
 
       expect(queryAllByTestId('attachment-viewer-button-previous')).toHaveLength(1);
       expect(queryAllByTestId('attachment-viewer-button-next')).toHaveLength(1);
@@ -54,9 +50,7 @@ describe('<AttachmentViewer />', () => {
 
     it('on page 3 it should render the correct image and only previous button', () => {
       const href = 'https://objectstore.eu/mock/image/3';
-      const { queryByTestId, queryAllByTestId } = render(
-        <AttachmentViewer {...props} href={href} />
-      );
+      const { queryByTestId, queryAllByTestId } = render(<AttachmentViewer {...props} href={href} />);
 
       expect(queryAllByTestId('attachment-viewer-button-previous')).toHaveLength(1);
       expect(queryAllByTestId('attachment-viewer-button-next')).toHaveLength(0);
@@ -67,9 +61,7 @@ describe('<AttachmentViewer />', () => {
 
   describe('events', () => {
     it('should navigate on click', () => {
-      const { queryByTestId } = render(
-        <AttachmentViewer {...props} href={props.attachments[1].location} />
-      );
+      const { queryByTestId } = render(<AttachmentViewer {...props} href={props.attachments[1].location} />);
 
       expect(queryByTestId('attachment-viewer-image')).toHaveAttribute('src', props.attachments[1].location);
 
@@ -97,41 +89,72 @@ describe('<AttachmentViewer />', () => {
     });
 
     it('should navigate on key press', () => {
+      const { queryByTestId } = render(<AttachmentViewer {...props} href={props.attachments[1].location} />);
+
+      expect(queryByTestId('attachment-viewer-image')).toHaveAttribute('src', props.attachments[1].location);
+
+      act(() => {
+        fireEvent.keyDown(document, { key: 'ArrowLeft', code: 37, keyCode: 37 });
+      });
+
+      expect(queryByTestId('attachment-viewer-image')).toHaveAttribute('src', props.attachments[0].location);
+
+      act(() => {
+        fireEvent.keyDown(document, { key: 'ArrowLeft', code: 37, keyCode: 37 });
+      });
+
+      expect(queryByTestId('attachment-viewer-image')).toHaveAttribute('src', props.attachments[0].location);
+
+      act(() => {
+        fireEvent.keyDown(document, { key: 'ArrowRight', code: 39, keyCode: 39 });
+      });
+
+      expect(queryByTestId('attachment-viewer-image')).toHaveAttribute('src', props.attachments[1].location);
+
+      act(() => {
+        fireEvent.keyDown(document, { key: 'ArrowRight', code: 39, keyCode: 39 });
+      });
+
+      expect(queryByTestId('attachment-viewer-image')).toHaveAttribute('src', props.attachments[2].location);
+
+      act(() => {
+        fireEvent.keyDown(document, { key: 'ArrowRight', code: 39, keyCode: 39 });
+      });
+
+      expect(queryByTestId('attachment-viewer-image')).toHaveAttribute('src', props.attachments[2].location);
+    });
+
+    it('should not navigate on keypress ', () => {
+      const { queryByTestId } = render(<AttachmentViewer {...props} href={props.attachments[1].location} />);
+
+      const initialSrc = props.attachments[1].location;
+
+      expect(queryByTestId('attachment-viewer-image')).toHaveAttribute('src', initialSrc);
+
+      act(() => {
+        fireEvent.keyDown(document, { key: 'ArrowUp', code: 38, keyCode: 38 });
+      });
+
+      expect(queryByTestId('attachment-viewer-image')).toHaveAttribute('src', initialSrc);
+    });
+
+    it('should not navigate on keypress when another element in the tree has the focus', () => {
       const { queryByTestId } = render(
-        <AttachmentViewer {...props} href={props.attachments[1].location} />
+        <div>
+          <input data-testid="input" />
+          <AttachmentViewer {...props} href={props.attachments[1].location} />
+        </div>
       );
 
-      expect(queryByTestId('attachment-viewer-image')).toHaveAttribute('src', props.attachments[1].location);
+      const initialSrc = props.attachments[1].location;
+
+      expect(queryByTestId('attachment-viewer-image')).toHaveAttribute('src', initialSrc);
 
       act(() => {
-        fireEvent.keyDown(document, { key: 'ArrowLeft', code: 37, keyCode: 37 });
+        fireEvent.keyDown(queryByTestId('input'), { key: 'ArrowLeft', code: 37, keyCode: 37 });
       });
 
-      expect(queryByTestId('attachment-viewer-image')).toHaveAttribute('src', props.attachments[0].location);
-
-      act(() => {
-        fireEvent.keyDown(document, { key: 'ArrowLeft', code: 37, keyCode: 37 });
-      });
-
-      expect(queryByTestId('attachment-viewer-image')).toHaveAttribute('src', props.attachments[0].location);
-
-      act(() => {
-        fireEvent.keyDown(document, { key: 'ArrowRight', code: 39, keyCode: 39 });
-      });
-
-      expect(queryByTestId('attachment-viewer-image')).toHaveAttribute('src', props.attachments[1].location);
-
-      act(() => {
-        fireEvent.keyDown(document, { key: 'ArrowRight', code: 39, keyCode: 39 });
-      });
-
-      expect(queryByTestId('attachment-viewer-image')).toHaveAttribute('src', props.attachments[2].location);
-
-      act(() => {
-        fireEvent.keyDown(document, { key: 'ArrowRight', code: 39, keyCode: 39 });
-      });
-
-      expect(queryByTestId('attachment-viewer-image')).toHaveAttribute('src', props.attachments[2].location);
+      expect(queryByTestId('attachment-viewer-image')).toHaveAttribute('src', initialSrc);
     });
   });
 });


### PR DESCRIPTION
This PR adds keyboard navigation to the incident detail `AttachmentViewer` component and removes the callback function, because the component handles its own state now.