### PR TITLE
(Fix) Matomo URL

### DIFF
--- a/environment.conf.json
+++ b/environment.conf.json
@@ -18,7 +18,7 @@
     "dsn": "https://3de59e3a93034a348089131aa565bdf4@sentry.data.amsterdam.nl/27"
   },
   "matomo": {
-    "urlBase": "https://analytics.data.amsterdam.nl",
+    "urlBase": "https://analytics.data.amsterdam.nl/",
     "siteId": 14
   },
   "language": {

--- a/src/index.html
+++ b/src/index.html
@@ -26,6 +26,6 @@
   </div>
 </body>
 
-<noscript><img src="$SIGNALS_MATOMO_URL_BASE/matomo.php?idsite=$SIGNALS_MATOMO_SITE_ID&amp;rec=1" alt="" /></noscript>
+<noscript><img src="$SIGNALS_MATOMO_URL_BASEmatomo.php?idsite=$SIGNALS_MATOMO_SITE_ID&amp;rec=1" alt="" /></noscript>
 
 </html>


### PR DESCRIPTION
This PR contains a change to the analytics service URL. Apparently, the Matomo JS tracker expects the URL to end with a slash 🤦‍♂️ 