### PR TITLE
[SIG-2471] - Allows the autosuggest to search in more than one municipality

### DIFF
--- a/internals/schemas/environment.conf.schema.json
+++ b/internals/schemas/environment.conf.schema.json
@@ -361,7 +361,7 @@
       "additionalProperties": false,
       "properties": {
         "municipality": {
-          "type": "string"
+          "type": ["string", "array"]
         },
         "options": {
           "$ref": "#/definitions/MapOptions"


### PR DESCRIPTION
This PR, updates the json schema in order to allow the autosuggest control to search addressed in more than one municipality. This change was needed to meet the requirements for the implementation of the `Amsterdamsebos` configuration