### PR TITLE
[SIG-2712] Remove responsible department indicator

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/components/MetaList/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/MetaList/index.js
@@ -137,11 +137,6 @@ const MetaList = ({ incident, onEditStatus, onPatchIncident }) => {
         <dd data-testid="meta-list-main-category-value">{incident.category.main}</dd>
       </Highlight>
 
-      <Highlight subscribeTo={incident.category.departments} valueChanged={valueChanged}>
-        <dt data-testid="meta-list-department-definition">Verantwoordelijke afdeling</dt>
-        <dd data-testid="meta-list-department-value">{incident.category.departments}</dd>
-      </Highlight>
-
       <dt data-testid="meta-list-source-definition">Bron</dt>
       <dd data-testid="meta-list-source-value">{incident.source}</dd>
     </List>

--- a/src/signals/incident-management/containers/IncidentDetail/components/MetaList/index.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/MetaList/index.test.js
@@ -48,9 +48,6 @@ describe('<MetaList />', () => {
       expect(queryByTestId('meta-list-main-category-definition')).toHaveTextContent(/^Hoofdcategorie$/);
       expect(queryByTestId('meta-list-main-category-value')).toHaveTextContent(incidentJson.category.main);
 
-      expect(queryByTestId('meta-list-department-definition')).toHaveTextContent(/^Verantwoordelijke afdeling$/);
-      expect(queryByTestId('meta-list-department-value')).toHaveTextContent(incidentJson.category.departments);
-
       expect(queryByTestId('meta-list-source-definition')).toHaveTextContent(/^Bron$/);
       expect(queryByTestId('meta-list-source-value')).toHaveTextContent(incidentJson.source);
     });


### PR DESCRIPTION
This PR removes the department name from the incident detail `MetaList` component since its going to be displayed as part of the subcategory name.