### PR TITLE
(Fix) Borken build

### DIFF
--- a/internals/webpack/template.js
+++ b/internals/webpack/template.js
@@ -1,14 +1,16 @@
 const fs = require('fs');
 const path = require('path');
-const config = require('../../environment.conf.json');
-
-const configPlaceholder = '$SIGNALS_CONFIG';
-const configString = JSON.stringify(config);
-const indexFile = path.join(__dirname, '..', '..', 'src', 'index.html');
 
 const template = {};
 
 if (process.env.NODE_ENV !== 'production') {
+  // eslint-disable-next-line
+  const config = require('../../environment.conf.json');
+
+  const configPlaceholder = '$SIGNALS_CONFIG';
+  const configString = JSON.stringify(config);
+  const indexFile = path.join(__dirname, '..', '..', 'src', 'index.html');
+
   template.templateContent = fs
     .readFileSync(indexFile)
     .toString()


### PR DESCRIPTION
This PR fixes the production build. The problem was that the production build was looking for a file (`environment.conf.json`) that wasn't present at the moment of execution.