### PR TITLE
[SIG-2775] update asc packages

### DIFF
--- a/internals/webpack/webpack.base.babel.js
+++ b/internals/webpack/webpack.base.babel.js
@@ -4,6 +4,7 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
 const devMode = process.env.NODE_ENV !== 'production';
+const __rootdir = process.cwd();
 
 module.exports = options => ({
   mode: options.mode,
@@ -17,7 +18,7 @@ module.exports = options => ({
   // eslint-disable-next-line prefer-object-spread
   output: Object.assign(
     {
-      path: path.resolve(process.cwd(), 'build'),
+      path: path.resolve(__rootdir, 'build'),
       publicPath: '/',
     },
     options.output
@@ -138,6 +139,10 @@ module.exports = options => ({
     modules: ['node_modules', 'src'],
     extensions: ['.js', '.jsx', '.react.js'],
     mainFields: ['browser', 'jsnext:main', 'main'],
+    alias: {
+      '@datapunt/asc-ui': path.resolve(__rootdir, 'node_modules/@datapunt/asc-ui/lib'),
+      '@datapunt/asc-assets': path.resolve(__rootdir, 'node_modules/@datapunt/asc-assets/lib'),
+    },
   },
   devtool: options.devtool,
   target: 'web', // Make web variables accessible to webpack, e.g. window

--- a/internals/webpack/webpack.base.babel.js
+++ b/internals/webpack/webpack.base.babel.js
@@ -139,10 +139,6 @@ module.exports = options => ({
     modules: ['node_modules', 'src'],
     extensions: ['.js', '.jsx', '.react.js'],
     mainFields: ['browser', 'jsnext:main', 'main'],
-    alias: {
-      '@datapunt/asc-ui': path.resolve(__rootdir, 'node_modules/@datapunt/asc-ui/lib'),
-      '@datapunt/asc-assets': path.resolve(__rootdir, 'node_modules/@datapunt/asc-assets/lib'),
-    },
   },
   devtool: options.devtool,
   target: 'web', // Make web variables accessible to webpack, e.g. window

--- a/package-lock.json
+++ b/package-lock.json
@@ -106,6 +106,7 @@
       "version": "7.10.1",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.10.1.tgz",
       "integrity": "sha512-u8XiZ6sMXW/gPmoP5ijonSUln4unazG291X0XAQ5h0s8qnAFr6BRRZGUEK+jtRWdmB0NTJQt7Uga25q8GetIIg==",
+      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.1",
         "@babel/generator": "^7.10.1",
@@ -129,6 +130,7 @@
           "version": "7.10.1",
           "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.1.tgz",
           "integrity": "sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==",
+          "dev": true,
           "requires": {
             "@babel/highlight": "^7.10.1"
           }
@@ -137,6 +139,7 @@
           "version": "7.10.1",
           "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.1.tgz",
           "integrity": "sha512-AT0YPLQw9DI21tliuJIdplVfLHya6mcGa8ctkv7n4Qv+hYacJrKmNWIteAK1P9iyLikFIAkwqJ7HAOqIDLFfgA==",
+          "dev": true,
           "requires": {
             "@babel/types": "^7.10.1",
             "jsesc": "^2.5.1",
@@ -148,6 +151,7 @@
           "version": "7.10.1",
           "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.1.tgz",
           "integrity": "sha512-fcpumwhs3YyZ/ttd5Rz0xn0TpIwVkN7X0V38B9TWNfVF42KEkhkAAuPCQ3oXmtTRtiPJrmZ0TrfS0GKF0eMaRQ==",
+          "dev": true,
           "requires": {
             "@babel/helper-get-function-arity": "^7.10.1",
             "@babel/template": "^7.10.1",
@@ -158,6 +162,7 @@
           "version": "7.10.1",
           "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.1.tgz",
           "integrity": "sha512-F5qdXkYGOQUb0hpRaPoetF9AnsXknKjWMZ+wmsIRsp5ge5sFh4c3h1eH2pRTTuy9KKAA2+TTYomGXAtEL2fQEw==",
+          "dev": true,
           "requires": {
             "@babel/types": "^7.10.1"
           }
@@ -166,6 +171,7 @@
           "version": "7.10.1",
           "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.1.tgz",
           "integrity": "sha512-UQ1LVBPrYdbchNhLwj6fetj46BcFwfS4NllJo/1aJsT+1dLTEnXJL0qHqtY7gPzF8S2fXBJamf1biAXV3X077g==",
+          "dev": true,
           "requires": {
             "@babel/types": "^7.10.1"
           }
@@ -174,6 +180,7 @@
           "version": "7.10.1",
           "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.1.tgz",
           "integrity": "sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==",
+          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.1",
             "chalk": "^2.0.0",
@@ -183,12 +190,14 @@
         "@babel/parser": {
           "version": "7.10.1",
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.1.tgz",
-          "integrity": "sha512-AUTksaz3FqugBkbTZ1i+lDLG5qy8hIzCaAxEtttU6C0BtZZU9pkNZtWSVAht4EW9kl46YBiyTGMp9xTTGqViNg=="
+          "integrity": "sha512-AUTksaz3FqugBkbTZ1i+lDLG5qy8hIzCaAxEtttU6C0BtZZU9pkNZtWSVAht4EW9kl46YBiyTGMp9xTTGqViNg==",
+          "dev": true
         },
         "@babel/template": {
           "version": "7.10.1",
           "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.1.tgz",
           "integrity": "sha512-OQDg6SqvFSsc9A0ej6SKINWrpJiNonRIniYondK2ViKhB06i3c0s+76XUft71iqBEe9S1OKsHwPAjfHnuvnCig==",
+          "dev": true,
           "requires": {
             "@babel/code-frame": "^7.10.1",
             "@babel/parser": "^7.10.1",
@@ -199,6 +208,7 @@
           "version": "7.10.1",
           "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.1.tgz",
           "integrity": "sha512-C/cTuXeKt85K+p08jN6vMDz8vSV0vZcI0wmQ36o6mjbuo++kPMdpOYw23W2XH04dbRt9/nMEfA4W3eR21CD+TQ==",
+          "dev": true,
           "requires": {
             "@babel/code-frame": "^7.10.1",
             "@babel/generator": "^7.10.1",
@@ -215,6 +225,7 @@
           "version": "7.10.1",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.1.tgz",
           "integrity": "sha512-L2yqUOpf3tzlW9GVuipgLEcZxnO+96SzR6fjXMuxxNkIgFJ5+07mHCZ+HkHqaeZu8+3LKnNJJ1bKbjBETQAsrA==",
+          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.1",
             "lodash": "^4.17.13",
@@ -225,6 +236,7 @@
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -235,6 +247,7 @@
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
           "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.1"
           }
@@ -243,6 +256,7 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -251,6 +265,7 @@
           "version": "2.1.3",
           "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
           "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+          "dev": true,
           "requires": {
             "minimist": "^1.2.5"
           }
@@ -258,7 +273,8 @@
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
         }
       }
     },
@@ -885,6 +901,7 @@
       "version": "7.10.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.1.tgz",
       "integrity": "sha512-u7XLXeM2n50gb6PWJ9hoO5oO7JFPaZtrh35t8RqKLT1jFKj9IWeD1zrcrYp1q1qiZTdEarfDWfTIP8nGsu0h5g==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.10.1"
       },
@@ -893,6 +910,7 @@
           "version": "7.10.1",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.1.tgz",
           "integrity": "sha512-L2yqUOpf3tzlW9GVuipgLEcZxnO+96SzR6fjXMuxxNkIgFJ5+07mHCZ+HkHqaeZu8+3LKnNJJ1bKbjBETQAsrA==",
+          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.1",
             "lodash": "^4.17.13",
@@ -913,6 +931,7 @@
       "version": "7.10.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.10.1.tgz",
       "integrity": "sha512-RLHRCAzyJe7Q7sF4oy2cB+kRnU4wDZY/H2xJFGof+M+SJEGhZsb+GFj5j1AD8NiSaVBJ+Pf0/WObiXu/zxWpFg==",
+      "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.10.1",
         "@babel/helper-replace-supers": "^7.10.1",
@@ -927,6 +946,7 @@
           "version": "7.10.1",
           "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.1.tgz",
           "integrity": "sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==",
+          "dev": true,
           "requires": {
             "@babel/highlight": "^7.10.1"
           }
@@ -935,6 +955,7 @@
           "version": "7.10.1",
           "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.1.tgz",
           "integrity": "sha512-SFxgwYmZ3HZPyZwJRiVNLRHWuW2OgE5k2nrVs6D9Iv4PPnXVffuEHy83Sfx/l4SqF+5kyJXjAyUmrG7tNm+qVg==",
+          "dev": true,
           "requires": {
             "@babel/types": "^7.10.1"
           }
@@ -943,6 +964,7 @@
           "version": "7.10.1",
           "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.1.tgz",
           "integrity": "sha512-UQ1LVBPrYdbchNhLwj6fetj46BcFwfS4NllJo/1aJsT+1dLTEnXJL0qHqtY7gPzF8S2fXBJamf1biAXV3X077g==",
+          "dev": true,
           "requires": {
             "@babel/types": "^7.10.1"
           }
@@ -951,6 +973,7 @@
           "version": "7.10.1",
           "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.1.tgz",
           "integrity": "sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==",
+          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.1",
             "chalk": "^2.0.0",
@@ -960,12 +983,14 @@
         "@babel/parser": {
           "version": "7.10.1",
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.1.tgz",
-          "integrity": "sha512-AUTksaz3FqugBkbTZ1i+lDLG5qy8hIzCaAxEtttU6C0BtZZU9pkNZtWSVAht4EW9kl46YBiyTGMp9xTTGqViNg=="
+          "integrity": "sha512-AUTksaz3FqugBkbTZ1i+lDLG5qy8hIzCaAxEtttU6C0BtZZU9pkNZtWSVAht4EW9kl46YBiyTGMp9xTTGqViNg==",
+          "dev": true
         },
         "@babel/template": {
           "version": "7.10.1",
           "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.1.tgz",
           "integrity": "sha512-OQDg6SqvFSsc9A0ej6SKINWrpJiNonRIniYondK2ViKhB06i3c0s+76XUft71iqBEe9S1OKsHwPAjfHnuvnCig==",
+          "dev": true,
           "requires": {
             "@babel/code-frame": "^7.10.1",
             "@babel/parser": "^7.10.1",
@@ -976,6 +1001,7 @@
           "version": "7.10.1",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.1.tgz",
           "integrity": "sha512-L2yqUOpf3tzlW9GVuipgLEcZxnO+96SzR6fjXMuxxNkIgFJ5+07mHCZ+HkHqaeZu8+3LKnNJJ1bKbjBETQAsrA==",
+          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.1",
             "lodash": "^4.17.13",
@@ -986,6 +1012,7 @@
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -998,6 +1025,7 @@
       "version": "7.10.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.1.tgz",
       "integrity": "sha512-a0DjNS1prnBsoKx83dP2falChcs7p3i8VMzdrSbfLhuQra/2ENC4sbri34dz/rWmDADsmF1q5GbfaXydh0Jbjg==",
+      "dev": true,
       "requires": {
         "@babel/types": "^7.10.1"
       },
@@ -1006,6 +1034,7 @@
           "version": "7.10.1",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.1.tgz",
           "integrity": "sha512-L2yqUOpf3tzlW9GVuipgLEcZxnO+96SzR6fjXMuxxNkIgFJ5+07mHCZ+HkHqaeZu8+3LKnNJJ1bKbjBETQAsrA==",
+          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.1",
             "lodash": "^4.17.13",
@@ -1189,6 +1218,7 @@
       "version": "7.10.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.1.tgz",
       "integrity": "sha512-SOwJzEfpuQwInzzQJGjGaiG578UYmyi2Xw668klPWV5n07B73S0a9btjLk/52Mlcxa+5AdIYqws1KyXRfMoB7A==",
+      "dev": true,
       "requires": {
         "@babel/helper-member-expression-to-functions": "^7.10.1",
         "@babel/helper-optimise-call-expression": "^7.10.1",
@@ -1200,6 +1230,7 @@
           "version": "7.10.1",
           "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.1.tgz",
           "integrity": "sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==",
+          "dev": true,
           "requires": {
             "@babel/highlight": "^7.10.1"
           }
@@ -1208,6 +1239,7 @@
           "version": "7.10.1",
           "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.1.tgz",
           "integrity": "sha512-AT0YPLQw9DI21tliuJIdplVfLHya6mcGa8ctkv7n4Qv+hYacJrKmNWIteAK1P9iyLikFIAkwqJ7HAOqIDLFfgA==",
+          "dev": true,
           "requires": {
             "@babel/types": "^7.10.1",
             "jsesc": "^2.5.1",
@@ -1219,6 +1251,7 @@
           "version": "7.10.1",
           "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.1.tgz",
           "integrity": "sha512-fcpumwhs3YyZ/ttd5Rz0xn0TpIwVkN7X0V38B9TWNfVF42KEkhkAAuPCQ3oXmtTRtiPJrmZ0TrfS0GKF0eMaRQ==",
+          "dev": true,
           "requires": {
             "@babel/helper-get-function-arity": "^7.10.1",
             "@babel/template": "^7.10.1",
@@ -1229,6 +1262,7 @@
           "version": "7.10.1",
           "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.1.tgz",
           "integrity": "sha512-F5qdXkYGOQUb0hpRaPoetF9AnsXknKjWMZ+wmsIRsp5ge5sFh4c3h1eH2pRTTuy9KKAA2+TTYomGXAtEL2fQEw==",
+          "dev": true,
           "requires": {
             "@babel/types": "^7.10.1"
           }
@@ -1237,6 +1271,7 @@
           "version": "7.10.1",
           "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.1.tgz",
           "integrity": "sha512-UQ1LVBPrYdbchNhLwj6fetj46BcFwfS4NllJo/1aJsT+1dLTEnXJL0qHqtY7gPzF8S2fXBJamf1biAXV3X077g==",
+          "dev": true,
           "requires": {
             "@babel/types": "^7.10.1"
           }
@@ -1245,6 +1280,7 @@
           "version": "7.10.1",
           "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.1.tgz",
           "integrity": "sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==",
+          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.1",
             "chalk": "^2.0.0",
@@ -1254,12 +1290,14 @@
         "@babel/parser": {
           "version": "7.10.1",
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.1.tgz",
-          "integrity": "sha512-AUTksaz3FqugBkbTZ1i+lDLG5qy8hIzCaAxEtttU6C0BtZZU9pkNZtWSVAht4EW9kl46YBiyTGMp9xTTGqViNg=="
+          "integrity": "sha512-AUTksaz3FqugBkbTZ1i+lDLG5qy8hIzCaAxEtttU6C0BtZZU9pkNZtWSVAht4EW9kl46YBiyTGMp9xTTGqViNg==",
+          "dev": true
         },
         "@babel/template": {
           "version": "7.10.1",
           "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.1.tgz",
           "integrity": "sha512-OQDg6SqvFSsc9A0ej6SKINWrpJiNonRIniYondK2ViKhB06i3c0s+76XUft71iqBEe9S1OKsHwPAjfHnuvnCig==",
+          "dev": true,
           "requires": {
             "@babel/code-frame": "^7.10.1",
             "@babel/parser": "^7.10.1",
@@ -1270,6 +1308,7 @@
           "version": "7.10.1",
           "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.1.tgz",
           "integrity": "sha512-C/cTuXeKt85K+p08jN6vMDz8vSV0vZcI0wmQ36o6mjbuo++kPMdpOYw23W2XH04dbRt9/nMEfA4W3eR21CD+TQ==",
+          "dev": true,
           "requires": {
             "@babel/code-frame": "^7.10.1",
             "@babel/generator": "^7.10.1",
@@ -1286,6 +1325,7 @@
           "version": "7.10.1",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.1.tgz",
           "integrity": "sha512-L2yqUOpf3tzlW9GVuipgLEcZxnO+96SzR6fjXMuxxNkIgFJ5+07mHCZ+HkHqaeZu8+3LKnNJJ1bKbjBETQAsrA==",
+          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.1",
             "lodash": "^4.17.13",
@@ -1296,6 +1336,7 @@
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -1306,6 +1347,7 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -1313,7 +1355,8 @@
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
         }
       }
     },
@@ -1321,6 +1364,7 @@
       "version": "7.10.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.1.tgz",
       "integrity": "sha512-VSWpWzRzn9VtgMJBIWTZ+GP107kZdQ4YplJlCmIrjoLVSi/0upixezHCDG8kpPVTBJpKfxTH01wDhh+jS2zKbw==",
+      "dev": true,
       "requires": {
         "@babel/template": "^7.10.1",
         "@babel/types": "^7.10.1"
@@ -1330,6 +1374,7 @@
           "version": "7.10.1",
           "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.1.tgz",
           "integrity": "sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==",
+          "dev": true,
           "requires": {
             "@babel/highlight": "^7.10.1"
           }
@@ -1338,6 +1383,7 @@
           "version": "7.10.1",
           "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.1.tgz",
           "integrity": "sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==",
+          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.1",
             "chalk": "^2.0.0",
@@ -1347,12 +1393,14 @@
         "@babel/parser": {
           "version": "7.10.1",
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.1.tgz",
-          "integrity": "sha512-AUTksaz3FqugBkbTZ1i+lDLG5qy8hIzCaAxEtttU6C0BtZZU9pkNZtWSVAht4EW9kl46YBiyTGMp9xTTGqViNg=="
+          "integrity": "sha512-AUTksaz3FqugBkbTZ1i+lDLG5qy8hIzCaAxEtttU6C0BtZZU9pkNZtWSVAht4EW9kl46YBiyTGMp9xTTGqViNg==",
+          "dev": true
         },
         "@babel/template": {
           "version": "7.10.1",
           "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.1.tgz",
           "integrity": "sha512-OQDg6SqvFSsc9A0ej6SKINWrpJiNonRIniYondK2ViKhB06i3c0s+76XUft71iqBEe9S1OKsHwPAjfHnuvnCig==",
+          "dev": true,
           "requires": {
             "@babel/code-frame": "^7.10.1",
             "@babel/parser": "^7.10.1",
@@ -1363,6 +1411,7 @@
           "version": "7.10.1",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.1.tgz",
           "integrity": "sha512-L2yqUOpf3tzlW9GVuipgLEcZxnO+96SzR6fjXMuxxNkIgFJ5+07mHCZ+HkHqaeZu8+3LKnNJJ1bKbjBETQAsrA==",
+          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.1",
             "lodash": "^4.17.13",
@@ -1373,6 +1422,7 @@
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -1392,7 +1442,8 @@
     "@babel/helper-validator-identifier": {
       "version": "7.10.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.1.tgz",
-      "integrity": "sha512-5vW/JXLALhczRCWP0PnFDMCJAchlBvM7f4uk/jXritBnIa6E1KmqmtrS3yn1LAnxFBypQ3eneLuXjsnfQsgILw=="
+      "integrity": "sha512-5vW/JXLALhczRCWP0PnFDMCJAchlBvM7f4uk/jXritBnIa6E1KmqmtrS3yn1LAnxFBypQ3eneLuXjsnfQsgILw==",
+      "dev": true
     },
     "@babel/helper-wrap-function": {
       "version": "7.10.1",
@@ -1544,6 +1595,7 @@
       "version": "7.10.1",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.1.tgz",
       "integrity": "sha512-muQNHF+IdU6wGgkaJyhhEmI54MOZBKsFfsXFhboz1ybwJ1Kl7IHlbm2a++4jwrmY5UYsgitt5lfqo1wMFcHmyw==",
+      "dev": true,
       "requires": {
         "@babel/template": "^7.10.1",
         "@babel/traverse": "^7.10.1",
@@ -1554,6 +1606,7 @@
           "version": "7.10.1",
           "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.1.tgz",
           "integrity": "sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==",
+          "dev": true,
           "requires": {
             "@babel/highlight": "^7.10.1"
           }
@@ -1562,6 +1615,7 @@
           "version": "7.10.1",
           "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.1.tgz",
           "integrity": "sha512-AT0YPLQw9DI21tliuJIdplVfLHya6mcGa8ctkv7n4Qv+hYacJrKmNWIteAK1P9iyLikFIAkwqJ7HAOqIDLFfgA==",
+          "dev": true,
           "requires": {
             "@babel/types": "^7.10.1",
             "jsesc": "^2.5.1",
@@ -1573,6 +1627,7 @@
           "version": "7.10.1",
           "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.1.tgz",
           "integrity": "sha512-fcpumwhs3YyZ/ttd5Rz0xn0TpIwVkN7X0V38B9TWNfVF42KEkhkAAuPCQ3oXmtTRtiPJrmZ0TrfS0GKF0eMaRQ==",
+          "dev": true,
           "requires": {
             "@babel/helper-get-function-arity": "^7.10.1",
             "@babel/template": "^7.10.1",
@@ -1583,6 +1638,7 @@
           "version": "7.10.1",
           "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.1.tgz",
           "integrity": "sha512-F5qdXkYGOQUb0hpRaPoetF9AnsXknKjWMZ+wmsIRsp5ge5sFh4c3h1eH2pRTTuy9KKAA2+TTYomGXAtEL2fQEw==",
+          "dev": true,
           "requires": {
             "@babel/types": "^7.10.1"
           }
@@ -1591,6 +1647,7 @@
           "version": "7.10.1",
           "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.1.tgz",
           "integrity": "sha512-UQ1LVBPrYdbchNhLwj6fetj46BcFwfS4NllJo/1aJsT+1dLTEnXJL0qHqtY7gPzF8S2fXBJamf1biAXV3X077g==",
+          "dev": true,
           "requires": {
             "@babel/types": "^7.10.1"
           }
@@ -1599,6 +1656,7 @@
           "version": "7.10.1",
           "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.1.tgz",
           "integrity": "sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==",
+          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.1",
             "chalk": "^2.0.0",
@@ -1608,12 +1666,14 @@
         "@babel/parser": {
           "version": "7.10.1",
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.1.tgz",
-          "integrity": "sha512-AUTksaz3FqugBkbTZ1i+lDLG5qy8hIzCaAxEtttU6C0BtZZU9pkNZtWSVAht4EW9kl46YBiyTGMp9xTTGqViNg=="
+          "integrity": "sha512-AUTksaz3FqugBkbTZ1i+lDLG5qy8hIzCaAxEtttU6C0BtZZU9pkNZtWSVAht4EW9kl46YBiyTGMp9xTTGqViNg==",
+          "dev": true
         },
         "@babel/template": {
           "version": "7.10.1",
           "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.1.tgz",
           "integrity": "sha512-OQDg6SqvFSsc9A0ej6SKINWrpJiNonRIniYondK2ViKhB06i3c0s+76XUft71iqBEe9S1OKsHwPAjfHnuvnCig==",
+          "dev": true,
           "requires": {
             "@babel/code-frame": "^7.10.1",
             "@babel/parser": "^7.10.1",
@@ -1624,6 +1684,7 @@
           "version": "7.10.1",
           "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.1.tgz",
           "integrity": "sha512-C/cTuXeKt85K+p08jN6vMDz8vSV0vZcI0wmQ36o6mjbuo++kPMdpOYw23W2XH04dbRt9/nMEfA4W3eR21CD+TQ==",
+          "dev": true,
           "requires": {
             "@babel/code-frame": "^7.10.1",
             "@babel/generator": "^7.10.1",
@@ -1640,6 +1701,7 @@
           "version": "7.10.1",
           "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.1.tgz",
           "integrity": "sha512-L2yqUOpf3tzlW9GVuipgLEcZxnO+96SzR6fjXMuxxNkIgFJ5+07mHCZ+HkHqaeZu8+3LKnNJJ1bKbjBETQAsrA==",
+          "dev": true,
           "requires": {
             "@babel/helper-validator-identifier": "^7.10.1",
             "lodash": "^4.17.13",
@@ -1650,6 +1712,7 @@
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -1660,6 +1723,7 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -1667,7 +1731,8 @@
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
         }
       }
     },
@@ -3649,291 +3714,21 @@
       }
     },
     "@datapunt/asc-assets": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/@datapunt/asc-assets/-/asc-assets-0.18.1.tgz",
-      "integrity": "sha512-TJxowJYb1PM7Bs6VlezMlRdltpTuhH1g6MCj2KFEYQ6N6xUaXyUG6aTyWjMvI+sVka3jCfBqt4TXrPL7jhUEWA==",
-      "requires": {
-        "@svgr/cli": "^4.3.2",
-        "@svgr/core": "^4.3.2",
-        "svgo": "^1.3.0"
-      },
-      "dependencies": {
-        "@svgr/babel-plugin-add-jsx-attribute": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-4.2.0.tgz",
-          "integrity": "sha512-j7KnilGyZzYr/jhcrSYS3FGWMZVaqyCG0vzMCwzvei0coIkczuYMcniK07nI0aHJINciujjH11T72ICW5eL5Ig=="
-        },
-        "@svgr/babel-plugin-remove-jsx-attribute": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-attribute/-/babel-plugin-remove-jsx-attribute-4.2.0.tgz",
-          "integrity": "sha512-3XHLtJ+HbRCH4n28S7y/yZoEQnRpl0tvTZQsHqvaeNXPra+6vE5tbRliH3ox1yZYPCxrlqaJT/Mg+75GpDKlvQ=="
-        },
-        "@svgr/babel-plugin-remove-jsx-empty-expression": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-remove-jsx-empty-expression/-/babel-plugin-remove-jsx-empty-expression-4.2.0.tgz",
-          "integrity": "sha512-yTr2iLdf6oEuUE9MsRdvt0NmdpMBAkgK8Bjhl6epb+eQWk6abBaX3d65UZ3E3FWaOwePyUgNyNCMVG61gGCQ7w=="
-        },
-        "@svgr/babel-plugin-replace-jsx-attribute-value": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-replace-jsx-attribute-value/-/babel-plugin-replace-jsx-attribute-value-4.2.0.tgz",
-          "integrity": "sha512-U9m870Kqm0ko8beHawRXLGLvSi/ZMrl89gJ5BNcT452fAjtF2p4uRzXkdzvGJJJYBgx7BmqlDjBN/eCp5AAX2w=="
-        },
-        "@svgr/babel-plugin-svg-dynamic-title": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-dynamic-title/-/babel-plugin-svg-dynamic-title-4.3.3.tgz",
-          "integrity": "sha512-w3Be6xUNdwgParsvxkkeZb545VhXEwjGMwExMVBIdPQJeyMQHqm9Msnb2a1teHBqUYL66qtwfhNkbj1iarCG7w=="
-        },
-        "@svgr/babel-plugin-svg-em-dimensions": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-svg-em-dimensions/-/babel-plugin-svg-em-dimensions-4.2.0.tgz",
-          "integrity": "sha512-C0Uy+BHolCHGOZ8Dnr1zXy/KgpBOkEUYY9kI/HseHVPeMbluaX3CijJr7D4C5uR8zrc1T64nnq/k63ydQuGt4w=="
-        },
-        "@svgr/babel-plugin-transform-react-native-svg": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-react-native-svg/-/babel-plugin-transform-react-native-svg-4.2.0.tgz",
-          "integrity": "sha512-7YvynOpZDpCOUoIVlaaOUU87J4Z6RdD6spYN4eUb5tfPoKGSF9OG2NuhgYnq4jSkAxcpMaXWPf1cePkzmqTPNw=="
-        },
-        "@svgr/babel-plugin-transform-svg-component": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-transform-svg-component/-/babel-plugin-transform-svg-component-4.2.0.tgz",
-          "integrity": "sha512-hYfYuZhQPCBVotABsXKSCfel2slf/yvJY8heTVX1PCTaq/IgASq1IyxPPKJ0chWREEKewIU/JMSsIGBtK1KKxw=="
-        },
-        "@svgr/babel-preset": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/@svgr/babel-preset/-/babel-preset-4.3.3.tgz",
-          "integrity": "sha512-6PG80tdz4eAlYUN3g5GZiUjg2FMcp+Wn6rtnz5WJG9ITGEF1pmFdzq02597Hn0OmnQuCVaBYQE1OVFAnwOl+0A==",
-          "requires": {
-            "@svgr/babel-plugin-add-jsx-attribute": "^4.2.0",
-            "@svgr/babel-plugin-remove-jsx-attribute": "^4.2.0",
-            "@svgr/babel-plugin-remove-jsx-empty-expression": "^4.2.0",
-            "@svgr/babel-plugin-replace-jsx-attribute-value": "^4.2.0",
-            "@svgr/babel-plugin-svg-dynamic-title": "^4.3.3",
-            "@svgr/babel-plugin-svg-em-dimensions": "^4.2.0",
-            "@svgr/babel-plugin-transform-react-native-svg": "^4.2.0",
-            "@svgr/babel-plugin-transform-svg-component": "^4.2.0"
-          }
-        },
-        "@svgr/cli": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/@svgr/cli/-/cli-4.3.3.tgz",
-          "integrity": "sha512-FHsb9+2zMy9XZgEBFEh+1iofE0TBQn7OnJ9JF/2YimdyE93u2/j1p1K71+rJQ0GWKy96aSSbFWkRVR1i3zATOQ==",
-          "requires": {
-            "@svgr/core": "^4.3.3",
-            "@svgr/plugin-jsx": "^4.3.3",
-            "@svgr/plugin-prettier": "^4.3.2",
-            "@svgr/plugin-svgo": "^4.3.1",
-            "camelcase": "^5.3.1",
-            "chalk": "^2.4.2",
-            "commander": "^2.20.0",
-            "dashify": "^2.0.0",
-            "glob": "^7.1.4",
-            "output-file-sync": "^2.0.1",
-            "recursive-readdir": "^2.2.2"
-          }
-        },
-        "@svgr/core": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/@svgr/core/-/core-4.3.3.tgz",
-          "integrity": "sha512-qNuGF1QON1626UCaZamWt5yedpgOytvLj5BQZe2j1k1B8DUG4OyugZyfEwBeXozCUwhLEpsrgPrE+eCu4fY17w==",
-          "requires": {
-            "@svgr/plugin-jsx": "^4.3.3",
-            "camelcase": "^5.3.1",
-            "cosmiconfig": "^5.2.1"
-          }
-        },
-        "@svgr/hast-util-to-babel-ast": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/@svgr/hast-util-to-babel-ast/-/hast-util-to-babel-ast-4.3.2.tgz",
-          "integrity": "sha512-JioXclZGhFIDL3ddn4Kiq8qEqYM2PyDKV0aYno8+IXTLuYt6TOgHUbUAAFvqtb0Xn37NwP0BTHglejFoYr8RZg==",
-          "requires": {
-            "@babel/types": "^7.4.4"
-          }
-        },
-        "@svgr/plugin-jsx": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/@svgr/plugin-jsx/-/plugin-jsx-4.3.3.tgz",
-          "integrity": "sha512-cLOCSpNWQnDB1/v+SUENHH7a0XY09bfuMKdq9+gYvtuwzC2rU4I0wKGFEp1i24holdQdwodCtDQdFtJiTCWc+w==",
-          "requires": {
-            "@babel/core": "^7.4.5",
-            "@svgr/babel-preset": "^4.3.3",
-            "@svgr/hast-util-to-babel-ast": "^4.3.2",
-            "svg-parser": "^2.0.0"
-          }
-        },
-        "@svgr/plugin-prettier": {
-          "version": "4.3.2",
-          "resolved": "https://registry.npmjs.org/@svgr/plugin-prettier/-/plugin-prettier-4.3.2.tgz",
-          "integrity": "sha512-GErOZQ0n/OinFDjyXg9svfVRNWP+18qqIxsc/9xRoRY7R/cPlnXkadLF7NdgDgSP2BYtt7XGcZ9TU+Skr1B3tw==",
-          "requires": {
-            "merge-deep": "^3.0.2",
-            "prettier": "^1.17.1"
-          }
-        },
-        "@svgr/plugin-svgo": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/@svgr/plugin-svgo/-/plugin-svgo-4.3.1.tgz",
-          "integrity": "sha512-PrMtEDUWjX3Ea65JsVCwTIXuSqa3CG9px+DluF1/eo9mlDrgrtFE7NE/DjdhjJgSM9wenlVBzkzneSIUgfUI/w==",
-          "requires": {
-            "cosmiconfig": "^5.2.1",
-            "merge-deep": "^3.0.2",
-            "svgo": "^1.2.2"
-          }
-        },
-        "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "coa": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/coa/-/coa-2.0.2.tgz",
-          "integrity": "sha512-q5/jG+YQnSy4nRTV4F7lPepBJZ8qBNJJDBuJdoejDyLXgmL7IEo+Le2JDZudFTFt7mrCqIRaSjws4ygRCTCAXA==",
-          "requires": {
-            "@types/q": "^1.5.1",
-            "chalk": "^2.4.1",
-            "q": "^1.1.2"
-          }
-        },
-        "css-select": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/css-select/-/css-select-2.1.0.tgz",
-          "integrity": "sha512-Dqk7LQKpwLoH3VovzZnkzegqNSuAziQyNZUcrdDM401iY+R5NkGBXGmtO05/yaXQziALuPogeG0b7UAgjnTJTQ==",
-          "requires": {
-            "boolbase": "^1.0.0",
-            "css-what": "^3.2.1",
-            "domutils": "^1.7.0",
-            "nth-check": "^1.0.2"
-          }
-        },
-        "css-tree": {
-          "version": "1.0.0-alpha.37",
-          "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.37.tgz",
-          "integrity": "sha512-DMxWJg0rnz7UgxKT0Q1HU/L9BeJI0M6ksor0OgqOnF+aRCDWg/N2641HmVyU9KVIu0OVVWOb2IpC9A+BJRnejg==",
-          "requires": {
-            "mdn-data": "2.0.4",
-            "source-map": "^0.6.1"
-          }
-        },
-        "css-what": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/css-what/-/css-what-3.2.1.tgz",
-          "integrity": "sha512-WwOrosiQTvyms+Ti5ZC5vGEK0Vod3FTt1ca+payZqvKuGJF+dq7bG63DstxtN0dpm6FxY27a/zS3Wten+gEtGw=="
-        },
-        "csso": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/csso/-/csso-4.0.3.tgz",
-          "integrity": "sha512-NL3spysxUkcrOgnpsT4Xdl2aiEiBG6bXswAABQVHcMrfjjBisFOKwLDOmf4wf32aPdcJws1zds2B0Rg+jqMyHQ==",
-          "requires": {
-            "css-tree": "1.0.0-alpha.39"
-          },
-          "dependencies": {
-            "css-tree": {
-              "version": "1.0.0-alpha.39",
-              "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.39.tgz",
-              "integrity": "sha512-7UvkEYgBAHRG9Nt980lYxjsTrCyHFN53ky3wVsDkiMdVqylqRt+Zc+jm5qw7/qyOvN2dHSYtX0e4MbCCExSvnA==",
-              "requires": {
-                "mdn-data": "2.0.6",
-                "source-map": "^0.6.1"
-              }
-            },
-            "mdn-data": {
-              "version": "2.0.6",
-              "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.6.tgz",
-              "integrity": "sha512-rQvjv71olwNHgiTbfPZFkJtjNMciWgswYeciZhtvWLO8bmX3TnhyA62I6sTWOyZssWHJJjY6/KiWwqQsWWsqOA=="
-            }
-          }
-        },
-        "domutils": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
-          "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
-          "requires": {
-            "dom-serializer": "0",
-            "domelementtype": "1"
-          }
-        },
-        "esprima": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
-        },
-        "js-yaml": {
-          "version": "3.13.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-          "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        },
-        "svgo": {
-          "version": "1.3.2",
-          "resolved": "https://registry.npmjs.org/svgo/-/svgo-1.3.2.tgz",
-          "integrity": "sha512-yhy/sQYxR5BkC98CY7o31VGsg014AKLEPxdfhora76l36hD9Rdy5NZA/Ocn6yayNPgSamYdtX2rFJdcv07AYVw==",
-          "requires": {
-            "chalk": "^2.4.1",
-            "coa": "^2.0.2",
-            "css-select": "^2.0.0",
-            "css-select-base-adapter": "^0.1.1",
-            "css-tree": "1.0.0-alpha.37",
-            "csso": "^4.0.2",
-            "js-yaml": "^3.13.1",
-            "mkdirp": "~0.5.1",
-            "object.values": "^1.1.0",
-            "sax": "~1.2.4",
-            "stable": "^0.1.8",
-            "unquote": "~1.1.1",
-            "util.promisify": "~1.0.0"
-          }
-        }
-      }
-    },
-    "@datapunt/asc-core": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/@datapunt/asc-core/-/asc-core-0.18.1.tgz",
-      "integrity": "sha512-4REkNQDGpDmWCihq7c2J6/nUR82CVk2gLDph7XVb+uSa/e3Ix4YLm1oqogG/+MLyDpuTwphvWqVagIukjBygmA==",
-      "requires": {
-        "styled-components": "^4.3.2"
-      }
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@datapunt/asc-assets/-/asc-assets-0.20.0.tgz",
+      "integrity": "sha512-NYgcEgZsM2AjWmdUFsyPp5w1LB9GNJcvk7XQIp+5VlboZEHDbgTyuy1zkWtHreg5qBjjaBgtivzkG0np1hO/Kg=="
     },
     "@datapunt/asc-ui": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@datapunt/asc-ui/-/asc-ui-0.19.1.tgz",
-      "integrity": "sha512-9rpCsbP4q+WwH0ESNrhoBdjLqlomko3TpaqHgo+6VGqABDrXS0FUcc3sngUsdsn2MsI4Z/X9+78peSBHvL1C8w==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@datapunt/asc-ui/-/asc-ui-0.20.0.tgz",
+      "integrity": "sha512-g00C1CqLsX4wNY4EnIHLpOqbDlxc7fouzAmEGgbOjInc5v5TXWEhRfNxz4H7gLwgscwal1twDztc5Zv9AtrK/w==",
       "requires": {
-        "@datapunt/asc-assets": "^0.19.1",
-        "@datapunt/asc-core": "^0.18.3-alpha.0",
+        "@datapunt/asc-assets": "^0.20.0",
         "classnames": "^2.2.6",
         "deepmerge": "^4.2.2",
+        "objectFitPolyfill": ">=2.3.0",
         "polished": "^3.5.1",
         "react-uid": "^2.2.0"
-      },
-      "dependencies": {
-        "@datapunt/asc-assets": {
-          "version": "0.19.1",
-          "resolved": "https://registry.npmjs.org/@datapunt/asc-assets/-/asc-assets-0.19.1.tgz",
-          "integrity": "sha512-Gv+VX5uWJD9iu4x5sh2GBfsk5kuo6y89F5q3ndlSid9oSgjDjnagTd/FiDzmlFqug1HVutBbIC6uyuvbXS2nPw=="
-        },
-        "@datapunt/asc-core": {
-          "version": "0.18.3-alpha.0",
-          "resolved": "https://registry.npmjs.org/@datapunt/asc-core/-/asc-core-0.18.3-alpha.0.tgz",
-          "integrity": "sha512-sKSuS+BjH8tKoFW56sX8Lne3Ly7aJt/OygIv6OOtESEo7K0MNBup7gh4SFLEiDUW27iiDMALobu7vXf7xOGcNQ=="
-        }
       }
     },
     "@datapunt/leaflet-geojson-bbox-layer": {
@@ -6113,7 +5908,8 @@
     "arr-union": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
+      "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
+      "dev": true
     },
     "array-equal": {
       "version": "1.0.0",
@@ -7631,6 +7427,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
       "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
+      "dev": true,
       "requires": {
         "callsites": "^2.0.0"
       },
@@ -7638,7 +7435,8 @@
         "callsites": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-          "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
+          "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
+          "dev": true
         }
       }
     },
@@ -7646,6 +7444,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
       "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
+      "dev": true,
       "requires": {
         "caller-callsite": "^2.0.0"
       }
@@ -8231,7 +8030,8 @@
     "commander": {
       "version": "2.20.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
+      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+      "dev": true
     },
     "common-tags": {
       "version": "1.8.0",
@@ -8592,6 +8392,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
       "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
+      "dev": true,
       "requires": {
         "import-fresh": "^2.0.0",
         "is-directory": "^0.3.1",
@@ -8602,12 +8403,14 @@
         "esprima": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+          "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+          "dev": true
         },
         "js-yaml": {
           "version": "3.13.1",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
           "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+          "dev": true,
           "requires": {
             "argparse": "^1.0.7",
             "esprima": "^4.0.0"
@@ -8617,6 +8420,7 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
           "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
           "requires": {
             "error-ex": "^1.3.1",
             "json-parse-better-errors": "^1.0.1"
@@ -9106,7 +8910,8 @@
     "css-select-base-adapter": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
-      "integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w=="
+      "integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w==",
+      "dev": true
     },
     "css-to-react-native": {
       "version": "2.3.2",
@@ -9482,11 +9287,6 @@
           "dev": true
         }
       }
-    },
-    "dashify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dashify/-/dashify-2.0.0.tgz",
-      "integrity": "sha512-hpA5C/YrPjucXypHPPc0oJ1l9Hf6wWbiOL7Ik42cxnsUOhWiCB/fylKbKqqJalW9FgkNQCw16YO8uW9Hs0Iy1A=="
     },
     "data-urls": {
       "version": "1.1.0",
@@ -10531,6 +10331,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
       "requires": {
         "is-arrayish": "^0.2.1"
       }
@@ -10539,6 +10340,7 @@
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
       "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+      "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.0",
         "function-bind": "^1.1.1",
@@ -10552,6 +10354,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
       "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+      "dev": true,
       "requires": {
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
@@ -12172,15 +11975,8 @@
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
-    },
-    "for-own": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-      "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-      "requires": {
-        "for-in": "^1.0.1"
-      }
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
     },
     "foreach": {
       "version": "2.0.4",
@@ -12290,7 +12086,8 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "fsevents": {
       "version": "1.2.12",
@@ -12981,7 +12778,8 @@
     "gensync": {
       "version": "1.0.0-beta.1",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
-      "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg=="
+      "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
+      "dev": true
     },
     "geojson": {
       "version": "0.5.0",
@@ -13111,6 +12909,7 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
       "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -13212,7 +13011,8 @@
     "globals": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true
     },
     "globby": {
       "version": "7.1.1",
@@ -13265,7 +13065,8 @@
     "graceful-fs": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
-      "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg=="
+      "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==",
+      "dev": true
     },
     "graceful-readlink": {
       "version": "1.0.1",
@@ -14344,6 +14145,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
       "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
+      "dev": true,
       "requires": {
         "caller-path": "^2.0.0",
         "resolve-from": "^3.0.0"
@@ -14352,7 +14154,8 @@
         "resolve-from": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
+          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+          "dev": true
         }
       }
     },
@@ -14481,6 +14284,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -14489,7 +14293,8 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "ini": {
       "version": "1.3.5",
@@ -14741,7 +14546,8 @@
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
     },
     "is-binary-path": {
       "version": "1.0.1",
@@ -14762,12 +14568,14 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
     },
     "is-callable": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+      "dev": true
     },
     "is-ci": {
       "version": "2.0.0",
@@ -14866,7 +14674,8 @@
     "is-directory": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
-      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE="
+      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+      "dev": true
     },
     "is-docker": {
       "version": "2.0.0",
@@ -14877,7 +14686,8 @@
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true
     },
     "is-extglob": {
       "version": "2.1.1",
@@ -15028,12 +14838,14 @@
     "is-plain-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true
     },
     "is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
       "requires": {
         "isobject": "^3.0.1"
       }
@@ -15171,7 +14983,8 @@
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "dev": true
     },
     "isstream": {
       "version": "0.1.2",
@@ -16438,7 +16251,8 @@
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true
     },
     "json-buffer": {
       "version": "3.0.0",
@@ -16450,7 +16264,8 @@
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
     },
     "json-schema": {
       "version": "0.2.3",
@@ -16583,11 +16398,6 @@
       "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
       "integrity": "sha1-eZllXoZGwX8In90YfRUNMyTVRRM=",
       "dev": true
-    },
-    "lazy-cache": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
-      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
     },
     "leaflet": {
       "version": "1.6.0",
@@ -17614,7 +17424,8 @@
     "mdn-data": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
-      "integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA=="
+      "integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==",
+      "dev": true
     },
     "media-typer": {
       "version": "0.3.0",
@@ -17755,64 +17566,6 @@
       "integrity": "sha512-dYOIAl9GFCJNctSIHWOj9OJtarCjsD16P8ObCl6oxrujAG+kOvlwJuOD9/O9iYZ9aTi1RGpGTG9q9etIvuUikQ==",
       "requires": {
         "is-what": "^3.3.1"
-      }
-    },
-    "merge-deep": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/merge-deep/-/merge-deep-3.0.2.tgz",
-      "integrity": "sha512-T7qC8kg4Zoti1cFd8Cr0M+qaZfOwjlPDEdZIIPPB2JZctjaPM4fX+i7HOId69tAti2fvO6X5ldfYUONDODsrkA==",
-      "requires": {
-        "arr-union": "^3.1.0",
-        "clone-deep": "^0.2.4",
-        "kind-of": "^3.0.2"
-      },
-      "dependencies": {
-        "clone-deep": {
-          "version": "0.2.4",
-          "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
-          "integrity": "sha1-TnPdCen7lxzDhnDF3O2cGJZIHMY=",
-          "requires": {
-            "for-own": "^0.1.3",
-            "is-plain-object": "^2.0.1",
-            "kind-of": "^3.0.2",
-            "lazy-cache": "^1.0.3",
-            "shallow-clone": "^0.1.2"
-          }
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-          "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        },
-        "shallow-clone": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz",
-          "integrity": "sha1-WQnodLp3EG1zrEFM/sH/yofZcGA=",
-          "requires": {
-            "is-extendable": "^0.1.1",
-            "kind-of": "^2.0.1",
-            "lazy-cache": "^0.2.3",
-            "mixin-object": "^2.0.1"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
-              "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
-              "requires": {
-                "is-buffer": "^1.0.2"
-              }
-            },
-            "lazy-cache": {
-              "version": "0.2.7",
-              "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
-              "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U="
-            }
-          }
-        }
       }
     },
     "merge-descriptors": {
@@ -18001,7 +17754,8 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
     },
     "minipass": {
       "version": "3.1.1",
@@ -18117,26 +17871,11 @@
         }
       }
     },
-    "mixin-object": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
-      "integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
-      "requires": {
-        "for-in": "^0.1.3",
-        "is-extendable": "^0.1.1"
-      },
-      "dependencies": {
-        "for-in": {
-          "version": "0.1.8",
-          "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
-          "integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE="
-        }
-      }
-    },
     "mkdirp": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dev": true,
       "requires": {
         "minimist": "^1.2.5"
       }
@@ -19148,6 +18887,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
       "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
         "es-abstract": "^1.5.1"
@@ -19166,12 +18906,19 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
       "integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.12.0",
         "function-bind": "^1.1.1",
         "has": "^1.0.3"
       }
+    },
+    "objectFitPolyfill": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/objectFitPolyfill/-/objectFitPolyfill-2.3.0.tgz",
+      "integrity": "sha512-VgF98xGs2upBxO6a4FKGEEip5kXQCYpIwrKSDQ6oyFvPAmTrm6nPD/Y/IetoHx62HE6N82hWvc7Tc0evEBkoyA==",
+      "optional": true
     },
     "offline-plugin": {
       "version": "5.0.7",
@@ -19236,6 +18983,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -19361,16 +19109,6 @@
       "resolved": "https://registry.npmjs.org/ospath/-/ospath-1.2.2.tgz",
       "integrity": "sha1-EnZjl3Sj+O8lcvf+QoDg6kVQwHs=",
       "dev": true
-    },
-    "output-file-sync": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-2.0.1.tgz",
-      "integrity": "sha512-mDho4qm7WgIXIGf4eYU1RHN2UU5tPfVYVSRwDJw0uTmj35DQUt/eNp19N7v6T3SrR0ESTEf2up2CGO73qI35zQ==",
-      "requires": {
-        "graceful-fs": "^4.1.11",
-        "is-plain-obj": "^1.1.0",
-        "mkdirp": "^0.5.1"
-      }
     },
     "ow": {
       "version": "0.13.2",
@@ -19644,7 +19382,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -19661,7 +19400,8 @@
     "path-parse": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
     },
     "path-to-regexp": {
       "version": "1.8.0",
@@ -19832,17 +19572,17 @@
       }
     },
     "polished": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/polished/-/polished-3.5.1.tgz",
-      "integrity": "sha512-GVbvskpBiDV5TknurGL6OyFfLHsCknxbU8w5iMppT8rW0tLEoQHrIRfrPNPqGXNj3HGhkjRvhmg59Fy7HSnCAw==",
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/polished/-/polished-3.6.4.tgz",
+      "integrity": "sha512-21moJXCm/7EvjeKQz5w89QDDKNPCoimc83CqwZZGJluFdMXsFlMQl9lPA/OMRkoceZ19kU0anKlMgZmY7LJSJw==",
       "requires": {
-        "@babel/runtime": "^7.8.7"
+        "@babel/runtime": "^7.9.2"
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.9.2",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
-          "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+          "version": "7.10.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.2.tgz",
+          "integrity": "sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -20543,7 +20283,8 @@
     "prettier": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew=="
+      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
+      "dev": true
     },
     "prettier-linter-helpers": {
       "version": "1.0.0",
@@ -21051,9 +20792,12 @@
       }
     },
     "react-uid": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/react-uid/-/react-uid-2.2.0.tgz",
-      "integrity": "sha512-z+g5+hFOQ08hCfrGcJ1PNs+cmvH8Uq2CVzCmPeWBsUi5A4W4NWXR5jouledzy3oSKGMU9HOzf8zFuGi15TXJoQ=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/react-uid/-/react-uid-2.3.0.tgz",
+      "integrity": "sha512-tsPZ77GR0pISGYmpCLHAbZTabKXZ7zBniKPVqVMMfnXFyo39zq5g/psIlD5vLTKkjQEhWOO8JhqcHnxkwNu6eA==",
+      "requires": {
+        "tslib": "^1.10.0"
+      }
     },
     "read-pkg": {
       "version": "2.0.0",
@@ -21164,14 +20908,6 @@
       "dev": true,
       "requires": {
         "resolve": "^1.1.6"
-      }
-    },
-    "recursive-readdir": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.2.tgz",
-      "integrity": "sha512-nRCcW9Sj7NuZwa2XvH9co8NPeXUBhZP7CRKJtU+cS6PW9FpCIFoI5ib0NT1ZrbNuPoRy0ylyCaUL8Gih4LSyFg==",
-      "requires": {
-        "minimatch": "3.0.4"
       }
     },
     "redent": {
@@ -21548,6 +21284,7 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
       "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
+      "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
       }
@@ -21943,7 +21680,8 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "dev": true
     },
     "scheduler": {
       "version": "0.19.1",
@@ -22015,7 +21753,8 @@
     "semver": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+      "dev": true
     },
     "semver-compare": {
       "version": "1.0.0",
@@ -22637,7 +22376,8 @@
     "stable": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
-      "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
+      "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
+      "dev": true
     },
     "stack-utils": {
       "version": "1.0.2",
@@ -23155,11 +22895,6 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
-    },
-    "svg-parser": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/svg-parser/-/svg-parser-2.0.4.tgz",
-      "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ=="
     },
     "svg-url-loader": {
       "version": "3.0.3",
@@ -24048,7 +23783,8 @@
     "unquote": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
-      "integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ="
+      "integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ=",
+      "dev": true
     },
     "unset-value": {
       "version": "1.0.0",
@@ -24270,6 +24006,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.0.0.tgz",
       "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
+      "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
         "object.getownpropertydescriptors": "^2.0.3"
@@ -25256,7 +24993,8 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "write": {
       "version": "1.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5603,6 +5603,7 @@
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
       "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
+      "dev": true,
       "requires": {
         "mime-types": "~2.1.24",
         "negotiator": "0.6.2"
@@ -7309,7 +7310,8 @@
     "bytes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+      "dev": true
     },
     "cacache": {
       "version": "13.0.1",
@@ -8055,6 +8057,7 @@
       "version": "2.0.17",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.17.tgz",
       "integrity": "sha512-BGHeLCK1GV7j1bSmQQAi26X+GgWcTjLr/0tzSvMCl3LH1w1IJ4PFSPoV5316b30cneTziC+B1a+3OjoSUcQYmw==",
+      "dev": true,
       "requires": {
         "mime-db": ">= 1.40.0 < 2"
       }
@@ -8063,6 +8066,7 @@
       "version": "1.7.4",
       "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
       "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
+      "dev": true,
       "requires": {
         "accepts": "~1.3.5",
         "bytes": "3.0.0",
@@ -9328,6 +9332,7 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -17637,12 +17642,14 @@
     "mime-db": {
       "version": "1.40.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
+      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
+      "dev": true
     },
     "mime-types": {
       "version": "2.1.24",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
       "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+      "dev": true,
       "requires": {
         "mime-db": "1.40.0"
       }
@@ -17931,7 +17938,8 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
     "mute-stream": {
       "version": "0.0.8",
@@ -17986,7 +17994,8 @@
     "negotiator": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
-      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
+      "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
+      "dev": true
     },
     "neo-async": {
       "version": "2.6.1",
@@ -18977,7 +18986,8 @@
     "on-headers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
-      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "dev": true
     },
     "once": {
       "version": "1.4.0",
@@ -21469,7 +21479,8 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -24054,7 +24065,8 @@
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+      "dev": true
     },
     "vendors": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -58,9 +58,8 @@
   "dependencies": {
     "@babel/polyfill": "^7.10.1",
     "@datapunt/amsterdam-react-maps": "^0.1.2",
-    "@datapunt/asc-assets": "^0.18.1",
-    "@datapunt/asc-core": "^0.18.1",
-    "@datapunt/asc-ui": "^0.19.1",
+    "@datapunt/asc-assets": "^0.20.0",
+    "@datapunt/asc-ui": "^0.20.0",
     "@datapunt/leaflet-geojson-bbox-layer": "0.1.1",
     "@datapunt/matomo-tracker-js": "0.0.15",
     "@datapunt/react-maps": "0.8.0",

--- a/src/components/AmsterdamLogo/__tests__/AmsterdamLogo.test.js
+++ b/src/components/AmsterdamLogo/__tests__/AmsterdamLogo.test.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+import { withAppContext } from 'test/utils';
+import { AmsterdamLogo } from '@datapunt/asc-ui';
+
+describe('components/AmsterdamLogo', () => {
+  it('should render correctly', () => {
+    const homeLink = "https://home-link";
+    const { container, queryByText } = render(withAppContext(<AmsterdamLogo href={homeLink}/>));
+
+    expect(container.querySelector(`a[href="${homeLink}"]`)).toBeInTheDocument();
+    expect(queryByText(`Gemeente Amsterdam`)).toBeInTheDocument();
+  });
+});

--- a/src/components/AmsterdamLogo/index.js
+++ b/src/components/AmsterdamLogo/index.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { LogoShort } from '@datapunt/asc-assets';
+import styled, { css } from 'styled-components';
+import { srOnlyStyle, breakpoint, themeSpacing, focusStyleOutline } from '@datapunt/asc-ui/lib/utils';
+
+export const LogoStyle = styled(LogoShort)`
+  display: block;
+  height: 100%;
+  width: 100%;
+`;
+
+export const LogoTitleStyle = styled.span`
+  ${srOnlyStyle()}
+`;
+
+const AmsterdamLogoStyle = styled.a`
+  display: inline-block;
+  height: 30px;
+  width: 68px;
+  flex-shrink: 0;
+  margin-right: ${themeSpacing(3)};
+  ${focusStyleOutline()}
+  ${({ tall }) => tall && css`
+    @media screen and ${breakpoint('min-width', 'laptopM')} {
+      margin-right: ${themeSpacing(10)};
+    }
+  `};
+`;
+
+
+const AmsterdamLogo = ({ ...otherProps }) => (
+  <AmsterdamLogoStyle {...otherProps}>
+    <LogoStyle />
+    <LogoTitleStyle srOnly>Gemeente Amsterdam</LogoTitleStyle>
+  </AmsterdamLogoStyle>
+);
+
+export default AmsterdamLogo;

--- a/src/components/AmsterdamLogo/index.js
+++ b/src/components/AmsterdamLogo/index.js
@@ -3,35 +3,16 @@ import { LogoShort } from '@datapunt/asc-assets';
 import styled, { css } from 'styled-components';
 import { breakpoint, themeSpacing, themeColor } from '@datapunt/asc-ui';
 
-export const srOnlyStyle = () => ({ srOnly }) =>
-  srOnly
-    ? css`
-        border-width: 0;
-        clip: rect(0, 0, 0, 0);
-        height: 1px;
-        margin: -1px;
-        overflow: hidden;
-        padding: 0;
-        position: absolute;
-        width: 1px;
-      `
-    : '';
-
 export const LogoStyle = styled(LogoShort)`
   display: block;
   height: 100%;
   width: 100%;
 `;
 
-export const LogoTitleStyle = styled.span`
-  ${srOnlyStyle()}
-`;
-
 const AmsterdamLogoStyle = styled.a`
   display: inline-block;
   height: 30px;
   width: 68px;
-  flex-shrink: 0;
   margin-right: ${themeSpacing(3)};
 
   &&:focus {
@@ -53,7 +34,6 @@ const AmsterdamLogoStyle = styled.a`
 const AmsterdamLogo = ({ ...otherProps }) => (
   <AmsterdamLogoStyle {...otherProps}>
     <LogoStyle />
-    <LogoTitleStyle srOnly>Gemeente Amsterdam</LogoTitleStyle>
   </AmsterdamLogoStyle>
 );
 

--- a/src/components/AmsterdamLogo/index.js
+++ b/src/components/AmsterdamLogo/index.js
@@ -1,7 +1,21 @@
 import React from 'react';
 import { LogoShort } from '@datapunt/asc-assets';
 import styled, { css } from 'styled-components';
-import { srOnlyStyle, breakpoint, themeSpacing, focusStyleOutline } from '@datapunt/asc-ui/lib/utils';
+import { breakpoint, themeSpacing, themeColor } from '@datapunt/asc-ui';
+
+export const srOnlyStyle = () => ({ srOnly }) =>
+  srOnly
+    ? css`
+        border-width: 0;
+        clip: rect(0, 0, 0, 0);
+        height: 1px;
+        margin: -1px;
+        overflow: hidden;
+        padding: 0;
+        position: absolute;
+        width: 1px;
+      `
+    : '';
 
 export const LogoStyle = styled(LogoShort)`
   display: block;
@@ -19,14 +33,22 @@ const AmsterdamLogoStyle = styled.a`
   width: 68px;
   flex-shrink: 0;
   margin-right: ${themeSpacing(3)};
-  ${focusStyleOutline()}
-  ${({ tall }) => tall && css`
-    @media screen and ${breakpoint('min-width', 'laptopM')} {
-      margin-right: ${themeSpacing(10)};
-    }
-  `};
-`;
 
+  &&:focus {
+    outline-color: ${themeColor('support', 'focus')};
+    outline-style: solid;
+    outline-offset: 0px;
+    outline-width: 3px;
+  }
+
+  ${({ tall }) =>
+    tall &&
+    css`
+      @media screen and ${breakpoint('min-width', 'laptopM')} {
+        margin-right: ${themeSpacing(10)};
+      }
+    `};
+`;
 
 const AmsterdamLogo = ({ ...otherProps }) => (
   <AmsterdamLogoStyle {...otherProps}>

--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -24,6 +24,7 @@ const StyledInput = styled.input`
   font-family: inherit;
   font-size: 16px;
   line-height: 22px;
+  padding: 10px; /* needed to style the textboxes as according to the design system */
 
   &[disabled] {
     border: 1px solid ${themeColor('tint', 'level4')};

--- a/src/components/MapInput/index.js
+++ b/src/components/MapInput/index.js
@@ -1,7 +1,7 @@
 import React, { useLayoutEffect, useContext, useState, useEffect, useCallback, useRef } from 'react';
 import PropTypes from 'prop-types';
 
-import styled from '@datapunt/asc-core';
+import styled from 'styled-components';
 import { Marker } from '@datapunt/react-maps';
 import { ViewerContainer } from '@datapunt/asc-ui';
 import 'leaflet/dist/leaflet.css';

--- a/src/components/MapSelect/index.js
+++ b/src/components/MapSelect/index.js
@@ -1,6 +1,6 @@
 import React, { useLayoutEffect, useEffect, useState, useCallback, useMemo, useRef } from 'react';
 import PropTypes from 'prop-types';
-import styled from '@datapunt/asc-core';
+import styled from 'styled-components';
 import BboxGeojsonLayer from '@datapunt/leaflet-geojson-bbox-layer';
 import 'leaflet/dist/leaflet.css';
 import classNames from 'classnames';

--- a/src/components/Notification/styled.js
+++ b/src/components/Notification/styled.js
@@ -5,8 +5,8 @@ import {
   Paragraph,
   themeSpacing,
   themeColor,
+  ascDefaultTheme as theme,
 } from '@datapunt/asc-ui';
-import { ascDefaultTheme as theme } from '@datapunt/asc-core';
 import {
   SITE_HEADER_BOTTOM_GAP_HEIGHT,
   SITE_HEADER_HEIGHT_TALL,

--- a/src/components/SiteHeader/__tests__/SiteHeader.test.js
+++ b/src/components/SiteHeader/__tests__/SiteHeader.test.js
@@ -99,11 +99,10 @@ describe('components/SiteHeader', () => {
   it('should render the Amsterdam logo by default', () => {
     jest.spyOn(auth, 'isAuthenticated').mockImplementation(() => false);
 
-    const { container, rerender, queryByText } = render(
+    const { container, rerender } = render(
       withAppContext(<SiteHeader permissions={[]} location={{ pathname: '/' }} />)
     );
 
-    expect(queryByText('Gemeente Amsterdam')).toBeInTheDocument();
     expect(container.querySelector('h1 img')).not.toBeInTheDocument();
 
     configuration.logoUrl = 'logoUrl';
@@ -111,7 +110,6 @@ describe('components/SiteHeader', () => {
     rerender(withAppContext(<SiteHeader permissions={[]} location={{ pathname: '/' }} />));
 
     expect(container.querySelector('h1 img[src="logoUrl"]')).toBeInTheDocument();
-    expect(queryByText('Gemeente Amsterdam')).not.toBeInTheDocument();
   });
 
   it('should render the correct homeLink', () => {

--- a/src/components/SiteHeader/__tests__/SiteHeader.test.js
+++ b/src/components/SiteHeader/__tests__/SiteHeader.test.js
@@ -7,7 +7,7 @@ import * as auth from 'shared/services/auth/auth';
 import { history, withAppContext } from 'test/utils';
 import configuration from 'shared/services/configuration/configuration';
 
-import SiteHeader, { breakpoint } from '../index';
+import SiteHeader, { menuBreakpoint } from '../index';
 
 const mmm = MatchMediaMock.create();
 
@@ -16,7 +16,7 @@ jest.mock('shared/services/configuration/configuration');
 
 describe('components/SiteHeader', () => {
   beforeEach(() => {
-    mmm.setConfig({ type: 'screen', width: breakpoint + 1 });
+    mmm.setConfig({ type: 'screen', width: menuBreakpoint + 1 });
 
     // eslint-disable-next-line no-undef
     Object.defineProperty(window, 'matchMedia', {
@@ -47,12 +47,8 @@ describe('components/SiteHeader', () => {
     cleanup();
 
     // narrow window toggle
-    mmm.setConfig({ type: 'screen', width: breakpoint - 1 });
+    mmm.setConfig({ type: 'screen', width: menuBreakpoint - 1 });
 
-    // eslint-disable-next-line no-undef
-    Object.defineProperty(window, 'matchMedia', {
-      value: mmm,
-    });
 
     act(() => {
       history.push('/manage');
@@ -88,7 +84,7 @@ describe('components/SiteHeader', () => {
     cleanup();
 
     // narrow window toggle
-    mmm.setConfig({ type: 'screen', width: breakpoint - 1 });
+    mmm.setConfig({ type: 'screen', width: menuBreakpoint - 1 });
 
     act(() => {
       history.push('/manage');

--- a/src/components/SiteHeader/index.js
+++ b/src/components/SiteHeader/index.js
@@ -4,7 +4,7 @@ import { NavLink } from 'react-router-dom';
 import styled, { css } from 'styled-components';
 import Media from 'react-media';
 
-import { svg, Logout as LogoutIcon } from '@datapunt/asc-assets';
+import { Logout as LogoutIcon } from '@datapunt/asc-assets';
 
 import {
   Header as HeaderComponent,
@@ -15,6 +15,7 @@ import {
   MenuToggle,
   themeColor,
   themeSpacing,
+  breakpoint,
 } from '@datapunt/asc-ui';
 import SearchBar from 'containers/SearchBar';
 import { isAuthenticated } from 'shared/services/auth/auth';
@@ -22,8 +23,9 @@ import useIsFrontOffice from 'hooks/useIsFrontOffice';
 import Notification from 'containers/Notification';
 import Logo from 'components/Logo';
 import configuration from 'shared/services/configuration/configuration';
+import AmsterdamLogo from 'components/AmsterdamLogo';
 
-export const breakpoint = 1170;
+export const menuBreakpoint = 1170;
 
 const StyledHeader = styled(HeaderComponent)`
   a:link {
@@ -39,22 +41,17 @@ const StyledHeader = styled(HeaderComponent)`
         h1 {
           margin-left: ${themeSpacing(-5)};
         }
-        h1 a {
-          &,
-          span {
-            width: 153px;
+
+        @media screen and ${breakpoint('min-width', 'tabletS')} {
+          h1 a {
+            &,
+            span {
+              width: 153px;
+            }
           }
         }
-        h1 a span {
-          background-image: url(${svg.LogoShort}) !important;
-        }
       }
-
-      h1 a span {
-        background-image: url(${svg.LogoShort}) !important;
-      }
-    }
-  `}
+    `}
 
   nav {
     width: 100%;
@@ -85,7 +82,7 @@ const StyledMenuFlyout = styled(MenuFlyOut)`
 const SearchBarMenuItem = styled(MenuItem)`
   margin-right: 0;
   max-width: 365px;
-  @media screen and (min-width: ${breakpoint + 1}px) {
+  @media screen and (min-width: ${menuBreakpoint + 1}px) {
     margin-right: auto;
     flex-basis: 365px;
   }
@@ -276,7 +273,7 @@ export const SiteHeader = props => {
 
   const navigation = useMemo(
     () => (
-      <Media query={`(max-width: ${breakpoint}px)`}>
+      <Media query={`(max-width: ${menuBreakpoint}px)`}>
         {matches =>
           matches ? (
             <MenuToggle align="right">
@@ -308,7 +305,7 @@ export const SiteHeader = props => {
           tall={tall}
           fullWidth={false}
           navigation={tall ? null : navigation}
-          {...(configuration.logoUrl ? { logo: Logo } : {})}
+          {...(configuration.logoUrl ? { logo: Logo } : { logo: AmsterdamLogo })}
         />
         {!tall && <Notification />}
       </HeaderWrapper>

--- a/src/components/SiteHeader/index.js
+++ b/src/components/SiteHeader/index.js
@@ -65,6 +65,7 @@ const StyledMenuButton = styled(MenuButton)`
   background: transparent;
   font-size: 16px;
   font-family: inherit;
+  font-weight: 400;
   color: ${themeColor('tint', 'level6')};
 `;
 

--- a/src/containers/SearchBar/index.js
+++ b/src/containers/SearchBar/index.js
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
-import { SearchBar } from '@datapunt/asc-ui';
+import { SearchBar, styles } from '@datapunt/asc-ui';
 import { connect } from 'react-redux';
 import { compose, bindActionCreators } from 'redux';
 import { createStructuredSelector } from 'reselect';
@@ -10,6 +10,14 @@ import {
   resetSearchQuery,
 } from 'containers/App/actions';
 import { makeSelectSearchQuery } from 'containers/App/selectors';
+import styled from 'styled-components';
+
+
+const StyledSearchBar = styled(SearchBar)`
+  ${styles.TextFieldStyle} > input {
+    padding: 10px; /* needed to style the textboxes as according to the design system */
+  }
+`;
 
 export const SearchBarComponent = ({
   className,
@@ -47,7 +55,7 @@ export const SearchBarComponent = ({
 
   return (
     <form onSubmit={onSearchSubmit}>
-      <SearchBar
+      <StyledSearchBar
         className={className}
         data-testid="searchBar"
         placeholder="Zoek op meldingsnummer"

--- a/src/signals/incident-management/containers/IncidentOverviewPage/styled.js
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/styled.js
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
-import { Column, Button, themeSpacing, Paragraph, themeColor } from '@datapunt/asc-ui';
+import { Column, themeSpacing, Paragraph, themeColor } from '@datapunt/asc-ui';
+import Button from 'components/Button';
 import Pagination from 'components/Pagination';
 
 export const StyledButton = styled(Button)`


### PR DESCRIPTION
Thie PR updates the `asc` packages to 0.20.0 and solves a breaking change around the the site Logo. A SIA variant of the Amsterdam Logo is added to this project because the default logo provided by asc is not according to the design of SIA.
