### PR TITLE
[SIG-2748] Fix KTO form submission

### DIFF
--- a/src/signals/incident/components/form/RadioInputGroup/index.js
+++ b/src/signals/incident/components/form/RadioInputGroup/index.js
@@ -36,7 +36,7 @@ const RadioInputGroup = ({ handler, touched, hasError, meta, parent, getError, v
                 checked={handler().value.id === key}
                 id={key}
                 idAttr={`${meta.name}-${key + 1}`}
-                info={value.info}
+                info={value?.info}
                 key={key}
                 label={value.value || value}
                 name={meta.name}

--- a/src/signals/incident/containers/KtoContainer/components/RadioInputGroup/__snapshots__/index.test.js.snap
+++ b/src/signals/incident/containers/KtoContainer/components/RadioInputGroup/__snapshots__/index.test.js.snap
@@ -1,0 +1,67 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Form component <RadioInput /> rendering should render no radio field when not visible 1`] = `""`;
+
+exports[`Form component <RadioInput /> rendering should render radio fields correctly 1`] = `
+<RadioInputGroup__StyledHeader
+  getError={[MockFunction]}
+  hasError={[MockFunction]}
+  meta={
+    Object {
+      "isVisible": true,
+      "name": "input-field-name",
+      "placeholder": "type here",
+      "values": Object {
+        "bar": "Bar",
+        "foo": "Foo",
+      },
+    }
+  }
+  touched={false}
+>
+  <RadioGroup
+    name="input-field-name"
+  >
+    <Label
+      htmlFor="foo"
+      key="foo"
+      label="Foo"
+      noActiveState={false}
+    >
+      <ForwardRef
+        checked={true}
+        id="foo"
+        onChange={[Function]}
+      />
+    </Label>
+    <Label
+      htmlFor="bar"
+      key="bar"
+      label="Bar"
+      noActiveState={false}
+    >
+      <ForwardRef
+        checked={false}
+        id="bar"
+        onChange={[Function]}
+      />
+    </Label>
+  </RadioGroup>
+</RadioInputGroup__StyledHeader>
+`;
+
+exports[`Form component <RadioInput /> rendering should render zero radio fields when values are not supplied 1`] = `
+<RadioInputGroup__StyledHeader
+  getError={[MockFunction]}
+  hasError={[MockFunction]}
+  meta={
+    Object {
+      "isVisible": true,
+      "name": "input-field-name",
+      "placeholder": "type here",
+      "values": undefined,
+    }
+  }
+  touched={false}
+/>
+`;

--- a/src/signals/incident/containers/KtoContainer/components/RadioInputGroup/index.js
+++ b/src/signals/incident/containers/KtoContainer/components/RadioInputGroup/index.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+import isObject from 'lodash.isobject';
+import { Label, Radio, RadioGroup, themeSpacing } from '@datapunt/asc-ui';
+
+import Header from 'signals/incident/components/form/Header';
+
+const StyledHeader = styled(Header)`
+  margin-top: ${themeSpacing(5)};
+`;
+
+const RadioInputGroup = ({ handler, touched, hasError, meta, parent, getError, validatorsOrOpts }) => {
+  if (!meta?.isVisible) return null;
+
+  return (
+    <StyledHeader meta={meta} options={validatorsOrOpts} touched={touched} hasError={hasError} getError={getError}>
+      {meta.values && isObject(meta.values) && (
+        <RadioGroup name={meta.name}>
+          {Object.entries(meta.values).map(([key, value]) => (
+            <Label htmlFor={key} key={key} label={value.value || value}>
+              <Radio
+                checked={handler().value.id === key}
+                id={key}
+                onChange={() => {
+                  parent.meta.updateIncident({
+                    [meta.name]: {
+                      id: key,
+                      label: value.value || value,
+                      info: value.info,
+                    },
+                  });
+                }}
+              />
+            </Label>
+          ))}
+        </RadioGroup>
+      )}
+    </StyledHeader>
+  );
+};
+
+RadioInputGroup.propTypes = {
+  handler: PropTypes.func,
+  touched: PropTypes.bool,
+  getError: PropTypes.func.isRequired,
+  hasError: PropTypes.func.isRequired,
+  meta: PropTypes.object,
+  parent: PropTypes.object,
+  validatorsOrOpts: PropTypes.object,
+};
+
+export default RadioInputGroup;

--- a/src/signals/incident/containers/KtoContainer/components/RadioInputGroup/index.test.js
+++ b/src/signals/incident/containers/KtoContainer/components/RadioInputGroup/index.test.js
@@ -1,0 +1,86 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import RadioInput from './index';
+
+describe('Form component <RadioInput />', () => {
+  const metaFields = {
+    name: 'input-field-name',
+    placeholder: 'type here',
+    values: {
+      foo: 'Foo',
+      bar: 'Bar',
+    },
+  };
+  let wrapper;
+  let handler;
+  let touched;
+  let getError;
+  let hasError;
+  let parent;
+
+  beforeEach(() => {
+    handler = jest.fn();
+    touched = false;
+    getError = jest.fn();
+    hasError = jest.fn();
+    parent = {
+      meta: {
+        updateIncident: jest.fn(),
+      },
+    };
+
+    wrapper = shallow(
+      <RadioInput
+        handler={handler}
+        parent={parent}
+        touched={touched}
+        hasError={hasError}
+        getError={getError}
+      />
+    );
+
+    handler.mockImplementation(() => ({
+      value: {
+        id: 'foo',
+        label: 'Foo',
+      },
+    }));
+  });
+
+  describe('rendering', () => {
+    it('should render radio fields correctly', () => {
+      wrapper.setProps({
+        meta: {
+          ...metaFields,
+          isVisible: true,
+        },
+      });
+
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('should render zero radio fields when values are not supplied', () => {
+      wrapper.setProps({
+        meta: {
+          ...metaFields,
+          isVisible: true,
+          values: undefined,
+        },
+      });
+
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    it('should render no radio field when not visible', () => {
+      wrapper.setProps({
+        meta: {
+          ...metaFields,
+          isVisible: false,
+        },
+      });
+
+      expect(wrapper).toMatchSnapshot();
+    });
+  });
+});

--- a/src/signals/incident/definitions/kto.js
+++ b/src/signals/incident/definitions/kto.js
@@ -1,8 +1,8 @@
 /* eslint-disable react/prop-types */
 import React from 'react';
-
 import { Validators } from 'react-reactive-form';
 
+import RadioInputGroup from 'signals/incident/containers/KtoContainer/components/RadioInputGroup';
 import FormComponents from '../components/form';
 
 export default {
@@ -16,11 +16,9 @@ export default {
         },
         values: {}, // will be populated from endpoint
       },
-      render: FormComponents.RadioInputGroup,
+      render: RadioInputGroup,
       options: {
-        validators: [
-          Validators.required,
-        ],
+        validators: [Validators.required],
       },
     },
     tevreden_anders: {
@@ -42,11 +40,9 @@ export default {
         },
         values: {}, // will be populated from endpoint
       },
-      render: FormComponents.RadioInputGroup,
+      render: RadioInputGroup,
       options: {
-        validators: [
-          Validators.required,
-        ],
+        validators: [Validators.required],
       },
     },
     niet_tevreden_anders: {
@@ -65,9 +61,7 @@ export default {
         maxLength: 1000,
       },
       options: {
-        validators: [
-          Validators.maxLength(1000),
-        ],
+        validators: [Validators.maxLength(1000)],
       },
       render: FormComponents.TextareaInput,
     },


### PR DESCRIPTION
This PR contains a fix for the KTO form where the submit button wouldn't get out of its disabled state. This was caused by a previous PR that refactored the `RadioInputGroup` component, but didn't take into account that, in that component, the function `parent.meta.updateIncident` actually isn't `updateIncident` in the context of the KTO form, but is actually `updateKTO` 🙄 