### PR TITLE
Release v1.18.1 Weesp and Amsterdamse bos

### DIFF
--- a/src/signals/incident-management/definitions/stadsdeelList.js
+++ b/src/signals/incident-management/definitions/stadsdeelList.js
@@ -7,6 +7,8 @@ const stadsdeelList = [
   { key: 'T', value: 'Zuidoost' },
   { key: 'K', value: 'Zuid' },
   { key: 'F', value: 'Nieuw-West' },
+  { key: 'H', value: 'Het Amsterdamse Bos' },
+  { key: 'W', value: 'Weesp' },
   { key: 'null', value: 'Niet bepaald' },
 ];
 


### PR DESCRIPTION
## Fixes

- Issue where the `Weesp` and `Het Amsterdamse Bos` were not shown in the filters and on the incident detail page