### PR TITLE
Do not run GitHub Actions twice for internal pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,10 @@
 name: CI
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - develop
+      - master
+  pull_request:
 
 env:
   TZ: "Europe/Amsterdam"


### PR DESCRIPTION
Actions for internal pull requests currently run twice. This PR fixes this behavior.

Related to Signalen/backend#18