### PR TITLE
Chore jenkinsfile prevent auto prod deploys

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,8 +42,8 @@ WORKDIR /app
 
 COPY assets /app/assets
 
-ARG GIT_COMMIT
-ENV GIT_COMMIT ${GIT_COMMIT}
+ARG GIT_BRANCH
+ENV GIT_BRANCH ${GIT_BRANCH}
 
 ENV NODE_ENV=production
 RUN echo "run build"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,7 @@ node('BS16 || BS17') {
                     }
 
                     def buildParams = "--shm-size 1G " +
-                        "--build-arg BUILD_NUMBER=${env.BUILD_NUMBER} " +
+                        "--build-arg BUILD_NUMBER=${env.BUILD_NUMBER} "
 
                     buildParams += IS_TAG ? "--build-arg GIT_BRANCH=${BRANCH} " : ''
                     buildParams += '.'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,6 @@ Boolean IS_TAG = BRANCH ==~ /v(\d{1,3}\.){2}\d{1,3}/
 node('BS16 || BS17') {
     stage("Checkout") {
         def scmVars = checkout(scm)
-        env.GIT_COMMIT = scmVars.GIT_COMMIT
         env.COMPOSE_DOCKER_CLI_BUILD = 1
     }
 
@@ -36,7 +35,6 @@ node('BS16 || BS17') {
 
                     def buildParams = "--shm-size 1G " +
                         "--build-arg BUILD_NUMBER=${env.BUILD_NUMBER} " +
-                        "--build-arg GIT_COMMIT=${env.GIT_COMMIT} "
 
                     buildParams += IS_TAG ? "--build-arg GIT_BRANCH=${BRANCH} " : ''
                     buildParams += '.'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ def tryStep(String message, Closure block, Closure tearDown = null) {
 }
 
 String BRANCH = "${env.BRANCH_NAME}"
-Boolean IS_TAG = BRANCH ==~ /v(\d{1,3}\.){2}\d{1,3}/
+Boolean IS_SEMVER_TAG = BRANCH ==~ /v(\d{1,3}\.){2}\d{1,3}/
 
 node('BS16 || BS17') {
     stage("Checkout") {
@@ -23,7 +23,7 @@ node('BS16 || BS17') {
         env.COMPOSE_DOCKER_CLI_BUILD = 1
     }
 
-    if (BRANCH == "develop" || IS_TAG) {
+    if (BRANCH == "develop" || IS_SEMVER_TAG) {
         stage("Build and push image") {
             tryStep "build", {
                 docker.withRegistry("${DOCKER_REGISTRY_HOST}",'docker_registry_auth') {
@@ -36,7 +36,7 @@ node('BS16 || BS17') {
                     def buildParams = "--shm-size 1G " +
                         "--build-arg BUILD_NUMBER=${env.BUILD_NUMBER} "
 
-                    buildParams += IS_TAG ? "--build-arg GIT_BRANCH=${BRANCH} " : ''
+                    buildParams += IS_SEMVER_TAG ? "--build-arg GIT_BRANCH=${BRANCH} " : ''
                     buildParams += '.'
 
                     def image = docker.build("ois/signalsfrontend:${env.BUILD_NUMBER}", buildParams)
@@ -61,7 +61,7 @@ node('BS16 || BS17') {
         }
     }
 
-    if (IS_TAG) {
+    if (IS_SEMVER_TAG) {
         stage("Deploy Amsterdam PROD") {
             tryStep "deployment", {
                 build job: '/SIA_Signalen_Amsterdam/signals-amsterdam/master'

--- a/internals/webpack/webpack.base.babel.js
+++ b/internals/webpack/webpack.base.babel.js
@@ -7,7 +7,6 @@ const CopyPlugin = require('copy-webpack-plugin');
 
 const devMode = process.env.NODE_ENV !== 'production';
 const __rootdir = pkgDir.sync();
-const version = require(path.resolve(__rootdir, 'package.json')).version;
 
 const esModules = [
   path.resolve(__rootdir, 'node_modules/@datapunt/asc-assets'),
@@ -123,7 +122,7 @@ module.exports = options => ({
     // drop any unreachable code.
     new webpack.EnvironmentPlugin({
       NODE_ENV: JSON.stringify(process.env.NODE_ENV),
-      GIT_COMMIT: JSON.stringify(process.env.GIT_COMMIT) || 'dummy',
+      GIT_BRANCH: JSON.stringify(process.env.GIT_BRANCH) || 'dummy',
     }),
 
     new MiniCssExtractPlugin({
@@ -137,9 +136,6 @@ module.exports = options => ({
     new CopyPlugin({ patterns: [{ from: path.resolve(__rootdir, 'assets'), to: 'assets' }] }),
 
     process.env.ANALYZE && new BundleAnalyzerPlugin(),
-    new webpack.DefinePlugin({
-      VERSION: JSON.stringify(version),
-    }),
   ]
     .concat(options.plugins)
     .filter(Boolean),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,7 @@
 {
   "name": "sia",
-  "version": "1.16.0",
-  "lockfileVersion": 1,
   "requires": true,
+  "lockfileVersion": 1,
   "dependencies": {
     "@babel/cli": {
       "version": "7.10.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,5 @@
 {
   "name": "sia",
-  "version": "1.16.0",
-  "description": "Signalen Informatievoorziening",
   "repository": {
     "type": "git",
     "url": "https://github.com/Amsterdam/signals-frontend.git"

--- a/src/app.js
+++ b/src/app.js
@@ -60,7 +60,7 @@ if (urlBase && siteId) {
 
 const render = () => {
   // eslint-disable-next-line no-undef,no-console
-  if (GIT_BRANCH) console.log(`Signals: tag ${GIT_BRANCH}`);
+  if (prelease) console.log(`Signals: tag ${release}`);
 
   ReactDOM.render(
     <Provider store={store}>

--- a/src/app.js
+++ b/src/app.js
@@ -30,7 +30,7 @@ import configureStore from './configureStore';
 const environment = process.env.NODE_ENV;
 
 const dsn = configuration?.sentry?.dsn;
-const release = process.env.GIT_COMMIT;
+const release = process.env.GIT_BRANCH;
 if (dsn) {
   Sentry.init({
     environment,
@@ -60,7 +60,7 @@ if (urlBase && siteId) {
 
 const render = () => {
   // eslint-disable-next-line no-undef,no-console
-  console.log(`Signals: version: ${VERSION}, build: ${process.env.NODE_ENV}`);
+  if (GIT_BRANCH) console.log(`Signals: tag ${GIT_BRANCH}`);
 
   ReactDOM.render(
     <Provider store={store}>


### PR DESCRIPTION
This PR contains changes to the `Jenkinsfile` that prevent automatic deploys to production on merges to `master`. Instead, only tags can be deployed. This change forces us to explicitly tag the `master` branch before each and every release. This also allows a rollback in case something went horribly wrong on deployment, for instance when we forget to include a required configuration prop in one of the `signals-amsterdam` or `signals-weesp` repositories.

Note that:
- the env var `GIT_COMMIT` has been replaced by `GIT_TAG`, which effectively will be a tag or `develop`
- both `version` and `description` props have been removed from `package.json`; neither are required and only make sense when the repository is published through NPM, which we never will. Also, having a `version` prop doesn't make sense when we're already tagging the `master` branch