### PR TITLE
[SIG-2994] Hides the send email checkbox for several statuses in the detail form

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/index.js
@@ -100,10 +100,14 @@ const StyledColumn = styled(Column)`
   position: relative;
 `;
 
+// Don't show the send email checkbox for statuses ingepland, hreopend, afgehandeld and geannuleerd
+const canSendMail = status => !['ingepland', 'reopened', 'o', 'a'].includes(status);
+
 const StatusForm = ({ defaultTexts }) => {
   const { incident, update, close } = useContext(IncidentDetailContext);
   const currentStatus = statusList.find(({ key }) => key === incident.status.state);
   const [warning, setWarning] = useState('');
+  const [showSendMail, setShowSendMail] = useState(canSendMail(currentStatus?.key));
   const isDeelmelding = !!incident?._links?.['sia:parent'];
 
   const form = useMemo(
@@ -120,6 +124,7 @@ const StatusForm = ({ defaultTexts }) => {
     form.controls.state.valueChanges.subscribe(status => {
       const found = statusList.find(s => s.key === status);
 
+      setShowSendMail(canSendMail(found?.key));
       setWarning(found?.warning);
 
       const hasDefaultTexts = Boolean(defaultTextsOptionList.find(s => s.key === status));
@@ -203,19 +208,23 @@ const StatusForm = ({ defaultTexts }) => {
                   render={TextAreaInput}
                   rows={10}
                 />
-                <Notification warning data-testid="statusFormToelichting">
-                  {isDeelmelding ? DEELMELDING_EXPLANATION : MELDING_EXPLANATION}
-                </Notification>
 
-                {!isDeelmelding && (
-                  <FieldControlWrapper
-                    control={form.get('send_email')}
-                    data-testid="statusFormSendEmailField"
-                    name="send_email"
-                    label={MELDING_CHECKBOX_DESCRIPTION}
-                    render={CheckboxInput}
-                  />
-                )}
+                {showSendMail && (<React.Fragment>
+                  <Notification warning data-testid="statusFormToelichting">
+                    {isDeelmelding ? DEELMELDING_EXPLANATION : MELDING_EXPLANATION}
+                  </Notification>
+
+                  {!isDeelmelding && (
+                    <FieldControlWrapper
+                      control={form.get('send_email')}
+                      data-testid="statusFormSendEmailField"
+                      name="send_email"
+                      label={MELDING_CHECKBOX_DESCRIPTION}
+                      render={CheckboxInput}
+                    />
+                  )}</React.Fragment>
+                )
+                }
 
                 <StyledButton data-testid="statusFormSubmitButton" type="submit" variant="secondary" disabled={invalid}>
                   Status opslaan

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/index.js
@@ -101,7 +101,8 @@ const StyledColumn = styled(Column)`
 `;
 
 // Don't show the send email checkbox for statuses ingepland, hreopend, afgehandeld and geannuleerd
-const canSendMail = status => !['ingepland', 'reopened', 'o', 'a'].includes(status);
+export const EMAIL_CHECKBOX_EXCLUDED_STATES = ['ingepland', 'reopened', 'o', 'a'];
+const canSendMail = status => !EMAIL_CHECKBOX_EXCLUDED_STATES.includes(status);
 
 const StatusForm = ({ defaultTexts }) => {
   const { incident, update, close } = useContext(IncidentDetailContext);

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/index.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/index.test.js
@@ -7,7 +7,7 @@ import { changeStatusOptionList } from '../../../../definitions/statusList';
 
 import { PATCH_TYPE_STATUS } from '../../constants';
 import IncidentDetailContext from '../../context';
-import StatusForm, { MELDING_EXPLANATION, DEELMELDING_EXPLANATION } from '.';
+import StatusForm, { MELDING_EXPLANATION, DEELMELDING_EXPLANATION, EMAIL_CHECKBOX_EXCLUDED_STATES } from '.';
 
 const defaultTexts = [
   {
@@ -196,5 +196,27 @@ describe('signals/incident-management/containers/IncidentDetail/components/Statu
 
     expect(queryByTestId('statusFormSendEmailField')).not.toBeInTheDocument();
     expect(getByText(DEELMELDING_EXPLANATION)).toBeInTheDocument();
+  });
+
+  it('hides the  send checkbox when the excludes state is selected', async () => {
+    const { queryByTestId } = render(renderWithContext());
+
+    const defaultRadioButton = queryByTestId('status-m');
+
+    await EMAIL_CHECKBOX_EXCLUDED_STATES.forEach(state => {
+      act(() => {
+        fireEvent.click(defaultRadioButton);
+      });
+
+      expect(queryByTestId('statusFormSendEmailField')).toBeInTheDocument();
+
+      const radioButton = queryByTestId(`status-${state}`);
+
+      act(() => {
+        fireEvent.click(radioButton);
+      });
+
+      expect(queryByTestId('statusFormSendEmailField')).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/index.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/index.test.js
@@ -198,12 +198,12 @@ describe('signals/incident-management/containers/IncidentDetail/components/Statu
     expect(getByText(DEELMELDING_EXPLANATION)).toBeInTheDocument();
   });
 
-  it('hides the  send checkbox when the excludes state is selected', async () => {
+  it('hides the  send checkbox when the excludes state is selected', () => {
     const { queryByTestId } = render(renderWithContext());
 
     const defaultRadioButton = queryByTestId('status-m');
 
-    await EMAIL_CHECKBOX_EXCLUDED_STATES.forEach(state => {
+    EMAIL_CHECKBOX_EXCLUDED_STATES.forEach(state => {
       act(() => {
         fireEvent.click(defaultRadioButton);
       });


### PR DESCRIPTION
This PR hides the send email checkbox in the detail form for the next statuses:
- `Ingepland`, `Heropend`, `Geannuleerd` en `Afgehandeld`