### PR TITLE
[SIG-3012] Incidents loading state

### DIFF
--- a/src/signals/incident-management/__tests__/reducer.test.js
+++ b/src/signals/incident-management/__tests__/reducer.test.js
@@ -68,6 +68,7 @@ const intermediateState = fromJS({
   error: false,
   ordering: 'stadsdeel,-created_at',
   loading: false,
+  loadingIncidents: false,
   incidents: {
     count: incidentsJson.length,
     results: incidentsJson,
@@ -343,7 +344,7 @@ describe('signals/incident-management/reducer', () => {
 
     const applied = state =>
       state
-        .set('loading', true)
+        .set('loadingIncidents', true)
         .set('error', false)
         .set('errorMessage', undefined);
 
@@ -364,7 +365,7 @@ describe('signals/incident-management/reducer', () => {
     const applied = state =>
       state
         .set('incidents', fromJS(requestIncidentsSuccess.payload))
-        .set('loading', false)
+        .set('loadingIncidents', false)
         .set('error', false)
         .set('errorMessage', undefined);
 
@@ -387,7 +388,7 @@ describe('signals/incident-management/reducer', () => {
       state
         .set('error', true)
         .set('errorMessage', error.message)
-        .set('loading', false);
+        .set('loadingIncidents', false);
 
     expect(reducer(initialState, requestIncidentsError)).toEqual(
       applied(initialState)

--- a/src/signals/incident-management/__tests__/selectors.test.js
+++ b/src/signals/incident-management/__tests__/selectors.test.js
@@ -148,16 +148,16 @@ describe('signals/incident-management/selectors', () => {
     const incidents = { count: 100, results };
 
     const stateLoading = fromJS({
-      incidentManagement: { ...initialState.toJS(), loading: true, incidents },
+      incidentManagement: { ...initialState.toJS(), loadingIncidents: true, incidents },
     });
 
-    expect(makeSelectIncidents(stateLoading)).toEqual({ ...incidents, loading: true });
+    expect(makeSelectIncidents(stateLoading)).toEqual({ ...incidents, loadingIncidents: true });
 
     const state = fromJS({
       incidentManagement: { ...initialState.toJS(), incidents },
     });
 
-    expect(makeSelectIncidents(state)).toEqual({ ...incidents, loading: false });
+    expect(makeSelectIncidents(state)).toEqual({ ...incidents, loadingIncidents: false });
   });
 
   it('should select incidents count', () => {

--- a/src/signals/incident-management/reducer.js
+++ b/src/signals/incident-management/reducer.js
@@ -40,6 +40,7 @@ export const initialState = fromJS({
     results: [],
   },
   loading: false,
+  loadingIncidents: false,
   ordering: '-created_at',
   page: 1,
 });
@@ -106,7 +107,7 @@ export default (state = initialState, action) => {
 
     case REQUEST_INCIDENTS:
       return state
-        .set('loading', true)
+        .set('loadingIncidents', true)
         .set('error', false)
         .set('errorMessage', undefined);
 
@@ -114,7 +115,7 @@ export default (state = initialState, action) => {
     case REQUEST_INCIDENTS_SUCCESS:
       return state
         .set('incidents', fromJS(action.payload))
-        .set('loading', false)
+        .set('loadingIncidents', false)
         .set('error', false)
         .set('errorMessage', undefined);
 
@@ -123,7 +124,7 @@ export default (state = initialState, action) => {
       return state
         .set('error', true)
         .set('errorMessage', action.payload)
-        .set('loading', false);
+        .set('loadingIncidents', false);
 
     case SET_SEARCH_QUERY:
       return state

--- a/src/signals/incident-management/selectors.js
+++ b/src/signals/incident-management/selectors.js
@@ -129,9 +129,9 @@ export const makeSelectSearchQuery = createSelector(selectIncidentManagementDoma
 });
 
 export const makeSelectIncidents = createSelector(selectIncidentManagementDomain, state => {
-  const { incidents, loading } = state.toJS();
+  const { incidents, loadingIncidents } = state.toJS();
 
-  return { ...incidents, loading };
+  return { ...incidents, loadingIncidents };
 });
 
 export const makeSelectIncidentsCount = createSelector(selectIncidentManagementDomain, state => {


### PR DESCRIPTION
This PR applies a change to the incident management module's state so that loading incidents has its own flag and a distinction can be made between loading of different resources.