### PR TITLE
[SIG-2750] Fix for error in summary page

### DIFF
--- a/src/signals/incident/components/IncidentPreview/components/ListObjectValue/__tests__/ListObjectValue.test.js
+++ b/src/signals/incident/components/IncidentPreview/components/ListObjectValue/__tests__/ListObjectValue.test.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { withAppContext } from 'test/utils';
+
+import ListObjectValue from '..';
+
+describe('signals/incident/components/ListObjectValue', () => {
+  /* eslint-disable no-console */
+  beforeEach(() => {
+    console.error = jest.fn();
+  });
+
+  afterEach(() => {
+    console.error.mockRestore();
+  });
+
+  it('returns a list', () => {
+    const value = [
+      { label: 'Foo' },
+      { label: 'Bar' },
+      { label: 'Baz' },
+    ];
+
+    const { container } = render(withAppContext(<ListObjectValue value={value} />));
+
+    expect(container.querySelector('ul')).toBeInTheDocument();
+    expect(container.querySelectorAll('li')).toHaveLength(3);
+  });
+
+  it('renders only valid entries', () => {
+    const value = [
+      { label: 'Foo' },
+      { labl: 'Bar' },
+      { lael: 'Baz' },
+    ];
+
+    const { container } = render(withAppContext(<ListObjectValue value={value} />));
+
+    expect(container.querySelector('ul')).toBeInTheDocument();
+    expect(container.querySelectorAll('li')).toHaveLength(1);
+  });
+
+  it('renders nothing when the value prop is an empty array', () => {
+    const { container } = render(withAppContext(<ListObjectValue value={[]} />));
+
+    expect(container.querySelector('ul')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when the value prop is not an array', () => {
+    const { container } = render(withAppContext(<ListObjectValue value={{}} />));
+
+    expect(container.querySelector('ul')).not.toBeInTheDocument();
+  });
+});

--- a/src/signals/incident/components/IncidentPreview/components/ListObjectValue/index.js
+++ b/src/signals/incident/components/IncidentPreview/components/ListObjectValue/index.js
@@ -7,13 +7,17 @@ const StyledList = styled(List)`
   margin-bottom: 0;
 `;
 
-const ListObjectValue = ({ value }) => (
-  <StyledList>
-    {value?.map(item => (
-      <ListItem key={item.label}>{item.label}</ListItem>
-    ))}
-  </StyledList>
-);
+const ListObjectValue = ({ value }) =>
+  Array.isArray(value) &&
+  value.length > 0 && (
+    <StyledList>
+      {value
+        .filter(({ label }) => Boolean(label))
+        .map(item => (
+          <ListItem key={item.label}>{item.label}</ListItem>
+        ))}
+    </StyledList>
+  );
 
 ListObjectValue.propTypes = {
   value: PropTypes.arrayOf(


### PR DESCRIPTION
This PR fixes an error in the incident submission summary page where a checkbox value was evaluated as if it was an array of objects. 