### PR TITLE
(Chore) Prevent multiple geolocation requests

### DIFF
--- a/src/components/GPSButton/index.js
+++ b/src/components/GPSButton/index.js
@@ -30,6 +30,8 @@ const GPSButton = ({ onLocationChange, onLocationSuccess, onLocationError, onLoc
     event => {
       event.preventDefault();
 
+      if (loading) return;
+
       if (toggled) {
         successCallbackFunc({ toggled: false });
         setToggled(false);
@@ -67,7 +69,7 @@ const GPSButton = ({ onLocationChange, onLocationSuccess, onLocationError, onLoc
         global.navigator.geolocation.getCurrentPosition(onSuccess, onError);
       }
     },
-    [onLocationError, onLocationOutOfBounds, successCallbackFunc, shouldWatch, toggled]
+    [onLocationError, onLocationOutOfBounds, successCallbackFunc, shouldWatch, toggled, loading]
   );
 
   return (


### PR DESCRIPTION
This PR contains a small addition to the `GPSButton` component that prevents multiple geolocation requests to be fired when another request is pending.
In addition to that, a test case has been added to increase the component's coverage to 100%