### PR TITLE
[SIG-2786] Show only responsible departments

### DIFF
--- a/src/signals/incident-management/components/RadioInput/index.js
+++ b/src/signals/incident-management/components/RadioInput/index.js
@@ -35,7 +35,7 @@ const RadioInput = ({ name, display, values }) => {
             {values?.map(({ key, value }) => (
               <StyledLabel key={key} label={value}>
                 <Radio
-                  defaultChecked={current === key}
+                  checked={current === key}
                   id={`${name}-${key}`}
                   data-testid={`${name}-${key}`}
                   {...handler('radio', key)}

--- a/src/signals/incident-management/containers/IncidentDetail/components/MetaList/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/MetaList/index.js
@@ -5,7 +5,7 @@ import { useSelector } from 'react-redux';
 import { Button, themeColor, themeSpacing } from '@datapunt/asc-ui';
 
 import { string2date, string2time } from 'shared/services/string-parser/string-parser';
-import {  makeSelectSubCategories } from 'models/categories/selectors';
+import { makeSelectSubCategories } from 'models/categories/selectors';
 import { typesList, priorityList } from 'signals/incident-management/definitions';
 
 import { incidentType } from 'shared/types';
@@ -45,19 +45,21 @@ const EditButton = styled(Button)`
 `;
 
 export const getCategoryName = ({ name, departments }) => {
-  const departmensStringList = departments?.length ? ` (${departments.map(({ code }) => code).join(', ')})` : '';
+  const departmensStringList = departments?.length > 0 ? ` (${departments.filter(({ is_responsible }) => is_responsible).map(({ code }) => code).join(', ')})` : '';
   return `${name}${departmensStringList}`;
 };
 
 const MetaList = ({ incident, onEditStatus, onPatchIncident }) => {
   const [valueChanged, setValueChanged] = useState(false);
   const subcategories = useSelector(makeSelectSubCategories);
-  const subcategoryOptions = useMemo(() => subcategories?.map(
-    category => ({
-      ...category,
-      value: getCategoryName(category),
-    })
-  ), [subcategories]);
+  const subcategoryOptions = useMemo(
+    () =>
+      subcategories?.map(category => ({
+        ...category,
+        value: getCategoryName(category),
+      })),
+    [subcategories]
+  );
 
   const subcatHighlightDisabled = ![
     'm',
@@ -90,7 +92,14 @@ const MetaList = ({ incident, onEditStatus, onPatchIncident }) => {
 
       <Highlight subscribeTo={incident.status.state} valueChanged={valueChanged}>
         <dt data-testid="meta-list-status-definition">
-          <EditButton data-testid="editStatusButton" icon={<IconEdit />} iconSize={18} variant="application" type="button" onClick={onEditStatus} />
+          <EditButton
+            data-testid="editStatusButton"
+            icon={<IconEdit />}
+            iconSize={18}
+            variant="application"
+            type="button"
+            onClick={onEditStatus}
+          />
           Status
         </dt>
         <dd className="alert" data-testid="meta-list-status-value">

--- a/src/signals/incident-management/containers/IncidentDetail/components/MetaList/index.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/MetaList/index.test.js
@@ -96,12 +96,12 @@ describe('<MetaList />', () => {
       const category = {
         name: 'Foo',
         departments:[
-          { code: 'Bar' },
-          { code: 'Baz' },
+          { code: 'Bar', is_responsible: true },
+          { code: 'Baz', is_responsible: false },
         ],
       };
 
-      expect(getCategoryName(category)).toEqual('Foo (Bar, Baz)');
+      expect(getCategoryName(category)).toEqual('Foo (Bar)');
     });
   });
 });


### PR DESCRIPTION
This PR contains changes that make sure that only departments that are responsible for handling incidents that are categorized by specific categories, are shown behind the subcategory name in the select element in the incident detail page.

Note that this PR also contains a change to an unrelated component `RadioInput`, because of a warning in the Jest output about the use of both `checked` and `defaultChecked` props on that component.