### PR TITLE
[SIG-2565] fix backlink when navigating from the map overview

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/components/DetailHeader/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/DetailHeader/index.js
@@ -88,7 +88,9 @@ const DetailHeader = ({ incident, baseUrl, onPatchIncident }) => {
     },
   };
 
-  const referrer = location.referrer || `${baseUrl}/incidents`;
+  const mapOverviewLocation = '/manage/incidents/kaart';
+
+  const referrer = location.referrer === mapOverviewLocation ? mapOverviewLocation : `${baseUrl}/incidents`;
 
   return (
     <Header className="detail-header">

--- a/src/signals/incident-management/containers/IncidentDetail/components/DetailHeader/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/DetailHeader/index.js
@@ -89,7 +89,7 @@ const DetailHeader = ({ incident, baseUrl, onPatchIncident }) => {
     },
   };
 
-  const referrer = location.referrer === MAP_URL ? MAP_URL : `${baseUrl}/incidents`;
+  const referrer = location.referrer?.startsWith(MAP_URL) ? MAP_URL : `${baseUrl}/incidents`;
 
   return (
     <Header className="detail-header">

--- a/src/signals/incident-management/containers/IncidentDetail/components/DetailHeader/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/DetailHeader/index.js
@@ -6,6 +6,7 @@ import BackLink from 'components/BackLink';
 import { themeColor, themeSpacing, Heading, styles } from '@datapunt/asc-ui';
 import { PATCH_TYPE_THOR } from 'models/incident/constants';
 import Button from 'components/Button';
+import { MAP_URL } from 'signals/incident-management/routes';
 
 import { incidentType } from 'shared/types';
 
@@ -88,9 +89,7 @@ const DetailHeader = ({ incident, baseUrl, onPatchIncident }) => {
     },
   };
 
-  const mapOverviewLocation = '/manage/incidents/kaart';
-
-  const referrer = location.referrer === mapOverviewLocation ? mapOverviewLocation : `${baseUrl}/incidents`;
+  const referrer = location.referrer === MAP_URL ? MAP_URL : `${baseUrl}/incidents`;
 
   return (
     <Header className="detail-header">

--- a/src/signals/incident-management/containers/IncidentDetail/components/DetailHeader/index.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/DetailHeader/index.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import { withAppContext } from 'test/utils';
 import * as reactRouterDom from 'react-router-dom';
+import { MAP_URL } from 'signals/incident-management/routes';
 
 import DetailHeader from './index';
 
@@ -104,13 +105,12 @@ describe('<DetailHeader />', () => {
 
     expect(getByTestId('backlink').href).toEqual(expect.stringContaining(incidentsUrl));
 
-    const mapReferrer = '/manage/incidents/kaart';
     jest.spyOn(reactRouterDom, 'useLocation').mockImplementation(() => ({
-      referrer: mapReferrer,
+      referrer: MAP_URL,
     }));
 
     rerender(withAppContext(<DetailHeader {...props} />));
 
-    expect(getByTestId('backlink').href).toEqual(expect.stringContaining(mapReferrer));
+    expect(getByTestId('backlink').href).toEqual(expect.stringContaining(MAP_URL));
   });
 });

--- a/src/signals/incident-management/containers/IncidentDetail/components/DetailHeader/index.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/DetailHeader/index.test.js
@@ -91,8 +91,9 @@ describe('<DetailHeader />', () => {
 
   it('should render a link with the correct referrer', () => {
     const { getByTestId, rerender } = render(withAppContext(<DetailHeader {...props} />));
+    const incidentsUrl = `${props.baseUrl}/incidents`;
 
-    expect(getByTestId('backlink').href).toEqual(expect.stringContaining(`${props.baseUrl}/incidents`));
+    expect(getByTestId('backlink').href).toEqual(expect.stringContaining(incidentsUrl));
 
     const referrer = '/some-url';
     jest.spyOn(reactRouterDom, 'useLocation').mockImplementation(() => ({
@@ -101,6 +102,15 @@ describe('<DetailHeader />', () => {
 
     rerender(withAppContext(<DetailHeader {...props} />));
 
-    expect(getByTestId('backlink').href).toEqual(expect.stringContaining(referrer));
+    expect(getByTestId('backlink').href).toEqual(expect.stringContaining(incidentsUrl));
+
+    const mapReferrer = '/manage/incidents/kaart';
+    jest.spyOn(reactRouterDom, 'useLocation').mockImplementation(() => ({
+      referrer: mapReferrer,
+    }));
+
+    rerender(withAppContext(<DetailHeader {...props} />));
+
+    expect(getByTestId('backlink').href).toEqual(expect.stringContaining(mapReferrer));
   });
 });


### PR DESCRIPTION
This PR ensures that the back link in the incident detail always navigate to the incidents overview excepting the situation when the incident detail is opened from the overview map. In the last case the back link will return to the overview map of incidents

