### PR TITLE
[Chore] Add the version information to the runtime

### DIFF
--- a/internals/webpack/webpack.base.babel.js
+++ b/internals/webpack/webpack.base.babel.js
@@ -7,6 +7,7 @@ const CopyPlugin = require('copy-webpack-plugin');
 
 const devMode = process.env.NODE_ENV !== 'production';
 const __rootdir = pkgDir.sync();
+const version = require(path.resolve(__rootdir, 'package.json')).version;
 
 const esModules = [
   path.resolve(__rootdir, 'node_modules/@datapunt/asc-assets'),
@@ -136,6 +137,9 @@ module.exports = options => ({
     new CopyPlugin({ patterns: [{ from: path.resolve(__rootdir, 'assets'), to: 'assets' }] }),
 
     process.env.ANALYZE && new BundleAnalyzerPlugin(),
+    new webpack.DefinePlugin({
+      VERSION: JSON.stringify(version),
+    }),
   ]
     .concat(options.plugins)
     .filter(Boolean),

--- a/src/app.js
+++ b/src/app.js
@@ -59,6 +59,9 @@ if (urlBase && siteId) {
 }
 
 const render = () => {
+  // eslint-disable-next-line no-undef,no-console
+  console.log(`Signals: version: ${VERSION}, build: ${process.env.NODE_ENV}`);
+
   ReactDOM.render(
     <Provider store={store}>
       <ConnectedRouter history={history}>


### PR DESCRIPTION
This PR adds a console.log with the version and build information of the application at start.
- the printed version is the version that is set in the package.json.
- the build version is 'develoment|production' depending on the NODE_ENV.
- this requires that in the release workflow `npm version [<newversion> | major | minor | patch]` will be called for the new releases.

## Todo

- [ ] Update the release workflow documentation on [docuwiki](https://dokuwiki.datapunt.amsterdam.nl/doku.php?id=start:toepassingen:toepassingen:signalen:releases&do=)
