### PR TITLE
Show responsible department on incident detail page

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/components/MetaList/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/MetaList/index.js
@@ -142,6 +142,9 @@ const MetaList = () => {
 
       <dt data-testid="meta-list-source-definition">Bron</dt>
       <dd data-testid="meta-list-source-value">{incident.source}</dd>
+
+      {incident.category.departments ? <dt data-testid="meta-list-department-definition">Verantwoordelijke afdeling</dt> : null}
+      {incident.category.departments ? <dd data-testid="meta-list-department-value">{incident.category.departments}</dd> : null}
     </List>
   );
 };

--- a/src/signals/incident-management/containers/IncidentDetail/components/MetaList/index.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/MetaList/index.test.js
@@ -55,6 +55,9 @@ describe('<MetaList />', () => {
 
       expect(queryByTestId('meta-list-source-definition')).toHaveTextContent(/^Bron$/);
       expect(queryByTestId('meta-list-source-value')).toHaveTextContent(incidentFixture.source);
+
+      expect(queryByTestId('meta-list-department-definition')).toHaveTextContent(/^Verantwoordelijke afdeling$/);
+      expect(queryByTestId('meta-list-department-value')).toHaveTextContent(incidentFixture.category.departments);
     });
 
     it('should render correctly with high priority', () => {


### PR DESCRIPTION
It seems responsible department is missing from the incident detail page. It is shown on the split incident page.