### PR TITLE
[SIG-2757] Show the `rederij` name in the summary

### DIFF
--- a/src/signals/incident/components/form/SelectInput/__snapshots__/index.test.js.snap
+++ b/src/signals/incident/components/form/SelectInput/__snapshots__/index.test.js.snap
@@ -52,18 +52,18 @@ exports[`Form component <SelectInput /> rendering should render select field cor
       Array [
         Object {
           "key": "foo",
-          "name": "foo",
-          "value": "Foo",
+          "name": "Foo",
+          "value": "foo",
         },
         Object {
           "key": "bar",
-          "name": "bar",
-          "value": "Bar",
+          "name": "Bar",
+          "value": "bar",
         },
         Object {
           "key": "baz",
-          "name": "baz",
-          "value": "Baz",
+          "name": "Baz",
+          "value": "baz",
         },
       ]
     }

--- a/src/signals/incident/components/form/SelectInput/index.js
+++ b/src/signals/incident/components/form/SelectInput/index.js
@@ -22,7 +22,7 @@ const SelectInput = ({ handler, touched, hasError, meta, parent, getError, valid
         }
         options={
           meta.values && isObject(meta.values)
-            ? Object.entries(meta.values).map(([key, value]) => ({ key, name: key, value }))
+            ? Object.entries(meta.values).map(([id, label]) => ({ key: id, name: label, value: id }))
             : []
         }
       />

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/overlast-op-het-water.js
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/overlast-op-het-water.js
@@ -21,6 +21,7 @@ export const controls = {
         subcategory: 'overlast-op-het-water-snel-varen',
       },
       label: 'Gaat de melding over een rondvaartboot?',
+      shortLabel: 'Rondvaartboot',
       pathMerge: 'extra_properties',
       values: {
         ja: 'Ja',

--- a/src/signals/incident/definitions/wizard-step-5-samenvatting.js
+++ b/src/signals/incident/definitions/wizard-step-5-samenvatting.js
@@ -26,6 +26,9 @@ export const renderPreview = ({ render: renderFunc, meta }) => {
 
       return () => 'Ja';
 
+    case 'SelectInput':
+      return ({ value }) => value?.label;
+
     case 'MultiTextInput':
       return SCSVLabel;
 
@@ -73,7 +76,8 @@ export default {
       sharing_allowed: {
         meta: {
           shortLabel: 'Toestemming contactgegevens delen',
-          value: 'Ja, ik geef de gemeente Amsterdam toestemming om mijn contactgegevens te delen met andere organisaties, als dat nodig is om mijn melding goed op te lossen.',
+          value:
+            'Ja, ik geef de gemeente Amsterdam toestemming om mijn contactgegevens te delen met andere organisaties, als dat nodig is om mijn melding goed op te lossen.',
           path: 'reporter.sharing_allowed',
         },
         render: FormComponents.EmphasisCheckboxInput,

--- a/src/signals/incident/definitions/wizard-step-5-samenvatting.js
+++ b/src/signals/incident/definitions/wizard-step-5-samenvatting.js
@@ -9,7 +9,7 @@ import { controls as afvalControls } from './wizard-step-2-vulaan/afval';
 import { controls as overlastPersonenGroepenControls } from './wizard-step-2-vulaan/overlast-van-en-door-personen-of-groepen';
 import FormComponents from '../components/form';
 
-export const ObjectLabel = ({ value }) => value.label;
+export const ObjectLabel = ({ value }) => value?.label;
 export const Label = ({ value }) => value;
 export const SCSVLabel = ({ value }) => value.filter(Boolean).join('; ');
 export const Null = () => null;
@@ -17,6 +17,7 @@ export const Null = () => null;
 export const renderPreview = ({ render: renderFunc, meta }) => {
   switch (renderFunc.name) {
     case 'RadioInputGroup':
+    case 'SelectInput':
       return ObjectLabel;
 
     case 'CheckboxInput':
@@ -25,9 +26,6 @@ export const renderPreview = ({ render: renderFunc, meta }) => {
       }
 
       return () => 'Ja';
-
-    case 'SelectInput':
-      return ({ value }) => value?.label;
 
     case 'MultiTextInput':
       return SCSVLabel;


### PR DESCRIPTION
This PR fixes an issue where the boat company name was not shown on the summary page.