### PR TITLE
(Chore) Comment Weesp job

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,11 +50,11 @@ node('BS16 || BS17') {
             }
         }
 
-        stage("Deploy Weesp ACC") {
-            tryStep "deployment", {
-                build job: '/SIA_Signalen_Amsterdam/signals-weesp/develop'
-            }
-        }
+        // stage("Deploy Weesp ACC") {
+        //     tryStep "deployment", {
+        //         build job: '/SIA_Signalen_Amsterdam/signals-weesp/develop'
+        //     }
+        // }
     }
 
     if (BRANCH == "master") {
@@ -64,10 +64,10 @@ node('BS16 || BS17') {
             }
         }
 
-        stage("Deploy Weesp PROD") {
-            tryStep "deployment", {
-                build job: '/SIA_Signalen_Amsterdam/signals-weesp/master'
-            }
-        }
+        // stage("Deploy Weesp PROD") {
+        //     tryStep "deployment", {
+        //         build job: '/SIA_Signalen_Amsterdam/signals-weesp/master'
+        //     }
+        // }
     }
 }


### PR DESCRIPTION
This PR comments out the lines that deploy the application for the Weesp instance. It caused the Weesp config to be deployed to acc.meldingen.amsterdam.nl, since acc.meldingen.weesp.nl isn't yet available.