### PR TITLE
(Chore) Fix toggling sharing checkbox

### DIFF
--- a/src/signals/incident/containers/IncidentContainer/saga.js
+++ b/src/signals/incident/containers/IncidentContainer/saga.js
@@ -111,12 +111,10 @@ export function* getPostData(action) {
     handling_message,
   };
 
-  if (primedPostData.reporter?.sharing_allowed?.value) {
-    primedPostData.reporter = {
-      ...primedPostData.reporter,
-      sharing_allowed: primedPostData.reporter.sharing_allowed.value,
-    };
-  }
+  primedPostData.reporter = {
+    ...primedPostData.reporter,
+    sharing_allowed: primedPostData.reporter?.sharing_allowed?.value || false,
+  };
 
   const validFields = [
     'category',

--- a/src/signals/incident/containers/IncidentContainer/saga.test.js
+++ b/src/signals/incident/containers/IncidentContainer/saga.test.js
@@ -160,6 +160,9 @@ describe('IncidentContainer saga', () => {
         category: {
           sub_category,
         },
+        reporter: {
+          sharing_allowed: false,
+        },
       };
 
       const mapControlsToParamsResponse = {
@@ -193,6 +196,9 @@ describe('IncidentContainer saga', () => {
         handling_message,
         category: {
           sub_category,
+        },
+        reporter: {
+          sharing_allowed: false,
         },
       };
 
@@ -228,6 +234,9 @@ describe('IncidentContainer saga', () => {
         },
         type: {
           code: payloadIncident.type.id,
+        },
+        reporter: {
+          sharing_allowed: false,
         },
       };
 


### PR DESCRIPTION
This PR contains a fix for an issue where the 'sharing allowed' checkbox would be ticked and unticked, the value passed on to the API would be of an unsupported format. By conditional chaining and falling back to 'false' this issue is resolved.