### PR TITLE
[SIG-2846] Alignment status form

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/index.js
@@ -14,13 +14,22 @@ import statusList, {
 import { patchIncident } from 'models/incident/actions';
 
 import Button from 'components/Button';
+import Label from 'components/Label';
 import FieldControlWrapper from '../../../../components/FieldControlWrapper';
 import RadioInput from '../../../../components/RadioInput';
 import TextAreaInput from '../../../../components/TextAreaInput';
 import DefaultTexts from './components/DefaultTexts';
 
+const UnselectableStatus = styled.div`
+  margin: ${themeSpacing(5, 0)};
+`;
+
 const Form = styled.form`
   position: relative;
+  width: 100%;
+`;
+
+const Header = styled(Row)`
   width: 100%;
 `;
 
@@ -54,17 +63,18 @@ const Notification = styled.div`
 `;
 
 const StatusForm = ({ defaultTexts, incident, onClose }) => {
-  const currentStatus = statusList.find(({ key }) => key === incident.status.state);
+  const currentStatus = statusList.find(status => status.key === incident.status.state);
   const [warning, setWarning] = useState('');
   const dispatch = useDispatch();
+  const isUnselectableStatus = !changeStatusOptionList.find(status => status.key === incident.status.state);
 
   const form = useMemo(
     () =>
       FormBuilder.group({
-        status: [currentStatus.key, Validators.required],
+        status: [incident.status.state, Validators.required],
         text: [''],
       }),
-    [currentStatus.key]
+    [incident.status.state]
   );
 
   useEffect(() => {
@@ -121,17 +131,24 @@ const StatusForm = ({ defaultTexts, incident, onClose }) => {
 
   return (
     <Fragment>
-      <Row>
+      <Header hasMargin={false}>
         <StyledColumn span={{ small: 2, medium: 2, big: 5, large: 6, xLarge: 6 }}>
           <StyledH4 forwardedAs="h2">Status wijzigen</StyledH4>
+
+          {isUnselectableStatus && (
+            <UnselectableStatus data-testid="unselectableStatus">
+              <Label as="span">Huidige status</Label>
+              <div>{currentStatus.value}</div>
+            </UnselectableStatus>
+          )}
         </StyledColumn>
-      </Row>
+      </Header>
 
       <FieldGroup
         control={form}
         render={({ invalid }) => (
           <Form onSubmit={handleSubmit}>
-            <Row>
+            <Row hasMargin={false}>
               <StyledColumn span={{ small: 2, medium: 2, big: 5, large: 6, xLarge: 6 }}>
                 <FieldControlWrapper
                   control={form.get('status')}
@@ -151,7 +168,7 @@ const StatusForm = ({ defaultTexts, incident, onClose }) => {
               </StyledColumn>
             </Row>
 
-            <Row>
+            <Row hasMargin={false}>
               <StyledColumn span={12}>
                 <FieldControlWrapper
                   control={form.get('text')}

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/index.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/index.test.js
@@ -6,7 +6,7 @@ import { PATCH_TYPE_STATUS } from 'models/incident/constants';
 import { patchIncident } from 'models/incident/actions';
 import { withAppContext } from 'test/utils';
 import incidentFixture from 'utils/__tests__/fixtures/incident.json';
-import { changeStatusOptionList } from '../../../../definitions/statusList';
+import statusList, { changeStatusOptionList } from '../../../../definitions/statusList';
 
 import StatusForm from '.';
 
@@ -52,6 +52,33 @@ describe('signals/incident-management/containers/IncidentDetail/components/Statu
     Object.values(changeStatusOptionList).forEach(({ value }) => {
       expect(getByText(value)).toBeInTheDocument();
     });
+  });
+
+  it('renders status when that status cannot be selected', () => {
+    const { queryByTestId, rerender, unmount } = render(
+      withAppContext(<StatusForm incident={incidentFixture} defaultTexts={defaultTexts} onClose={onClose} />)
+    );
+
+    expect(queryByTestId('unselectableStatus')).not.toBeInTheDocument();
+
+    unmount();
+
+    const changeStatusKeys = changeStatusOptionList.map(({ key }) => key);
+    const unselectableStatus = statusList.find(({ key }) => !changeStatusKeys.includes(key));
+
+    const fixtureWithUnselectableStatus = {
+      ...incidentFixture,
+      status: {
+        state: unselectableStatus.key,
+      },
+    };
+
+    rerender(
+      withAppContext(<StatusForm incident={fixtureWithUnselectableStatus} defaultTexts={defaultTexts} onClose={onClose} />)
+    );
+
+    expect(queryByTestId('unselectableStatus')).toBeInTheDocument();
+    expect(queryByTestId('unselectableStatus')).toHaveTextContent(unselectableStatus.value);
   });
 
   it('shows default texts', () => {


### PR DESCRIPTION
This PR fixes three issues on the status form page:
1. Alignment of the header
2. Excess padding on the form
3. Not showing of the current status of the incident. It appears that there are statuses that are set on an incident, but cannot be selected by an admin. A status would be shown in the list of radio buttons where the appropriate status radio button would be selected, but that isn't possible for statuses that are not in that list. In that case, the status is printed above the form, like so:
![Screenshot 2020-06-26 at 09 20 47](https://user-images.githubusercontent.com/1062191/85831676-ee54df00-b78e-11ea-9b15-b99eefdb6e71.png)
