### PR TITLE
[SIG-2778] Show information sharing option in incident detail

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/components/Detail/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/Detail/index.js
@@ -82,6 +82,9 @@ const Detail = ({ incident, attachments, onShowLocation, onEditLocation, onShowA
 
         <dt data-testid="detail-phone-definition">Telefoon melder</dt>
         <dd data-testid="detail-phone-value">{incident.reporter.phone}</dd>
+
+        <dt data-testid="detail-sharing-definition">Toestemming contactgegevens delen</dt>
+        <dd data-testid="detail-sharing-value">{incident.reporter.sharing_allowed ? 'Ja' : 'Nee'}</dd>
       </DefinitionList>
     </Wrapper>
   );

--- a/src/signals/incident-management/containers/IncidentDetail/components/Detail/index.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/Detail/index.test.js
@@ -11,6 +11,7 @@ describe('<Detail />', () => {
       reporter: {
         email: 'steve@apple.com',
         phone: '098754321',
+        sharing_allowed: true,
       },
       location: {
         address: {
@@ -68,6 +69,8 @@ describe('<Detail />', () => {
     expect(queryByTestId('detail-email-value')).toHaveTextContent(props.incident.reporter.email);
     expect(queryByTestId('detail-phone-definition')).toHaveTextContent(/^Telefoon melder$/);
     expect(queryByTestId('detail-phone-value')).toHaveTextContent(props.incident.reporter.phone);
+    expect(queryByTestId('detail-sharing-definition')).toHaveTextContent('Toestemming contactgegevens delen');
+    expect(queryByTestId('detail-sharing-value')).toHaveTextContent('Ja');
 
     expect(getByText(props.incident.extra_properties[0].label)).toBeInTheDocument();
     expect(getByText(props.incident.extra_properties[1].label)).toBeInTheDocument();


### PR DESCRIPTION
This PR adds the rendering of the `sharing_allowed` prop to the `IncidentDetail` `Detail` component