### PR TITLE
(Chore) Return undefined instead of throwing

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -15,7 +15,9 @@ import configuration from 'shared/services/configuration/configuration';
 import loadModels from 'models';
 
 // Make sure these icons are picked up by webpack
+// eslint-disable-next-line import/no-unresolved,import/extensions
 import '!file-loader?name=[name].[ext]!./images/favicon.png';
+// eslint-disable-next-line import/no-unresolved,import/extensions
 import '!file-loader?name=[name].[ext]!./images/icon_180x180.png';
 
 // Import CSS and Global Styles
@@ -26,18 +28,14 @@ import configureStore from './configureStore';
 
 const environment = process.env.NODE_ENV;
 
-try {
-  const dsn = configuration?.sentry?.dsn;
-  const release = process.env.GIT_COMMIT;
-  if (dsn) {
-    Sentry.init({
-      environment,
-      dsn,
-      release,
-    });
-  }
-} catch (error) {
-  // noop
+const dsn = configuration?.sentry?.dsn;
+const release = process.env.GIT_COMMIT;
+if (dsn) {
+  Sentry.init({
+    environment,
+    dsn,
+    release,
+  });
 }
 
 // Create redux store with history
@@ -48,19 +46,15 @@ const MOUNT_NODE = document.getElementById('app');
 loadModels(store);
 
 // Setup Matomo
-try {
-  const urlBase = configuration?.matomo?.urlBase;
-  const siteId = configuration?.matomo?.siteId;
+const urlBase = configuration?.matomo?.urlBase;
+const siteId = configuration?.matomo?.siteId;
 
-  if (urlBase && siteId) {
-    const MatomoInstance = new MatomoTracker({
-      urlBase,
-      siteId,
-    });
-    MatomoInstance.trackPageView();
-  }
-} catch (error) {
-  // noop
+if (urlBase && siteId) {
+  const MatomoInstance = new MatomoTracker({
+    urlBase,
+    siteId,
+  });
+  MatomoInstance.trackPageView();
 }
 
 const render = () => {

--- a/src/shared/services/configuration/configuration.js
+++ b/src/shared/services/configuration/configuration.js
@@ -5,7 +5,7 @@ const applicationConfig = {
 const configProxy = new Proxy(applicationConfig, {
   get(target, name, receiver) {
     if (!Reflect.has(target, name)) {
-      throw new Error(`Setting ${name} not available in configuration`);
+      return undefined;
     }
 
     return Reflect.get(target, name, receiver);

--- a/src/shared/services/configuration/configuration.test.js
+++ b/src/shared/services/configuration/configuration.test.js
@@ -27,10 +27,9 @@ describe('shared/services/configuration/configuration', () => {
     }).toThrow();
   });
 
-  it('should throw an error for missing props', () => {
-    expect(() => {
-      // eslint-disable-next-line
-      const { missing } = configuration;
-    }).toThrow();
+  it('should return undefined for missing props', () => {
+    const { missing } = configuration;
+
+    expect(missing).toBeUndefined();
   });
 });


### PR DESCRIPTION
This PR changes the configuration service so that it doesn't throw an exception whenever a missing config prop is encountered, but returns `undefined`. This to prevent `try/catch` structures throughout the code.