### PR TITLE
(Chore) Add space

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/components/MetaList/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/MetaList/index.js
@@ -45,7 +45,7 @@ const EditButton = styled(Button)`
 `;
 
 export const getCategoryName = ({ name, departments }) => {
-  const departmensStringList = departments?.length ? ` (${departments.map(({ code }) => code).join(',')})` : '';
+  const departmensStringList = departments?.length ? ` (${departments.map(({ code }) => code).join(', ')})` : '';
   return `${name}${departmensStringList}`;
 };
 

--- a/src/signals/incident-management/containers/IncidentDetail/components/MetaList/index.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/MetaList/index.test.js
@@ -97,7 +97,7 @@ describe('<MetaList />', () => {
         ],
       };
 
-      expect(getCategoryName(category)).toEqual('Foo (Bar,Baz)');
+      expect(getCategoryName(category)).toEqual('Foo (Bar, Baz)');
     });
   });
 });

--- a/src/signals/incident-management/containers/IncidentDetail/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/index.js
@@ -11,7 +11,6 @@ import { incidentType, dataListType, defaultTextsType, attachmentsType, historyT
 
 import LoadingIndicator from 'shared/components/LoadingIndicator';
 import { makeSelectLoading, makeSelectError } from 'containers/App/selectors';
-import { makeSelectSubCategories } from 'models/categories/selectors';
 import {
   requestIncident,
   patchIncident,
@@ -130,7 +129,6 @@ export class IncidentDetail extends React.Component {
       match: {
         params: { id },
       },
-      subCategories,
       onPatchIncident,
       onDismissError,
     } = this.props;
@@ -242,12 +240,11 @@ export class IncidentDetail extends React.Component {
                   </DetailContainer>
 
                   <DetailContainer span={4} push={1}>
-                    {incident && subCategories && (
+                    {incident && (
                       <MetaList
                         incident={incident}
                         priorityList={priorityList}
                         typesList={typesList}
-                        subcategories={subCategories}
                         onPatchIncident={onPatchIncident}
                         onEditStatus={this.onEditStatus}
                       />
@@ -293,7 +290,6 @@ IncidentDetail.propTypes = {
   historyModel: PropTypes.shape({
     list: historyType.isRequired,
   }).isRequired,
-  subCategories: dataListType,
 
   match: PropTypes.shape({
     params: PropTypes.shape({
@@ -315,7 +311,6 @@ const mapStateToProps = () =>
     loading: makeSelectLoading(),
     error: makeSelectError(),
     incidentModel: makeSelectIncidentModel,
-    subCategories: makeSelectSubCategories,
     historyModel: makeSelectHistoryModel(),
   });
 


### PR DESCRIPTION
This PR:
- adds a space between the department names that are shown behind the selected category name in the incident detail page
- removes the unused `makeSelectSubCategories` selector from the `IncidentDetail` container