### PR TITLE
(Chore) Move dispatch to underlying components

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/components/AddNote/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/AddNote/index.js
@@ -2,11 +2,13 @@ import React, { useCallback, useEffect, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { themeSpacing } from '@datapunt/asc-ui';
-import Button from 'components/Button';
+import { useDispatch } from 'react-redux';
 
+import Button from 'components/Button';
 import TextArea from 'components/TextArea';
 import Label from 'components/Label';
 import { PATCH_TYPE_NOTES } from 'models/incident/constants';
+import { patchIncident } from 'models/incident/actions';
 
 const NewNoteButton = styled(Button)`
   margin: ${themeSpacing(2, 2, 2, 0)};
@@ -16,7 +18,8 @@ const NoteButton = styled(Button)`
   margin: ${themeSpacing(8, 2, 4, 0)};
 `;
 
-const AddNote = ({ id, onPatchIncident }) => {
+const AddNote = ({ id }) => {
+  const dispatch = useDispatch();
   const areaRef = useRef(null);
   const [showForm, setShowForm] = useState(false);
   const [note, setNote] = useState('');
@@ -29,16 +32,18 @@ const AddNote = ({ id, onPatchIncident }) => {
 
       const notes = [{ text: note }];
 
-      onPatchIncident({
-        id,
-        type: PATCH_TYPE_NOTES,
-        patch: { notes },
-      });
+      dispatch(
+        patchIncident({
+          id,
+          type: PATCH_TYPE_NOTES,
+          patch: { notes },
+        })
+      );
 
       setNote('');
       setShowForm(false);
     },
-    [id, onPatchIncident, note]
+    [id, dispatch, note]
   );
 
   const onChange = useCallback(
@@ -101,7 +106,6 @@ const AddNote = ({ id, onPatchIncident }) => {
 
 AddNote.propTypes = {
   id: PropTypes.string.isRequired,
-  onPatchIncident: PropTypes.func.isRequired,
 };
 
 export default AddNote;

--- a/src/signals/incident-management/containers/IncidentDetail/components/AddNote/index.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/AddNote/index.test.js
@@ -1,13 +1,19 @@
 import React from 'react';
 import { render, fireEvent, act } from '@testing-library/react';
+import * as reactRedux from 'react-redux';
+
 import { withAppContext } from 'test/utils';
+import { patchIncident } from 'models/incident/actions';
+import { PATCH_TYPE_NOTES } from 'models/incident/constants';
 
 import AddNote from './index';
+
+const dispatch = jest.fn();
+jest.spyOn(reactRedux, 'useDispatch').mockImplementation(() => dispatch);
 
 describe('<AddNote />', () => {
   const props = {
     id: '42',
-    onPatchIncident: jest.fn(),
   };
 
   describe('show value', () => {
@@ -50,17 +56,21 @@ describe('<AddNote />', () => {
       fireEvent.change(addNoteTextArea, { target: { value } });
     });
 
+    expect(dispatch).not.toHaveBeenCalled();
+
     act(() => {
       fireEvent.click(saveNoteButton);
     });
 
-    expect(props.onPatchIncident).toHaveBeenCalledWith({
-      id: '42',
-      type: 'notes',
-      patch: {
-        notes: [{ text: value }],
-      },
-    });
+    expect(dispatch).toHaveBeenCalledWith(
+      patchIncident({
+        id: props.id,
+        type: PATCH_TYPE_NOTES,
+        patch: {
+          notes: [{ text: value }],
+        },
+      })
+    );
   });
 
   it('should clear the textarea', async () => {

--- a/src/signals/incident-management/containers/IncidentDetail/components/DetailHeader/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/DetailHeader/index.js
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Link, useLocation } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
 import { themeColor, themeSpacing, Heading, styles } from '@datapunt/asc-ui';
 
 import BackLink from 'components/BackLink';
@@ -9,6 +10,7 @@ import { PATCH_TYPE_THOR } from 'models/incident/constants';
 import Button from 'components/Button';
 import { MAP_URL, INCIDENT_URL, INCIDENTS_URL } from 'signals/incident-management/routes';
 import { linksType } from 'shared/types';
+import { patchIncident as patchIncidentAction } from 'models/incident/actions';
 
 import DownloadButton from './components/DownloadButton';
 
@@ -86,7 +88,8 @@ const ParentLink = styled(Link)`
   color: black;
 `;
 
-const DetailHeader = ({ status, incidentId, links, onPatchIncident }) => {
+const DetailHeader = ({ status, incidentId, links }) => {
+  const dispatch = useDispatch();
   const location = useLocation();
   const canSplit = status === 'm' && !(links?.['sia:children'] || links?.['sia:parent']);
   const canThor = ['m', 'i', 'b', 'h', 'send failed', 'reopened'].some(value => value === status);
@@ -105,6 +108,10 @@ const DetailHeader = ({ status, incidentId, links, onPatchIncident }) => {
 
   const referrer = location.referrer?.startsWith(MAP_URL) ? MAP_URL : INCIDENTS_URL;
   const parentId = links?.['sia:parent']?.href?.split('/').pop();
+
+  const patchIncident = useCallback(() => {
+    dispatch(patchIncidentAction(patch));
+  }, [dispatch, patch]);
 
   return (
     <Header className="detail-header">
@@ -137,7 +144,7 @@ const DetailHeader = ({ status, incidentId, links, onPatchIncident }) => {
         )}
 
         {canThor && (
-          <Button variant="application" onClick={() => onPatchIncident(patch)} data-testid="detail-header-button-thor">
+          <Button variant="application" onClick={patchIncident} data-testid="detail-header-button-thor">
             THOR
           </Button>
         )}
@@ -156,7 +163,6 @@ const DetailHeader = ({ status, incidentId, links, onPatchIncident }) => {
 DetailHeader.propTypes = {
   incidentId: PropTypes.number.isRequired,
   links: linksType,
-  onPatchIncident: PropTypes.func.isRequired,
   status: PropTypes.string.isRequired,
 };
 

--- a/src/signals/incident-management/containers/IncidentDetail/components/DetailHeader/index.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/DetailHeader/index.test.js
@@ -1,9 +1,13 @@
 import React from 'react';
 import { render, fireEvent, act } from '@testing-library/react';
-import { withAppContext } from 'test/utils';
+import * as reactRedux from 'react-redux';
 import * as reactRouterDom from 'react-router-dom';
+
+import { withAppContext } from 'test/utils';
 import { MAP_URL, INCIDENTS_URL } from 'signals/incident-management/routes';
 import incidentFixture from 'utils/__tests__/fixtures/incident.json';
+import { patchIncident } from 'models/incident/actions';
+import { PATCH_TYPE_THOR } from 'models/incident/constants';
 
 import DetailHeader from './index';
 
@@ -17,6 +21,9 @@ jest.mock('react-router-dom', () => ({
   }),
 }));
 
+const dispatch = jest.fn();
+jest.spyOn(reactRedux, 'useDispatch').mockImplementation(() => dispatch);
+
 describe('<DetailHeader />', () => {
   let props;
 
@@ -25,7 +32,6 @@ describe('<DetailHeader />', () => {
       status: 'm',
       incidentId: 1234,
       links: incidentFixture._links,
-      onPatchIncident: jest.fn(),
     };
   });
 
@@ -84,13 +90,15 @@ describe('<DetailHeader />', () => {
   it('test clicking the thor button', () => {
     const { queryByTestId } = render(withAppContext(<DetailHeader {...props} />));
 
+    expect(dispatch).not.toHaveBeenCalled();
+
     act(() => {
       fireEvent.click(queryByTestId('detail-header-button-thor'));
     });
 
-    expect(props.onPatchIncident).toHaveBeenCalledWith({
+    expect(dispatch).toHaveBeenCalledWith(patchIncident({
       id: props.incidentId,
-      type: 'thor',
+      type: PATCH_TYPE_THOR,
       patch: {
         status: {
           state: 'ready to send',
@@ -98,7 +106,7 @@ describe('<DetailHeader />', () => {
           target_api: 'sigmax',
         },
       },
-    });
+    }));
   });
 
   it('should render a link with the correct referrer', () => {

--- a/src/signals/incident-management/containers/IncidentDetail/components/LocationForm/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/LocationForm/index.js
@@ -1,15 +1,19 @@
 import React, { useCallback, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { FormBuilder, FieldGroup } from 'react-reactive-form';
+import { useDispatch } from 'react-redux';
 
 import { locationType } from 'shared/types';
 import { PATCH_TYPE_LOCATION } from 'models/incident/constants';
 import MapContext from 'containers/MapContext';
+import { patchIncident } from 'models/incident/actions';
 
 import { mapLocation } from 'shared/services/map-location';
 import LocationInput from './components/LocationInput';
 
-const LocationForm = ({ incidentId, location, onPatchIncident, onClose }) => {
+const LocationForm = ({ incidentId, location, onClose }) => {
+  const dispatch = useDispatch();
+
   const form = useMemo(
     () =>
       FormBuilder.group({
@@ -31,15 +35,17 @@ const LocationForm = ({ incidentId, location, onPatchIncident, onClose }) => {
     event => {
       event.preventDefault();
 
-      onPatchIncident({
-        id: incidentId,
-        type: PATCH_TYPE_LOCATION,
-        patch: { location: form.value.location },
-      });
+      dispatch(
+        patchIncident({
+          id: incidentId,
+          type: PATCH_TYPE_LOCATION,
+          patch: { location: form.value.location },
+        })
+      );
 
       onClose();
     },
-    [onPatchIncident, form.value, incidentId, onClose]
+    [dispatch, form.value, incidentId, onClose]
   );
 
   return (
@@ -63,7 +69,6 @@ LocationForm.propTypes = {
   incidentId: PropTypes.number.isRequired,
   location: locationType.isRequired,
   onClose: PropTypes.func.isRequired,
-  onPatchIncident: PropTypes.func.isRequired,
 };
 
 export default LocationForm;

--- a/src/signals/incident-management/containers/IncidentDetail/components/LocationForm/index.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/LocationForm/index.test.js
@@ -1,9 +1,16 @@
 import React from 'react';
 import { render, act, fireEvent } from '@testing-library/react';
+import * as reactRedux from 'react-redux';
+
+import { PATCH_TYPE_LOCATION } from 'models/incident/constants';
 import { withMapContext } from 'test/utils';
 import incidentFixture from 'utils/__tests__/fixtures/incident.json';
+import { patchIncident } from 'models/incident/actions';
 
 import LocationForm from './index';
+
+const dispatch = jest.fn();
+jest.spyOn(reactRedux, 'useDispatch').mockImplementation(() => dispatch);
 
 describe('incident-management/containers/IncidentDetail/components/LocationForm', () => {
   it('should render a form', () => {
@@ -13,7 +20,6 @@ describe('incident-management/containers/IncidentDetail/components/LocationForm'
           incidentId={incidentFixture.id}
           location={incidentFixture.location}
           onClose={() => {}}
-          onPatchIncident={() => {}}
         />
       )
     );
@@ -24,26 +30,30 @@ describe('incident-management/containers/IncidentDetail/components/LocationForm'
 
   it('should call handlers', () => {
     const onClose = jest.fn();
-    const onPatchIncident = jest.fn();
     const { queryByTestId } = render(
       withMapContext(
         <LocationForm
           incidentId={incidentFixture.id}
           location={incidentFixture.location}
           onClose={onClose}
-          onPatchIncident={onPatchIncident}
         />
       )
     );
 
     expect(onClose).not.toHaveBeenCalled();
-    expect(onPatchIncident).not.toHaveBeenCalled();
+    expect(dispatch).not.toHaveBeenCalled();
 
     act(() => {
       fireEvent.click(queryByTestId('submitBtn'));
     });
 
-    expect(onPatchIncident).toHaveBeenCalled();
+    expect(dispatch).toHaveBeenCalledWith(
+      patchIncident({
+        id: incidentFixture.id,
+        type: PATCH_TYPE_LOCATION,
+        patch: { location: incidentFixture.location },
+      })
+    );
     expect(onClose).toHaveBeenCalled();
   });
 });

--- a/src/signals/incident-management/containers/IncidentDetail/components/MetaList/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/MetaList/index.js
@@ -1,12 +1,13 @@
 import React, { useLayoutEffect, useCallback, useState, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 import { Button, themeColor, themeSpacing } from '@datapunt/asc-ui';
 
 import { string2date, string2time } from 'shared/services/string-parser/string-parser';
 import { makeSelectSubCategories } from 'models/categories/selectors';
 import { typesList, priorityList } from 'signals/incident-management/definitions';
+import { patchIncident as patchIncidentAction } from 'models/incident/actions';
 
 import { incidentType } from 'shared/types';
 import RadioInput from 'signals/incident-management/components/RadioInput';
@@ -49,7 +50,8 @@ export const getCategoryName = ({ name, departments }) => {
   return `${name}${departmensStringList}`;
 };
 
-const MetaList = ({ incident, onEditStatus, onPatchIncident }) => {
+const MetaList = ({ incident, onEditStatus }) => {
+  const dispatch = useDispatch();
   const [valueChanged, setValueChanged] = useState(false);
   const subcategories = useSelector(makeSelectSubCategories);
   const subcategoryOptions = useMemo(
@@ -78,9 +80,10 @@ const MetaList = ({ incident, onEditStatus, onPatchIncident }) => {
   const patchIncident = useCallback(
     patchedData => {
       setValueChanged(true);
-      onPatchIncident(patchedData);
+
+      dispatch(patchIncidentAction(patchedData));
     },
-    [onPatchIncident]
+    [dispatch]
   );
 
   return (
@@ -168,7 +171,6 @@ const MetaList = ({ incident, onEditStatus, onPatchIncident }) => {
 MetaList.propTypes = {
   incident: incidentType.isRequired,
   onEditStatus: PropTypes.func.isRequired,
-  onPatchIncident: PropTypes.func.isRequired,
 };
 
 export default MetaList;

--- a/src/signals/incident-management/containers/IncidentDetail/components/MetaList/index.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/MetaList/index.test.js
@@ -1,11 +1,13 @@
 import React from 'react';
 import { fireEvent, render, cleanup, act } from '@testing-library/react';
+import * as reactRedux from 'react-redux';
 
 import { string2date, string2time } from 'shared/services/string-parser/string-parser';
 import { store, withAppContext } from 'test/utils';
-import incidentJson from 'utils/__tests__/fixtures/incident.json';
+import incidentFixture from 'utils/__tests__/fixtures/incident.json';
 import categoriesPrivate from 'utils/__tests__/fixtures/categories_private.json';
 import { fetchCategoriesSuccess } from 'models/categories/actions';
+import { patchIncident } from 'models/incident/actions';
 
 import MetaList, { getCategoryName }from './index';
 
@@ -13,13 +15,15 @@ jest.mock('shared/services/string-parser/string-parser');
 
 store.dispatch(fetchCategoriesSuccess(categoriesPrivate));
 
+const dispatch = jest.fn();
+jest.spyOn(reactRedux, 'useDispatch').mockImplementation(() => dispatch);
+
 describe('<MetaList />', () => {
   let props;
 
   beforeEach(() => {
     props = {
-      incident: incidentJson,
-      onPatchIncident: jest.fn(),
+      incident: incidentFixture,
       onEditStatus: jest.fn(),
       onShowAttachment: jest.fn(),
     };
@@ -44,14 +48,14 @@ describe('<MetaList />', () => {
       expect(queryByText('Normaal')).toBeInTheDocument();
 
       expect(queryByText('Subcategorie')).toBeInTheDocument();
-      const subcategory = categoriesPrivate.results.find(cat => cat.name === incidentJson.category.sub);
-      const categoryName = getCategoryName({ name: incidentJson.category.sub, departments: subcategory.departments });
+      const subcategory = categoriesPrivate.results.find(cat => cat.name === incidentFixture.category.sub);
+      const categoryName = getCategoryName({ name: incidentFixture.category.sub, departments: subcategory.departments });
       expect(queryByText(categoryName)).toBeInTheDocument();
       expect(queryByTestId('meta-list-main-category-definition')).toHaveTextContent(/^Hoofdcategorie$/);
-      expect(queryByTestId('meta-list-main-category-value')).toHaveTextContent(incidentJson.category.main);
+      expect(queryByTestId('meta-list-main-category-value')).toHaveTextContent(incidentFixture.category.main);
 
       expect(queryByTestId('meta-list-source-definition')).toHaveTextContent(/^Bron$/);
-      expect(queryByTestId('meta-list-source-value')).toHaveTextContent(incidentJson.source);
+      expect(queryByTestId('meta-list-source-value')).toHaveTextContent(incidentFixture.source);
     });
 
     it('should render correctly with high priority', () => {
@@ -81,13 +85,21 @@ describe('<MetaList />', () => {
 
       const submitButtons = getAllByTestId(submitTestId);
 
-      expect(props.onPatchIncident).not.toHaveBeenCalled();
+      expect(dispatch).not.toHaveBeenCalled();
 
       act(() => {
         fireEvent.click(submitButtons[0]);
       });
 
-      expect(props.onPatchIncident).toHaveBeenCalled();
+      expect(dispatch).toHaveBeenCalledWith(patchIncident({
+        id: incidentFixture.id,
+        patch: {
+          priority: {
+            priority: 'high',
+          },
+        },
+        type: 'priority',
+      }));
     });
   });
 

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/DefaultTexts/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/DefaultTexts/index.js
@@ -1,8 +1,7 @@
-/* eslint-disable react/no-array-index-key */
 import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { Link, Heading, themeColor, themeSpacing  } from '@datapunt/asc-ui';
+import { Link, Heading, themeColor, themeSpacing } from '@datapunt/asc-ui';
 
 import { defaultTextsType } from 'shared/types';
 
@@ -19,7 +18,7 @@ const StyledDefaultText = styled.div`
 `;
 
 const StyledTitle = styled.div`
-  font-family: "Avenir Next LT W01 Demi";
+  font-family: 'Avenir Next LT W01 Demi';
   margin-bottom: ${themeSpacing(2)};
 `;
 
@@ -31,46 +30,41 @@ const StyledLink = styled(Link)`
   cursor: pointer;
 `;
 
-const DefaultTexts = ({ defaultTexts, status, hasDefaultTexts, onHandleUseDefaultText }) => {
-  const allText = (defaultTexts && defaultTexts.length && defaultTexts.find(text => text.state === status));
+const DefaultTexts = ({ defaultTexts, status, onHandleUseDefaultText }) => {
+  const allText = defaultTexts?.length > 0 && defaultTexts.find(text => text.state === status);
+
+  if (!allText) return null;
 
   return (
-    <div>
-      {hasDefaultTexts && allText
-        ? (
-          <Fragment>
-            <StyledH4 forwardedAs="h4" data-testid="defaultTextsTitle">Standaard teksten</StyledH4>
+    <Fragment>
+      <StyledH4 forwardedAs="h4" data-testid="defaultTextsTitle">
+        Standaard teksten
+      </StyledH4>
 
-            {allText.templates.map((item, index) => (
-              <StyledDefaultText key={index}>
-                <StyledTitle
-                  data-testid="defaultTextsItemTitle"
-                >{item.title}</StyledTitle>
-                <div
-                  data-testid="defaultTextsItemText"
-                >{item.text}</div>
-                <StyledLink
-                  data-testid="defaultTextsItemButton"
-                  variant="inline"
-                  onClick={e => onHandleUseDefaultText(e, item.text)}
-                >
-                  Gebruik deze tekst
-                </StyledLink>
-              </StyledDefaultText>
-            ))}
-          </Fragment>
-        )
-        : ''}
-    </div>
+      {allText.templates
+        .filter(({ title, text }) => title && text)
+        .map((item, index) => (
+          // eslint-disable-next-line react/no-array-index-key
+          <StyledDefaultText key={`${index}${status}${JSON.stringify(item)}`}>
+            <StyledTitle data-testid="defaultTextsItemTitle">{item.title}</StyledTitle>
+            <div data-testid="defaultTextsItemText">{item.text}</div>
+            <StyledLink
+              data-testid="defaultTextsItemButton"
+              variant="inline"
+              onClick={e => onHandleUseDefaultText(e, item.text)}
+            >
+              Gebruik deze tekst
+            </StyledLink>
+          </StyledDefaultText>
+        ))}
+    </Fragment>
   );
 };
 
 DefaultTexts.propTypes = {
   defaultTexts: defaultTextsType.isRequired,
-  status: PropTypes.string.isRequired,
-  hasDefaultTexts: PropTypes.bool.isRequired,
-
   onHandleUseDefaultText: PropTypes.func.isRequired,
+  status: PropTypes.string.isRequired,
 };
 
 export default DefaultTexts;

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/index.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/index.test.js
@@ -1,199 +1,185 @@
 import React from 'react';
-import { render } from '@testing-library/react';
-import { shallow } from 'enzyme';
+import { render, fireEvent, act } from '@testing-library/react';
+import * as reactRedux from 'react-redux';
+
+import { PATCH_TYPE_STATUS } from 'models/incident/constants';
+import { patchIncident } from 'models/incident/actions';
 import { withAppContext } from 'test/utils';
+import incidentFixture from 'utils/__tests__/fixtures/incident.json';
+import { changeStatusOptionList } from '../../../../definitions/statusList';
 
-import { FieldGroup } from 'react-reactive-form';
+import StatusForm from '.';
 
-import StatusForm from './index';
+const defaultTexts = [
+  {
+    state: 'ingepland',
+    templates: [
+      { title: 'Ingepland', text: 'Over 1 dag' },
+      { title: 'Ingepland', text: 'Over 2 dagen' },
+      { title: '', text: '' },
+    ],
+  },
+  {
+    state: 'o',
+    templates: [
+      { title: 'Niet opgelost', text: 'Geen probleem gevonden' },
+      { title: 'Niet opgelost', text: 'Niet voor regio Amsterdam' },
+      { title: 'Opgelost', text: 'Lamp vervangen' },
+      { title: 'Opgelost', text: 'Lantaarnpaal vervangen' },
+    ],
+  },
+];
 
-import statusList, { changeStatusOptionList, defaultTextsOptionList } from '../../../../definitions/statusList';
+const onClose = jest.fn();
+const dispatch = jest.fn();
+jest.spyOn(reactRedux, 'useDispatch').mockImplementation(() => dispatch);
 
-jest.mock('./components/DefaultTexts', () => () => <div data-testid="status-form-default-texts" />);
-
-describe('<StatusForm />', () => {
-  let wrapper;
-  let props;
-  let instance;
-
+describe('signals/incident-management/containers/IncidentDetail/components/StatusForm', () => {
   beforeEach(() => {
-    props = {
-      incident: {
-        id: 42,
-        status: {
-          state: 'reopen requested',
-        },
-      },
-      patching: { location: false },
-      error: false,
-      changeStatusOptionList,
-      defaultTextsOptionList,
-      statusList,
-      defaultTexts: [],
-      onPatchIncident: jest.fn(),
-      onDismissError: jest.fn(),
-      onClose: jest.fn(),
-    };
+    onClose.mockReset();
+    dispatch.mockReset();
   });
 
-  const getComponent = prps => {
-    const wrap = shallow(
-      <StatusForm {...prps} />
+  it('renders correctly', () => {
+    const { container, getByTestId, getByText } = render(
+      withAppContext(<StatusForm incident={incidentFixture} defaultTexts={defaultTexts} onClose={onClose} />)
     );
 
-    const inst = wrap.instance();
+    expect(container.querySelector('textarea')).toBeInTheDocument();
+    expect(getByTestId('statusFormSubmitButton')).toBeInTheDocument();
+    expect(getByTestId('statusFormCancelButton')).toBeInTheDocument();
 
-    return [wrap, inst];
-  };
-
-  afterEach(() => {
-    jest.resetAllMocks();
+    Object.values(changeStatusOptionList).forEach(({ value }) => {
+      expect(getByText(value)).toBeInTheDocument();
+    });
   });
 
-  it('should contain the FieldGroup', () => {
-    [wrapper] = getComponent(props);
+  it('shows default texts', () => {
+    const stateWithTexts = defaultTexts[0].state;
 
-    expect(wrapper.find(FieldGroup)).toHaveLength(1);
-    expect(props.onDismissError).toHaveBeenCalledTimes(1);
-  });
-
-  it('should contain render unauthorized error', () => {
-    props.error = {
-      response: {
-        status: 403,
-      },
-    };
-
-    const { queryByTestId } = render(
-      withAppContext(<StatusForm {...props} />)
+    const { getByText, getByTestId, queryByTestId } = render(
+      withAppContext(<StatusForm incident={incidentFixture} defaultTexts={defaultTexts} onClose={onClose} />)
     );
 
-    expect(queryByTestId('statusFormError')).toHaveTextContent(/^Je bent niet geautoriseerd om dit te doen\.$/);
-  });
+    const radioButton = getByTestId(`status-${stateWithTexts}`);
 
-  it('should contain render other error', () => {
-    props.error = {
-      response: {
-        status: 400,
-      },
-    };
+    expect(queryByTestId('defaultTextsTitle')).not.toBeInTheDocument();
 
-    const { queryByTestId } = render(
-      withAppContext(<StatusForm {...props} />)
-    );
-
-    expect(queryByTestId('statusFormError')).toHaveTextContent(/^De gekozen status is niet mogelijk in deze situatie\.$/);
-  });
-
-
-  it('should contain loading indicator when patching error', () => {
-    props.patching = {
-      status: true,
-    };
-
-    const { queryByTestId } = render(
-      withAppContext(<StatusForm {...props} />)
-    );
-
-    expect(queryByTestId('statusFormSpinner')).not.toBeNull();
-  });
-
-  it('should render form correctly', () => {
-    const { queryByText, queryByTestId } = render(
-      withAppContext(<StatusForm {...props} />)
-    );
-
-    expect(queryByText('Huidige status')).not.toBeNull();
-    expect(queryByText('Verzoek tot heropenen')).not.toBeNull();
-
-    expect(queryByText('Nieuwe status')).not.toBeNull();
-    expect(queryByText('In behandeling')).not.toBeNull();
-
-    expect(queryByTestId('statusFormSubmitButton')).toHaveTextContent(/^Status opslaan$/);
-    expect(queryByTestId('statusFormCancelButton')).toHaveTextContent(/^Annuleren$/);
-  });
-
-  it('should close the status form when result is ok', () => {
-    const { rerender } = render(
-      withAppContext(<StatusForm {...props} />)
-    );
-
-    props.patching = { status: false };
-    props.error = { response: { ok: true } };
-
-    rerender(
-      withAppContext(<StatusForm {...props} />)
-    );
-
-    expect(props.onClose).toHaveBeenCalledTimes(1);
-  });
-
-  it('should not close the status form when result triggers an error', () => {
-    const { rerender } = render(
-      withAppContext(<StatusForm {...props} />)
-    );
-
-    props.patching = { status: false };
-    props.error = { response: { ok: false, status: 500 } };
-
-    rerender(
-      withAppContext(<StatusForm {...props} />)
-    );
-
-    expect(props.onClose).not.toHaveBeenCalled();
-  });
-
-  describe('FieldGroup', () => {
-    let renderedFormGroup;
-
-    beforeEach(() => {
-      [wrapper, instance] = getComponent(props);
-
-      renderedFormGroup = wrapper.find(FieldGroup).shallow().dive();
+    act(() => {
+      fireEvent.click(radioButton);
     });
 
-    it('should set default text when it has triggered', () => {
-      instance.handleUseDefaultText({ preventDefault: jest.fn() }, 'default text');
+    expect(queryByTestId('defaultTextsTitle')).toBeInTheDocument();
 
-      expect(instance.form.value.text).toEqual('default text');
+    Object.values(defaultTexts[0].templates).forEach(({ text }) => {
+      if (text) expect(getByText(text)).toBeInTheDocument();
     });
+  });
 
-    it('should call patch status when the form is submitted (submit button is clicked)', () => {
-      const form = instance.form;
-      const formValues = {
-        status: 'o',
-        text: 'boooooo',
-      };
-      form.patchValue(formValues);
+  it('does not show default texts', () => {
+    const { getByTestId, queryByTestId } = render(
+      withAppContext(<StatusForm incident={incidentFixture} defaultTexts={defaultTexts} onClose={onClose} />)
+    );
 
-      // click on the submit button doesn't work in Enzyme, this is the way to test submit functionality
-      renderedFormGroup.find('form').simulate('submit', { preventDefault() { } });
-      expect(props.onPatchIncident).toHaveBeenCalledWith({
-        id: 42,
-        patch: {
-          status: {
-            state: 'o',
-            text: 'boooooo',
-          },
-        },
-        type: 'status',
+    expect(queryByTestId('defaultTextsTitle')).not.toBeInTheDocument();
+
+    act(() => {
+      changeStatusOptionList.forEach(({ key }) => {
+        const radioButton = getByTestId(`status-${key}`);
+        fireEvent.click(radioButton);
+
+        expect(queryByTestId('defaultTextsTitle')).not.toBeInTheDocument();
       });
     });
+  });
 
-    it('should show an alert when the text contains template characters', () => {
-      global.alert = jest.fn();
-      const form = instance.form;
-      const formValues = {
-        status: 'o',
-        text: 'Bedankt voor het melden, binnen {{ aantal }} werkdagen zal uw verzoek in behandeling worden genomen.',
-      };
-      form.patchValue(formValues);
+  it('applies default text selection', () => {
+    const stateWithTexts = defaultTexts[0].state;
 
-      // click on the submit button doesn't work in Enzyme, this is the way to test submit functionality
-      renderedFormGroup.find('form').simulate('submit', { preventDefault() { } });
+    const { container, getByTestId, getAllByTestId } = render(
+      withAppContext(<StatusForm incident={incidentFixture} defaultTexts={defaultTexts} onClose={onClose} />)
+    );
 
-      expect(global.alert).toHaveBeenCalled();
-      expect(props.onPatchIncident).not.toHaveBeenCalledWith();
+    const radioButton = getByTestId(`status-${stateWithTexts}`);
+
+    act(() => {
+      fireEvent.click(radioButton);
     });
+
+    const textarea = container.querySelector('textarea');
+    expect(textarea).toBeInTheDocument();
+    expect(textarea.value).toEqual('');
+
+    act(() => {
+      fireEvent.click(radioButton);
+    });
+
+    const useTextButton1 = getAllByTestId('defaultTextsItemButton')[0];
+
+    act(() => {
+      fireEvent.click(useTextButton1);
+    });
+
+    expect(textarea.value).toEqual(defaultTexts[0].templates[0].text);
+
+    const useTextButton2 = getAllByTestId('defaultTextsItemButton')[1];
+
+    act(() => {
+      fireEvent.click(useTextButton2);
+    });
+
+    expect(textarea.value).toEqual(defaultTexts[0].templates[1].text);
+  });
+
+  it('should alert on presence of specific characters', () => {
+    global.alert = jest.fn();
+
+    const { container, getByTestId } = render(
+      withAppContext(<StatusForm incident={incidentFixture} defaultTexts={defaultTexts} onClose={onClose} />)
+    );
+
+    act(() => {
+      fireEvent.click(getByTestId('statusFormSubmitButton'));
+    });
+
+    expect(global.alert).not.toHaveBeenCalled();
+
+    const textarea = container.querySelector('textarea');
+
+    act(() => {
+      fireEvent.change(textarea, { target: { value: '{{ replace_me }}' } });
+    });
+
+    act(() => {
+      fireEvent.click(getByTestId('statusFormSubmitButton'));
+    });
+
+    expect(global.alert).toHaveBeenCalled();
+
+    global.alert.mockRestore();
+  });
+
+  it('should handle submit', () => {
+    const { getByTestId } = render(
+      withAppContext(<StatusForm incident={incidentFixture} defaultTexts={defaultTexts} onClose={onClose} />)
+    );
+
+    expect(onClose).not.toHaveBeenCalled();
+    expect(dispatch).not.toHaveBeenCalled();
+
+    act(() => {
+      fireEvent.click(getByTestId('statusFormSubmitButton'));
+    });
+
+    expect(dispatch).toHaveBeenCalledWith(
+      patchIncident({
+        id: incidentFixture.id,
+        type: PATCH_TYPE_STATUS,
+        patch: {
+          status: { state: incidentFixture.status.state, text: '' },
+        },
+      })
+    );
+    expect(onClose).toHaveBeenCalled();
   });
 });

--- a/src/signals/incident-management/containers/IncidentDetail/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/index.js
@@ -13,7 +13,6 @@ import LoadingIndicator from 'shared/components/LoadingIndicator';
 import { makeSelectLoading, makeSelectError } from 'containers/App/selectors';
 import {
   requestIncident,
-  patchIncident,
   requestAttachments,
   requestDefaultTexts,
   dismissError,
@@ -129,7 +128,6 @@ export class IncidentDetail extends React.Component {
       match: {
         params: { id },
       },
-      onPatchIncident,
       onDismissError,
     } = this.props;
     const { list } = this.props.historyModel;
@@ -162,7 +160,6 @@ export class IncidentDetail extends React.Component {
                       incidentId={incident.id}
                       status={incident?.status?.state}
                       links={incident?._links}
-                      onPatchIncident={onPatchIncident}
                     />
                   </Column>
                 </Row>
@@ -194,7 +191,6 @@ export class IncidentDetail extends React.Component {
                       <LocationForm
                         incidentId={incident.id}
                         location={incident.location}
-                        onPatchIncident={onPatchIncident}
                         onClose={this.onCloseAll}
                       />
                     )}
@@ -208,7 +204,6 @@ export class IncidentDetail extends React.Component {
                         defaultTextsOptionList={defaultTextsOptionList}
                         statusList={statusList}
                         defaultTexts={defaultTexts}
-                        onPatchIncident={onPatchIncident}
                         onDismissError={onDismissError}
                         onClose={this.onCloseAll}
                       />
@@ -231,7 +226,7 @@ export class IncidentDetail extends React.Component {
                           onShowAttachment={this.onShowAttachment}
                         />
 
-                        <AddNote id={id} onPatchIncident={onPatchIncident} />
+                        <AddNote id={id} />
 
                         <ChildIncidents incident={incident} />
 
@@ -246,7 +241,6 @@ export class IncidentDetail extends React.Component {
                         incident={incident}
                         priorityList={priorityList}
                         typesList={typesList}
-                        onPatchIncident={onPatchIncident}
                         onEditStatus={this.onEditStatus}
                       />
                     )}
@@ -299,7 +293,6 @@ IncidentDetail.propTypes = {
   }),
 
   onRequestIncident: PropTypes.func.isRequired,
-  onPatchIncident: PropTypes.func.isRequired,
   onRequestHistoryList: PropTypes.func.isRequired,
   onRequestAttachments: PropTypes.func.isRequired,
   onRequestDefaultTexts: PropTypes.func.isRequired,
@@ -319,7 +312,6 @@ export const mapDispatchToProps = dispatch =>
   bindActionCreators(
     {
       onRequestIncident: requestIncident,
-      onPatchIncident: patchIncident,
       onRequestHistoryList: requestHistoryList,
       onRequestAttachments: requestAttachments,
       onRequestDefaultTexts: requestDefaultTexts,

--- a/src/signals/incident-management/containers/IncidentDetail/index.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/index.test.js
@@ -3,7 +3,7 @@ import { shallow } from 'enzyme';
 
 import LoadingIndicator from 'shared/components/LoadingIndicator';
 import categories from 'utils/__tests__/fixtures/categories_structured.json';
-import incidentJSON from 'utils/__tests__/fixtures/incident.json';
+import incidentFixture from 'utils/__tests__/fixtures/incident.json';
 
 import History from 'components/History';
 import { IncidentDetail } from '.';
@@ -39,7 +39,7 @@ describe('<IncidentDetail />', () => {
       patching: {},
       defaultTexts: [],
       error: false,
-      incident: incidentJSON,
+      incident: incidentFixture,
 
       attachments: [
         {
@@ -285,6 +285,7 @@ describe('<IncidentDetail />', () => {
         incidentModel: {
           ...props.incidentModel,
           incident: {
+            ...props.incidentModel.incident,
             category: { category_url: 'bar' },
           },
         },


### PR DESCRIPTION
This PR moves the responsibility of dispatching the `patchIncident` action from the `IncidentDetail` container to its underlying components. This in preparation of the refactoring of the `IncidentDetail` container and the introduction of `useContext` and `useReducer` for that container.