### PR TITLE
(Chore) Remove Jenkins stages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,31 +20,7 @@ node('BS16 || BS17') {
         env.GIT_COMMIT = scmVars.GIT_COMMIT
         env.COMPOSE_DOCKER_CLI_BUILD = 1
     }
-    stage("Get cached build") {
-        docker.withRegistry("${DOCKER_REGISTRY_HOST}",'docker_registry_auth') {
-            def image = docker.image("ois/signalsfrontend-base:acceptance")
 
-            if (image) {
-                image.pull()
-            }
-        }
-    }
-    stage("Lint") {
-        String PROJECT = "sia-eslint-${env.BUILD_TAG}"
-        tryStep "lint start", {
-            sh "docker-compose -p ${PROJECT} up --build --exit-code-from lint-container lint-container"
-        }, {
-            sh "docker-compose -p ${PROJECT} down -v || true"
-        }
-    }
-    stage("Test") {
-        String PROJECT = "sia-unittests-${env.BUILD_TAG}"
-        tryStep "unittests start", {
-            sh "docker-compose -p ${PROJECT} up --build --exit-code-from unittest-container unittest-container"
-        }, {
-            sh "docker-compose -p ${PROJECT} down -v || true"
-        }
-    }
     if (BRANCH == "develop") {
         stage("Build and push the base image to speed up lint and unittest builds") {
             tryStep "build", {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,25 +10,3 @@ services:
     ipc: host
     ports:
       - "3001:80"
-
-  lint-container:
-    build:
-      cache_from:
-        - docker-registry.data.amsterdam.nl/ois/signalsfrontend-base:acceptance
-      context: .
-      target: base
-    environment:
-      - CI=true
-      - TZ=Europe/Amsterdam
-    command: npm run lint
-
-  unittest-container:
-    build:
-      cache_from:
-        - docker-registry.data.amsterdam.nl/ois/signalsfrontend-base:acceptance
-      context: .
-      target: base
-    environment:
-      - CI=true
-      - TZ=Europe/Amsterdam
-    command: npm run test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,3 +10,25 @@ services:
     ipc: host
     ports:
       - "3001:80"
+  
+  lint-container:
+    build:
+      cache_from:
+        - docker-registry.data.amsterdam.nl/ois/signalsfrontend-base:acceptance
+      context: .
+      target: base
+    environment:
+      - CI=true
+      - TZ=Europe/Amsterdam
+    command: npm run lint
+
+  unittest-container:
+    build:
+      cache_from:
+        - docker-registry.data.amsterdam.nl/ois/signalsfrontend-base:acceptance
+      context: .
+      target: base
+    environment:
+      - CI=true
+      - TZ=Europe/Amsterdam
+    command: npm run test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     ipc: host
     ports:
       - "3001:80"
-  
+
   lint-container:
     build:
       cache_from:


### PR DESCRIPTION
This PR removes the test and lint stages from the `Jenkinsfile` as well as test and lint container settings in the `docker-compose.yml`. The stages aren't needed since they are covered by Github actions.