### PR TITLE
[SIG-3007] Show send_email checkbox for cancelled status

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/index.js
@@ -102,9 +102,8 @@ const StyledColumn = styled(Column)`
   margin-bottom: ${themeSpacing(3)};
 `;
 
-// Don't show the send email checkbox for statuses ingepland, hreopend, afgehandeld and geannuleerd
-export const EMAIL_CHECKBOX_EXCLUDED_STATES = ['ingepland', 'reopened', 'o', 'a'];
-const canSendMail = status => !EMAIL_CHECKBOX_EXCLUDED_STATES.includes(status);
+const canSendMail = status =>
+  Boolean(changeStatusOptionList.find(({ can_send_email, key }) => can_send_email && status === key));
 
 const StatusForm = ({ defaultTexts }) => {
   const { incident, update, close } = useContext(IncidentDetailContext);
@@ -112,7 +111,6 @@ const StatusForm = ({ defaultTexts }) => {
   const [warning, setWarning] = useState('');
   const [showSendMail, setShowSendMail] = useState(canSendMail(currentStatus?.key));
   const isDeelmelding = !!incident?._links?.['sia:parent'];
-
   const form = useMemo(
     () =>
       FormBuilder.group({

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/index.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/index.test.js
@@ -7,7 +7,11 @@ import { changeStatusOptionList } from '../../../../definitions/statusList';
 
 import { PATCH_TYPE_STATUS } from '../../constants';
 import IncidentDetailContext from '../../context';
-import StatusForm, { MELDING_EXPLANATION, DEELMELDING_EXPLANATION, EMAIL_CHECKBOX_EXCLUDED_STATES } from '.';
+import StatusForm, { MELDING_EXPLANATION, DEELMELDING_EXPLANATION } from '.';
+
+const EMAIL_CHECKBOX_EXCLUDED_STATES = changeStatusOptionList
+  .filter(({ can_send_email }) => !can_send_email)
+  .map(({ key }) => key);
 
 const defaultTexts = [
   {
@@ -257,8 +261,13 @@ describe('signals/incident-management/containers/IncidentDetail/components/Statu
   });
 
   it("doesn't show the send checkbox for a deelmelding", () => {
+    const statusThatShowsCheckbox = changeStatusOptionList.find(({ can_send_email }) => can_send_email);
+
     const deelmelding = {
       ...incidentFixture,
+      status: {
+        state: statusThatShowsCheckbox.key,
+      },
       _links: {
         ...incidentFixture._links,
         'sia:parent': {

--- a/src/signals/incident-management/definitions/statusList.js
+++ b/src/signals/incident-management/definitions/statusList.js
@@ -2,18 +2,21 @@ const GEMELD = {
   key: 'm',
   value: 'Gemeld',
   color: 'red',
+  can_send_email: true,
 };
 
 const AFWACHTING = {
   key: 'i',
   value: 'In afwachting van behandeling',
   color: 'purple',
+  can_send_email: true,
 };
 
 const BEHANDELING = {
   key: 'b',
   value: 'In behandeling',
   color: 'blue',
+  can_send_email: true,
 };
 
 const AFGEHANDELD = {
@@ -22,12 +25,14 @@ const AFGEHANDELD = {
   warning:
     'De melder ontvangt deze toelichting per e-mail, let dus op de schrijfstijl. De e-mail bevat al een aanhef en afsluiting. Verwijs nooit naar een andere afdeling; hercategoriseer dan de melding. Gebruik deze status alleen als de melding ook echt is afgehandeld, gebruik anders de status Ingepland. Let op: als de huidige status “Verzoek tot heropenen” is, dan wordt er geen e-mail naar de melder gestuurd.',
   color: 'lightgreen',
+  can_send_email: false,
 };
 
 const GESPLITST = {
   key: 's',
   value: 'Gesplitst',
   color: 'lightgreen',
+  can_send_email: false,
 };
 
 const INGEPLAND = {
@@ -36,6 +41,7 @@ const INGEPLAND = {
   warning:
     'De melder ontvangt deze toelichting per e-mail, let dus op de schrijfstijl. De e-mail bevat al een aanhef en afsluiting.',
   color: 'grey',
+  can_send_email: false,
 };
 
 const GEANNULEERD = {
@@ -44,12 +50,14 @@ const GEANNULEERD = {
   warning:
     'Bij deze status wordt de melding afgesloten. Gebruik deze status alleen voor test- en nepmeldingen of meldingen van veelmelders.',
   color: 'darkgrey',
+  can_send_email: true,
 };
 
 const VERZOEK_TOT_HEROPENEN = {
   key: 'reopen requested',
   value: 'Verzoek tot heropenen',
   color: 'orange',
+  can_send_email: false,
 };
 
 const HEROPEND = {
@@ -58,31 +66,37 @@ const HEROPEND = {
   warning:
     'De melder ontvangt deze toelichting per e-mail, let dus op de schrijfstijl. De e-mail bevat al een aanhef en afsluiting. Verwijs nooit naar een andere afdeling; hercategoriseer dan de melding.',
   color: 'orange',
+  can_send_email: false,
 };
 
 const TE_VERZENDEN = {
   key: 'ready to send',
   value: 'Extern: te verzenden',
+  can_send_email: false,
 };
 
 const VERZONDEN = {
   key: 'sent',
   value: 'Extern: verzonden',
+  can_send_email: false,
 };
 
 const VERZENDEN_MISLUKT = {
   key: 'send failed',
   value: 'Extern: mislukt',
+  can_send_email: false,
 };
 
 const VERZOEK_TOT_AFHANDELING = {
   key: 'closure requested',
   value: 'Extern: verzoek tot afhandeling',
+  can_send_email: false,
 };
 
 const AFGEHANDELD_EXTERN = {
   key: 'done external',
   value: 'Extern: afgehandeld',
+  can_send_email: false,
 };
 
 const statusList = [


### PR DESCRIPTION
This PR ensures that the `send_email` checkbox in the status form will also be shown in case the selected status equals 'Geannuleerd'. 
The hardcoded status keys are removed from the `StatusForm` component and converted to boolean values in the `statusList` definition file.