### PR TITLE
(Chore) useEventEmitter hook

### DIFF
--- a/src/hooks/__tests__/useEventEmitter.test.js
+++ b/src/hooks/__tests__/useEventEmitter.test.js
@@ -1,0 +1,121 @@
+import { renderHook } from '@testing-library/react-hooks';
+
+import useEventEmitter from '../useEventEmitter';
+
+jest.spyOn(global.document, 'dispatchEvent');
+jest.spyOn(global.document, 'addEventListener');
+jest.spyOn(global.document, 'removeEventListener');
+
+describe('hooks/useEventEmitter', () => {
+  beforeEach(() => {
+    global.document.dispatchEvent.mockReset();
+    global.document.addEventListener.mockReset();
+    global.document.removeEventListener.mockReset();
+    global.CustomEvent = jest.fn((...params) => new Event(...params));
+  });
+
+  it('creates a custom event on the document', () => {
+    const { result } = renderHook(() => useEventEmitter());
+
+    expect(global.document.dispatchEvent).not.toHaveBeenCalled();
+
+    const name = 'FooBar';
+    result.current.emit(name);
+
+    expect(global.document.dispatchEvent).toHaveBeenCalledWith(new Event(name));
+  });
+
+  it('creates a custom event with payload', () => {
+    const { result } = renderHook(() => useEventEmitter());
+
+    expect(global.document.dispatchEvent).not.toHaveBeenCalled();
+
+    const name = 'BarBaz';
+    const payload = { hereBe: 'dragons' };
+    result.current.emit(name, payload);
+
+    expect(global.document.dispatchEvent).toHaveBeenCalledWith(new Event(name, { detail: payload }));
+  });
+
+  it('creates a custom event on an element', () => {
+    const { result } = renderHook(() => useEventEmitter());
+
+    expect(global.CustomEvent).not.toHaveBeenCalled();
+
+    const target = document.createElement('div');
+    document.body.appendChild(target);
+
+    jest.spyOn(target, 'dispatchEvent');
+
+    expect(target.dispatchEvent).not.toHaveBeenCalled();
+
+    const name = 'BazQux';
+    result.current.emit(name, undefined, target);
+
+    expect(global.CustomEvent).toHaveBeenCalledWith(name);
+    expect(target.dispatchEvent).toHaveBeenCalledWith(new Event(name));
+  });
+
+  it('registers a listener on the document', () => {
+    const { result } = renderHook(() => useEventEmitter());
+
+    expect(global.document.addEventListener).not.toHaveBeenCalled();
+
+    const callback = () => {};
+    const name = 'Zork';
+    result.current.listenFor(name, callback);
+
+    expect(global.document.addEventListener).toHaveBeenCalledWith(name, callback);
+  });
+
+  it('registers a listener on an element', () => {
+    const { result } = renderHook(() => useEventEmitter());
+
+    const target = document.createElement('div');
+    document.body.appendChild(target);
+
+    jest.spyOn(target, 'addEventListener');
+
+    expect(target.addEventListener).not.toHaveBeenCalled();
+
+    const callback = () => {};
+    const name = 'Bazzz';
+    result.current.listenFor(name, callback, target);
+
+    expect(target.addEventListener).toHaveBeenCalledWith(name, callback);
+  });
+
+  it('removes a listener on the document', () => {
+    const { result } = renderHook(() => useEventEmitter());
+    const callback = () => {};
+    const name = 'Zork';
+
+    result.current.listenFor(name, callback);
+
+    expect(global.document.removeEventListener).not.toHaveBeenCalled();
+
+    result.current.unlisten(name, callback);
+
+    expect(global.document.removeEventListener).toHaveBeenCalledWith(name, callback);
+  });
+
+  it('removes a listener on an element', () => {
+    const { result } = renderHook(() => useEventEmitter());
+
+    const target = document.createElement('div');
+    document.body.appendChild(target);
+
+    jest.spyOn(target, 'removeEventListener');
+
+    const callback = () => {};
+    const name = 'Zork';
+
+    result.current.listenFor(name, callback, target);
+
+    expect(target.removeEventListener).not.toHaveBeenCalled();
+
+    result.current.unlisten(name, callback, target);
+
+    expect(target.removeEventListener).toHaveBeenCalledWith(name, callback);
+  });
+});

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,0 +1,6 @@
+export { default as useDelayedDoubleClick } from './useDelayedDoubleClick';
+export { default as useEventEmitter } from './useEventEmitter';
+export { default as useFetch } from './useFetch';
+export { default as useFormValidation } from './useFormValidation';
+export { default as useIsFrontOffice } from './useIsFrontOffice';
+export { default as useLocationReferrer } from './useLocationReferrer';

--- a/src/hooks/useEventEmitter.js
+++ b/src/hooks/useEventEmitter.js
@@ -1,0 +1,26 @@
+import { useCallback } from 'react';
+
+const useEventEmitter = () => {
+  const emit = useCallback((name, payload, target = global.document) => {
+    const args = [name, payload && { detail: payload }].filter(Boolean);
+    const event = new CustomEvent(...args);
+
+    target.dispatchEvent(event);
+  }, []);
+
+  const listenFor = useCallback((eventName, callback, target = global.document) => {
+    target.addEventListener(eventName, callback);
+  }, []);
+
+  const unlisten = useCallback((eventName, callback, target = global.document) => {
+    target.removeEventListener(eventName, callback);
+  }, []);
+
+  return {
+    emit,
+    listenFor,
+    unlisten,
+  };
+};
+
+export default useEventEmitter;

--- a/src/signals/incident-management/containers/IncidentOverviewPage/index.js
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/index.js
@@ -17,6 +17,7 @@ import * as types from 'shared/types';
 import { FILTER_PAGE_SIZE } from 'signals/incident-management/constants';
 import MapContext from 'containers/MapContext';
 import dataLists from 'signals/incident-management/definitions';
+import useEventEmitter from 'hooks/useEventEmitter';
 
 import {
   makeSelectActiveFilter,
@@ -47,6 +48,7 @@ export const IncidentOverviewPageContainerComponent = ({
   page,
   pageChangedAction,
 }) => {
+  const { listenFor, unlisten } = useEventEmitter();
   const [modalFilterIsOpen, toggleFilterModal] = useState(false);
   const [modalMyFiltersIsOpen, toggleMyFiltersModal] = useState(false);
   const { count, loading, results } = incidents;
@@ -97,14 +99,14 @@ export const IncidentOverviewPageContainerComponent = ({
   );
 
   useEffect(() => {
-    document.addEventListener('keydown', escFunction);
-    document.addEventListener('openFilter', openFilterModal);
+    listenFor('keydown', escFunction);
+    listenFor('openFilter', openFilterModal);
 
     return () => {
-      document.removeEventListener('keydown', escFunction);
-      document.removeEventListener('openFilter', openFilterModal);
+      unlisten('keydown', escFunction);
+      unlisten('openFilter', openFilterModal);
     };
-  }, [escFunction, openFilterModal]);
+  }, [escFunction, openFilterModal, listenFor, unlisten]);
 
   const totalPages = useMemo(() => Math.ceil(count / FILTER_PAGE_SIZE), [count]);
 

--- a/src/signals/incident-management/containers/MyFilters/index.js
+++ b/src/signals/incident-management/containers/MyFilters/index.js
@@ -11,6 +11,7 @@ import {
 } from 'signals/incident-management/actions';
 import { makeSelectAllFilters } from 'signals/incident-management/selectors';
 import * as types from 'shared/types';
+import useEventEmitter from 'hooks/useEventEmitter';
 
 import FilterItem from './components/FilterItem';
 
@@ -31,6 +32,8 @@ export const MyFiltersComponent = ({
   onRemoveFilter,
   onClose,
 }) => {
+  const { emit } = useEventEmitter();
+
   /**
    * Selecting apply filter should show the filtered incidents as well as set the filter values
    * for the filter form and should thus call both the onApplyFilter and onEditFilter actions
@@ -41,21 +44,9 @@ export const MyFiltersComponent = ({
 
   const handleEditFilter = useCallback(filter => {
     onEditFilter(filter);
-    // IE11 doesn't support dispatching an event without initialisation
-    // @see {@link https://developer.mozilla.org/en-US/docs/Web/Guide/Events/Creating_and_triggering_events#Creating_custom_events}
-    let event;
-    if (typeof Event === 'function') {
-      event = new Event('openFilter');
-    } else {
-      event = document.createEvent('Event');
-      const bubbles = false;
-      const cancelable = false;
-      event.initEvent('openFilter', bubbles, cancelable);
-    }
 
-    event.data = filter;
-    document.dispatchEvent(event);
-  }, [onEditFilter]);
+    emit('openFilter');
+  }, [onEditFilter, emit]);
 
   return (
     <div className="my-filters">


### PR DESCRIPTION
This PR adds the `useEventEmitter` hook that allows us to do
```jsx
// somewhere in the application
const payload = { foo: 'bar' };
emit('myEvent', payload);

...

// somewhere deep down in a component
useEffect(() => {
  const listener = payload => {
    const { foo } = payload;
    // do something with payload
  };

  listenFor('myEvent', listener);

  return () => {
    unlisten('myEvent', listener);
  };
}, []);