### PR TITLE
[SIG-2810] Show correct questions

### DIFF
--- a/src/signals/incident/definitions/wizard-step-2-vulaan/wegen-verkeer-straatmeubilair.js
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/wegen-verkeer-straatmeubilair.js
@@ -111,9 +111,13 @@ export const controls = {
     meta: {
       ifAllOf: {
         subcategory: 'lantaarnpaal-straatverlichting',
+        ifOneOf: {
+          extra_straatverlichting_probleem: ['lamp_doet_het_niet', 'lamp_is_zichtbaar_beschadigd', 'overig'],
+        },
       },
       ifOneOf: {
         extra_straatverlichting: [
+          'drie_of_meer_kapot',
           'is_gevolg_van_aanrijding',
           'lamp_op_grond_of_scheef',
           'deurtje_weg_of_open',


### PR DESCRIPTION
This PR changes the logic of showing the `extra_straatverlichting_gevaar` question in the incident form.