### PR TITLE
[SIG-2873] Fix tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,7 +24,7 @@ module.exports = {
   },
   rules: {
     camelcase: 0,
-    'arrow-parens': ['error', 'as-needed'],
+    'arrow-parens': ['error', 'as-needed', { requireForBlockBody: false }],
     'arrow-body-style': [2, 'as-needed'],
     'class-methods-use-this': 0,
     'comma-dangle': ['error', 'always-multiline'],

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
+  "arrowParens": "avoid",
   "trailingComma": "es5",
   "tabWidth": 2,
   "semi": true,

--- a/internals/testing/test-bundler.js
+++ b/internals/testing/test-bundler.js
@@ -44,3 +44,7 @@ if (process.env.CI) {
 }
 
 global.URL.createObjectURL = jest.fn(() => 'https://url-from-data/image.jpg');
+global.URL.revokeObjectURL = jest.fn();
+
+const noop = () => {};
+Object.defineProperty(global.window, 'scrollTo', { value: noop, writable: true });

--- a/src/components/AutoSuggest/__tests__/AutoSuggest.test.js
+++ b/src/components/AutoSuggest/__tests__/AutoSuggest.test.js
@@ -1,5 +1,5 @@
 import React, { Fragment } from 'react';
-import { render, fireEvent, wait, act } from '@testing-library/react';
+import { render, fireEvent, waitFor, act } from '@testing-library/react';
 import { withAppContext, resolveAfterMs } from 'test/utils';
 
 import AutoSuggest, { INPUT_DELAY } from '..';
@@ -49,7 +49,7 @@ describe('src/components/AutoSuggest', () => {
       fireEvent.change(input, { target: { value: 'A' } });
     });
 
-    await wait(() => resolveAfterMs(INPUT_DELAY));
+    await waitFor(() => resolveAfterMs(INPUT_DELAY));
 
     expect(fetch).not.toHaveBeenCalled();
 
@@ -57,7 +57,7 @@ describe('src/components/AutoSuggest', () => {
       fireEvent.change(input, { target: { value: 'Am' } });
     });
 
-    await wait(() => resolveAfterMs(INPUT_DELAY));
+    await waitFor(() => resolveAfterMs(INPUT_DELAY));
 
     expect(fetch).not.toHaveBeenCalled();
 
@@ -67,7 +67,7 @@ describe('src/components/AutoSuggest', () => {
 
     expect(fetch).not.toHaveBeenCalled();
 
-    await wait(() => resolveAfterMs(INPUT_DELAY));
+    await waitFor(() => resolveAfterMs(INPUT_DELAY));
 
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(fetch).toHaveBeenCalledWith(`${url}Ams`, expect.anything());
@@ -440,7 +440,7 @@ describe('src/components/AutoSuggest', () => {
       fireEvent.change(input, { target: { value: 'Rembrandt' } });
     });
 
-    await wait(() => resolveAfterMs(INPUT_DELAY));
+    await waitFor(() => resolveAfterMs(INPUT_DELAY));
 
     expect(onClear).not.toHaveBeenCalled();
 
@@ -448,7 +448,7 @@ describe('src/components/AutoSuggest', () => {
       fireEvent.change(input, { target: { value: '' } });
     });
 
-    await wait(() => resolveAfterMs(INPUT_DELAY));
+    await waitFor(() => resolveAfterMs(INPUT_DELAY));
 
     expect(onClear).toHaveBeenCalled();
   });

--- a/src/components/AutoSuggest/index.js
+++ b/src/components/AutoSuggest/index.js
@@ -169,6 +169,8 @@ const AutoSuggest = ({
     setShowList(false);
   }, []);
 
+  // linter complaining about the use of the debounce function
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const delayedCallback = useCallback(
     debounce(inputValue => serviceRequest(inputValue), INPUT_DELAY),
     [serviceRequest, url]

--- a/src/components/PDOKAutoSuggest/__tests__/PDOKAutoSuggest.test.js
+++ b/src/components/PDOKAutoSuggest/__tests__/PDOKAutoSuggest.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent, wait, act } from '@testing-library/react';
+import { render, fireEvent, waitFor, act } from '@testing-library/react';
 import { withAppContext } from 'test/utils';
 
 import JSONResponse from 'utils/__tests__/fixtures/PDOKResponseData.json';
@@ -36,7 +36,7 @@ describe('components/PDOKAutoSuggest', () => {
       fireEvent.change(input, { target: { value: 'Amsterdam' } });
     });
 
-    await wait(() => resolveAfterMs(INPUT_DELAY));
+    await waitFor(() => resolveAfterMs(INPUT_DELAY));
 
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(fetch).toHaveBeenCalledWith(expect.stringContaining('fq=gemeentenaam:amsterdam'), expect.anything());
@@ -47,7 +47,7 @@ describe('components/PDOKAutoSuggest', () => {
       fireEvent.change(input, { target: { value: 'Westerp' } });
     });
 
-    await wait(() => resolveAfterMs(INPUT_DELAY));
+    await waitFor(() => resolveAfterMs(INPUT_DELAY));
 
     expect(fetch).toHaveBeenCalledTimes(2);
     expect(fetch).toHaveBeenLastCalledWith(

--- a/src/hooks/useDelayedDoubleClick.js
+++ b/src/hooks/useDelayedDoubleClick.js
@@ -34,6 +34,8 @@ const useDelayedDoubleClick = clickFunc => {
     [clickFunc]
   );
 
+  // linter complaining about the use of the debounce function
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const click = useCallback(debounce(debouncedClick, DOUBLE_CLICK_TIMEOUT), [debouncedClick]);
 
   return {

--- a/src/signals/incident-management/containers/DefaultTextsAdmin/components/DefaultTextsForm/index.js
+++ b/src/signals/incident-management/containers/DefaultTextsAdmin/components/DefaultTextsForm/index.js
@@ -43,22 +43,19 @@ const StyledButton = styled(Button)`
 
 const DEFAULT_TEXT_FIELDS = 15;
 
+const fields = [...new Array(DEFAULT_TEXT_FIELDS).keys()].reduce(
+  (acc, key) => ({
+    ...acc,
+    [`item${key}`]: FormBuilder.group({
+      title: [''],
+      text: [''],
+    }),
+  }),
+  {}
+);
+
 const DefaultTextsForm = ({ categoryUrl, state, defaultTexts, subCategories, onSubmitTexts, onOrderDefaultTexts }) => {
-  const form = useMemo(() => {
-    const fields = [...new Array(DEFAULT_TEXT_FIELDS).keys()].reduce(
-      (acc, key) => ({
-        ...acc,
-        [`item${key}`]: FormBuilder.group({
-          title: [''],
-          text: [''],
-        }),
-      }),
-      {}
-    );
-
-    return FormBuilder.group(fields);
-  }, []);
-
+  const form = useMemo(() => FormBuilder.group(fields), []);
   const items = Object.keys(form.controls).slice(0, -2);
 
   const handleSubmit = useCallback(

--- a/src/signals/incident-management/containers/IncidentDetail/components/DetailHeader/components/DownloadButton/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/DetailHeader/components/DownloadButton/index.js
@@ -32,7 +32,7 @@ const DownloadButton = ({ label, url, filename }) => {
     if (navigator.msSaveOrOpenBlob) {
       navigator.msSaveOrOpenBlob(data, filename);
     } else {
-      const href = global.window.URL.createObjectURL(data);
+      const href = global.URL.createObjectURL(data);
       const link = document.createElement('a');
       link.href = href;
       link.download = filename;

--- a/src/signals/incident-management/containers/IncidentDetail/components/DetailHeader/components/DownloadButton/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/DetailHeader/components/DownloadButton/index.js
@@ -32,14 +32,14 @@ const DownloadButton = ({ label, url, filename }) => {
     if (navigator.msSaveOrOpenBlob) {
       navigator.msSaveOrOpenBlob(data, filename);
     } else {
-      const href = URL.createObjectURL(data);
+      const href = global.window.URL.createObjectURL(data);
       const link = document.createElement('a');
       link.href = href;
       link.download = filename;
       document.body.appendChild(link);
       link.click();
 
-      window.URL.revokeObjectURL(href);
+      global.URL.revokeObjectURL(href);
       document.body.removeChild(link);
     }
   }, [data, filename]);

--- a/src/signals/incident-management/containers/IncidentDetail/components/DetailHeader/components/DownloadButton/index.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/DetailHeader/components/DownloadButton/index.test.js
@@ -43,9 +43,15 @@ describe('<DownloadButton />', () => {
       const { queryByTestId, findByTestId } = render(<DownloadButton {...props} />);
       const downloadButton = queryByTestId('download-button');
 
+      // suppress console error because of unimplemented navigation in JSDOM
+      // @see {@link https://github.com/jsdom/jsdom/issues/2112}
+      global.window.console.error = jest.fn();
+
       act(() => {
         fireEvent.click(downloadButton);
       });
+
+      global.window.console.error.mockRestore();
 
       expect(downloadButton.disabled).toEqual(true);
 

--- a/src/signals/incident/components/form/CheckboxInput/index.js
+++ b/src/signals/incident/components/form/CheckboxInput/index.js
@@ -63,6 +63,10 @@ const CheckboxInput = ({ handler, touched, hasError, meta, parent, getError, val
     </Header>
   );
 
+CheckboxInput.defaultProps = {
+  hasError: () => {},
+};
+
 CheckboxInput.propTypes = {
   handler: PropTypes.func,
   touched: PropTypes.bool,

--- a/src/signals/incident/components/form/DateTimeInput/__snapshots__/index.test.js.snap
+++ b/src/signals/incident/components/form/DateTimeInput/__snapshots__/index.test.js.snap
@@ -3,6 +3,7 @@
 exports[`Form component <DateTimeInput /> rendering should render date time field correctly 1`] = `
 <Header
   className=""
+  hasError={[Function]}
   meta={
     Object {
       "isVisible": true,

--- a/src/signals/incident/components/form/DateTimeInput/index.js
+++ b/src/signals/incident/components/form/DateTimeInput/index.js
@@ -66,6 +66,10 @@ const DateTimeInput = ({ touched, hasError, meta, parent, getError, validatorsOr
   );
 };
 
+DateTimeInput.defaultProps = {
+  hasError: () => {},
+};
+
 DateTimeInput.propTypes = {
   touched: PropTypes.bool,
   hasError: PropTypes.func,

--- a/src/signals/incident/components/form/MapSelect/index.js
+++ b/src/signals/incident/components/form/MapSelect/index.js
@@ -70,6 +70,10 @@ const MapSelect = ({ handler, touched, hasError, meta, parent, getError, validat
   );
 };
 
+MapSelect.defaultProps = {
+  hasError: () => {},
+};
+
 MapSelect.propTypes = {
   handler: PropTypes.func.isRequired,
   touched: PropTypes.bool,

--- a/src/signals/settings/__tests__/index.test.js
+++ b/src/signals/settings/__tests__/index.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { mount } from 'enzyme';
-import { render, wait } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import { act } from 'react-dom/test-utils';
 import * as auth from 'shared/services/auth/auth';
 import * as reactRouterDom from 'react-router-dom';
@@ -166,7 +166,7 @@ describe('signals/settings', () => {
     // load users overview page
     await act(async () => history.push(USERS_URL));
 
-    await wait(() =>
+    await waitFor(() =>
       expect(
         reactRouterDom.useLocation.mock.results.pop().value.pathname
       ).toEqual(USERS_URL)
@@ -175,7 +175,7 @@ describe('signals/settings', () => {
     // load roles overview page (should not be allowed)
     await act(async () => history.push(ROLES_URL));
 
-    await wait(() =>
+    await waitFor(() =>
       expect(
         reactRouterDom.useLocation.mock.results.pop().value.pathname
       ).not.toEqual(ROLES_URL)
@@ -199,7 +199,7 @@ describe('signals/settings', () => {
     // load roles overview page
     await act(async () => history.push(ROLES_URL));
 
-    await wait(() =>
+    await waitFor(() =>
       expect(
         reactRouterDom.useLocation.mock.results.pop().value.pathname
       ).toEqual(ROLES_URL)
@@ -208,7 +208,7 @@ describe('signals/settings', () => {
     // load users overview page (should not be allowed)
     await act(async () => history.push(USERS_URL));
 
-    await wait(() =>
+    await waitFor(() =>
       expect(
         reactRouterDom.useLocation.mock.results.pop().value.pathname
       ).not.toEqual(USERS_URL)

--- a/src/signals/settings/categories/Detail/__tests__/Detail.test.js
+++ b/src/signals/settings/categories/Detail/__tests__/Detail.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent, wait, act } from '@testing-library/react';
+import { render, fireEvent, waitFor, act } from '@testing-library/react';
 import * as reactRouterDom from 'react-router-dom';
 import * as reactRedux from 'react-redux';
 import { withAppContext } from 'test/utils';
@@ -61,7 +61,7 @@ describe('signals/settings/categories/Detail', () => {
   it('should render a backlink', async () => {
     const { container } = render(withAppContext(<CategoryDetailContainer />));
 
-    await wait(() => container.querySelector('a'));
+    await waitFor(() => container.querySelector('a'));
 
     expect(container.querySelector('a').getAttribute('href')).toEqual(routes.categories);
   });
@@ -75,7 +75,7 @@ describe('signals/settings/categories/Detail', () => {
 
     const { container } = render(withAppContext(<CategoryDetailContainer />));
 
-    await wait(() => container.querySelector('a'));
+    await waitFor(() => container.querySelector('a'));
 
     expect(container.querySelector('a').getAttribute('href')).toEqual(referrer);
   });
@@ -83,7 +83,7 @@ describe('signals/settings/categories/Detail', () => {
   it('should render the correct page title for a new category', async () => {
     const { getByText } = render(withAppContext(<CategoryDetailContainer />));
 
-    await wait(() => getByText('Categorie toevoegen'));
+    await waitFor(() => getByText('Categorie toevoegen'));
     expect(getByText('Categorie toevoegen')).toBeInTheDocument();
   });
 
@@ -94,7 +94,7 @@ describe('signals/settings/categories/Detail', () => {
 
     const { getByText } = render(withAppContext(<CategoryDetailContainer />));
 
-    await wait(() => getByText('Categorie wijzigen'));
+    await waitFor(() => getByText('Categorie wijzigen'));
     expect(getByText('Categorie wijzigen')).toBeInTheDocument();
   });
 
@@ -105,7 +105,7 @@ describe('signals/settings/categories/Detail', () => {
 
     const { getByTestId } = render(withAppContext(<CategoryDetailContainer />));
 
-    await wait(() => getByTestId('detailCategoryForm'));
+    await waitFor(() => getByTestId('detailCategoryForm'));
     expect(getByTestId('detailCategoryForm')).toBeInTheDocument();
 
     document.querySelectorAll('input[type="text"], textarea').forEach(element => {
@@ -262,7 +262,7 @@ describe('signals/settings/categories/Detail', () => {
     );
 
     // on patch success, re-request all categories
-    await wait(() => getByTestId('detailCategoryForm'));
+    await waitFor(() => getByTestId('detailCategoryForm'));
 
     expect(dispatch).toHaveBeenCalledWith(fetchCategories());
   });
@@ -280,7 +280,7 @@ describe('signals/settings/categories/Detail', () => {
 
     const { getByTestId } = render(withAppContext(<CategoryDetailContainer />));
 
-    await wait(() => getByTestId('detailCategoryForm'));
+    await waitFor(() => getByTestId('detailCategoryForm'));
     expect(getByTestId('detailCategoryForm')).toBeInTheDocument();
 
     const submitBtn = getByTestId('submitBtn');
@@ -292,7 +292,7 @@ describe('signals/settings/categories/Detail', () => {
     expect(dispatch).not.toHaveBeenCalled();
     expect(push).not.toHaveBeenCalled();
 
-    await wait(() => getByTestId('detailCategoryForm'));
+    await waitFor(() => getByTestId('detailCategoryForm'));
 
     expect(dispatch).toHaveBeenCalledWith(showGlobalNotification(expect.any(Object)));
 
@@ -306,7 +306,7 @@ describe('signals/settings/categories/Detail', () => {
 
     const { getByTestId } = render(withAppContext(<CategoryDetailContainer />));
 
-    await wait(() => getByTestId('detailCategoryForm'));
+    await waitFor(() => getByTestId('detailCategoryForm'));
 
     expect(fetch).not.toHaveBeenLastCalledWith(expect.stringContaining('/history'), expect.any(Object));
 
@@ -320,7 +320,7 @@ describe('signals/settings/categories/Detail', () => {
 
     render(withAppContext(<CategoryDetailContainer />));
 
-    await wait(() => getByTestId('detailCategoryForm'));
+    await waitFor(() => getByTestId('detailCategoryForm'));
 
     expect(fetch).toHaveBeenLastCalledWith(expect.stringContaining('/history'), expect.any(Object));
   });

--- a/src/signals/settings/categories/Overview/__tests__/Overview.test.js
+++ b/src/signals/settings/categories/Overview/__tests__/Overview.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent, act, waitForElement } from '@testing-library/react';
+import { render, fireEvent, act, waitFor } from '@testing-library/react';
 import * as reactRouterDom from 'react-router-dom';
 import { withAppContext } from 'test/utils';
 
@@ -42,18 +42,12 @@ describe('signals/settings/categories/containers/Overview', () => {
 
   it('should render header', () => {
     const { getByText, rerender } = render(
-      withAppContext(
-        <CategoriesOverview subCategories={null} userCan={() => {}} />
-      )
+      withAppContext(<CategoriesOverview subCategories={null} userCan={() => {}} />)
     );
 
     expect(getByText('Categorieën')).toBeInTheDocument();
 
-    rerender(
-      withAppContext(
-        <CategoriesOverview subCategories={subCategories} userCan={() => {}} />
-      )
-    );
+    rerender(withAppContext(<CategoriesOverview subCategories={subCategories} userCan={() => {}} />));
 
     expect(getByText(`Categorieën (${count})`)).toBeInTheDocument();
   });
@@ -64,47 +58,29 @@ describe('signals/settings/categories/containers/Overview', () => {
 
     // render the first page
     const { container, rerender } = render(
-      withAppContext(
-        <CategoriesOverview subCategories={subCategories} userCan={() => {}} />
-      )
+      withAppContext(<CategoriesOverview subCategories={subCategories} userCan={() => {}} />)
     );
 
-    expect(
-      container.querySelector(`tr[data-item-id="${firstCategory.fk}"]`)
-    ).toBeInTheDocument();
-    expect(
-      container.querySelector(`tr[data-item-id="${lastCategory.fk}"]`)
-    ).toBeInTheDocument();
+    expect(container.querySelector(`tr[data-item-id="${firstCategory.fk}"]`)).toBeInTheDocument();
+    expect(container.querySelector(`tr[data-item-id="${lastCategory.fk}"]`)).toBeInTheDocument();
 
     // render the second page
     jest.spyOn(reactRouterDom, 'useParams').mockImplementation(() => ({
       pageNum: '2',
     }));
 
-    rerender(
-      withAppContext(
-        <CategoriesOverview subCategories={subCategories} userCan={() => {}} />
-      )
-    );
+    rerender(withAppContext(<CategoriesOverview subCategories={subCategories} userCan={() => {}} />));
 
     const secondPageFirstCategory = subCategories[constants.PAGE_SIZE + 1];
     const secondPageLastCategory = subCategories[constants.PAGE_SIZE * 2 - 1];
 
-    expect(
-      container.querySelector(
-        `tr[data-item-id="${secondPageFirstCategory.fk}"]`
-      )
-    ).toBeInTheDocument();
-    expect(
-      container.querySelector(`tr[data-item-id="${secondPageLastCategory.fk}"]`)
-    ).toBeInTheDocument();
+    expect(container.querySelector(`tr[data-item-id="${secondPageFirstCategory.fk}"]`)).toBeInTheDocument();
+    expect(container.querySelector(`tr[data-item-id="${secondPageLastCategory.fk}"]`)).toBeInTheDocument();
   });
 
   it('should only render specific data columns', () => {
     const { getByText } = render(
-      withAppContext(
-        <CategoriesOverview subCategories={subCategories} userCan={() => {}} />
-      )
+      withAppContext(<CategoriesOverview subCategories={subCategories} userCan={() => {}} />)
     );
 
     expect(getByText('Categorie')).toBeInTheDocument();
@@ -114,20 +90,14 @@ describe('signals/settings/categories/containers/Overview', () => {
 
   it('should render pagination controls', () => {
     const { rerender, queryByTestId } = render(
-      withAppContext(
-        <CategoriesOverview subCategories={subCategories} userCan={() => {}} />
-      )
+      withAppContext(<CategoriesOverview subCategories={subCategories} userCan={() => {}} />)
     );
 
     expect(queryByTestId('pagination')).toBeInTheDocument();
 
     constants.PAGE_SIZE = count + 1;
 
-    rerender(
-      withAppContext(
-        <CategoriesOverview subCategories={subCategories} userCan={() => {}} />
-      )
-    );
+    rerender(withAppContext(<CategoriesOverview subCategories={subCategories} userCan={() => {}} />));
 
     expect(queryByTestId('pagination')).not.toBeInTheDocument();
 
@@ -140,9 +110,7 @@ describe('signals/settings/categories/containers/Overview', () => {
     }));
 
     const { getByText } = render(
-      withAppContext(
-        <CategoriesOverview subCategories={subCategories} userCan={() => {}} />
-      )
+      withAppContext(<CategoriesOverview subCategories={subCategories} userCan={() => {}} />)
     );
 
     const pageButton = getByText('2');
@@ -161,16 +129,15 @@ describe('signals/settings/categories/containers/Overview', () => {
 
   it('should push on list item with an itemId click', async () => {
     const { container } = render(
-      withAppContext(
-        <CategoriesOverview subCategories={subCategories} userCan={() => true} />
-      )
+      withAppContext(<CategoriesOverview subCategories={subCategories} userCan={() => true} />)
     );
     const itemId = 666;
 
-    const row = await waitForElement(
-      () => container.querySelector('tbody tr:nth-child(42)'),
-      { container }
-    );
+    let row;
+
+    await waitFor(() => {
+      row = container.querySelector('tbody tr:nth-child(42)');
+    });
 
     // Explicitly set an 'itemId' so that we can easily test against its value.
     row.dataset.itemId = itemId;
@@ -205,16 +172,15 @@ describe('signals/settings/categories/containers/Overview', () => {
 
   it('should not push on list item click when permissions are insufficient', async () => {
     const { container } = render(
-      withAppContext(
-        <CategoriesOverview subCategories={subCategories} userCan={() => false} />
-      )
+      withAppContext(<CategoriesOverview subCategories={subCategories} userCan={() => false} />)
     );
     const itemId = 666;
 
-    const row = await waitForElement(
-      () => container.querySelector('tbody tr:nth-child(42)'),
-      { container }
-    );
+    let row;
+
+    await waitFor(() => {
+      row = container.querySelector('tbody tr:nth-child(42)');
+    });
 
     // Explicitly set an 'itemId' so that we can easily test against its value.
     row.dataset.itemId = itemId;

--- a/src/signals/settings/components/PageHeader/index.js
+++ b/src/signals/settings/components/PageHeader/index.js
@@ -24,7 +24,7 @@ const StyledHeading = styled(Heading)`
 `;
 
 const PageHeader = ({ BackLink, className, children, title }) => (
-  <StyledSection className={className} hasBackLink={Boolean(BackLink)}>
+  <StyledSection data-testid="settingsPageHeader" className={className} hasBackLink={Boolean(BackLink)}>
     <Row>
       <div>
         {BackLink}

--- a/src/signals/settings/departments/Detail/index.js
+++ b/src/signals/settings/departments/Detail/index.js
@@ -75,7 +75,7 @@ export const DepartmentDetailContainer = ({
 
       {!isLoading && data && (
         <Fragment>
-          <Row>
+          <Row data-testid="departmentDetail">
             <Column span={12}>
               <div>
                 <Heading forwardedAs="h2" styleAs="h4">
@@ -86,7 +86,7 @@ export const DepartmentDetailContainer = ({
             </Column>
           </Row>
 
-          {categories && data && (
+          {categories && (
             <DepartmentDetailContext.Provider value={{ categories, department: data, subCategories, findByMain }}>
               <CategoryLists
                 onCancel={confirmedCancel}

--- a/src/signals/settings/departments/Overview/__tests__/Overview.test.js
+++ b/src/signals/settings/departments/Overview/__tests__/Overview.test.js
@@ -1,10 +1,5 @@
 import React from 'react';
-import {
-  render,
-  fireEvent,
-  waitForElement,
-  act,
-} from '@testing-library/react';
+import { render, fireEvent, waitFor, act } from '@testing-library/react';
 import * as reactRouterDom from 'react-router-dom';
 
 import { withAppContext } from 'test/utils';
@@ -38,23 +33,17 @@ jest.mock('models/departments/selectors', () => ({
   ...jest.requireActual('models/departments/selectors'),
 }));
 
-jest
-  .spyOn(appSelectors, 'makeSelectUserCan')
-  .mockImplementation(() => () => {});
+jest.spyOn(appSelectors, 'makeSelectUserCan').mockImplementation(() => () => {});
 
 describe('signals/settings/departments/Overview', () => {
   beforeEach(() => {
     push.mockReset();
 
-    jest
-      .spyOn(modelSelectors, 'makeSelectDepartments')
-      .mockImplementation(() => ({ ...departments, loading: false }));
+    jest.spyOn(modelSelectors, 'makeSelectDepartments').mockImplementation(() => ({ ...departments, loading: false }));
   });
 
   it('should show a loading indicator while loading', () => {
-    jest
-      .spyOn(modelSelectors, 'makeSelectDepartments')
-      .mockImplementation(() => ({ ...departments, loading: true }));
+    jest.spyOn(modelSelectors, 'makeSelectDepartments').mockImplementation(() => ({ ...departments, loading: true }));
 
     const { queryByTestId } = render(withAppContext(<DepartmentOverview />));
 
@@ -68,9 +57,7 @@ describe('signals/settings/departments/Overview', () => {
   });
 
   it('should render a title', () => {
-    jest
-      .spyOn(modelSelectors, 'makeSelectDepartments')
-      .mockImplementation(() => ({ list: [], loading: true }));
+    jest.spyOn(modelSelectors, 'makeSelectDepartments').mockImplementation(() => ({ list: [], loading: true }));
 
     const { getByText } = render(withAppContext(<DepartmentOverview />));
 
@@ -84,15 +71,11 @@ describe('signals/settings/departments/Overview', () => {
   });
 
   it('should render a list', () => {
-    const { container, rerender, unmount } = render(
-      withAppContext(<DepartmentOverview />)
-    );
+    const { container, rerender, unmount } = render(withAppContext(<DepartmentOverview />));
 
     expect(container.querySelector('table')).toBeInTheDocument();
 
-    jest
-      .spyOn(modelSelectors, 'makeSelectDepartments')
-      .mockImplementation(() => ({ list: [], loading: true }));
+    jest.spyOn(modelSelectors, 'makeSelectDepartments').mockImplementation(() => ({ list: [], loading: true }));
 
     unmount();
 
@@ -102,17 +85,16 @@ describe('signals/settings/departments/Overview', () => {
   });
 
   it('should push on list item click', async () => {
-    jest
-      .spyOn(appSelectors, 'makeSelectUserCan')
-      .mockImplementation(() => () => true);
+    jest.spyOn(appSelectors, 'makeSelectUserCan').mockImplementation(() => () => true);
 
     const { id } = departmentsJson.results[12];
     const { container } = render(withAppContext(<DepartmentOverview />));
 
-    const row = await waitForElement(
-      () => container.querySelector(`tr[data-item-id="${id}"]`),
-      { container }
-    );
+    let row;
+
+    await waitFor(() => {
+      row = container.querySelector(`tr[data-item-id="${id}"]`);
+    });
 
     // Explicitly set an 'itemId' so that we can easily test against its value.
     row.dataset.itemId = id;
@@ -146,16 +128,15 @@ describe('signals/settings/departments/Overview', () => {
   });
 
   it('should not push on list item click when permissions are insufficient', async () => {
-    jest
-      .spyOn(appSelectors, 'makeSelectUserCan')
-      .mockImplementation(() => () => false);
+    jest.spyOn(appSelectors, 'makeSelectUserCan').mockImplementation(() => () => false);
     const { id } = departmentsJson.results[9];
     const { container } = render(withAppContext(<DepartmentOverview />));
 
-    const row = await waitForElement(
-      () => container.querySelector(`tr[data-item-id="${id}"]`),
-      { container }
-    );
+    let row;
+
+    await waitFor(() => {
+      row = container.querySelector(`tr[data-item-id="${id}"]`);
+    });
 
     // Explicitly set an 'itemId' so that we can easily test against its value.
     row.dataset.itemId = id;

--- a/src/signals/settings/users/Overview/index.js
+++ b/src/signals/settings/users/Overview/index.js
@@ -93,6 +93,8 @@ const UsersOverviewContainer = () => {
     [filters, setUsernameFilter]
   );
 
+  // linter complaining about the use of the debounce function
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   const debouncedOnChangeFilter = useCallback(debounce(createOnChangeFilter('username'), 250), [createOnChangeFilter]);
 
   const selectUserActiveOnChange = useCallback(
@@ -151,7 +153,7 @@ const UsersOverviewContainer = () => {
         )}
       </PageHeader>
 
-      <Row>
+      <Row data-testid="usersOverview">
         {isLoading && <LoadingIndicator />}
 
         <Column span={12} wrap>


### PR DESCRIPTION
This PR contains fixes for several tests that used deprecated functions from `@testing-library/react`. All tests have been run with the `--runInBand --detectOpenHandles` options to detect memory leaks. Where necessary, tests have been modified to prevent leaks.

Next to that, a small modification has been added to the linter configuration that prevented formatting files without generating  unnecessary changes.

For a couple of components where `useCallback` is used in conjunction with Lodash' `debounce` function, the linter has been disabled for the `react-hooks/exhaustive-deps` rule.