### PR TITLE
[SIG-2690] Remove wonen category

### DIFF
--- a/src/signals/incident/definitions/wizard-step-2-vulaan.js
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan.js
@@ -5,7 +5,6 @@ import overlastOpHetWater from './wizard-step-2-vulaan/overlast-op-het-water';
 import overlastVanDieren from './wizard-step-2-vulaan/overlast-van-dieren';
 import overlastPersonenEnGroepen from './wizard-step-2-vulaan/overlast-van-en-door-personen-of-groepen';
 import wegenVerkeerStraatmeubilair from './wizard-step-2-vulaan/wegen-verkeer-straatmeubilair';
-import wonen from './wizard-step-2-vulaan/wonen';
 
 export default {
   label: 'Dit hebben we nog van u nodig',
@@ -36,9 +35,6 @@ export default {
 
       case 'wegen-verkeer-straatmeubilair':
         return wegenVerkeerStraatmeubilair;
-
-      case 'wonen':
-        return wonen;
 
       default:
         return { controls: {} };


### PR DESCRIPTION
This PR removes the 'wonen' category questions from the incident submission form. Some parts are untested and need changes. To prevent errors in incident submissions, the safest bet is to temporarily remove the category altogether.