### PR TITLE
(Chore) Lazy load wizard definition

### DIFF
--- a/src/signals/incident/components/IncidentWizard/index.js
+++ b/src/signals/incident/components/IncidentWizard/index.js
@@ -20,7 +20,7 @@ const IncidentWizard = ({ wizardDefinition, getClassification, updateIncident, c
   const incident = useMemo(() => incidentContainer.incident, [incidentContainer.incident]);
 
   return (
-    <div className="incident-wizard">
+    <div data-testid="incidentWizard" className="incident-wizard">
       <Route
         render={({ history }) => (
           <Wizard history={history} onNext={wiz => onNext(wizardDefinition, wiz, incident)}>

--- a/src/signals/incident/containers/IncidentContainer/index.test.js
+++ b/src/signals/incident/containers/IncidentContainer/index.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, act } from '@testing-library/react';
 
 import { withAppContext } from 'test/utils';
 import { IncidentContainerComponent } from '.';
@@ -19,10 +19,18 @@ describe('signals/incident/containers/IncidentContainer', () => {
     createIncidentAction: jest.fn(),
   };
 
-  it('should render correctly', () => {
-    const { getByTestId } = render(withAppContext(<IncidentContainerComponent {...props} />));
+  it('should load wizard definition lazily', async () => {
+    const { queryByTestId, getByTestId, findByTestId } = render(withAppContext(<IncidentContainerComponent {...props} />));
 
     expect(getByTestId('alertMessage')).toBeInTheDocument();
-    expect(getByTestId('incidentWizard')).toBeInTheDocument();
+    expect(queryByTestId('incidentWizard')).not.toBeInTheDocument();
+
+    let incidentWizard;
+
+    await act(async () => {
+      incidentWizard = await findByTestId('incidentWizard');
+    });
+
+    expect(incidentWizard).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
This PR contains changes that load the wizard's definition files in a lazy fashion. I noticed that the code inside the definition files gets executed in every module that is loaded in the application. For instance, when loading one of the settings pages, the entire wizard definition is imported and its code gets executed, even though that code is unrelated to said settings page.

The solution is to lazy load the definitions module, so that only when the `Incident` container is loaded, the definitions file is loaded as well.