### PR TITLE
[SIG-1741] minor fix for empty predictions in the incident form

### DIFF
--- a/src/signals/incident/components/form/DescriptionWithClassificationInput/index.js
+++ b/src/signals/incident/components/form/DescriptionWithClassificationInput/index.js
@@ -7,7 +7,7 @@ import Header from '../Header';
 import './style.scss';
 
 function get(e, meta, parent) {
-  parent.meta.getClassification(e.target.value);
+  if(e.target.value) parent.meta.getClassification(e.target.value);
   parent.meta.updateIncident({ [meta.name]: e.target.value });
 }
 

--- a/src/signals/incident/components/form/DescriptionWithClassificationInput/index.test.js
+++ b/src/signals/incident/components/form/DescriptionWithClassificationInput/index.test.js
@@ -107,5 +107,20 @@ describe('Form component <DescriptionWithClassificationInput />', () => {
         'input-field-name': 'diabolo',
       });
     });
+
+    it('doesn\'t call the predictions for empty values', () => {
+      wrapper.setProps({
+        meta: {
+          ...metaFields,
+          isVisible: true,
+        },
+      });
+
+      wrapper.find(TextArea).simulate('blur', { target: { value: '' } });
+      expect(parent.meta.getClassification).not.toHaveBeenCalled();
+      expect(parent.meta.updateIncident).toHaveBeenCalledWith({
+        'input-field-name': '',
+      });
+    });
   });
 });


### PR DESCRIPTION
This PR prevents that an unnecessary api prediction call is made when the decription text area is left empty in the IncidentForm 

