### PR TITLE
[SIG-2889] 24-Hour map request fix

### DIFF
--- a/src/signals/incident-management/containers/IncidentOverviewPage/components/Map/__tests__/Map.test.js
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/components/Map/__tests__/Map.test.js
@@ -7,12 +7,49 @@ import OverviewMap from '..';
 fetch.mockResponse(JSON.stringify(geographyJSON));
 
 describe('signals/incident-management/containers/IncidentOverviewPage/components/Map', () => {
+  afterEach(() => {
+    fetch.resetMocks();
+  });
+
   it('should render the map and the autosuggest', async () => {
     const { getByTestId, findByTestId } = render(withMapContext(<OverviewMap />));
 
     await findByTestId('map-base');
 
     expect(getByTestId('autoSuggest')).toBeInTheDocument();
+  });
+
+  it('should request locations', async () => {
+    const { findByTestId, rerender, unmount } = render(withMapContext(<OverviewMap />));
+
+    await findByTestId('map-base');
+
+    const reDateTime = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/;
+    const expectedFilterParams = {
+      created_after: reDateTime,
+      created_before: reDateTime,
+      page_size: /4000/,
+    };
+
+    expect(fetch.mock.calls).toHaveLength(1);
+
+    const requestUrl = new URL(fetch.mock.calls[0][0]);
+    const params = new URLSearchParams(requestUrl.search);
+
+    Object.keys(expectedFilterParams).forEach(key => {
+      expect([...params.keys()].includes(key)).toBeTruthy();
+
+      const [, param] = [...params.entries()].find(([k]) => k === key);
+      expect(param).toMatch(expectedFilterParams[key]);
+    });
+
+    unmount();
+
+    rerender(withMapContext(<OverviewMap />));
+
+    await findByTestId('map-base');
+
+    expect(fetch.mock.calls).toHaveLength(2);
   });
 
   it('should render detail panel', async () => {

--- a/src/signals/incident-management/containers/IncidentOverviewPage/components/Map/index.js
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/components/Map/index.js
@@ -106,8 +106,8 @@ const OverviewMap = ({ showPanelOnInit, ...rest }) => {
   const { ...params } = filterParams;
 
   // fixed query period (24 hours)
-  params.created_after = useMemo(() => format(subDays(new Date(), -1), 'yyyy-MM-ddTHH:mm:ss'), []);
-  params.created_before = useMemo(() => format(new Date(), 'yyyy-MM-ddTHH:mm:ss'), []);
+  params.created_after = useMemo(() => format(subDays(new Date(), -1), "yyyy-MM-dd'T'HH:mm:ss"), []);
+  params.created_before = useMemo(() => format(new Date(), "yyyy-MM-dd'T'HH:mm:ss"), []);
 
   // fixed page size (default is 50; 4000 is 2.5 times the highest daily average)
   params.page_size = 4000;


### PR DESCRIPTION
This PR fixes an issue where a request to the incidents geography endpoint would result in a `400` error response. The cause was a faulty date/time string after merging #974.