### PR TITLE
[SIG-2087] GPS Button modifications

### DIFF
--- a/src/components/GPSButton/index.js
+++ b/src/components/GPSButton/index.js
@@ -16,7 +16,7 @@ const GPSIcon = styled(GPS)`
   display: inline-block;
 `;
 
-const GPSButton = ({ onLocationChange, onLocationSuccess, onLocationError, onLocationOutOfBounds }) => {
+const GPSButton = ({ className, onLocationChange, onLocationSuccess, onLocationError, onLocationOutOfBounds }) => {
   const [loading, setLoading] = useState(false);
   const [toggled, setToggled] = useState(false);
   const shouldWatch = typeof onLocationChange === 'function';
@@ -29,6 +29,8 @@ const GPSButton = ({ onLocationChange, onLocationSuccess, onLocationError, onLoc
   const onClick = useCallback(
     event => {
       event.preventDefault();
+
+      if (loading) return;
 
       if (toggled) {
         successCallbackFunc({ toggled: false });
@@ -67,11 +69,12 @@ const GPSButton = ({ onLocationChange, onLocationSuccess, onLocationError, onLoc
         global.navigator.geolocation.getCurrentPosition(onSuccess, onError);
       }
     },
-    [onLocationError, onLocationOutOfBounds, successCallbackFunc, shouldWatch, toggled]
+    [onLocationError, onLocationOutOfBounds, successCallbackFunc, shouldWatch, toggled, loading]
   );
 
   return (
     <StyledButton
+      className={className}
       data-testid="gpsButton"
       icon={loading ? <Spinner /> : <GPSIcon fill={toggled ? '#009de6' : 'black'} />}
       iconSize={20}
@@ -82,7 +85,12 @@ const GPSButton = ({ onLocationChange, onLocationSuccess, onLocationError, onLoc
   );
 };
 
+GPSButton.defaultProps = {
+  className: '',
+};
+
 GPSButton.propTypes = {
+  className: PropTypes.string,
   onLocationChange: PropTypes.func,
   onLocationError: PropTypes.func,
   onLocationOutOfBounds: PropTypes.func,

--- a/src/components/LocationMarker/index.js
+++ b/src/components/LocationMarker/index.js
@@ -17,7 +17,7 @@ const locationDotOptions = {
 
 const accuracyCircleOptions = {
   fillColor: '#009de6',
-  fillOpacity: 0.2,
+  fillOpacity: 0.1,
   interactive: false,
   stroke: false,
 };
@@ -33,12 +33,12 @@ const LocationMarker = ({ geolocation }) => {
   useEffect(() => {
     if (!mapInstance) return undefined;
 
-    locationDot.addTo(mapInstance);
-    locationDot.setLatLng([latitude, longitude]);
-
     accuracyCircle.addTo(mapInstance);
     accuracyCircle.setLatLng([latitude, longitude]);
     accuracyCircle.setRadius(accuracy);
+
+    locationDot.addTo(mapInstance);
+    locationDot.setLatLng([latitude, longitude]);
 
     return () => {
       locationDot.remove();

--- a/src/components/Map/index.js
+++ b/src/components/Map/index.js
@@ -24,7 +24,9 @@ const StyledMap = styled(MapComponent)`
   }
 `;
 
-const ButtonWrapper = styled.div``;
+const StyledGPSButton = styled(GPSButton)`
+  margin-bottom: 8px;
+`;
 
 const Map = ({
   canBeDragged,
@@ -85,9 +87,9 @@ const Map = ({
     >
       <StyledViewerContainer
         bottomRight={
-          <ButtonWrapper data-testid="mapZoom">
+          <div data-testid="mapZoom">
             {hasGPSControl && (
-              <GPSButton
+              <StyledGPSButton
                 onLocationSuccess={location => {
                   setGeolocation(location);
                 }}
@@ -113,7 +115,7 @@ const Map = ({
               />
             )}
             {showZoom && <Zoom />}
-          </ButtonWrapper>
+          </div>
         }
       />
 


### PR DESCRIPTION
This PR:
- changes the opacity of the `LocationMarker` accuracy circle
- makes sure the location dot is rendered on top of the accuracy circle
- sets the distance between the gps button and the zoom buttons