### PR TITLE
Do not check xhr.statusText as this is not supported in HTTP/2

### DIFF
--- a/src/shared/services/file-upload-channel/index.js
+++ b/src/shared/services/file-upload-channel/index.js
@@ -29,7 +29,7 @@ export default (endpoint, file, id) =>
     /* istanbul ignore next */
     xhr.onload = () => {
       // upload success
-      if (xhr.readyState === 4 && xhr.status === 202 && xhr.statusText === 'Accepted') {
+      if (xhr.readyState === 4 && xhr.status === 202) {
         emitter({ success: true });
         emitter(END);
       } else {


### PR DESCRIPTION
We are using an HTTP/2 load balancer in front of our Signalen deployments. As HTTP/2 does not support a reason phrase, the frontend shows an upload error to the user while the upload is actual successful. This PR fixes this behavior.

From the spec:

> HTTP/2 does not define a way to carry the version or reason phrase that is included in an HTTP/1.1 status line.

https://tools.ietf.org/html/rfc7540#section-8.1.2.4

Fixes https://github.com/Signalen/backend/issues/37