### PR TITLE
[SIG-3004] Prevent send_email flag to be sent

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/index.js
@@ -125,6 +125,9 @@ const StatusForm = ({ defaultTexts }) => {
 
   useEffect(() => {
     form.controls.state.valueChanges.subscribe(status => {
+      // reset the send_email field to make sure that a previously set value isn't accidentally sent to the API
+      form.controls.send_email.value = false;
+
       const found = statusList.find(s => s.key === status);
 
       setShowSendMail(canSendMail(found?.key));
@@ -140,7 +143,7 @@ const StatusForm = ({ defaultTexts }) => {
 
       form.controls.text.updateValueAndValidity();
     });
-  }, [form.controls.state.valueChanges, form.controls.text]);
+  }, [form.controls.state.valueChanges, form.controls.text, form.controls.send_email]);
 
   const handleSubmit = useCallback(
     event => {


### PR DESCRIPTION
This PR contains a change that resets the value of the `send_email` field in the status form so that, when a status is selected that should not show the checkbox, will not send the previously selected value to the API.