### PR TITLE
[SIG-3005] Hides the `optioneel` text for `fietsrek-nietje`

### DIFF
--- a/src/signals/incident/definitions/wizard-step-2-vulaan/wegen-verkeer-straatmeubilair.js
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/wegen-verkeer-straatmeubilair.js
@@ -519,6 +519,9 @@ export const controls = {
         nee: 'Nee, ik wil direct verder gaan',
       },
     },
+    options: {
+      validators: [Validators.required],
+    },
     render: FormComponents.RadioInputGroup,
   },
   extra_fietsrek_text: {


### PR DESCRIPTION
This PR hides the `optioneel` text for the `fietsrek-nietje` question