### PR TITLE
[SIG-2616] Deelmelding component

### DIFF
--- a/src/components/ChildIncidents/__tests__/ChildIncidents.test.js
+++ b/src/components/ChildIncidents/__tests__/ChildIncidents.test.js
@@ -1,0 +1,84 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import 'jest-styled-components';
+
+import { withAppContext } from 'test/utils';
+
+import { INCIDENT_URL } from 'signals/incident-management/routes';
+import { statusList } from 'signals/incident-management/definitions';
+import categories from 'utils/__tests__/fixtures/categories.json';
+import departments from 'utils/__tests__/fixtures/departments.json';
+import incident from 'utils/__tests__/fixtures/incident.json';
+
+import ChildIncidents, { STATUS_RESPONSE_REQUIRED, STATUS_NONE } from '..';
+
+const randomElement = array => array[Math.floor(Math.random() * array.length)];
+
+const getChildren = (opts = {}) => {
+  const options = { ...{ numValues: 4, withHref: true, withStatus: true }, ...opts };
+
+  return incident._links['sia:children'].map(({ href }) => {
+    const id = href.substring(href.lastIndexOf('/') + 1, href.length);
+    const values = {
+      id,
+      status: options.numValues > 1 && randomElement(statusList).value,
+      categorie: options.numValues > 2 && randomElement(categories.sub).value,
+      afdeling: options.numValues > 3 && randomElement(departments.results).code,
+    };
+
+    return {
+      href: options.withHref ? `${INCIDENT_URL}/${id}` : undefined,
+      status: options.withStatus ? STATUS_RESPONSE_REQUIRED : STATUS_NONE,
+      values,
+    };
+  });
+};
+
+describe('components/ChildIncidents', () => {
+  it('should render a list', () => {
+    const children = getChildren();
+    const { getByTestId } = render(withAppContext(<ChildIncidents incidents={children} />));
+
+    const list = getByTestId('childIncidents');
+
+    expect(list).toBeInTheDocument();
+    expect(list.nodeName).toEqual('UL');
+    expect(document.querySelectorAll('li')).toHaveLength(children.length);
+  });
+
+  it('should render links', () => {
+    const children = getChildren();
+    const { container, rerender } = render(withAppContext(<ChildIncidents incidents={children} />));
+
+    expect(container.querySelectorAll('a').length).toBeGreaterThan(0);
+
+    rerender(withAppContext(<ChildIncidents incidents={getChildren({ withHref: false })} />));
+
+    expect(container.querySelectorAll('a').length).toEqual(0);
+  });
+
+  it('should show a status incidator', () => {
+    const children = getChildren();
+    const { container, rerender } = render(withAppContext(<ChildIncidents incidents={children} />));
+
+    container.querySelectorAll('li').forEach(element => {
+      expect(element).toHaveStyleRule('border-right', '2px solid white', {
+        modifier: '::before',
+      });
+    });
+
+    rerender(withAppContext(<ChildIncidents incidents={getChildren({ withStatus: false })} />));
+
+    container.querySelectorAll('li').forEach(element => {
+      expect(element).not.toHaveStyleRule('border-right', '2px solid white', {
+        modifier: '::before',
+      });
+    });
+  });
+
+  it('should wrap contents', () => {});
+
+  it('should set the flex basis for all but the first and last element', () => {});
+
+  it('should set the max width for the fourth element', () => {});
+});

--- a/src/components/ChildIncidents/index.js
+++ b/src/components/ChildIncidents/index.js
@@ -1,0 +1,130 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled, { css } from 'styled-components';
+import { Link } from 'react-router-dom';
+import { List, ListItem, themeColor, themeSpacing } from '@datapunt/asc-ui';
+
+export const STATUS_NONE = 'components/ChildIncidents/STATUS_NONE';
+export const STATUS_RESPONSE_REQUIRED = 'components/ChildIncidents/STATUS_RESPONSE_REQUIRED';
+
+const FIRST_VALUE_WIDTH = 100;
+const LAST_VALUE_WIDTH = 80;
+
+const Li = styled(ListItem)`
+  display: flex;
+  background-color: ${themeColor('tint', 'level3')};
+  margin: 0;
+  padding: 0;
+  position: relative;
+
+  & + & {
+    margin-top: ${themeSpacing(1)};
+  }
+
+  ${({ status }) => {
+    switch (status) {
+      case STATUS_RESPONSE_REQUIRED:
+        return css`
+          &::before {
+            background-color: ${themeColor('support', 'focus')};
+            border-right: 2px solid white;
+            bottom: 0;
+            content: '';
+            left: 0;
+            position: absolute;
+            width: ${themeSpacing(1.5)};
+            top: 0;
+          }
+        `;
+
+      case STATUS_NONE:
+      default:
+        return null;
+    }
+  }}
+
+  & > a {
+    &:hover > :first-child {
+      color: ${themeColor('secondary')};
+      text-decoration: underline;
+    }
+  }
+
+  & > * {
+    padding: ${themeSpacing(3, 5, 3, 7)};
+    display: flex;
+    width: 100%;
+    text-decoration: none;
+    color: black;
+
+    @media (max-width: ${({ theme }) => theme.layouts.large.min}px) {
+      flex-wrap: wrap;
+      justify-content: space-between;
+    }
+
+    & > :not(:first-child):not(:last-child) {
+      flex: 1 1
+        calc(
+          50% -
+            ${({ numValues }) => (numValues > 3 ? (FIRST_VALUE_WIDTH + LAST_VALUE_WIDTH) / 2 : FIRST_VALUE_WIDTH / 2)}px
+        );
+
+      @media (max-width: ${({ theme }) => theme.layouts.large.min}px) {
+        flex: 0 0 auto;
+        min-width: 150px;
+      }
+    }
+
+    & > :first-child {
+      flex: 0 0 ${FIRST_VALUE_WIDTH}px;
+
+      @media (max-width: ${({ theme }) => theme.layouts.large.min}px) {
+        flex: 0 0 100%;
+      }
+    }
+
+    & > *:nth-last-child(4) ~ *:last-child {
+      flex: 0 0 100%;
+
+      @media (min-width: ${({ theme }) => theme.layouts.medium.max}px) {
+        display: flex;
+        justify-content: flex-end;
+        flex: 0 0 ${FIRST_VALUE_WIDTH}px;
+      }
+    }
+  }
+`;
+
+const ChildIncidents = ({ className, incidents }) => (
+  <List className={className} data-testid="childIncidents">
+    {incidents.map(({ href, status, values }) => {
+      const valueEntries = Object.entries(values).map(([key, value]) => (
+        <span key={key} title={key}>
+          {value}
+        </span>
+      ));
+
+      return (
+        <Li key={JSON.stringify(values)} status={status} numValues={values.length}>
+          {href ? <Link to={href}>{valueEntries}</Link> : <div>{valueEntries}</div>}
+        </Li>
+      );
+    })}
+  </List>
+);
+
+ChildIncidents.propTypes = {
+  /** @ignore */
+  className: PropTypes.string,
+  incidents: PropTypes.arrayOf(
+    PropTypes.exact({
+      href: PropTypes.string,
+      status: PropTypes.string,
+      values: PropTypes.shape({
+        id: PropTypes.string.isRequired,
+      }),
+    })
+  ),
+};
+
+export default ChildIncidents;

--- a/src/signals/incident-management/containers/IncidentDetail/components/ChildIncidents/__tests__/ChildIncidents.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/ChildIncidents/__tests__/ChildIncidents.test.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { withAppContext } from 'test/utils';
+import incident from 'utils/__tests__/fixtures/incident.json';
+
+import ChildIncidents from '..';
+
+describe('signals/management/containers/IncidentDetail/components/ChildIncidents', () => {
+  it('should not render anything', () => {
+    const { queryByText, queryByTestId } = render(withAppContext(<ChildIncidents incident={{}} />));
+
+    expect(queryByText('Deelmelding')).not.toBeInTheDocument();
+    expect(queryByTestId('childIncidents')).not.toBeInTheDocument();
+  });
+
+  it('should render correctly', () => {
+    const { getByText, getByTestId } = render(withAppContext(<ChildIncidents incident={incident} />));
+
+    expect(getByText('Deelmelding')).toBeInTheDocument();
+    expect(getByTestId('childIncidents')).toBeInTheDocument();
+  });
+});

--- a/src/signals/incident-management/containers/IncidentDetail/components/ChildIncidents/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/ChildIncidents/index.js
@@ -1,0 +1,49 @@
+import React, { Fragment, useMemo } from 'react';
+import styled from 'styled-components';
+import { themeSpacing, Heading } from '@datapunt/asc-ui';
+
+import { incidentType } from 'shared/types';
+import ChildIncidentsList from 'components/ChildIncidents';
+import { INCIDENT_URL } from 'signals/incident-management/routes';
+
+const Title = styled(Heading)`
+  font-weight: 400;
+  margin: ${themeSpacing(4)} 0;
+`;
+
+const ChildIncidents = ({ incident }) => {
+  const children = useMemo(
+    () =>
+      incident?._links?.['sia:children']?.map(({ href }) => {
+        const id = href.substring(href.lastIndexOf('/') + 1, href.length);
+
+        return {
+          href: `${INCIDENT_URL}/${id}`,
+          values: {
+            id,
+          },
+        };
+      }),
+    [incident]
+  );
+
+  if (!children?.length) {
+    return null;
+  }
+
+  return (
+    <Fragment>
+      <Title data-testid="detail-title" forwardedAs="h2" styleAs="h4">
+        Deelmelding
+      </Title>
+
+      <ChildIncidentsList incidents={children} />
+    </Fragment>
+  );
+};
+
+ChildIncidents.propTypes = {
+  incident: incidentType.isRequired,
+};
+
+export default ChildIncidents;

--- a/src/signals/incident-management/containers/IncidentDetail/components/MetaList/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/MetaList/index.js
@@ -50,7 +50,6 @@ const EditButton = styled(Button)`
 
 const MetaList = ({ incident, onEditStatus, onPatchIncident }) => {
   const [valueChanged, setValueChanged] = useState(false);
-  const children = get(incident, '_links.sia:children');
   const parent = get(incident, '_links.sia:parent');
   const subcategories = useSelector(makeSelectSubCategories);
   const subcatHighlightDisabled = ![
@@ -150,26 +149,6 @@ const MetaList = ({ incident, onEditStatus, onPatchIncident }) => {
             <AscLink data-testid="meta-list-parent-link" as={Link} variant="inline" to={`/manage/incident/${getId(parent)}`}>
               {getId(parent)}
             </AscLink>
-          </dd>
-        </Fragment>
-      )}
-
-      {children?.length > 0 && (
-        <Fragment>
-          <dt data-testid="meta-list-children-definition">Gesplitst in</dt>
-          <dd>
-            {children.map(child => (
-              <AscLink
-                className="childLink"
-                data-testid={`meta-list-children-link-${getId(child)}`}
-                key={child.href}
-                as={Link}
-                variant="inline"
-                to={`/manage/incident/${getId(child)}`}
-              >
-                {getId(child)}
-              </AscLink>
-            ))}
           </dd>
         </Fragment>
       )}

--- a/src/signals/incident-management/containers/IncidentDetail/components/MetaList/index.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/MetaList/index.test.js
@@ -81,22 +81,6 @@ describe('<MetaList />', () => {
       expect(queryByTestId('meta-list-parent-link')).toHaveAttribute('href', '/manage/incident/3094');
     });
 
-    it('should render correctly with children', () => {
-      props.incident._links['sia:children'] = [
-        { href: 'https://acc.api.data.amsterdam.nl/signals/v1/private/signals/3095' },
-        { href: 'https://acc.api.data.amsterdam.nl/signals/v1/private/signals/3096' },
-      ];
-
-      const { queryByTestId } = render(withAppContext(<MetaList {...props} />));
-
-      expect(queryByTestId('meta-list-children-definition')).toHaveTextContent(/^Gesplitst in$/);
-      expect(queryByTestId('meta-list-children-link-3095')).toHaveTextContent(/^3095$/);
-      expect(queryByTestId('meta-list-children-link-3096')).toHaveTextContent(/^3096$/);
-
-      expect(queryByTestId('meta-list-children-link-3095')).toHaveAttribute('href', '/manage/incident/3095');
-      expect(queryByTestId('meta-list-children-link-3096')).toHaveAttribute('href', '/manage/incident/3096');
-    });
-
     it('should call onPatchIncident', async () => {
       const { getAllByTestId } = render(withAppContext(<MetaList {...props} />));
       const editButtons = getAllByTestId('editButton');

--- a/src/signals/incident-management/containers/IncidentDetail/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/index.js
@@ -36,6 +36,7 @@ import History from 'components/History';
 
 import './style.scss';
 
+import ChildIncidents from './components/ChildIncidents';
 import DetailHeader from './components/DetailHeader';
 import MetaList from './components/MetaList';
 import AddNote from './components/AddNote';
@@ -260,6 +261,8 @@ export class IncidentDetail extends React.Component {
                         />
 
                         <AddNote id={id} onPatchIncident={onPatchIncident} />
+
+                        <ChildIncidents incident={incident} />
 
                         <History list={list} />
                       </Fragment>

--- a/src/utils/__tests__/fixtures/incident.json
+++ b/src/utils/__tests__/fixtures/incident.json
@@ -15,7 +15,18 @@
     },
     "sia:pdf": {
       "href": "https://acc.api.data.amsterdam.nl/signals/v1/private/signals/4440/pdf"
-    }
+    },
+    "sia:children": [
+      {
+        "href": "https://acc.api.data.amsterdam.nl/signals/v1/private/signals/5319"
+      },
+      {
+        "href": "https://acc.api.data.amsterdam.nl/signals/v1/private/signals/5320"
+      },
+      {
+        "href": "https://acc.api.data.amsterdam.nl/signals/v1/private/signals/5321"
+      }
+    ]
   },
   "id": 4440,
   "signal_id": "6acdb051-41aa-4984-b7f3-e2177036bf92",


### PR DESCRIPTION
This PR contains a new component; `ChildIncidents` that replaces the inline list of child incidents on the incident detail page.

The component supports passing multiple values and by default requires an `id` to be present.

Each child in the list can be given a status (currently, none of the items will get one). The status is indicated by a pseudo element with a background color and right border.