### PR TITLE
[SIG-2659] DetailHeader main incident link

### DIFF
--- a/src/shared/types/index.js
+++ b/src/shared/types/index.js
@@ -268,10 +268,22 @@ export const permissionsType = PropTypes.arrayOf(PropTypes.shape({
   codename: PropTypes.string.isRequired,
 }));
 
-const linksType = PropTypes.shape({
+export const linksType = PropTypes.shape({
   self: PropTypes.shape({
     href: PropTypes.string.isRequired,
   }).isRequired,
+  'sia-attachments': PropTypes.shape({
+    href: PropTypes.string.isRequired,
+  }),
+  'sia-parent': PropTypes.shape({
+    href: PropTypes.string.isRequired,
+  }),
+  'sia-pdf': PropTypes.shape({
+    href: PropTypes.string.isRequired,
+  }),
+  'sia-children': PropTypes.arrayOf(PropTypes.shape({
+    href: PropTypes.string.isRequired,
+  })),
 }).isRequired;
 
 const userRolePermissionType = PropTypes.arrayOf(PropTypes.shape({
@@ -301,4 +313,3 @@ export const userType = PropTypes.shape({
     note: PropTypes.string,
   }),
 });
-

--- a/src/signals/incident-management/containers/IncidentDetail/components/DetailHeader/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/DetailHeader/index.js
@@ -2,13 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Link, useLocation } from 'react-router-dom';
-import BackLink from 'components/BackLink';
 import { themeColor, themeSpacing, Heading, styles } from '@datapunt/asc-ui';
+
+import BackLink from 'components/BackLink';
 import { PATCH_TYPE_THOR } from 'models/incident/constants';
 import Button from 'components/Button';
-import { MAP_URL } from 'signals/incident-management/routes';
-
-import { incidentType } from 'shared/types';
+import { MAP_URL, INCIDENT_URL, INCIDENTS_URL } from 'signals/incident-management/routes';
+import { linksType } from 'shared/types';
 
 import DownloadButton from './components/DownloadButton';
 
@@ -61,6 +61,16 @@ const HeadingContainer = styled.div`
   }
 `;
 
+const StyledHeading = styled(Heading)`
+  font-size: 16px;
+  margin: 0;
+
+  & > *:not(:first-child)::before {
+    content: ' / ';
+    white-space: pre;
+  }
+`;
+
 const ButtonLink = styled(Button)`
   color: ${themeColor('tint', 'level7')};
   text-decoration: none;
@@ -71,14 +81,18 @@ const ButtonLink = styled(Button)`
   }
 `;
 
-const DetailHeader = ({ incident, baseUrl, onPatchIncident }) => {
+const ParentLink = styled(Link)`
+  text-decoration: underline;
+  color: black;
+`;
+
+const DetailHeader = ({ status, incidentId, links, onPatchIncident }) => {
   const location = useLocation();
-  const status = incident?.status?.state;
-  const canSplit = status === 'm' && !(incident && (incident._links['sia:children'] || incident._links['sia:parent']));
+  const canSplit = status === 'm' && !(links?.['sia:children'] || links?.['sia:parent']);
   const canThor = ['m', 'i', 'b', 'h', 'send failed', 'reopened'].some(value => value === status);
-  const downloadLink = incident._links && incident._links['sia:pdf'] && incident._links['sia:pdf'].href;
+  const downloadLink = links?.['sia:pdf']?.href;
   const patch = {
-    id: incident.id,
+    id: incidentId,
     type: PATCH_TYPE_THOR,
     patch: {
       status: {
@@ -89,7 +103,8 @@ const DetailHeader = ({ incident, baseUrl, onPatchIncident }) => {
     },
   };
 
-  const referrer = location.referrer?.startsWith(MAP_URL) ? MAP_URL : `${baseUrl}/incidents`;
+  const referrer = location.referrer?.startsWith(MAP_URL) ? MAP_URL : INCIDENTS_URL;
+  const parentId = links?.['sia:parent']?.href?.split('/').pop();
 
   return (
     <Header className="detail-header">
@@ -98,9 +113,15 @@ const DetailHeader = ({ incident, baseUrl, onPatchIncident }) => {
       </BackLinkContainer>
 
       <HeadingContainer>
-        <Heading styleAs="h4" data-testid="detail-header-title">
-          Melding {incident.id}
-        </Heading>
+        <StyledHeading data-testid="detail-header-title">
+          Melding&nbsp;
+          {parentId && (
+            <ParentLink data-testid="parentLink" to={`${INCIDENT_URL}/${parentId}`}>
+              {parentId}
+            </ParentLink>
+          )}
+          <span>{incidentId}</span>
+        </StyledHeading>
       </HeadingContainer>
 
       <ButtonContainer>
@@ -108,7 +129,7 @@ const DetailHeader = ({ incident, baseUrl, onPatchIncident }) => {
           <ButtonLink
             variant="application"
             forwardedAs={Link}
-            to={`${baseUrl}/incident/${incident.id}/split`}
+            to={`${INCIDENT_URL}/${incidentId}/split`}
             data-testid="detail-header-button-split"
           >
             Splitsen
@@ -124,7 +145,7 @@ const DetailHeader = ({ incident, baseUrl, onPatchIncident }) => {
         <DownloadButton
           label="PDF"
           url={downloadLink}
-          filename={`SIA melding ${incident.id}.pdf`}
+          filename={`SIA melding ${incidentId}.pdf`}
           data-testid="detail-header-button-download"
         />
       </ButtonContainer>
@@ -133,9 +154,10 @@ const DetailHeader = ({ incident, baseUrl, onPatchIncident }) => {
 };
 
 DetailHeader.propTypes = {
-  incident: incidentType.isRequired,
-  baseUrl: PropTypes.string.isRequired,
+  incidentId: PropTypes.number.isRequired,
+  links: linksType,
   onPatchIncident: PropTypes.func.isRequired,
+  status: PropTypes.string.isRequired,
 };
 
 export default DetailHeader;

--- a/src/signals/incident-management/containers/IncidentDetail/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/index.js
@@ -172,8 +172,9 @@ export class IncidentDetail extends React.Component {
                 <Row>
                   <Column span={12}>
                     <DetailHeader
-                      incident={incident}
-                      baseUrl="/manage"
+                      incidentId={incident.id}
+                      status={incident?.status?.state}
+                      links={incident?._links}
                       onPatchIncident={onPatchIncident}
                     />
                   </Column>


### PR DESCRIPTION
This PR places a link to the main incident (whenever an incident has a parent) in the `DetailHeader` component on the incident detail page.