### PR TITLE
[SIG-2754] Add configuration for showing the extra questionary

### DIFF
--- a/environment.conf.json
+++ b/environment.conf.json
@@ -54,6 +54,7 @@
       "gemeentenaam": "amsterdam"
     }
   },
+  "hasExtraProps": true,
   "ROOT": "http://localhost:3001/",
   "AUTH_ROOT": "https://acc.api.data.amsterdam.nl/",
   "API_ROOT_MAPSERVER": "https://map.data.amsterdam.nl/",

--- a/environment.conf.json
+++ b/environment.conf.json
@@ -54,7 +54,7 @@
       "gemeentenaam": "amsterdam"
     }
   },
-  "hasExtraProps": true,
+  "showVulaanControls": true,
   "ROOT": "http://localhost:3001/",
   "AUTH_ROOT": "https://acc.api.data.amsterdam.nl/",
   "API_ROOT_MAPSERVER": "https://map.data.amsterdam.nl/",

--- a/src/signals/incident/definitions/__tests__/wizard-step-2-vulaan.test.js
+++ b/src/signals/incident/definitions/__tests__/wizard-step-2-vulaan.test.js
@@ -1,0 +1,19 @@
+import configuration from 'shared/services/configuration/configuration';
+import vullaan from '../wizard-step-2-vulaan';
+
+describe('wizard-step-2-vullaan', () => {
+  it('should return controls when hasExtraProps is true', () => {
+    configuration.hasExtraProps = true;
+    expect(vullaan.formFactory({ category: "afval" }).controls).not.toEqual({ });
+  });
+
+  it('should return empty controls when hasExtraProps is false', () => {
+    configuration.hasExtraProps = false;
+    expect(vullaan.formFactory({ category: "afval" }).controls).toEqual({ });
+  });
+
+  it('should return empty controls when hasExtraProps is true but no category is found', () => {
+    configuration.hasExtraProps = false;
+    expect(vullaan.formFactory({ category: "not-existing-category" }).controls).toEqual({ });
+  });
+});

--- a/src/signals/incident/definitions/__tests__/wizard-step-2-vulaan.test.js
+++ b/src/signals/incident/definitions/__tests__/wizard-step-2-vulaan.test.js
@@ -1,19 +1,19 @@
 import configuration from 'shared/services/configuration/configuration';
-import vullaan from '../wizard-step-2-vulaan';
+import vulaan from '../wizard-step-2-vulaan';
 
 describe('wizard-step-2-vullaan', () => {
-  it('should return controls when hasExtraProps is true', () => {
-    configuration.hasExtraProps = true;
-    expect(vullaan.formFactory({ category: "afval" }).controls).not.toEqual({ });
+  it('should return controls when showVulaanControls is true', () => {
+    configuration.showVulaanControls = true;
+    expect(vulaan.formFactory({ category: 'afval' }).controls).not.toEqual({});
   });
 
-  it('should return empty controls when hasExtraProps is false', () => {
-    configuration.hasExtraProps = false;
-    expect(vullaan.formFactory({ category: "afval" }).controls).toEqual({ });
+  it('should return empty controls when showVulaanControls is false', () => {
+    configuration.showVulaanControls = false;
+    expect(vulaan.formFactory({ category: 'afval' }).controls).toEqual({});
   });
 
-  it('should return empty controls when hasExtraProps is true but no category is found', () => {
-    configuration.hasExtraProps = false;
-    expect(vullaan.formFactory({ category: "not-existing-category" }).controls).toEqual({ });
+  it('should return empty controls when showVulaanControls is true but no category is found', () => {
+    configuration.showVulaanControls = false;
+    expect(vulaan.formFactory({ category: 'not-existing-category' }).controls).toEqual({});
   });
 });

--- a/src/signals/incident/definitions/wizard-step-2-vulaan.js
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan.js
@@ -1,3 +1,4 @@
+import configuration from 'shared/services/configuration/configuration';
 import afval from './wizard-step-2-vulaan/afval';
 import overlastBedrijvenEnHoreca from './wizard-step-2-vulaan/overlast-bedrijven-en-horeca';
 import overlastInDeOpenbareRuimte from './wizard-step-2-vulaan/overlast-in-de-openbare-ruimte';
@@ -15,6 +16,9 @@ export default {
   previousButtonClass: 'action startagain',
   formAction: 'UPDATE_INCIDENT',
   formFactory: ({ category }) => {
+    const noExtraProps = { controls: {} };
+    if(!configuration.hasExtraProps) return noExtraProps;
+
     switch (category) {
       case 'afval':
         return afval;
@@ -41,7 +45,7 @@ export default {
         return wonen;
 
       default:
-        return { controls: {} };
+        return noExtraProps;
     }
   },
 };

--- a/src/signals/incident/definitions/wizard-step-2-vulaan.js
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan.js
@@ -17,7 +17,7 @@ export default {
   formAction: 'UPDATE_INCIDENT',
   formFactory: ({ category }) => {
     const noExtraProps = { controls: {} };
-    if(!configuration.hasExtraProps) return noExtraProps;
+    if (!configuration.showVulaanControls) return noExtraProps;
 
     switch (category) {
       case 'afval':

--- a/src/signals/incident/definitions/wizard-step-2-vulaan.js
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan.js
@@ -17,7 +17,7 @@ export default {
   formAction: 'UPDATE_INCIDENT',
   formFactory: ({ category }) => {
     const noExtraProps = { controls: {} };
-    if (!configuration.showVulaanControls) return noExtraProps;
+    if (!configuration?.showVulaanControls) return noExtraProps;
 
     switch (category) {
       case 'afval':


### PR DESCRIPTION
This PR
- adds a new property in the application configuration: `hasExtraProps`
- when this property si set to false, no extra questionary wil be presented to the user.
- this property will be used to switch off the extra questionaries for the Wesp implementation

Note that the specific configuration of the build repositories for Weesp and Amsterdam wil be done after this PR is Approved
