### PR TITLE
(Chore) Node 12 for Github actions

### DIFF
--- a/.github/MAINTAINERS.md
+++ b/.github/MAINTAINERS.md
@@ -1,3 +1,0 @@
-# Maintainers
- - aditudorache
- - jasperswart

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,10 +2,9 @@
 
 Before opening a pull request, please ensure:
 
-- [ ] double-check your branch is based on `develop` and targets `develop` 
+- [ ] double-check your branch is based on `develop` and targets `develop`
 - [ ] Pull request has tests (we are going for 100% coverage!)
 - [ ] Code is well-commented, linted and follows project conventions
 - [ ] Internal code generators and templates are updated (if necessary)
 
 Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,10 @@ jobs:
       - name: Install libgif-dev
         run: sudo apt install libgif-dev
 
-      - name: Setup Node 11.15
+      - name: Setup Node 12
         uses: actions/setup-node@v1
         with:
-          node-version: 11.15
+          node-version: 12.18
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
This PR contains changes that make sure that the correct Node version is used when running Github actions.