### PR TITLE
(Fix) import/no-unresolved

### DIFF
--- a/.eslintrc.cli.js
+++ b/.eslintrc.cli.js
@@ -1,0 +1,10 @@
+module.exports = {
+  extends: '.eslintrc.js',
+  settings: {
+    'import/resolver': {
+      webpack: {
+        config: './internals/webpack/webpack.dev.babel.js',
+      },
+    },
+  },
+};

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+require('@babel/register');
 
 const prettierOptions = JSON.parse(fs.readFileSync(path.resolve(__dirname, '.prettierrc'), 'utf8'));
 
@@ -36,7 +37,7 @@ module.exports = {
     'import/no-dynamic-require': 0,
     'import/no-extraneous-dependencies': 0,
     'import/no-named-as-default': 0,
-    'import/no-unresolved': 2,
+    'import/no-unresolved': [2, { commonjs: true }],
     'import/no-webpack-loader-syntax': 0,
     'import/prefer-default-export': 0,
     indent: [
@@ -101,8 +102,9 @@ module.exports = {
   },
   settings: {
     'import/resolver': {
-      webpack: {
-        config: './internals/webpack/webpack.dev.babel.js',
+      node: {
+        extensions: ['.js', '.jsx', '.react.js'],
+        moduleDirectory: ['node_modules', './src'],
       },
     },
   },

--- a/internals/webpack/webpack.base.babel.js
+++ b/internals/webpack/webpack.base.babel.js
@@ -135,15 +135,9 @@ module.exports = options => ({
     .concat(options.plugins)
     .filter(Boolean),
   resolve: {
-    modules: ['node_modules', 'src'],
+    modules: [path.resolve(__rootdir, 'src'), 'node_modules'],
     extensions: ['.js', '.jsx', '.react.js'],
     mainFields: ['browser', 'jsnext:main', 'main'],
-    alias: {
-      signals: path.resolve(__rootdir, 'src/signals/'),
-      components: path.resolve(__rootdir, 'src/components/'),
-      containers: path.resolve(__rootdir, 'src/containers/'),
-      hooks: path.resolve(__rootdir, 'src/hooks/'),
-    },
   },
   devtool: options.devtool,
   target: 'web', // Make web variables accessible to webpack, e.g. window

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,23 +1,13 @@
 {
   "compilerOptions": {
-    "allowSyntheticDefaultImports": true,
+    "allowSyntheticDefaultImports": false,
     "module": "commonjs",
     "target": "es6",
     "baseUrl": "./src",
-    "paths": {
-      "shared/": [
-        "./shared/*"
-      ],
-      "components/": [
-        "./components/*"
-      ],
-      "containers/": [
-        "./containers/*"
-      ],
-      "hooks/": [
-        "./hooks/*"
-      ]
-    }
+  },
+  "env": {
+    "NODE_ENV": "development",
+    "BABEL_ENV": "development"
   },
   "exclude": [
     "node_modules",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "clean": "shjs ./internals/scripts/clean.js",
     "coveralls": "cat ./coverage/lcov.info | coveralls",
     "cy:open": "cypress open",
-    "lint:eslint": "BABEL_ENV=lint NODE_ENV=production eslint --ignore-path .gitignore --ignore-pattern internals/scripts",
+    "lint:eslint": "BABEL_ENV=lint NODE_ENV=production eslint -c ./.eslintrc.cli.js --ignore-path .gitignore --ignore-pattern internals/scripts",
     "lint:js": "npm run lint:eslint -- . ",
     "lint:staged": "BABEL_ENV=lint lint-staged",
     "lint:fix": "npm run lint:js -- --fix",

--- a/src/signals/incident-management/containers/IncidentDetail/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/index.js
@@ -172,6 +172,7 @@ export class IncidentDetail extends React.Component {
                 <Row>
                   <DetailContainer span={12}>
                     <button
+                      aria-label="Sluiten"
                       className="incident-detail__preview-close incident-detail__button--close"
                       type="button"
                       onClick={this.onCloseAll}


### PR DESCRIPTION
This PR fixes an issue where VS Code wasn't able to resolve module located in the `src` folder. As it turned out, the lint configuration that is used by VS Code needs a `node` setting where running the linter from the command line does not. The latter requires the Webpack config to be able to resolve module properly.