### PR TITLE
[SIG-2899] GPS functionality

### DIFF
--- a/src/components/GPSButton/__tests__/GPSButton.test.js
+++ b/src/components/GPSButton/__tests__/GPSButton.test.js
@@ -52,7 +52,6 @@ describe('components/GPSButton', () => {
     });
 
     expect(onLocationSuccess).toHaveBeenLastCalledWith({
-      ...coords,
       toggled: false,
     });
   });
@@ -95,7 +94,6 @@ describe('components/GPSButton', () => {
     });
 
     expect(onLocationChange).toHaveBeenLastCalledWith({
-      ...coords,
       toggled: false,
     });
   });
@@ -133,6 +131,54 @@ describe('components/GPSButton', () => {
       code,
       message,
     });
+  });
+
+  it('should call onLocationOutOfBounds', () => {
+    const coords = {
+      accuracy: 1234,
+      latitude: 55,
+      longitude: 5,
+    };
+    const mockGeolocation = {
+      getCurrentPosition: jest.fn().mockImplementation(success =>
+        Promise.resolve(
+          success({
+            coords,
+          })
+        )
+      ),
+    };
+
+    global.navigator.geolocation = mockGeolocation;
+
+    const onLocationOutOfBounds = jest.fn();
+    const onLocationSuccess = jest.fn();
+
+    const { getByTestId, rerender, unmount } = render(
+      withAppContext(<GPSButton onLocationSuccess={onLocationSuccess} onLocationOutOfBounds={null} />)
+    );
+
+    expect(onLocationOutOfBounds).not.toHaveBeenCalled();
+
+    act(() => {
+      fireEvent.click(getByTestId('gpsButton'));
+    });
+
+    expect(onLocationOutOfBounds).not.toHaveBeenCalled();
+
+    unmount();
+
+    rerender(
+      withAppContext(<GPSButton onLocationSuccess={onLocationSuccess} onLocationOutOfBounds={onLocationOutOfBounds} />)
+    );
+
+    expect(onLocationOutOfBounds).not.toHaveBeenCalled();
+
+    act(() => {
+      fireEvent.click(getByTestId('gpsButton'));
+    });
+
+    expect(onLocationOutOfBounds).toHaveBeenCalled();
   });
 
   it('should throw an error', () => {

--- a/src/components/LocationMarker/index.js
+++ b/src/components/LocationMarker/index.js
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import Leaflet from 'leaflet';
 
@@ -46,7 +46,7 @@ const LocationMarker = ({ geolocation }) => {
     };
   }, [mapInstance, latitude, longitude, accuracy]);
 
-  return null;
+  return <span data-testid="locationMarker" />;
 };
 
 LocationMarker.propTypes = {

--- a/src/components/Map/__tests__/Map.test.js
+++ b/src/components/Map/__tests__/Map.test.js
@@ -1,12 +1,23 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, act, fireEvent } from '@testing-library/react';
+import * as reactRedux from 'react-redux';
 
+import { withAppContext } from 'test/utils';
 import MAP_OPTIONS from 'shared/services/configuration/map-options';
+import { showGlobalNotification } from 'containers/App/actions';
+import { TYPE_LOCAL, VARIANT_NOTICE } from 'containers/Notification/constants';
 import Map from '..';
 
+const dispatch = jest.fn();
+jest.spyOn(reactRedux, 'useDispatch').mockImplementation(() => dispatch);
+
 describe('components/Map', () => {
+  beforeEach(() => {
+    dispatch.mockReset();
+  });
+
   it('should render the map', () => {
-    const { getByTestId, queryByText } = render(<Map mapOptions={MAP_OPTIONS} />);
+    const { getByTestId, queryByText } = render(withAppContext(<Map mapOptions={MAP_OPTIONS} />));
 
     // Map
     expect(getByTestId('map-base')).toBeInTheDocument();
@@ -16,11 +27,123 @@ describe('components/Map', () => {
   });
 
   it('should render the zoom control', () => {
-    const { container, rerender } = render(<Map mapOptions={MAP_OPTIONS} />);
+    const { container, rerender, unmount } = render(withAppContext(<Map mapOptions={MAP_OPTIONS} />));
 
     expect(container.querySelector('button[title="Inzoomen"]')).not.toBeInTheDocument();
 
-    rerender(<Map mapOptions={MAP_OPTIONS} hasZoomControls />);
+    unmount();
+
+    rerender(withAppContext(<Map mapOptions={MAP_OPTIONS} hasZoomControls />));
     expect(container.querySelector('button[title="Inzoomen"]')).toBeInTheDocument();
+  });
+
+  it('should render a gps button', () => {
+    const { getByTestId, queryByTestId, unmount, rerender } = render(withAppContext(<Map mapOptions={MAP_OPTIONS} />));
+
+    expect(queryByTestId('gpsButton')).not.toBeInTheDocument();
+
+    unmount();
+
+    rerender(withAppContext(<Map mapOptions={MAP_OPTIONS} hasGPSControl />));
+
+    expect(getByTestId('gpsButton')).toBeInTheDocument();
+  });
+
+  it('should render a location marker', () => {
+    const coords = {
+      accuracy: 50,
+      latitude: 52.3731081,
+      longitude: 4.8932945,
+    };
+    const mockGeolocation = {
+      getCurrentPosition: jest.fn().mockImplementation(success =>
+        Promise.resolve(
+          success({
+            coords,
+          })
+        )
+      ),
+    };
+
+    global.navigator.geolocation = mockGeolocation;
+
+    const { getByTestId, queryByTestId } = render(withAppContext(<Map mapOptions={MAP_OPTIONS} hasGPSControl />));
+
+    expect(queryByTestId('locationMarker')).not.toBeInTheDocument();
+
+    act(() => {
+      fireEvent.click(getByTestId('gpsButton'));
+    });
+
+    expect(getByTestId('locationMarker')).toBeInTheDocument();
+  });
+
+  it('should show a notification whenever the location cannot be retrieved', () => {
+    const code = 1;
+    const message = 'User denied geolocation';
+    const mockGeolocation = {
+      getCurrentPosition: jest.fn().mockImplementation((success, error) =>
+        Promise.resolve(
+          error({
+            code,
+            message,
+          })
+        )
+      ),
+    };
+
+    global.navigator.geolocation = mockGeolocation;
+
+    const { getByTestId } = render(withAppContext(<Map mapOptions={MAP_OPTIONS} hasGPSControl />));
+
+    expect(dispatch).not.toHaveBeenCalled();
+
+    act(() => {
+      fireEvent.click(getByTestId('gpsButton'));
+    });
+
+    expect(dispatch).toHaveBeenCalledWith(
+      showGlobalNotification(expect.objectContaining({
+        title: 'meldingen.amsterdam.nl heeft geen toestemming om uw locatie te gebruiken.',
+        type: TYPE_LOCAL,
+        variant: VARIANT_NOTICE,
+      }))
+    );
+  });
+
+
+  it('should show a notification whenever the location is out of bounds', () => {
+    const coords = {
+      accuracy: 50,
+      latitude: 55.3731081,
+      longitude: 4.8932945,
+    };
+    const mockGeolocation = {
+      getCurrentPosition: jest.fn().mockImplementation(success =>
+        Promise.resolve(
+          success({
+            coords,
+          })
+        )
+      ),
+    };
+
+    global.navigator.geolocation = mockGeolocation;
+
+    const { getByTestId } = render(withAppContext(<Map mapOptions={MAP_OPTIONS} hasGPSControl />));
+
+    expect(dispatch).not.toHaveBeenCalled();
+
+    act(() => {
+      fireEvent.click(getByTestId('gpsButton'));
+    });
+
+    expect(dispatch).toHaveBeenCalledWith(
+      showGlobalNotification(expect.objectContaining({
+        title: 'Uw locatie valt buiten de kaart en is daardoor niet te zien',
+        type: TYPE_LOCAL,
+        variant: VARIANT_NOTICE,
+      }))
+    );
   });
 });

--- a/src/components/Map/index.js
+++ b/src/components/Map/index.js
@@ -1,11 +1,16 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState, useLayoutEffect, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { ViewerContainer } from '@datapunt/asc-ui';
 import { Zoom } from '@datapunt/amsterdam-react-maps/lib/components';
 import styled from 'styled-components';
 import { Map as MapComponent, TileLayer } from '@datapunt/react-maps';
+import { useDispatch } from 'react-redux';
 
+import { TYPE_LOCAL, VARIANT_NOTICE } from 'containers/Notification/constants';
+import { showGlobalNotification } from 'containers/App/actions';
 import configuration from 'shared/services/configuration/configuration';
+import GPSButton from '../GPSButton';
+import LocationMarker from '../LocationMarker';
 
 const StyledViewerContainer = styled(ViewerContainer)`
   z-index: 400; // this elevation ensures that this container comes on top of the internal leaflet components
@@ -19,34 +24,100 @@ const StyledMap = styled(MapComponent)`
   }
 `;
 
-const ZoomButtons = styled.div``;
+const ButtonWrapper = styled.div``;
 
-const Map = ({ className, mapOptions, hasZoomControls, canBeDragged, children, events, setInstance }) => {
+const Map = ({
+  canBeDragged,
+  children,
+  className,
+  events,
+  hasGPSControl,
+  hasZoomControls,
+  mapOptions,
+  setInstance,
+}) => {
+  const dispatch = useDispatch();
+  const [mapInstance, setMapInstance] = useState();
+  const [geolocation, setGeolocation] = useState();
   const hasTouchCapabilities = 'ontouchstart' in window;
   const showZoom = hasZoomControls && !hasTouchCapabilities;
-  const options = useMemo(
-    () => ({
-      ...mapOptions,
+  const options = useMemo(() => {
+    const center = geolocation ? [geolocation.latitude, geolocation.longitude] : mapOptions.center;
+
+    return {
+      ...{ ...mapOptions, center },
       maxZoom: mapOptions.maxZoom || configuration.map.options.maxZoom,
       minZoom: mapOptions.minZoom || configuration.map.options.minZoom,
       dragging: canBeDragged && !hasTouchCapabilities,
       tap: false,
       scrollWheelZoom: false,
-    }),
-    [canBeDragged, hasTouchCapabilities, mapOptions]
+    };
+  }, [canBeDragged, hasTouchCapabilities, mapOptions, geolocation]);
+
+  useLayoutEffect(() => {
+    if (!mapInstance || !geolocation || !geolocation.toggled) return;
+
+    mapInstance.flyTo(
+      [geolocation.latitude, geolocation.longitude],
+      mapOptions.maxZoom || configuration.map.options.maxZoom,
+      { animate: true, noMoveStart: true }
+    );
+  }, [geolocation, mapInstance, mapOptions.maxZoom]);
+
+  const captureInstance = useCallback(
+    instance => {
+      setMapInstance(instance);
+
+      if (typeof setInstance === 'function') {
+        setInstance(instance);
+      }
+    },
+    [setInstance]
   );
 
   return (
-    <StyledMap className={className} data-testid="map-base" options={options} events={events} setInstance={setInstance}>
-      {showZoom && (
-        <StyledViewerContainer
-          bottomRight={
-            <ZoomButtons data-testid="mapZoom">
-              <Zoom />
-            </ZoomButtons>
-          }
-        />
-      )}
+    <StyledMap
+      className={className}
+      data-testid="map-base"
+      options={options}
+      events={events}
+      setInstance={captureInstance}
+    >
+      <StyledViewerContainer
+        bottomRight={
+          <ButtonWrapper data-testid="mapZoom">
+            {hasGPSControl && (
+              <GPSButton
+                onLocationSuccess={location => {
+                  setGeolocation(location);
+                }}
+                onLocationError={() => {
+                  dispatch(
+                    showGlobalNotification({
+                      variant: VARIANT_NOTICE,
+                      title: 'meldingen.amsterdam.nl heeft geen toestemming om uw locatie te gebruiken.',
+                      message: 'Dit kunt u wijzigen in de voorkeuren of instellingen van uw browser of systeem.',
+                      type: TYPE_LOCAL,
+                    })
+                  );
+                }}
+                onLocationOutOfBounds={() => {
+                  dispatch(
+                    showGlobalNotification({
+                      variant: VARIANT_NOTICE,
+                      title: 'Uw locatie valt buiten de kaart en is daardoor niet te zien',
+                      type: TYPE_LOCAL,
+                    })
+                  );
+                }}
+              />
+            )}
+            {showZoom && <Zoom />}
+          </ButtonWrapper>
+        }
+      />
+
+      {geolocation?.toggled && <LocationMarker geolocation={geolocation} />}
 
       {children}
 
@@ -57,6 +128,7 @@ const Map = ({ className, mapOptions, hasZoomControls, canBeDragged, children, e
 Map.defaultProps = {
   canBeDragged: true,
   className: '',
+  hasGPSControl: false,
   hasZoomControls: false,
 };
 
@@ -71,6 +143,7 @@ Map.propTypes = {
    * @see {@link https://leafletjs.com/reference-1.6.0.html#map-event}
    */
   events: PropTypes.shape({}),
+  hasGPSControl: PropTypes.bool,
   hasZoomControls: PropTypes.bool,
   /**
    * Leaflet configuration options
@@ -78,6 +151,7 @@ Map.propTypes = {
    */
   mapOptions: PropTypes.shape({
     attributionControl: PropTypes.bool,
+    center: PropTypes.arrayOf(PropTypes.number),
     maxZoom: PropTypes.number,
     minZoom: PropTypes.number,
   }).isRequired,

--- a/src/components/MapInput/index.js
+++ b/src/components/MapInput/index.js
@@ -53,7 +53,7 @@ const StyledAutosuggest = styled(PDOKAutoSuggest)`
   }
 `;
 
-const MapInput = ({ className, value, onChange, mapOptions, events }) => {
+const MapInput = ({ className, hasGPSControl, value, onChange, mapOptions, events }) => {
   const { state, dispatch } = useContext(MapContext);
   const [map, setMap] = useState();
   const [marker, setMarker] = useState();
@@ -151,6 +151,7 @@ const MapInput = ({ className, value, onChange, mapOptions, events }) => {
     <Wrapper data-testid="map-input" className={className}>
       <StyledMap
         events={{ click, dblclick: doubleClick, ...events }}
+        hasGPSControl={hasGPSControl}
         hasZoomControls
         mapOptions={mapOptions}
         setInstance={setMap}
@@ -189,6 +190,7 @@ MapInput.propTypes = {
    * @see {@link https://leafletjs.com/reference-1.6.0.html#map-event}
    */
   events: PropTypes.shape({}),
+  hasGPSControl: PropTypes.bool,
   /**
    * leaflet options
    * @see {@link https://leafletjs.com/reference-1.6.0.html#map-option}

--- a/src/components/MapSelect/index.js
+++ b/src/components/MapSelect/index.js
@@ -32,6 +32,7 @@ const StyledMap = styled(Map)`
 const MapSelect = ({
   geojsonUrl,
   getIcon,
+  hasGPSControl,
   iconField,
   idField,
   latlng,
@@ -219,6 +220,7 @@ const MapSelect = ({
       <StyledMap
         className={classNames('map-component', { write: onSelectionChange })}
         data-testid="mapSelect"
+        hasGPSControl={hasGPSControl}
         hasZoomControls
         mapOptions={mapOptions}
         setInstance={setMapInstance}
@@ -228,6 +230,7 @@ const MapSelect = ({
 };
 
 MapSelect.defaultProps = {
+  hasGPSControl: false,
   value: [],
   selectionOnly: false,
 };
@@ -240,6 +243,7 @@ MapSelect.propTypes = {
   geojsonUrl: PropTypes.string.isRequired,
   onSelectionChange: PropTypes.func,
   getIcon: PropTypes.func.isRequired,
+  hasGPSControl: PropTypes.bool,
   legend: PropTypes.arrayOf(
     PropTypes.shape({
       label: PropTypes.string.isRequired,

--- a/src/components/MapSelect/index.test.js
+++ b/src/components/MapSelect/index.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 
+import { withAppContext } from 'test/utils';
 import ZoomMessageControl from './control/ZoomMessageControl';
 import LegendControl from './control/LegendControl';
 import LoadingControl from './control/LoadingControl';
@@ -55,19 +56,23 @@ describe('<MapSelect />', () => {
   });
 
   it('should render correctly', async () => {
-    const { findByTestId } = render(
-      <MapSelect
-        latlng={latlng}
-        onSelectionChange={onSelectionChange}
-        getIcon={getIcon}
-        geojsonUrl={url}
-        iconField="type_name"
-        idField="objectnummer"
-      />
+    const { findByTestId, getByTestId } = render(
+      withAppContext(
+        <MapSelect
+          latlng={latlng}
+          onSelectionChange={onSelectionChange}
+          getIcon={getIcon}
+          geojsonUrl={url}
+          iconField="type_name"
+          idField="objectnummer"
+          hasGPSControl
+        />
+      )
     );
 
     await findByTestId('map-base');
 
+    expect(getByTestId('gpsButton')).toBeInTheDocument();
     expect(LegendControl).not.toHaveBeenCalled();
     expect(ZoomMessageControl.mock.instances[0].addTo).toHaveBeenCalled();
     expect(ErrorControl.mock.instances[0].addTo).toHaveBeenCalled();
@@ -76,15 +81,17 @@ describe('<MapSelect />', () => {
 
   it('should render legend', async () => {
     const { findByTestId } = render(
-      <MapSelect
-        latlng={latlng}
-        onSelectionChange={onSelectionChange}
-        getIcon={getIcon}
-        geojsonUrl={url}
-        legend={legend}
-        iconField="type_name"
-        idField="objectnummer"
-      />
+      withAppContext(
+        <MapSelect
+          latlng={latlng}
+          onSelectionChange={onSelectionChange}
+          getIcon={getIcon}
+          geojsonUrl={url}
+          legend={legend}
+          iconField="type_name"
+          idField="objectnummer"
+        />
+      )
     );
 
     await findByTestId('map-base');
@@ -96,15 +103,17 @@ describe('<MapSelect />', () => {
     expect(fetch).not.toHaveBeenCalled();
 
     const { findByTestId } = render(
-      <MapSelect
-        latlng={latlng}
-        onSelectionChange={onSelectionChange}
-        getIcon={getIcon}
-        legend={legend}
-        geojsonUrl={url}
-        iconField="type_name"
-        idField="objectnummer"
-      />
+      withAppContext(
+        <MapSelect
+          latlng={latlng}
+          onSelectionChange={onSelectionChange}
+          getIcon={getIcon}
+          legend={legend}
+          geojsonUrl={url}
+          iconField="type_name"
+          idField="objectnummer"
+        />
+      )
     );
 
     await findByTestId('map-base');

--- a/src/shared/services/map-location/index.js
+++ b/src/shared/services/map-location/index.js
@@ -1,3 +1,5 @@
+import configuration from 'shared/services/configuration/configuration';
+
 export const locationTofeature = location => ({
   type: 'Point',
   coordinates: [location.lng, location.lat],
@@ -127,3 +129,10 @@ export const formatPDOKResponse = ({ response }) =>
       },
     };
   });
+
+export const pointWithinBounds = (coordinates, bounds = configuration.map.options.maxBounds) => {
+  const latWithinBounds = coordinates[0] > bounds[0][0] && coordinates[0] < bounds[1][0];
+  const lngWithinBounds = coordinates[1] > bounds[0][1] && coordinates[1] < bounds[1][1];
+
+  return latWithinBounds && lngWithinBounds;
+};

--- a/src/shared/services/map-location/index.test.js
+++ b/src/shared/services/map-location/index.test.js
@@ -8,6 +8,7 @@ import {
   formatMapLocation,
   serviceResultToAddress,
   formatPDOKResponse,
+  pointWithinBounds,
 } from './index';
 
 const testAddress = {
@@ -251,5 +252,29 @@ describe('formatPDOKResponse', () => {
         },
       },
     ]);
+  });
+});
+
+describe('pointWithinBounds', () => {
+  it('returns a boolean', () => {
+    const minLat = 2;
+    const maxLat = 7;
+
+    const minLng = 2;
+    const maxLng = 9;
+
+    const bounds = [[minLat, minLng], [maxLat, maxLng]];
+
+    const middle = [5, 6];
+    const outsideLeft = [1, 6];
+    const outsideRight = [5, 10];
+    const outsideTop = [5, 1];
+    const outsideBottom = [5, 10];
+
+    expect(pointWithinBounds(middle, bounds)).toEqual(true);
+    expect(pointWithinBounds(outsideLeft, bounds)).toEqual(false);
+    expect(pointWithinBounds(outsideRight, bounds)).toEqual(false);
+    expect(pointWithinBounds(outsideTop, bounds)).toEqual(false);
+    expect(pointWithinBounds(outsideBottom, bounds)).toEqual(false);
   });
 });

--- a/src/signals/incident-management/containers/IncidentDetail/components/MapDetail/index.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/MapDetail/index.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
+import { withAppContext } from 'test/utils';
 
 import { markerIcon } from 'shared/services/configuration/map-markers';
 import MapDetail from './index';
@@ -21,7 +22,7 @@ describe('<MapDetail />', () => {
   });
 
   it('should render correctly', () => {
-    const { container, getByTestId } = render(<MapDetail {...props} />);
+    const { container, getByTestId } = render(withAppContext(<MapDetail {...props} />));
 
     // Map
     expect(getByTestId('map-base')).toBeInTheDocument();
@@ -32,7 +33,7 @@ describe('<MapDetail />', () => {
 
   it('should not render without value', () => {
     props.value = {};
-    const { container, queryByTestId } = render(<MapDetail {...props} />);
+    const { container, queryByTestId } = render(withAppContext(<MapDetail {...props} />));
 
     // Map
     expect(queryByTestId('map')).not.toBeInTheDocument();

--- a/src/signals/incident/components/form/MapInput/__snapshots__/index.test.js.snap
+++ b/src/signals/incident/components/form/MapInput/__snapshots__/index.test.js.snap
@@ -18,6 +18,7 @@ exports[`Form component <MapInput /> rendering should render map field correctly
   >
     <Memo(MapContext)>
       <MapInput
+        hasGPSControl={true}
         mapOptions={
           Object {
             "attributionControl": true,

--- a/src/signals/incident/components/form/MapInput/index.js
+++ b/src/signals/incident/components/form/MapInput/index.js
@@ -25,7 +25,7 @@ const MapInput = ({ handler, touched, hasError, meta, parent, getError, validato
     <Header className="mapInput" meta={meta} options={validatorsOrOpts} touched={touched} hasError={hasError} getError={getError}>
       <div className="invoer">
         <MapContext>
-          <MapInputComponent onChange={onLocationChange} value={value} mapOptions={mapOptions} />
+          <MapInputComponent onChange={onLocationChange} value={value} mapOptions={mapOptions} hasGPSControl />
         </MapContext>
       </div>
     </Header>

--- a/src/signals/incident/components/form/MapSelect/index.js
+++ b/src/signals/incident/components/form/MapSelect/index.js
@@ -54,15 +54,16 @@ const MapSelect = ({ handler, touched, hasError, meta, parent, getError, validat
         getError={getError}
       >
         <MapSelectComponent
-          latlng={latlng}
-          onSelectionChange={onSelectionChange}
-          getIcon={getOVLIcon}
-          legend={filtered_legend}
           geojsonUrl={url}
+          getIcon={getOVLIcon}
+          hasGPSControl
           iconField="type_name"
           idField="objectnummer"
-          zoomMin={meta.zoomMin}
+          latlng={latlng}
+          legend={filtered_legend}
+          onSelectionChange={onSelectionChange}
           value={selection}
+          zoomMin={meta.zoomMin}
         />
         {selection.length > 0 && <Selection>Het gaat om lamp of lantaarnpaal met nummer: {selection.join('; ')}</Selection>}
       </Header>

--- a/src/signals/incident/components/form/MapSelect/index.test.js
+++ b/src/signals/incident/components/form/MapSelect/index.test.js
@@ -45,6 +45,7 @@ describe('signals/incident/components/form/MapSelect', () => {
       );
 
       expect(queryByTestId('map-base')).toBeInTheDocument();
+      expect(queryByTestId('gpsButton')).toBeInTheDocument();
       expect(container.firstChild.classList.contains('mapSelect')).toBeTruthy();
 
       rerender(withAppContext(<MapSelect parent={parent} meta={{ ...meta, isVisible: false }} handler={handler} />));


### PR DESCRIPTION
This PR combines #999 and #1001 and ties them together in the map components.

It also:
- alters the `GPSButton` component so that, when the button is toggled off, not another geolocation request is performed
- adds `onLocationOutOfBounds` prop to the `GPSButton` component
- add `pointWithinBounds` function to the `map-location` service
- has the `LocationMarker` component render an empty `<span>` so that a `data-testid` attribute can be rendered and checked for in other tests
- has the `Map` component render the `GPSButton` component and show notifications when the location cannot be retrieved or is out of bounds