### PR TITLE
[SIG-2894] Status form layout fix

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/DefaultTexts/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/DefaultTexts/index.js
@@ -8,7 +8,6 @@ import { defaultTextsType } from 'shared/types';
 const StyledH4 = styled(Heading)`
   font-weight: normal;
   margin-bottom: ${themeSpacing(2)};
-  margin-top: ${themeSpacing(5)};
 `;
 
 const StyledDefaultText = styled.div`
@@ -33,7 +32,11 @@ const StyledLink = styled(Link)`
 const DefaultTexts = ({ defaultTexts, status, onHandleUseDefaultText }) => {
   const allText = defaultTexts?.length > 0 && defaultTexts.find(text => text.state === status);
 
-  if (!allText) return null;
+  if (!allText?.templates?.length > 0) return null;
+
+  const templates = allText.templates.filter(({ title, text }) => title && text);
+
+  if (!templates) return null;
 
   return (
     <Fragment>
@@ -41,22 +44,20 @@ const DefaultTexts = ({ defaultTexts, status, onHandleUseDefaultText }) => {
         Standaard teksten
       </StyledH4>
 
-      {allText.templates
-        .filter(({ title, text }) => title && text)
-        .map((item, index) => (
-          // eslint-disable-next-line react/no-array-index-key
-          <StyledDefaultText key={`${index}${status}${JSON.stringify(item)}`}>
-            <StyledTitle data-testid="defaultTextsItemTitle">{item.title}</StyledTitle>
-            <div data-testid="defaultTextsItemText">{item.text}</div>
-            <StyledLink
-              data-testid="defaultTextsItemButton"
-              variant="inline"
-              onClick={e => onHandleUseDefaultText(e, item.text)}
-            >
-              Gebruik deze tekst
-            </StyledLink>
-          </StyledDefaultText>
-        ))}
+      {allText.templates.map((item, index) => (
+        // eslint-disable-next-line react/no-array-index-key
+        <StyledDefaultText key={`${index}${status}${JSON.stringify(item)}`}>
+          <StyledTitle data-testid="defaultTextsItemTitle">{item.title}</StyledTitle>
+          <div data-testid="defaultTextsItemText">{item.text}</div>
+          <StyledLink
+            data-testid="defaultTextsItemButton"
+            variant="inline"
+            onClick={e => onHandleUseDefaultText(e, item.text)}
+          >
+            Gebruik deze tekst
+          </StyledLink>
+        </StyledDefaultText>
+      ))}
     </Fragment>
   );
 };

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/DefaultTexts/index.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/DefaultTexts/index.test.js
@@ -75,6 +75,18 @@ describe('<DefaultTexts />', () => {
       expect(queryAllByTestId('defaultTextsTitle')).toHaveLength(0);
       expect(queryAllByTestId('defaultTextsItemText')).toHaveLength(0);
     });
+
+    it('should not render when list has no templates', () => {
+      props.hasDefaultTexts = true;
+      props.defaultTexts[0].templates = [];
+
+      const { queryAllByTestId } = render(
+        <DefaultTexts {...props} />
+      );
+
+      expect(queryAllByTestId('defaultTextsTitle')).toHaveLength(0);
+      expect(queryAllByTestId('defaultTextsItemText')).toHaveLength(0);
+    });
   });
 
   describe('events', () => {

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/index.js
@@ -4,7 +4,7 @@ import { FormBuilder, FieldGroup, Validators } from 'react-reactive-form';
 import styled, { css } from 'styled-components';
 import { useDispatch } from 'react-redux';
 
-import { Heading, Row, Column, themeSpacing } from '@datapunt/asc-ui';
+import { Heading, themeSpacing } from '@datapunt/asc-ui';
 import { incidentType, defaultTextsType } from 'shared/types';
 import { PATCH_TYPE_STATUS } from 'models/incident/constants';
 import statusList, {
@@ -27,15 +27,38 @@ const UnselectableStatus = styled.div`
 const Form = styled.form`
   position: relative;
   width: 100%;
+  grid-template-areas:
+    'header'
+    'options'
+    'texts'
+    'form';
+  grid-column-gap: 20px;
+  display: grid;
+
+  @media (min-width: ${({ theme }) => theme.layouts.medium.max}px) {
+    grid-template-columns: 6fr 6fr;
+    grid-template-areas:
+      'header texts'
+      'options texts'
+      'form texts'
+      '. texts';
+  }
 `;
 
-const Header = styled(Row)`
-  width: 100%;
+const HeaderArea = styled.div`
+  grid-area: header;
 `;
 
-const StyledColumn = styled(Column)`
-  display: block;
-  background: white;
+const OptionsArea = styled.div`
+  grid-area: options;
+`;
+
+const TextsArea = styled.div`
+  grid-area: texts;
+`;
+
+const FormArea = styled.div`
+  grid-area: form;
 `;
 
 const StyledH4 = styled(Heading)`
@@ -131,66 +154,60 @@ const StatusForm = ({ defaultTexts, incident, onClose }) => {
 
   return (
     <Fragment>
-      <Header hasMargin={false}>
-        <StyledColumn span={{ small: 2, medium: 2, big: 5, large: 6, xLarge: 6 }}>
-          <StyledH4 forwardedAs="h2">Status wijzigen</StyledH4>
-
-          {isUnselectableStatus && (
-            <UnselectableStatus data-testid="unselectableStatus">
-              <Label as="span">Huidige status</Label>
-              <div>{currentStatus.value}</div>
-            </UnselectableStatus>
-          )}
-        </StyledColumn>
-      </Header>
-
       <FieldGroup
         control={form}
         render={({ invalid }) => (
           <Form onSubmit={handleSubmit}>
-            <Row hasMargin={false}>
-              <StyledColumn span={{ small: 2, medium: 2, big: 5, large: 6, xLarge: 6 }}>
-                <FieldControlWrapper
-                  control={form.get('status')}
-                  data-testid="statusFormStatusField"
-                  name="status"
-                  render={RadioInput}
-                  values={changeStatusOptionList}
-                />
-              </StyledColumn>
+            <HeaderArea>
+              <StyledH4 forwardedAs="h2">Status wijzigen</StyledH4>
 
-              <StyledColumn span={{ small: 2, medium: 2, big: 5, large: 6, xLarge: 6 }}>
-                <DefaultTexts
-                  defaultTexts={defaultTexts}
-                  onHandleUseDefaultText={handleUseDefaultText}
-                  status={form.get('status').value}
-                />
-              </StyledColumn>
-            </Row>
+              {isUnselectableStatus && (
+                <UnselectableStatus data-testid="unselectableStatus">
+                  <Label as="span">Huidige status</Label>
+                  <div>{currentStatus.value}</div>
+                </UnselectableStatus>
+              )}
+            </HeaderArea>
 
-            <Row hasMargin={false}>
-              <StyledColumn span={12}>
-                <FieldControlWrapper
-                  control={form.get('text')}
-                  display="Toelichting"
-                  name="text"
-                  render={TextAreaInput}
-                  rows={10}
-                />
+            <OptionsArea>
+              <FieldControlWrapper
+                control={form.get('status')}
+                data-testid="statusFormStatusField"
+                name="status"
+                render={RadioInput}
+                values={changeStatusOptionList}
+              />
+            </OptionsArea>
 
-                <Notification warning data-testid="statusFormWarning">
-                  {warning}
-                </Notification>
+            <FormArea>
+              <FieldControlWrapper
+                control={form.get('text')}
+                display="Toelichting"
+                name="text"
+                render={TextAreaInput}
+                rows={10}
+              />
 
-                <StyledButton data-testid="statusFormSubmitButton" type="submit" variant="secondary" disabled={invalid}>
-                  Status opslaan
-                </StyledButton>
+              <Notification warning data-testid="statusFormWarning">
+                {warning}
+              </Notification>
 
-                <StyledButton data-testid="statusFormCancelButton" variant="tertiary" onClick={onClose}>
-                  Annuleren
-                </StyledButton>
-              </StyledColumn>
-            </Row>
+              <StyledButton data-testid="statusFormSubmitButton" type="submit" variant="secondary" disabled={invalid}>
+                Status opslaan
+              </StyledButton>
+
+              <StyledButton data-testid="statusFormCancelButton" variant="tertiary" onClick={onClose}>
+                Annuleren
+              </StyledButton>
+            </FormArea>
+
+            <TextsArea>
+              <DefaultTexts
+                defaultTexts={defaultTexts}
+                onHandleUseDefaultText={handleUseDefaultText}
+                status={form.get('status').value}
+              />
+            </TextsArea>
           </Form>
         )}
       />

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/index.js
@@ -20,7 +20,7 @@ import RadioInput from '../../../../components/RadioInput';
 import TextAreaInput from '../../../../components/TextAreaInput';
 import DefaultTexts from './components/DefaultTexts';
 
-const UnselectableStatus = styled.div`
+const CurrentStatus = styled.div`
   margin: ${themeSpacing(5, 0)};
 `;
 
@@ -38,7 +38,7 @@ const Form = styled.form`
   @media (min-width: ${({ theme }) => theme.layouts.medium.max}px) {
     grid-template-columns: 6fr 6fr;
     grid-template-areas:
-      'header texts'
+      'header header'
       'options texts'
       'form texts'
       '. texts';
@@ -89,7 +89,6 @@ const StatusForm = ({ defaultTexts, incident, onClose }) => {
   const currentStatus = statusList.find(status => status.key === incident.status.state);
   const [warning, setWarning] = useState('');
   const dispatch = useDispatch();
-  const isUnselectableStatus = !changeStatusOptionList.find(status => status.key === incident.status.state);
 
   const form = useMemo(
     () =>
@@ -161,12 +160,10 @@ const StatusForm = ({ defaultTexts, incident, onClose }) => {
             <HeaderArea>
               <StyledH4 forwardedAs="h2">Status wijzigen</StyledH4>
 
-              {isUnselectableStatus && (
-                <UnselectableStatus data-testid="unselectableStatus">
-                  <Label as="span">Huidige status</Label>
-                  <div>{currentStatus.value}</div>
-                </UnselectableStatus>
-              )}
+              <CurrentStatus data-testid="currentStatus">
+                <Label as="span">Huidige status</Label>
+                <div>{currentStatus.value}</div>
+              </CurrentStatus>
             </HeaderArea>
 
             <OptionsArea>
@@ -177,6 +174,10 @@ const StatusForm = ({ defaultTexts, incident, onClose }) => {
                 render={RadioInput}
                 values={changeStatusOptionList}
               />
+
+              <Notification warning data-testid="statusFormWarning">
+                {warning}
+              </Notification>
             </OptionsArea>
 
             <FormArea>
@@ -187,10 +188,6 @@ const StatusForm = ({ defaultTexts, incident, onClose }) => {
                 render={TextAreaInput}
                 rows={10}
               />
-
-              <Notification warning data-testid="statusFormWarning">
-                {warning}
-              </Notification>
 
               <StyledButton data-testid="statusFormSubmitButton" type="submit" variant="secondary" disabled={invalid}>
                 Status opslaan

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/index.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/index.test.js
@@ -6,7 +6,7 @@ import { PATCH_TYPE_STATUS } from 'models/incident/constants';
 import { patchIncident } from 'models/incident/actions';
 import { withAppContext } from 'test/utils';
 import incidentFixture from 'utils/__tests__/fixtures/incident.json';
-import statusList, { changeStatusOptionList } from '../../../../definitions/statusList';
+import { changeStatusOptionList } from '../../../../definitions/statusList';
 
 import StatusForm from '.';
 
@@ -41,7 +41,7 @@ describe('signals/incident-management/containers/IncidentDetail/components/Statu
   });
 
   it('renders correctly', () => {
-    const { container, getByTestId, getByText } = render(
+    const { container, getByTestId, getByLabelText } = render(
       withAppContext(<StatusForm incident={incidentFixture} defaultTexts={defaultTexts} onClose={onClose} />)
     );
 
@@ -50,35 +50,8 @@ describe('signals/incident-management/containers/IncidentDetail/components/Statu
     expect(getByTestId('statusFormCancelButton')).toBeInTheDocument();
 
     Object.values(changeStatusOptionList).forEach(({ value }) => {
-      expect(getByText(value)).toBeInTheDocument();
+      expect(getByLabelText(value)).toBeInTheDocument();
     });
-  });
-
-  it('renders status when that status cannot be selected', () => {
-    const { queryByTestId, rerender, unmount } = render(
-      withAppContext(<StatusForm incident={incidentFixture} defaultTexts={defaultTexts} onClose={onClose} />)
-    );
-
-    expect(queryByTestId('unselectableStatus')).not.toBeInTheDocument();
-
-    unmount();
-
-    const changeStatusKeys = changeStatusOptionList.map(({ key }) => key);
-    const unselectableStatus = statusList.find(({ key }) => !changeStatusKeys.includes(key));
-
-    const fixtureWithUnselectableStatus = {
-      ...incidentFixture,
-      status: {
-        state: unselectableStatus.key,
-      },
-    };
-
-    rerender(
-      withAppContext(<StatusForm incident={fixtureWithUnselectableStatus} defaultTexts={defaultTexts} onClose={onClose} />)
-    );
-
-    expect(queryByTestId('unselectableStatus')).toBeInTheDocument();
-    expect(queryByTestId('unselectableStatus')).toHaveTextContent(unselectableStatus.value);
   });
 
   it('shows default texts', () => {


### PR DESCRIPTION
This PR changes the layout of the status form so that the options and the input area are both located in the left column and the defaults texts in the right column instead of the default texts pushing the input area down the page.