### PR TITLE
(Chore) Matomo noscript tracking

### DIFF
--- a/environment.conf.json
+++ b/environment.conf.json
@@ -18,7 +18,7 @@
     "dsn": "https://3de59e3a93034a348089131aa565bdf4@sentry.data.amsterdam.nl/27"
   },
   "matomo": {
-    "urlBase": "https://analytics.data.amsterdam.nl/",
+    "urlBase": "https://analytics.data.amsterdam.nl",
     "siteId": 14
   },
   "language": {

--- a/internals/webpack/template.js
+++ b/internals/webpack/template.js
@@ -25,6 +25,8 @@ if (process.env.NODE_ENV && process.env.NODE_ENV !== 'production') {
     $SIGNALS_CONFIG: JSON.stringify(combinedConfig),
     $SIGNALS_FAVICON: combinedConfig.head.favicon,
     $SIGNALS_IOS_ICON: combinedConfig.head.iosIcon,
+    $SIGNALS_MATOMO_SITE_ID: combinedConfig.matomo.siteId,
+    $SIGNALS_MATOMO_URL_BASE: combinedConfig.matomo.urlBase,
     $SIGNALS_PWA_SHORT_TITLE: combinedConfig.language.shortTitle,
     $SIGNALS_PWA_TITLE: combinedConfig.language.title,
     $SIGNALS_SITE_TITLE: combinedConfig.language.siteTitle,
@@ -37,13 +39,13 @@ if (process.env.NODE_ENV && process.env.NODE_ENV !== 'production') {
   const manifestFile = path.join(__dirname, '..', '..', 'src', 'manifest.json');
   const manifestString = fs.readFileSync(manifestFile).toString();
 
-  template.templateContent = Object.keys(placeholders).reduce(
-    (acc, key) => acc.replace(key, placeholders[key]),
+  template.templateContent = Object.entries(placeholders).reduce(
+    (acc, [key, value]) => acc.replace(new RegExp(`\\${key}`, 'gm'), value),
     templateString
   );
 
-  template.manifestContent = Object.keys(placeholders).reduce(
-    (acc, key) => acc.replace(key, placeholders[key]),
+  template.manifestContent = Object.entries(placeholders).reduce(
+    (acc, [key, value]) => acc.replace(key, value),
     manifestString
   );
 } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1371,9 +1371,9 @@
       "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
     },
     "@exodus/schemasafe": {
-      "version": "1.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.0.0-beta.1.tgz",
-      "integrity": "sha512-3H4VeIYMfSH672iDP2uljt02V7W4VZrpJBW9At0htnZdfE2ZUXUe9tRrdaWBe6RvhyWt4BiEh0BIobMrGLmQrQ==",
+      "version": "1.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@exodus/schemasafe/-/schemasafe-1.0.0-rc.2.tgz",
+      "integrity": "sha512-W98NvvOe/Med3o66xTO03pd7a2omZebH79PV64gSE+ceDdU8uxQhFTa7ISiD1kseyqyOrMyW5/MNdsGEU02i3Q==",
       "dev": true
     },
     "@istanbuljs/load-nyc-config": {

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "@babel/preset-env": "^7.10.2",
     "@babel/preset-react": "^7.10.1",
     "@babel/register": "^7.10.1",
-    "@exodus/schemasafe": "^1.0.0-beta.1",
+    "@exodus/schemasafe": "^1.0.0-rc.2",
     "@redux-saga/is": "^1.1.2",
     "@testing-library/jest-dom": "^5.10.1",
     "@testing-library/react": "^10.4.3",

--- a/src/index.html
+++ b/src/index.html
@@ -18,11 +18,14 @@
 </head>
 
 <body>
-  <noscript>If you're seeing this message, that means
-    <strong>JavaScript has been disabled on your browser</strong>, please
-    <strong>enable JS</strong> to make this app work.</noscript>
-
-  <div id="app"></div>
+  <div id="app">
+    <noscript>
+      <p>Deze website werkt helaas niet zonder javascript. Sta het uitvoeren van javascript toe in uw browser om
+        $SIGNALS_PWA_TITLE te kunnen bekijken</p>
+    </noscript>
+  </div>
 </body>
+
+<noscript><img src="$SIGNALS_MATOMO_URL_BASE/matomo.php?idsite=$SIGNALS_MATOMO_SITE_ID&amp;rec=1" alt="" /></noscript>
 
 </html>

--- a/start.sh
+++ b/start.sh
@@ -12,6 +12,8 @@ export SIGNALS_ANDROID_ICON=$(cat /environment.conf.json | jq -r '.head.androidI
 export SIGNALS_BACKGROUND_COLOR=$(cat /environment.conf.json | jq -r '.head.backgroundColor')
 export SIGNALS_FAVICON=$(cat /environment.conf.json | jq -r '.head.favicon')
 export SIGNALS_IOS_ICON=$(cat /environment.conf.json | jq -r '.head.iosIcon')
+export SIGNALS_MATOMO_SITE_ID=$(cat /environment.conf.json | jq -r '.matomo.siteId')
+export SIGNALS_MATOMO_URL_BASE=$(cat /environment.conf.json | jq -r '.matomo.urlBase')
 export SIGNALS_PWA_SHORT_TITLE=$(cat /environment.conf.json | jq -r '.language.shortTitle')
 export SIGNALS_PWA_TITLE=$(cat /environment.conf.json | jq -r '.language.title')
 export SIGNALS_SITE_TITLE=$(cat /environment.conf.json | jq -r '.language.siteTitle')
@@ -19,7 +21,7 @@ export SIGNALS_STATUS_BAR_STYLE=$(cat /environment.conf.json | jq -r '.head.stat
 export SIGNALS_THEME_COLOR=$(cat /environment.conf.json | jq -r '.head.themeColor')
 
 envsubst < /usr/share/nginx/html/sw.js > /tmp/sw.js
-envsubst < /usr/share/nginx/html/index.html > /tmp/index.html
+envsubst "`printf '${%s} ' $(sh -c "env|cut -d'=' -f1")`" < /usr/share/nginx/html/index.html > /tmp/index.html
 envsubst < /usr/share/nginx/html/manifest.json > /tmp/manifest.json
 
 mv /tmp/sw.js /usr/share/nginx/html/sw.js


### PR DESCRIPTION
This PR contains changes that allow tracking of visitors that do not have javascript support.

In order to accomplish that, a few changes had to be made to ensure that, at build-time, all env vars were correctly replaced; the previous implementation only replaced the first occurrences.

Next to that change, the error message that is shown, has been translated to Dutch.