### PR TITLE
[SIG-2861] Add Weesp and Amsterdamse bos to the stadsdeel options

### DIFF
--- a/src/signals/incident-management/definitions/stadsdeelList.js
+++ b/src/signals/incident-management/definitions/stadsdeelList.js
@@ -7,6 +7,8 @@ const stadsdeelList = [
   { key: 'T', value: 'Zuidoost' },
   { key: 'K', value: 'Zuid' },
   { key: 'F', value: 'Nieuw-West' },
+  { key: 'H', value: 'Het Amsterdamse Bos' },
+  { key: 'W', value: 'Weesp' },
   { key: 'null', value: 'Niet bepaald' },
 ];
 


### PR DESCRIPTION
This PP adds the `Weesp` and `Amsterdamse Bos` options to the filters and to the Incident detail in the backoffice