### PR TITLE
[SIG-2573] Prevent extra BAG request

### DIFF
--- a/internals/webpack/template.js
+++ b/internals/webpack/template.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const merge = require('lodash.merge');
 
 const template = {};
 
@@ -17,11 +18,7 @@ if (process.env.NODE_ENV !== 'production') {
     console.log(`You can use \`${devConfigFile}\` for configuration overwrites in your development environment.\n`);
   }
 
-  const combinedConfig = {
-    ...config,
-    ...devConfig,
-  };
-
+  const combinedConfig = merge({}, config, devConfig);
   const configPlaceholder = '$SIGNALS_CONFIG';
   const configString = JSON.stringify(combinedConfig);
   const indexFile = path.join(__dirname, '..', '..', 'src', 'index.html');

--- a/package-lock.json
+++ b/package-lock.json
@@ -17132,6 +17132,11 @@
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
       "dev": true
     },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    },
     "lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "lodash.isobject": "^3.0.2",
     "lodash.isstring": "^4.0.1",
     "lodash.map": "^4.6.0",
+    "lodash.merge": "^4.6.2",
     "lodash.orderby": "^4.6.0",
     "lodash.set": "^4.3.2",
     "lodash.some": "^4.6.0",

--- a/src/components/MapInput/index.js
+++ b/src/components/MapInput/index.js
@@ -73,7 +73,7 @@ const MapInput = ({ className, value, onChange, mapOptions, events }) => {
       dispatch(setLocationAction(event.latlng));
 
       const response = await reverseGeocoderService(event.latlng);
-      const stadsdeel = await getStadsdeel(event.latlng);
+      const stadsdeel = configuration?.map?.options?.stadsdeel || (await getStadsdeel(event.latlng));
 
       const onChangePayload = {
         geometrie: locationTofeature(event.latlng),
@@ -107,7 +107,7 @@ const MapInput = ({ className, value, onChange, mapOptions, events }) => {
         setValuesAction({ location: option.data.location, address: option.data.address, addressText: option.value })
       );
 
-      const stadsdeel = await getStadsdeel(option.data.location);
+      const stadsdeel = configuration?.map?.options?.stadsdeel || (await getStadsdeel(option.data.location));
 
       onChange({
         geometrie: locationTofeature(option.data.location),


### PR DESCRIPTION
This PR:
- applies a change to the webpack `template` file so that configuration files are merged instead of fully replaced
- has the `MapInput` component look for the `stadsdeel` prop in the map options configuration and when it finds it uses that value instead of performing an extra BAG request