### PR TITLE
[SIG-2875] Show responsible department codes

### DIFF
--- a/src/models/categories/__tests__/selectors.test.js
+++ b/src/models/categories/__tests__/selectors.test.js
@@ -117,6 +117,19 @@ describe('models/categories/selectors', () => {
     expect(slugs).toEqual(keys);
   });
 
+  test('makeSelectSubCategories extendedName', () => {
+    const subCategories = makeSelectSubCategories.resultFunc(
+      makeSelectCategories.resultFunc(state)
+    );
+
+    const subCatWithResponsibleDepts = subCategories.find(({ departments }) => departments.filter(({ is_responsible }) => is_responsible).length > 0);
+    const deptCodes = subCatWithResponsibleDepts.departments.map(({ code }) => code);
+
+    deptCodes.forEach(code => {
+      expect(subCatWithResponsibleDepts.extendedName.indexOf(code) > 0);
+    });
+  });
+
   test('makeSelectAllSubCategories', () => {
     expect(makeSelectAllSubCategories.resultFunc()).toBeNull();
 

--- a/src/models/categories/selectors.js
+++ b/src/models/categories/selectors.js
@@ -103,7 +103,21 @@ export const makeSelectSubCategories = createSelector(
       return null;
     }
 
-    return getHasParent(state).toJS();
+    const subCategories = getHasParent(state).toJS();
+
+    return subCategories.map(subCategory => {
+      const responsibleDeptCodes = subCategory.departments.filter(({ is_responsible }) => is_responsible).map(({ code }) => code);
+      let extendedName = subCategory.name;
+
+      if (responsibleDeptCodes.length > 0) {
+        extendedName = `${subCategory.name} (${responsibleDeptCodes.join(', ')})`;
+      }
+
+      return ({
+        ...subCategory,
+        extendedName,
+      });
+    });
   }
 );
 

--- a/src/signals/incident-management/components/SelectInput/index.js
+++ b/src/signals/incident-management/components/SelectInput/index.js
@@ -9,9 +9,9 @@ const Wrapper = styled.div`
 `;
 
 export const SelectInput = ({ name, display, values, useSlug, emptyOptionText }) => {
-  const options = values.map(({ key, value, slug, name: valueName }) => ({
+  const options = values.map(({ key, value, slug }) => ({
     key: useSlug ? slug : key,
-    name: valueName || emptyOptionText || value,
+    name: key ? value : emptyOptionText || value,
     value: useSlug ? slug : key,
   }));
 

--- a/src/signals/incident-management/containers/IncidentDetail/components/MetaList/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/MetaList/index.js
@@ -45,11 +45,6 @@ const EditButton = styled(Button)`
   padding: ${themeSpacing(0, 1.5)};
 `;
 
-export const getCategoryName = ({ name, departments }) => {
-  const departmensStringList = departments?.length > 0 ? ` (${departments.filter(({ is_responsible }) => is_responsible).map(({ code }) => code).join(', ')})` : '';
-  return `${name}${departmensStringList}`;
-};
-
 const MetaList = ({ incident, onEditStatus }) => {
   const dispatch = useDispatch();
   const [valueChanged, setValueChanged] = useState(false);
@@ -58,7 +53,7 @@ const MetaList = ({ incident, onEditStatus }) => {
     () =>
       subcategories?.map(category => ({
         ...category,
-        value: getCategoryName(category),
+        value: category.extendedName,
       })),
     // disabling linter; we want to allow possible null subcategories
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/signals/incident-management/containers/IncidentDetail/components/MetaList/index.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/MetaList/index.test.js
@@ -9,7 +9,7 @@ import categoriesPrivate from 'utils/__tests__/fixtures/categories_private.json'
 import { fetchCategoriesSuccess } from 'models/categories/actions';
 import { patchIncident } from 'models/incident/actions';
 
-import MetaList, { getCategoryName }from './index';
+import MetaList from './index';
 
 jest.mock('shared/services/string-parser');
 
@@ -48,9 +48,6 @@ describe('<MetaList />', () => {
       expect(queryByText('Normaal')).toBeInTheDocument();
 
       expect(queryByText('Subcategorie')).toBeInTheDocument();
-      const subcategory = categoriesPrivate.results.find(cat => cat.name === incidentFixture.category.sub);
-      const categoryName = getCategoryName({ name: incidentFixture.category.sub, departments: subcategory.departments });
-      expect(queryByText(categoryName)).toBeInTheDocument();
       expect(queryByTestId('meta-list-main-category-definition')).toHaveTextContent(/^Hoofdcategorie$/);
       expect(queryByTestId('meta-list-main-category-value')).toHaveTextContent(incidentFixture.category.main);
 
@@ -100,20 +97,6 @@ describe('<MetaList />', () => {
         },
         type: 'priority',
       }));
-    });
-  });
-
-  describe('getCategoryName', () => {
-    it('should create the correct category name', () => {
-      const category = {
-        name: 'Foo',
-        departments:[
-          { code: 'Bar', is_responsible: true },
-          { code: 'Baz', is_responsible: false },
-        ],
-      };
-
-      expect(getCategoryName(category)).toEqual('Foo (Bar)');
     });
   });
 });

--- a/src/signals/incident-management/containers/IncidentSplitContainer/components/IncidentPart/index.js
+++ b/src/signals/incident-management/containers/IncidentSplitContainer/components/IncidentPart/index.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React, { Fragment, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { Heading, themeColor, themeSpacing } from '@datapunt/asc-ui';
 import styled from 'styled-components';
@@ -27,6 +27,16 @@ const StyledH2 = styled(Heading)`
 
 const IncidentPart = ({ index, attachments, splitForm }) => {
   const subcategories = useSelector(makeSelectSubCategories);
+  const subcategoryOptions = useMemo(
+    () =>
+      subcategories?.map(category => ({
+        ...category,
+        value: category.extendedName,
+      })),
+    // disabling linter; we want to allow possible null subcategories
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [subcategories]
+  );
 
   if (!subcategories) return null;
 
@@ -44,7 +54,7 @@ const IncidentPart = ({ index, attachments, splitForm }) => {
             name={`part${index}.subcategory`}
             display="Subcategorie"
             control={splitForm.get(`part${index}.subcategory`)}
-            values={subcategories}
+            values={subcategoryOptions}
             sort
           />
 


### PR DESCRIPTION
This PR fixes an issue where the subcategory select wouldn't show the responsible department names after the subcategory name. The cause was a change in the `SelectInput` component in the `incident-management` module.

I reverted the change and moved the responsibility of generating the string that combines the responsible department names to the subcategory selector. That allows us to use the value anywhere. That's also why I added it to the split form as well.