### PR TITLE
clears the user search filter when the clear button is pressed

### DIFF
--- a/src/signals/settings/users/Overview/__tests__/Overview.test.js
+++ b/src/signals/settings/users/Overview/__tests__/Overview.test.js
@@ -381,7 +381,7 @@ describe('signals/settings/users/containers/Overview', () => {
 
 
 
-  it('should remove reset the filter filter the search box is cleared ', async () => {
+  it('should remove reset the filter when the search box is cleared ', async () => {
     const { findByTestId } = render(usersOverviewWithAppContext());
 
     const filterByUserName = await findByTestId('filterUsersByUsername');

--- a/src/signals/settings/users/Overview/__tests__/Overview.test.js
+++ b/src/signals/settings/users/Overview/__tests__/Overview.test.js
@@ -379,6 +379,33 @@ describe('signals/settings/users/containers/Overview', () => {
     expect(dispatch).toHaveBeenCalledWith(setUserFilters({ username: filterValue }));
   });
 
+
+
+  it('should remove reset the filter filter the search box is cleared ', async () => {
+    const { findByTestId } = render(usersOverviewWithAppContext());
+
+    const filterByUserName = await findByTestId('filterUsersByUsername');
+    const filterByUserNameInput = filterByUserName.querySelector('input');
+    const filterValue = 'test1';
+
+    act(() => {
+      fireEvent.change(filterByUserNameInput, { target: { value: filterValue } });
+    });
+
+    await wait(() => resolveAfterMs(300));
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(dispatch).toHaveBeenCalledWith(setUserFilters({ username: filterValue }));
+
+    const clearButton = filterByUserName.querySelector('button[aria-label="Close"]');
+    act(() => {
+      fireEvent.click(clearButton);
+    });
+
+    await findByTestId('filterUsersByUsername');
+    expect(dispatch).toHaveBeenCalledTimes(2);
+    expect(dispatch).toHaveBeenLastCalledWith(setUserFilters({ username: '' }));
+  });
+
   it('should not dispatch filter values when input value has not changed', async () => {
     const username = 'foo bar baz';
     const stateCfg = { users: { filters: { username } } };

--- a/src/signals/settings/users/Overview/index.js
+++ b/src/signals/settings/users/Overview/index.js
@@ -75,16 +75,22 @@ const UsersOverviewContainer = () => {
     }
   }, [pageNumFromQueryString, page]);
 
-  const createOnChangeFilter = useCallback(
-    filter => event => {
-      const { value } = event.target;
-      if (filters[filter] === value) return;
-
+  const setUsernameFilter = useCallback(
+    value => {
       dispatch(setUserFilters({ username: value }));
       setPage(1);
       history.push(`${USERS_PAGED_URL}/1`);
     },
-    [dispatch, history, filters]
+    [dispatch, history]
+  );
+
+  const createOnChangeFilter = useCallback(
+    filter => event => {
+      const { value } = event.target;
+      if (filters[filter] === value) return;
+      setUsernameFilter(value);
+    },
+    [filters, setUsernameFilter]
   );
 
   const debouncedOnChangeFilter = useCallback(debounce(createOnChangeFilter('username'), 250), [createOnChangeFilter]);
@@ -159,6 +165,7 @@ const UsersOverviewContainer = () => {
                     event.persist();
                     debouncedOnChangeFilter(event);
                   }}
+                  onClear={() => setUsernameFilter('')}
                   value={filters.username}
                   data-testid="filterUsersByUsername"
                 />,


### PR DESCRIPTION
This PR fixes a bug in the UsersOverview. When the search filter was removed by clicking the clear button, no action was triggered. 
