### PR TITLE
Improve development, test and deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ HTTPS=true npm run start:prod
 
 ## Deployment
 
-Pre-build images of the Signalen frontend are available on [DockerHub](https://hub.docker.com/r/signalen/frontend). To build a Docker image locally use:
+We provide [Helm charts](https://github.com/signalen/helm-charts) for production deployments of the Signalen stack on Kubernetes.
+
+Pre-build images of the Signalen frontend are available on [DockerHub](https://hub.docker.com/r/signalen/frontend). To build the frontend Docker image locally use:
 
 ```bash
 docker build -t signalen/frontend .

--- a/README.md
+++ b/README.md
@@ -1,93 +1,91 @@
 
-# Signalen
+# Signalen frontend
 
-This project is based on the react boilerplate that was adapted for the needs of the municipality of Amsterdam.
-See https://github.com/Amsterdam/react-boilerplate.git for more information on the react boilerplate
+This project provides a web frontend for Signalen, an application that helps cities manage and prioritize nuisance reports.
 
-## Requirements
+## Setup a development environment
 
-  -  npm >= 6.11
-  -  node 12.18
+Make sure you installed the following versions on your machine:
 
-This project relies on the[ `leaflet-headless`](https://www.npmjs.com/package/leaflet-headless) package. On OSX, you'll need to have [`cairo`](https://formulae.brew.sh/formula/cairo), [`pango`](https://formulae.brew.sh/formula/pango) and [`cmake`](https://formulae.brew.sh/formula/cmake) installed.
+-  npm >= 6.11
+-  node 12.18
 
-## Installation
+For testing this project relies on the[ `leaflet-headless`](https://www.npmjs.com/package/leaflet-headless) package. On OSX, you'll need to have [`cairo`](https://formulae.brew.sh/formula/cairo), [`pango`](https://formulae.brew.sh/formula/pango) and [`cmake`](https://formulae.brew.sh/formula/cmake) installed.
 
-  -  npm install
+Install the dependencies:
+
+```bash
+npm install
+```
+
+And start the watch server:
+
+```bash
+npm start
+```
+
+The server listens runs on port 3001 by default. You can change the by setting the environment variable `PORT`.
 
 ## Configuration
 
-Configuration for theming, map and API endpoint URLs is defined in
-`environment.conf.json`.
-
-## Development
-
-To overwrite some configuration for development purposes you can define them in
-`environment.conf.development.json`. This file is ignored by git.
-
-The SPA will run over HTTP on `localhost` at port `3001`. The port can be configured by setting the environment variable `PORT`.
-
-    npm start
-
-    PORT=8000 npm start
-
-Do note that the application uses an external authentication service that does not accept any port. The whitelisted ports are `3000` and `3001`
-
-### HTTPS
-
-The application's production build uses a [serviceworker](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) that is configured through the Webpack Offline plugin (see [webpack config](./internals/webpack/webpack.prod.babel.js)) and is installed in [app.js](./src/app.js).
-
-To run the application with the production code and have the serviceworker available, the site needs to be run over HTTPS. This can be accomplished by running
-
-    HTTPS=true npm run start:prod
+Configuration for theming, map and API endpoint URLs is defined in `environment.conf.json`. Override the default configuration by creating the file `environment.conf.development.json`. This file is ignored by Git.
 
 ## Testing
 
-By default, the unit test generates a coverage report (thresholds are set in [jest.config.js](./jest.config.js)).
+Run the unit-tests and generate a coverage report with:
 
-Running all tests and generate the coverage report:
+```bash
+npm test
+```
 
-    npm test
+Run the end-to-end tests with:
+
+```bash
+npm run cy:open
+```
+
+## Service Worker
+
+The production build uses a [Service Worker](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) that requires HTTPS. Start a HTTPS server with the production build as follows:
+
+```bash
+HTTPS=true npm run start:prod
+```
 
 ## Deployment
 
-When deploying the docker container, there are some files you can overwrite for
-branding purposes.
+Pre-build images of the Signalen frontend are available on [DockerHub](https://hub.docker.com/r/signalen/frontend). To build a Docker image locally use:
 
-- `environment.conf.json` with configuration for theming and endpoint URLs.
-- The logo, as defined by `logo.url` in `environment.conf.json`.
+```bash
+docker build -t signalen/frontend .
+```
+
+Start the frontend server with a custom configuration as follows:
+
+```bash
+docker run -d -p 8080:80 \
+  -v /branding/config.json:/environment.conf.json \
+  -v /branding/logo.png:/usr/share/nginx/html/logo.png \
+  -v /branding/favicon.png:/usr/share/nginx/html/favicon.png \
+  -v /branding/android.png:/usr/share/nginx/html/icon_192x192.png \
+  -v /branding/ios.png:/usr/share/nginx/html/icon_180x180.png \
+  signalen/frontend
+```
+
+The `-v` flags mount a custom configuration from the host in the container:
+
+- `environment.conf.json` with configuration for theming, map and API endpoint URLs.
 - `favicon.png` the favicon, needs to be a PNG.
 - `manifest.json` with configuration for the PWA.
 - `icon_...x....png` the icons for the PWA in various sizes, need to be PNGs.
 
-The logo displayed on the website is defined by the `logo.url` parameter in
-`environment.conf.json`. This can be a remote URL or a local file path. Define
-for instance `/logo.svg` and you can inject your own `logo.svg` when starting
-the docker container.
+The logo displayed on the website is defined by the `logo.url` parameter in `environment.conf.json`. This can be a remote URL or a local file path. Define for instance `/logo.svg` and you can inject your own `logo.svg` when starting the docker container.
 
-The `manifest.json` file for the PWA is generated by webpack, but you can
-overwrite it with your own configuration. This file also defines some icons,
-which, in turn, can be injected into the container as well.
+The `manifest.json` file for the PWA is generated by webpack, but you can overwrite it with your own configuration. This file also defines some icons, which, in turn, can be injected into the container as well.
 
-There is an icon for android of 192 x 192 pixels in size, defined in
-`manifest.json`. For iOS there's an icon of 180 x 180 pixels in size, this is
-defined directly in `index.html`. All icons have to be PNGs. The icon for iOS
-must not contain transparency.
-
-See also
-https://stackoverflow.com/questions/2997437/what-size-should-apple-touch-icon-png-be-for-ipad-and-iphone?answertab=votes#tab-top
-and
-https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariWebContent/ConfiguringWebApplications/ConfiguringWebApplications.html.
-
-An example command for running the container and injecting some files:
-
-    docker run -d -p 8080:80 \¬
-      -v /branding/config.json:/environment.conf.json \¬
-      -v /branding/logo.png:/usr/share/nginx/html/logo.png \¬
-      -v /branding/favicon.png:/usr/share/nginx/html/favicon.png \¬
-      -v /branding/android.png:/usr/share/nginx/html/icon_192x192.png \¬
-      -v /branding/ios.png:/usr/share/nginx/html/icon_180x180.png \¬
-      signalen/frontend¬
+There is an icon for android of 192 x 192 pixels in size, defined in `manifest.json`. For iOS there's an icon of 180 x 180 pixels in size, this is defined directly in `index.html`. All icons have to be PNGs. The icon for iOS must not contain transparency. For more information on icons see [this Stack Overflow question](https://stackoverflow.com/questions/2997437/what-size-should-apple-touch-icon-png-be-for-ipad-and-iphone?answertab=votes#tab-top)
+and [the Apple developer documentation](https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariWebContent/ConfiguringWebApplications/ConfiguringWebApplications.html).
 
 ## Thanks to
+
 <a href="http://browserstack.com/"><img src="src/images/browserstack-logo-600x315.png" height="130" alt="BrowserStack Logo" /></a>

--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ Make sure you installed the following versions on your machine:
 -  npm >= 6.11
 -  node 12.18
 
-For testing this project relies on the[ `leaflet-headless`](https://www.npmjs.com/package/leaflet-headless) package. On OSX, you'll need to have [`cairo`](https://formulae.brew.sh/formula/cairo), [`pango`](https://formulae.brew.sh/formula/pango) and [`cmake`](https://formulae.brew.sh/formula/cmake) installed.
-
 Install the dependencies:
 
 ```bash
@@ -28,7 +26,7 @@ The server listens runs on port 3001 by default. You can change the by setting t
 
 ## Configuration
 
-Configuration for theming, map and API endpoint URLs is defined in `environment.conf.json`. Override the default configuration by creating the file `environment.conf.development.json`. This file is ignored by Git.
+Configuration for theming, map and API endpoint URLs is defined in `environment.conf.json`. Override the default configuration by creating the file `environment.conf.development.json`. This file is ignored by Git. Changes to the configuration file will only be picked up when the development server is restarted.
 
 ## Testing
 

--- a/environment.conf.json
+++ b/environment.conf.json
@@ -39,7 +39,24 @@
     "home": "https://www.amsterdam.nl",
     "privacy": "https://www.amsterdam.nl/privacy/specifieke/privacyverklaringen-wonen/meldingen-overlast-privacy/"
   },
-  "theme": {},
+  "theme": {
+    "primary": {
+      "main": "#004699",
+      "dark": "#00387a"
+    },
+    "secondary": {
+      "main": "#ec0000",
+      "dark": "#bc0000"
+    },
+    "support": {
+      "valid": "#00A03C",
+      "invalid": "#EC0000",
+      "focus": "#FEC813"
+    },
+    "error": {
+      "main": "#ec0000"
+    }
+  },
   "map": {
     "municipality": "amsterdam",
     "options": {

--- a/internals/schemas/environment.conf.schema.json
+++ b/internals/schemas/environment.conf.schema.json
@@ -495,9 +495,9 @@
       "title": "Sentry"
     },
     "Theme": {
-      "description": "Configuration object that is merged with the application's theme provider configuration and will override any existing theme configuration. See the `amsterdam styled components theme configuration (https://github.com/Amsterdam/amsterdam-styled-components/blob/master/packages/asc-ui/src/theme/default/index.ts) for the structure of the object.\n\nUsed in the `ThemeProvider` component (src/components/ThemeProvider/index.js)",
+      "description": "Configuration object that is merged with the application's theme provider configuration and will override any existing theme configuration. See the `amsterdam styled components theme configuration (https://github.com/Amsterdam/amsterdam-styled-components/blob/master/packages/asc-ui/src/theme/default/index.ts) for the structure of the object.\n\nUsed in the `ThemeProvider` component (src/components/ThemeProvider/index.js). For more information on the options see: https://github.com/Amsterdam/amsterdam-styled-components/tree/master/packages/asc-ui/src/theme",
       "type": "object",
-      "additionalProperties": false,
+      "additionalProperties": true,
       "title": "Theme"
     }
   }


### PR DESCRIPTION
This PR should improve setting up Signalen for new users.

- Improve development, test and deployment instructions.
- Refer to the public Docker registry for pre-build images.
- Refer to Helm charts for easy deployment on Kubernetes.
- Add example settings of the theme object.

Closes Signalen/frontend#68