### PR TITLE
(Chore) Track custom dimension

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -3,7 +3,6 @@ import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import { ConnectedRouter } from 'connected-react-router/immutable';
 import * as Sentry from '@sentry/browser';
-import MatomoTracker from '@datapunt/matomo-tracker-js';
 import Immutable from 'immutable';
 import history from 'utils/history';
 
@@ -45,18 +44,6 @@ const store = configureStore(initialState, history);
 const MOUNT_NODE = document.getElementById('app');
 
 loadModels(store);
-
-// Setup Matomo
-const urlBase = configuration?.matomo?.urlBase;
-const siteId = configuration?.matomo?.siteId;
-
-if (urlBase && siteId) {
-  const MatomoInstance = new MatomoTracker({
-    urlBase,
-    siteId,
-  });
-  MatomoInstance.trackPageView();
-}
 
 const render = () => {
   // eslint-disable-next-line no-undef,no-console

--- a/src/containers/App/index.js
+++ b/src/containers/App/index.js
@@ -9,6 +9,7 @@ import { authenticate, isAuthenticated } from 'shared/services/auth/auth';
 import ThemeProvider from 'components/ThemeProvider';
 import injectSaga from 'utils/injectSaga';
 import injectReducer from 'utils/injectReducer';
+import useMatomo from 'hooks/useMatomo';
 
 import NotFoundPage from 'components/NotFoundPage';
 import Footer from 'components/Footer';
@@ -48,8 +49,16 @@ export const AppContainer = ({ resetIncidentAction }) => {
   const location = useLocationReferrer();
   const isFrontOffice = useIsFrontOffice();
   const headerIsTall = isFrontOffice && !isAuthenticated();
+  const matomoInstance = useMatomo();
 
   authenticate();
+  matomoInstance.track({
+    data: [],
+    documentTitle: window.document.title,
+    href: window.location,
+    customDimensions: [{ id: isAuthenticated() ? 1 : 2 }],
+  });
+  matomoInstance.trackPageView();
 
   useEffect(() => {
     const { referrer } = location;

--- a/src/containers/App/index.js
+++ b/src/containers/App/index.js
@@ -56,7 +56,7 @@ export const AppContainer = ({ resetIncidentAction }) => {
     data: [],
     documentTitle: window.document.title,
     href: window.location,
-    customDimensions: [{ id: isAuthenticated() ? 1 : 2 }],
+    customDimensions: [{ id: 1, value: `${!isAuthenticated() ? 'not ' : ''}authenticated` }],
   });
   matomoInstance.trackPageView();
 

--- a/src/hooks/useMatomo.js
+++ b/src/hooks/useMatomo.js
@@ -1,0 +1,28 @@
+import MatomoTracker from '@datapunt/matomo-tracker-js';
+import configuration from 'shared/services/configuration/configuration';
+
+// Setup Matomo
+const urlBase = configuration?.matomo?.urlBase;
+const siteId = configuration?.matomo?.siteId;
+
+const useMatomo = () => {
+  if (!(urlBase && siteId)) {
+    return {};
+  }
+
+  const MatomoInstance = new MatomoTracker({
+    urlBase,
+    siteId,
+  });
+
+  return {
+    track: MatomoInstance.track,
+    trackEvent: MatomoInstance.trackEvent,
+    trackEvents: MatomoInstance.trackEvents,
+    trackLink: MatomoInstance.trackLink,
+    trackPageView: MatomoInstance.trackPageView,
+    trackSiteSearch: MatomoInstance.trackSiteSearch,
+  };
+};
+
+export default useMatomo;


### PR DESCRIPTION
This PR contains a change for the way page views are tracked in Matomo.

Because of [a known bug in Matomo](https://forum.matomo.org/t/filter-page-urls-by-segments/34859/17), we cannot differentiate between visitors that visit the maintenance part of the website and visitors that merely submit incidents (and aren't authenticated). 

We can, however, track those visits by setting up [custom dimensions](https://matomo.org/docs/custom-dimensions/). This requires a plugin to be installed which is still a pending request.