### PR TITLE
resets the search query when a filter is applied

### DIFF
--- a/src/containers/App/reducer.js
+++ b/src/containers/App/reducer.js
@@ -2,6 +2,7 @@ import { fromJS } from 'immutable';
 
 import { VARIANT_DEFAULT, TYPE_DEFAULT } from 'containers/Notification/constants';
 
+import { APPLY_FILTER } from "signals/incident-management/constants";
 import {
   LOGIN_FAILED,
   LOGOUT_FAILED,
@@ -80,6 +81,9 @@ function appReducer(state = initialState, action) {
       return state.set('searchQuery', action.payload);
 
     case RESET_SEARCH_QUERY:
+      return state.set('searchQuery', initialState.get('searchQuery'));
+
+    case APPLY_FILTER:
       return state.set('searchQuery', initialState.get('searchQuery'));
 
     default:

--- a/src/containers/App/reducer.js
+++ b/src/containers/App/reducer.js
@@ -2,7 +2,7 @@ import { fromJS } from 'immutable';
 
 import { VARIANT_DEFAULT, TYPE_DEFAULT } from 'containers/Notification/constants';
 
-import { APPLY_FILTER } from "signals/incident-management/constants";
+import { APPLY_FILTER } from 'signals/incident-management/constants';
 import {
   LOGIN_FAILED,
   LOGOUT_FAILED,
@@ -81,8 +81,6 @@ function appReducer(state = initialState, action) {
       return state.set('searchQuery', action.payload);
 
     case RESET_SEARCH_QUERY:
-      return state.set('searchQuery', initialState.get('searchQuery'));
-
     case APPLY_FILTER:
       return state.set('searchQuery', initialState.get('searchQuery'));
 

--- a/src/containers/App/reducer.test.js
+++ b/src/containers/App/reducer.test.js
@@ -1,6 +1,7 @@
 import { fromJS } from 'immutable';
 
 import userJson from 'utils/__tests__/fixtures/user.json';
+import { APPLY_FILTER } from "signals/incident-management/constants";
 import appReducer, { initialState } from './reducer';
 import {
   AUTHORIZE_USER,
@@ -238,6 +239,24 @@ describe('containers/App/reducer', () => {
         .set('searchQuery', initialState.get('searchQuery'));
 
     expect(appReducer(otherState, resetSearchQuery)).toEqual(
+      applied(initialState)
+    );
+  });
+
+  it('should handle APPLY_FILTER', () => {
+    const applyFilter = {
+      type: APPLY_FILTER,
+    };
+
+
+    const otherState = initialState.set('searchQuery', 'search-term');
+    expect(otherState.get('searchQuery')).toBe('search-term');
+
+    const applied = state =>
+      state
+        .set('searchQuery', initialState.get('searchQuery'));
+
+    expect(appReducer(otherState, applyFilter)).toEqual(
       applied(initialState)
     );
   });

--- a/src/signals/incident-management/__tests__/reducer.test.js
+++ b/src/signals/incident-management/__tests__/reducer.test.js
@@ -152,7 +152,6 @@ describe('signals/incident-management/reducer', () => {
       state
         .set('ordering', initialState.get('ordering'))
         .set('page', initialState.get('page'))
-        .set('searchQuery', initialState.get('searchQuery'))
         .set('activeFilter', fromJS(appliedFilter))
         .set('editFilter', fromJS(appliedFilter));
 
@@ -209,8 +208,7 @@ describe('signals/incident-management/reducer', () => {
         .set('loading', false)
         .set('error', false)
         .set('errorMessage', undefined)
-        .set('activeFilter', fromJS(activeFilter))
-        .set('searchQuery', initialState.get('searchQuery'));
+        .set('activeFilter', fromJS(activeFilter));
 
     expect(reducer(initialState, filterSaveSuccess)).toEqual(
       applied(initialState)
@@ -231,8 +229,7 @@ describe('signals/incident-management/reducer', () => {
         .set('loading', false)
         .set('error', false)
         .set('errorMessage', undefined)
-        .set('activeFilter', fromJS(filterUpdatedSuccess.payload))
-        .set('searchQuery', initialState.get('searchQuery'));
+        .set('activeFilter', fromJS(filterUpdatedSuccess.payload));
 
     expect(reducer(initialState, filterUpdatedSuccess)).toEqual(
       applied(initialState)

--- a/src/signals/incident-management/reducer.js
+++ b/src/signals/incident-management/reducer.js
@@ -27,14 +27,12 @@ export const initialState = fromJS({
   activeFilter: {
     // filter settings for the list of incidents
     name: '',
-    options: {
-    },
+    options: {},
   },
   editFilter: {
     // settings selected for editing
     name: '',
-    options: {
-    },
+    options: {},
   },
   filters: [],
   incidents: {
@@ -44,7 +42,6 @@ export const initialState = fromJS({
   loading: false,
   ordering: '-created_at',
   page: 1,
-  searchQuery: '',
 });
 
 export default (state = initialState, action) => {
@@ -74,8 +71,7 @@ export default (state = initialState, action) => {
         .set('activeFilter', fromJS(action.payload))
         .set('editFilter', fromJS(action.payload))
         .set('ordering', initialState.get('ordering'))
-        .set('page', initialState.get('page'))
-        .set('searchQuery', initialState.get('searchQuery'));
+        .set('page', initialState.get('page'));
 
     case EDIT_FILTER:
       return state.set('editFilter', fromJS(action.payload));
@@ -93,8 +89,7 @@ export default (state = initialState, action) => {
         .set('activeFilter', fromJS(action.payload))
         .set('error', false)
         .set('errorMessage', undefined)
-        .set('loading', false)
-        .set('searchQuery', initialState.get('searchQuery'));
+        .set('loading', false);
 
     case CLEAR_EDIT_FILTER:
       return state


### PR DESCRIPTION
This PR fixes the issue that when a filter is applied, the search term was not reseted in the search bar.
