### PR TITLE
[SIG-2800] Child incidents call

### DIFF
--- a/src/components/ChildIncidents/__tests__/ChildIncidents.test.js
+++ b/src/components/ChildIncidents/__tests__/ChildIncidents.test.js
@@ -5,25 +5,18 @@ import 'jest-styled-components';
 import { withAppContext } from 'test/utils';
 
 import { INCIDENT_URL } from 'signals/incident-management/routes';
-import { statusList } from 'signals/incident-management/definitions';
-import categories from 'utils/__tests__/fixtures/categories.json';
-import departments from 'utils/__tests__/fixtures/departments.json';
-import incident from 'utils/__tests__/fixtures/incident.json';
+import childIncidentsFixture from 'utils/__tests__/fixtures/childIncidents.json';
 
 import ChildIncidents, { STATUS_RESPONSE_REQUIRED, STATUS_NONE } from '..';
-
-const randomElement = array => array[Math.floor(Math.random() * array.length)];
 
 const getChildren = (opts = {}) => {
   const options = { ...{ numValues: 4, withHref: true, withStatus: true }, ...opts };
 
-  return incident._links['sia:children'].map(({ href }) => {
-    const id = href.substring(href.lastIndexOf('/') + 1, href.length);
+  return childIncidentsFixture.results.map(({ status, category, id }) => {
     const values = {
       id,
-      status: options.numValues > 1 && randomElement(statusList).value,
-      categorie: options.numValues > 2 && randomElement(categories.sub).value,
-      afdeling: options.numValues > 3 && randomElement(departments.results).code,
+      status: status.state_display,
+      category: `${category.sub} (${category.departments})`,
     };
 
     return {
@@ -75,10 +68,4 @@ describe('components/ChildIncidents', () => {
       });
     });
   });
-
-  it('should wrap contents', () => {});
-
-  it('should set the flex basis for all but the first and last element', () => {});
-
-  it('should set the max width for the fourth element', () => {});
 });

--- a/src/components/ChildIncidents/index.js
+++ b/src/components/ChildIncidents/index.js
@@ -121,7 +121,9 @@ ChildIncidents.propTypes = {
       href: PropTypes.string,
       status: PropTypes.string,
       values: PropTypes.shape({
-        id: PropTypes.string.isRequired,
+        id: PropTypes.number.isRequired,
+        status: PropTypes.string.isRequired,
+        category: PropTypes.string.isRequired,
       }),
     })
   ),

--- a/src/shared/types/index.js
+++ b/src/shared/types/index.js
@@ -156,6 +156,26 @@ export const incidentType = PropTypes.shape({
   updated_at: dateType,
 });
 
+export const childIncidentType = PropTypes.exact({
+  _links: PropTypes.exact({
+    self: PropTypes.shape({
+      href: PropTypes.string.isRequired,
+    }).isRequired,
+  }).isRequired,
+  category: PropTypes.exact({
+    departments: PropTypes.string.isRequired,
+    main: PropTypes.string.isRequired,
+    main_slug: PropTypes.string.isRequired,
+    sub: PropTypes.string.isRequired,
+    sub_slug: PropTypes.string.isRequired,
+  }).isRequired,
+  id: PropTypes.number.isRequired,
+  status: PropTypes.exact({
+    state: PropTypes.string.isRequired,
+    state_display: PropTypes.string.isRequired,
+  }),
+});
+
 export const attachmentsType = PropTypes.arrayOf(
   PropTypes.shape({
     _display: PropTypes.string,

--- a/src/signals/incident-management/containers/IncidentDetail/__tests__/IncidentDetail.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/__tests__/IncidentDetail.test.js
@@ -118,7 +118,7 @@ describe('signals/incident-management/containers/IncidentDetail', () => {
     );
 
     expect(fetch).toHaveBeenCalledWith(
-      `${configuration.INCIDENT_PRIVATE_ENDPOINT}${id}/children`,
+      `${configuration.INCIDENT_PRIVATE_ENDPOINT}${id}/children/`,
       expect.objectContaining({ method: 'GET' })
     );
   });

--- a/src/signals/incident-management/containers/IncidentDetail/__tests__/IncidentDetail.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/__tests__/IncidentDetail.test.js
@@ -6,12 +6,13 @@ import * as reactRedux from 'react-redux';
 import configuration from 'shared/services/configuration/configuration';
 import { withAppContext } from 'test/utils';
 import incidentFixture from 'utils/__tests__/fixtures/incident.json';
+import childIncidentFixture from 'utils/__tests__/fixtures/childIncidents.json';
 import historyFixture from 'utils/__tests__/fixtures/history.json';
 import useEventEmitter from 'hooks/useEventEmitter';
 import { showGlobalNotification } from 'containers/App/actions';
 import { VARIANT_ERROR, TYPE_LOCAL } from 'containers/Notification/constants';
 
-import IncidentDetail from '.';
+import IncidentDetail from '..';
 
 // prevent fetch requests that we don't need to verify
 jest.mock('components/MapStatic', () => () => <span data-testid="mapStatic" />);
@@ -82,13 +83,12 @@ describe('signals/incident-management/containers/IncidentDetail', () => {
       [JSON.stringify(incidentFixture), { status: 200 }],
       [JSON.stringify(historyFixture), { status: 200 }],
       [JSON.stringify(statusMessageTemplates), { status: 200 }],
-      [JSON.stringify(attachments), { status: 200 }]
+      [JSON.stringify(attachments), { status: 200 }],
+      [JSON.stringify(childIncidentFixture), { status: 200 }]
     );
   });
 
   it('should retrieve incident data', async () => {
-    fetch.mockResponseOnce(JSON.stringify(incidentFixture));
-
     const { findByTestId } = render(withAppContext(<IncidentDetail />));
 
     expect(fetch).toHaveBeenCalledWith(
@@ -116,6 +116,11 @@ describe('signals/incident-management/containers/IncidentDetail', () => {
       `${configuration.INCIDENT_PRIVATE_ENDPOINT}${id}/attachments`,
       expect.objectContaining({ method: 'GET' })
     );
+
+    expect(fetch).toHaveBeenCalledWith(
+      `${configuration.INCIDENT_PRIVATE_ENDPOINT}${id}/children`,
+      expect.objectContaining({ method: 'GET' })
+    );
   });
 
   it('should not retrieve data', () => {
@@ -131,20 +136,37 @@ describe('signals/incident-management/containers/IncidentDetail', () => {
 
     await findByTestId('incidentDetail');
 
-    expect(fetch).toHaveBeenCalledTimes(4);
-
-    fetch.mockResponses(
-      [JSON.stringify(incidentFixture), { status: 200 }],
-      [JSON.stringify(historyFixture), { status: 200 }],
-      [JSON.stringify(statusMessageTemplates), { status: 200 }],
-      [JSON.stringify(attachments), { status: 200 }]
-    );
+    expect(fetch).toHaveBeenCalledTimes(5);
 
     rerender(withAppContext(<IncidentDetail />));
 
     await findByTestId('incidentDetail');
 
+    expect(fetch).toHaveBeenCalledTimes(5);
+  });
+
+  it('should not get child incidents', async () => {
+    fetch.resetMocks();
+
+    const incidentWithoutChildren = {
+      ...incidentFixture,
+      _links: { ...incidentFixture._links, 'sia:children': undefined },
+    };
+
+    fetch.mockResponses(
+      [JSON.stringify(incidentWithoutChildren), { status: 200 }],
+      [JSON.stringify(historyFixture), { status: 200 }],
+      [JSON.stringify(statusMessageTemplates), { status: 200 }],
+      [JSON.stringify(attachments), { status: 200 }]
+    );
+
+    const { queryByTestId, findByTestId } = render(withAppContext(<IncidentDetail />));
+
+    await findByTestId('incidentDetail');
+
     expect(fetch).toHaveBeenCalledTimes(4);
+
+    expect(queryByTestId('childIncidents')).not.toBeInTheDocument();
   });
 
   it('should retrieve data when id param changes', async () => {
@@ -152,13 +174,14 @@ describe('signals/incident-management/containers/IncidentDetail', () => {
 
     await findByTestId('incidentDetail');
 
-    expect(fetch).toHaveBeenCalledTimes(4);
+    expect(fetch).toHaveBeenCalledTimes(5);
 
     fetch.mockResponses(
       [JSON.stringify(incidentFixture), { status: 200 }],
       [JSON.stringify(historyFixture), { status: 200 }],
       [JSON.stringify(statusMessageTemplates), { status: 200 }],
-      [JSON.stringify(attachments), { status: 200 }]
+      [JSON.stringify(attachments), { status: 200 }],
+      [JSON.stringify(childIncidentFixture), { status: 200 }]
     );
 
     reactRouterDom.useParams.mockImplementation(() => ({
@@ -171,7 +194,7 @@ describe('signals/incident-management/containers/IncidentDetail', () => {
 
     await findByTestId('incidentDetail');
 
-    expect(fetch).toHaveBeenCalledTimes(8);
+    expect(fetch).toHaveBeenCalledTimes(10);
   });
 
   it('should render correctly', async () => {
@@ -180,12 +203,14 @@ describe('signals/incident-management/containers/IncidentDetail', () => {
     expect(queryByTestId('attachmentsDefinition')).not.toBeInTheDocument();
     expect(queryByTestId('history')).not.toBeInTheDocument();
     expect(queryByTestId('mapStatic')).not.toBeInTheDocument();
+    expect(queryByTestId('childIncidents')).not.toBeInTheDocument();
 
     await findByTestId('incidentDetail');
 
     expect(getByTestId('attachmentsDefinition')).toBeInTheDocument();
     expect(getByTestId('history')).toBeInTheDocument();
     expect(getByTestId('mapStatic')).toBeInTheDocument();
+    expect(getByTestId('childIncidents')).toBeInTheDocument();
   });
 
   it('should handle Escape key', async () => {

--- a/src/signals/incident-management/containers/IncidentDetail/__tests__/reducer.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/__tests__/reducer.test.js
@@ -1,0 +1,108 @@
+import {
+  CLOSE_ALL,
+  EDIT,
+  PATCH_START,
+  PATCH_SUCCESS,
+  PREVIEW,
+  RESET,
+  SET_ATTACHMENTS,
+  SET_CHILDREN,
+  SET_DEFAULT_TEXTS,
+  SET_ERROR,
+  SET_HISTORY,
+  SET_INCIDENT,
+} from '../constants';
+import reducer, { initialState, closedState } from '../reducer';
+
+describe('signals/incident-management/containers/IncidentDetail/reducer', () => {
+  const state = {
+    ...initialState,
+    foo: 'bar',
+  };
+
+  it('should return the state', () => {
+    expect(reducer(state, {})).toEqual(state);
+  });
+
+  it('should handle RESET', () => {
+    expect(reducer(state, { type: RESET })).toEqual(initialState);
+  });
+
+  it('should handle CLOSE_ALL', () => {
+    expect(reducer(state, { type: CLOSE_ALL })).toEqual({ ...state, ...closedState });
+  });
+
+  it('should handle SET_ERROR', () => {
+    const error = new Error('Whoopsie!');
+    expect(reducer(state, { type: SET_ERROR, payload: error })).toEqual({ ...state, error });
+  });
+
+  it('should handle SET_ATTACHMENTS', () => {
+    const attachments = [{ id: 123 }, { id: 456 }];
+    expect(reducer(state, { type: SET_ATTACHMENTS, payload: attachments })).toEqual({ ...state, attachments });
+  });
+
+  it('should handle SET_CHILDREN', () => {
+    const children = [{ foo: 'bar' }, { bar: 'baz' }];
+    expect(reducer(state, { type: SET_CHILDREN, payload: children })).toEqual({ ...state, children });
+  });
+
+  it('should handle SET_DEFAULT_TEXTS', () => {
+    const defaultTexts = ['foo', 'bar', 'baz'];
+    expect(reducer(state, { type: SET_DEFAULT_TEXTS, payload: defaultTexts })).toEqual({ ...state, defaultTexts });
+  });
+
+  it('should handle SET_HISTORY', () => {
+    const history = ['zork', 'bar', 'baz'];
+    expect(reducer(state, { type: SET_HISTORY, payload: history })).toEqual({ ...state, history });
+  });
+
+  it('should handle SET_INCIDENT', () => {
+    const children = [{ foo: 'bar' }, { bar: 'baz' }];
+    const incident = { id: 999, text: 'Hic sunt dracones' };
+
+    const intermediateState = {
+      ...state,
+      incident: { status: 'o' },
+      children,
+    };
+
+    expect(reducer(intermediateState, { type: SET_INCIDENT, payload: incident })).toEqual({
+      ...intermediateState,
+      incident: {
+        ...intermediateState.incident,
+        ...incident,
+      },
+      children: undefined,
+    });
+  });
+
+  it('should handle PATCH_START', () => {
+    const patching = 'status';
+    expect(reducer(state, { type: PATCH_START, payload: patching })).toEqual({ ...state, patching });
+  });
+
+  it('should handle PATCH_SUCCESS', () => {
+    const intermediateState = {
+      ...state,
+      patching: 'zork',
+    };
+    expect(reducer(intermediateState, { type: PATCH_SUCCESS })).toEqual({ ...intermediateState, patching: undefined });
+  });
+
+  it('should handle PREVIEW', () => {
+    const payload = {
+      preview: 'attachment',
+      attachmentHref: 'foo',
+    };
+    expect(reducer(state, { type: PREVIEW, payload })).toEqual({ ...state, edit: undefined, ...payload });
+  });
+
+  it('should handle EDIT', () => {
+    const payload = {
+      edit: 'location',
+      foo: 'bar',
+    };
+    expect(reducer(state, { type: EDIT, payload })).toEqual({ ...state, preview: undefined, ...payload });
+  });
+});

--- a/src/signals/incident-management/containers/IncidentDetail/components/ChildIncidents/__tests__/ChildIncidents.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/ChildIncidents/__tests__/ChildIncidents.test.js
@@ -2,27 +2,22 @@ import React from 'react';
 import { render } from '@testing-library/react';
 
 import { withAppContext } from 'test/utils';
-import incidentFixture from 'utils/__tests__/fixtures/incident.json';
+import childIncidentsFixture from 'utils/__tests__/fixtures/childIncidents.json';
 
-import IncidentDetailContext from '../../../context';
 import ChildIncidents from '..';
 
-const renderWithContext = (incident = incidentFixture) =>
-  withAppContext(
-    <IncidentDetailContext.Provider value={{ incident }}>
-      <ChildIncidents />
-    </IncidentDetailContext.Provider>
-  );
 describe('signals/management/containers/IncidentDetail/components/ChildIncidents', () => {
   it('should not render anything', () => {
-    const { queryByText, queryByTestId } = render(renderWithContext({}));
+    const childIncidents = [];
+    const { queryByText, queryByTestId } = render(withAppContext(<ChildIncidents incidents={childIncidents} />));
 
     expect(queryByText('Deelmelding')).not.toBeInTheDocument();
     expect(queryByTestId('childIncidents')).not.toBeInTheDocument();
   });
 
   it('should render correctly', () => {
-    const { getByText, getByTestId } = render(renderWithContext());
+    const childIncidents = childIncidentsFixture.results;
+    const { getByTestId, getByText } = render(withAppContext(<ChildIncidents incidents={childIncidents} />));
 
     expect(getByText('Deelmelding')).toBeInTheDocument();
     expect(getByTestId('childIncidents')).toBeInTheDocument();

--- a/src/signals/incident-management/containers/IncidentDetail/components/ChildIncidents/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/ChildIncidents/index.js
@@ -1,34 +1,29 @@
-import React, { Fragment, useMemo, useContext } from 'react';
+import React, { Fragment, useMemo } from 'react';
+import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { themeSpacing, Heading } from '@datapunt/asc-ui';
 
+import { childIncidentType } from 'shared/types';
 import ChildIncidentsList from 'components/ChildIncidents';
 import { INCIDENT_URL } from 'signals/incident-management/routes';
-import IncidentDetailContext from '../../context';
 
 const Title = styled(Heading)`
   font-weight: 400;
   margin: ${themeSpacing(4)} 0;
 `;
 
-const ChildIncidents = () => {
-  const { incident } = useContext(IncidentDetailContext);
-
+const ChildIncidents = ({ incidents }) => {
   const children = useMemo(
     () =>
-      incident?._links?.['sia:children']?.map(({ href }) => {
-        const id = href.substring(href.lastIndexOf('/') + 1, href.length);
-
-        return {
-          href: `${INCIDENT_URL}/${id}`,
-          values: {
-            id,
-          },
-        };
-      }),
-    // disabling linter; we want to allow possible null incident
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [incident]
+      Object.values(incidents).map(({ status, category, id }) => ({
+        href: `${INCIDENT_URL}/${id}`,
+        values: {
+          id,
+          status: status.state_display,
+          category: `${category.sub} (${category.departments})`,
+        },
+      })),
+    [incidents]
   );
 
   if (!children?.length) {
@@ -44,6 +39,10 @@ const ChildIncidents = () => {
       <ChildIncidentsList incidents={children} />
     </Fragment>
   );
+};
+
+ChildIncidents.propTypes = {
+  incidents: PropTypes.arrayOf(childIncidentType).isRequired,
 };
 
 export default ChildIncidents;

--- a/src/signals/incident-management/containers/IncidentDetail/constants.js
+++ b/src/signals/incident-management/containers/IncidentDetail/constants.js
@@ -5,3 +5,16 @@ export const PATCH_TYPE_STATUS = 'status';
 export const PATCH_TYPE_SUBCATEGORY = 'subcategory';
 export const PATCH_TYPE_THOR = 'thor';
 export const PATCH_TYPE_TYPE = 'type';
+
+export const RESET = 'sia/incidentManagement/containers/IncidentDetail/RESET';
+export const CLOSE_ALL = 'sia/incidentManagement/containers/IncidentDetail/CLOSE_ALL';
+export const SET_ERROR = 'sia/incidentManagement/containers/IncidentDetail/SET_ERROR';
+export const SET_ATTACHMENTS = 'sia/incidentManagement/containers/IncidentDetail/SET_ATTACHMENTS';
+export const SET_HISTORY = 'sia/incidentManagement/containers/IncidentDetail/SET_HISTORY';
+export const SET_CHILDREN = 'sia/incidentManagement/containers/IncidentDetail/SET_CHILDREN';
+export const SET_DEFAULT_TEXTS = 'sia/incidentManagement/containers/IncidentDetail/SET_DEFAULT_TEXTS';
+export const SET_INCIDENT = 'sia/incidentManagement/containers/IncidentDetail/SET_INCIDENT';
+export const PATCH_START = 'sia/incidentManagement/containers/IncidentDetail/PATCH_START';
+export const PATCH_SUCCESS = 'sia/incidentManagement/containers/IncidentDetail/PATCH_SUCCESS';
+export const PREVIEW = 'sia/incidentManagement/containers/IncidentDetail/PREVIEW';
+export const EDIT = 'sia/incidentManagement/containers/IncidentDetail/EDIT';

--- a/src/signals/incident-management/containers/IncidentDetail/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/index.js
@@ -168,7 +168,7 @@ const IncidentDetail = () => {
     const hasChildren = incident?._links['sia:children']?.length > 0;
 
     if (!state.children && hasChildren) {
-      getChildren(`${configuration.INCIDENT_PRIVATE_ENDPOINT}${id}/children`);
+      getChildren(`${configuration.INCIDENT_PRIVATE_ENDPOINT}${id}/children/`);
     }
   }, [
     getAttachments,

--- a/src/signals/incident-management/containers/IncidentDetail/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/index.js
@@ -23,6 +23,20 @@ import LocationPreview from './components/LocationPreview';
 import CloseButton from './components/CloseButton';
 import IncidentDetailContext from './context';
 import reducer, { initialState } from './reducer';
+import {
+  CLOSE_ALL,
+  EDIT,
+  PATCH_START,
+  PATCH_SUCCESS,
+  PREVIEW,
+  RESET,
+  SET_ATTACHMENTS,
+  SET_CHILDREN,
+  SET_DEFAULT_TEXTS,
+  SET_ERROR,
+  SET_HISTORY,
+  SET_INCIDENT,
+} from './constants';
 
 const StyledRow = styled(Row)`
   position: relative;
@@ -67,7 +81,7 @@ const IncidentDetail = () => {
   }, [handleKeyUp, listenFor, unlisten]);
 
   useEffect(() => {
-    dispatch({ type: 'error', payload: error });
+    dispatch({ type: SET_ERROR, payload: error });
 
     if (error) {
       const title = error.status === 401 || error.status === 403 ? 'Geen bevoegdheid' : 'Bewerking niet mogelijk';
@@ -87,31 +101,31 @@ const IncidentDetail = () => {
   useEffect(() => {
     if (!history) return;
 
-    dispatch({ type: 'history', payload: history });
+    dispatch({ type: SET_HISTORY, payload: history });
   }, [history]);
 
   useEffect(() => {
     if (!attachments) return;
 
-    dispatch({ type: 'attachments', payload: attachments?.results });
+    dispatch({ type: SET_ATTACHMENTS, payload: attachments?.results });
   }, [attachments]);
 
   useEffect(() => {
     if (!defaultTexts) return;
 
-    dispatch({ type: 'defaultTexts', payload: defaultTexts });
+    dispatch({ type: SET_DEFAULT_TEXTS, payload: defaultTexts });
   }, [defaultTexts]);
 
   useEffect(() => {
     if (!children) return;
 
-    dispatch({ type: 'children', payload: children });
+    dispatch({ type: SET_CHILDREN, payload: children });
   }, [children]);
 
   useEffect(() => {
     if (!id) return;
 
-    dispatch({ type: 'reset' });
+    dispatch({ type: RESET });
     getIncident(`${configuration.INCIDENT_PRIVATE_ENDPOINT}${id}`);
 
     // disabling linter; only need to update when the id changes
@@ -122,13 +136,13 @@ const IncidentDetail = () => {
     if (!isSuccess || !state.patching) return;
 
     emit('highlight', { type: state.patching });
-    dispatch({ type: 'patchSuccess', payload: state.patching });
+    dispatch({ type: PATCH_SUCCESS, payload: state.patching });
   }, [isSuccess, state.patching, emit]);
 
   useEffect(() => {
     if (!incident) return;
 
-    dispatch({ type: 'incident', payload: incident });
+    dispatch({ type: SET_INCIDENT, payload: incident });
 
     retrieveUnderlyingData();
   }, [incident, retrieveUnderlyingData]);
@@ -185,22 +199,22 @@ const IncidentDetail = () => {
 
   const updateDispatch = useCallback(
     action => {
-      dispatch({ type: 'patchStart', payload: action.type });
+      dispatch({ type: PATCH_START, payload: action.type });
       patch(`${configuration.INCIDENT_PRIVATE_ENDPOINT}${id}`, action.patch);
     },
     [id, patch]
   );
 
   const previewDispatch = useCallback((section, payload) => {
-    dispatch({ type: 'preview', payload: { preview: section, ...payload } });
+    dispatch({ type: PREVIEW, payload: { preview: section, ...payload } });
   }, []);
 
   const editDispatch = useCallback((section, payload) => {
-    dispatch({ type: 'edit', payload: { edit: section, ...payload } });
+    dispatch({ type: EDIT, payload: { edit: section, ...payload } });
   }, []);
 
   const closeDispatch = useCallback(() => {
-    dispatch({ type: 'closeAll' });
+    dispatch({ type: CLOSE_ALL });
   }, []);
 
   if (!state.incident) return null;

--- a/src/signals/incident-management/containers/IncidentDetail/reducer.js
+++ b/src/signals/incident-management/containers/IncidentDetail/reducer.js
@@ -1,0 +1,55 @@
+export const initialState = {
+  attachmentHref: undefined,
+  attachments: undefined,
+  children: undefined,
+  error: undefined,
+  history: undefined,
+  incident: undefined,
+  patching: undefined,
+};
+
+const reducer = (state, action) => {
+  // disabling linter; default case does not apply, because all actions are known
+  // eslint-disable-next-line default-case
+  switch (action.type) {
+    case 'closeAll':
+      return { ...state, preview: undefined, edit: undefined, error: undefined, attachmentHref: '' };
+
+    case 'error':
+      return { ...state, error: action.payload };
+
+    case 'attachments':
+      return { ...state, attachments: action.payload };
+
+    case 'history':
+      return { ...state, history: action.payload };
+
+    case 'children':
+      return { ...state, children: action.payload };
+
+    case 'defaultTexts':
+      return { ...state, defaultTexts: action.payload };
+
+    case 'incident':
+      return { ...state, children: undefined, incident: { ...state.incident, ...action.payload } };
+
+    case 'patchStart':
+      return { ...state, patching: action.payload };
+
+    case 'patchSuccess':
+      return { ...state, patching: undefined };
+
+    case 'preview':
+      return { ...state, edit: undefined, ...action.payload };
+
+    case 'edit':
+      return { ...state, preview: undefined, ...action.payload };
+
+    case 'reset':
+      return initialState;
+  }
+
+  return state;
+};
+
+export default reducer;

--- a/src/signals/incident-management/containers/IncidentDetail/reducer.js
+++ b/src/signals/incident-management/containers/IncidentDetail/reducer.js
@@ -1,3 +1,18 @@
+import {
+  CLOSE_ALL,
+  EDIT,
+  PATCH_START,
+  PATCH_SUCCESS,
+  PREVIEW,
+  RESET,
+  SET_ATTACHMENTS,
+  SET_CHILDREN,
+  SET_DEFAULT_TEXTS,
+  SET_ERROR,
+  SET_HISTORY,
+  SET_INCIDENT,
+} from './constants';
+
 export const initialState = {
   attachmentHref: undefined,
   attachments: undefined,
@@ -8,48 +23,55 @@ export const initialState = {
   patching: undefined,
 };
 
-const reducer = (state, action) => {
-  // disabling linter; default case does not apply, because all actions are known
-  // eslint-disable-next-line default-case
-  switch (action.type) {
-    case 'closeAll':
-      return { ...state, preview: undefined, edit: undefined, error: undefined, attachmentHref: '' };
+// values that will be set whenever the CLOSE_ALL type is dispatched
+export const closedState = {
+  preview: undefined,
+  edit: undefined,
+  error: undefined,
+  attachmentHref: '',
+};
 
-    case 'error':
+const reducer = (state, action) => {
+  switch (action.type) {
+    case CLOSE_ALL:
+      return { ...state, ...closedState };
+
+    case SET_ERROR:
       return { ...state, error: action.payload };
 
-    case 'attachments':
+    case SET_ATTACHMENTS:
       return { ...state, attachments: action.payload };
 
-    case 'history':
+    case SET_HISTORY:
       return { ...state, history: action.payload };
 
-    case 'children':
+    case SET_CHILDREN:
       return { ...state, children: action.payload };
 
-    case 'defaultTexts':
+    case SET_DEFAULT_TEXTS:
       return { ...state, defaultTexts: action.payload };
 
-    case 'incident':
+    case SET_INCIDENT:
       return { ...state, children: undefined, incident: { ...state.incident, ...action.payload } };
 
-    case 'patchStart':
+    case PATCH_START:
       return { ...state, patching: action.payload };
 
-    case 'patchSuccess':
+    case PATCH_SUCCESS:
       return { ...state, patching: undefined };
 
-    case 'preview':
-      return { ...state, edit: undefined, ...action.payload };
+    case PREVIEW:
+      return { ...state, edit: undefined, ...action.payload, preview: action.payload.preview };
 
-    case 'edit':
-      return { ...state, preview: undefined, ...action.payload };
+    case EDIT:
+      return { ...state, preview: undefined, ...action.payload, edit: action.payload.edit };
 
-    case 'reset':
-      return initialState;
+    case RESET:
+      return { ...initialState, incident: state.incident };
+
+    default:
+      return state;
   }
-
-  return state;
 };
 
 export default reducer;

--- a/src/utils/__tests__/fixtures/childIncidents.json
+++ b/src/utils/__tests__/fixtures/childIncidents.json
@@ -1,0 +1,73 @@
+{
+  "_links": {
+    "self": {
+      "href": "https://acc.api.data.amsterdam.nl/signals/v1/private/signals/5296/children/"
+    },
+    "next": {
+      "href": null
+    },
+    "previous": {
+      "href": null
+    }
+  },
+  "count": 3,
+  "results": [
+    {
+      "_links": {
+        "self": {
+          "href": "https://acc.api.data.amsterdam.nl/signals/v1/private/signals/5371"
+        }
+      },
+      "id": 5371,
+      "status": {
+        "state": "m",
+        "state_display": "Gemeld"
+      },
+      "category": {
+        "sub": "Veeg- / zwerfvuil",
+        "sub_slug": "veegzwerfvuil",
+        "departments": "STW",
+        "main": "Schoon",
+        "main_slug": "schoon"
+      }
+    },
+    {
+      "_links": {
+        "self": {
+          "href": "https://acc.api.data.amsterdam.nl/signals/v1/private/signals/5372"
+        }
+      },
+      "id": 5372,
+      "status": {
+        "state": "m",
+        "state_display": "Gemeld"
+      },
+      "category": {
+        "sub": "Kades",
+        "sub_slug": "kades",
+        "departments": "STW",
+        "main": "Civiele Constructies",
+        "main_slug": "civiele-constructies"
+      }
+    },
+    {
+      "_links": {
+        "self": {
+          "href": "https://acc.api.data.amsterdam.nl/signals/v1/private/signals/5373"
+        }
+      },
+      "id": 5373,
+      "status": {
+        "state": "m",
+        "state_display": "Gemeld"
+      },
+      "category": {
+        "sub": "Asbest / accu",
+        "sub_slug": "asbest-accu",
+        "departments": "ASC, FB, THO",
+        "main": "Afval",
+        "main_slug": "afval"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This PR:
- adjusts the `IncidentDetail` container component so that it retrieves child incidents
- extracts the `IncidentDetail` reducer into a separate file and adds tests
- changes the `ChildIncidents` components in order to display the correct data