### PR TITLE
(Chore) Copy manifest.json

### DIFF
--- a/internals/webpack/webpack.prod.babel.js
+++ b/internals/webpack/webpack.prod.babel.js
@@ -123,7 +123,14 @@ module.exports = require('./webpack.base.babel')({
       safeToUseOptionalCaches: true,
     }),
 
-    new CopyPlugin({ patterns: [{ from: path.resolve(__rootdir, 'src', 'manifest.json'), to: path.resolve(__rootdir, 'build', 'manifest.json') }] }),
+    new CopyPlugin({
+      patterns: [
+        {
+          from: path.resolve(__rootdir, 'src', 'manifest.json'),
+          to: path.resolve(__rootdir, 'build', 'manifest.json'),
+        },
+      ],
+    }),
   ],
 
   performance: {

--- a/internals/webpack/webpack.prod.babel.js
+++ b/internals/webpack/webpack.prod.babel.js
@@ -1,11 +1,15 @@
 const path = require('path');
+const pkgDir = require('pkg-dir');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const OfflinePlugin = require('offline-plugin');
 const { HashedModuleIdsPlugin } = require('webpack');
 const TerserPlugin = require('terser-webpack-plugin');
 const CompressionPlugin = require('compression-webpack-plugin');
 const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
+const CopyPlugin = require('copy-webpack-plugin');
 const template = require('./template');
+
+const __rootdir = pkgDir.sync();
 
 module.exports = require('./webpack.base.babel')({
   mode: 'production',
@@ -118,6 +122,8 @@ module.exports = require('./webpack.base.babel')({
       // Removes warning for about `additional` section usage
       safeToUseOptionalCaches: true,
     }),
+
+    new CopyPlugin({ patterns: [{ from: path.resolve(__rootdir, 'src', 'manifest.json'), to: path.resolve(__rootdir, 'build', 'manifest.json') }] }),
   ],
 
   performance: {


### PR DESCRIPTION
This PR contains changes that make sure that `manifest.json` is copied in the `build` folder. Not having the file there throws an error when spinning up the `amsterdam` or `weesp` container.