### PR TITLE
[SIG-1553] Show spinner during create incident

### DIFF
--- a/src/signals/incident/components/IncidentForm/index.js
+++ b/src/signals/incident/components/IncidentForm/index.js
@@ -139,10 +139,15 @@ class IncidentForm extends React.Component {
         break;
 
       case 'CREATE_INCIDENT':
+        this.setState({
+          submitting: true,
+          loading: false,
+        });
         this.props.createIncident({
           incident: this.props.incidentContainer.incident,
           wizard: this.props.wizard,
         });
+        break;
     }
   }
 
@@ -164,7 +169,7 @@ class IncidentForm extends React.Component {
 
       if (this.form.valid) {
         this.setIncident(formAction);
-        next();
+        if (formAction !== 'CREATE_INCIDENT') next();
       }
     }
 

--- a/src/signals/incident/components/IncidentForm/index.test.js
+++ b/src/signals/incident/components/IncidentForm/index.test.js
@@ -171,7 +171,7 @@ describe('<IncidentForm />', () => {
         expect(next).toHaveBeenCalled();
       });
 
-      it('submit should trigger next when form is valid and CREATE_INCIDENT defined', () => {
+      it('submit should not trigger next when form is valid and CREATE_INCIDENT defined', () => {
         const next = jest.fn();
         instance.form.valid = true;
 
@@ -181,7 +181,7 @@ describe('<IncidentForm />', () => {
         instance.handleSubmit(event, next, 'CREATE_INCIDENT');
 
         expect(props.createIncident).toHaveBeenCalledWith(expect.objectContaining({ incident: {} }));
-        expect(next).toHaveBeenCalled();
+        expect(next).not.toHaveBeenCalled();
       });
 
       it('submit should not be triggered next when form is not valid', () => {

--- a/src/signals/incident/components/IncidentNavigation/__snapshots__/index.test.js.snap
+++ b/src/signals/incident/components/IncidentNavigation/__snapshots__/index.test.js.snap
@@ -97,13 +97,9 @@ exports[`<IncidentNavigation /> rendering render correctly button with submittin
     >
       Volgende
     </span>
-    <span
-      className="working"
-    >
-      <div
-        className="progress-indicator progress-white"
-      />
-    </span>
+    <IncidentNavigation__Spinner
+      size="25"
+    />
   </NextButton>
 </div>
 `;

--- a/src/signals/incident/components/IncidentNavigation/index.js
+++ b/src/signals/incident/components/IncidentNavigation/index.js
@@ -7,10 +7,21 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { WithWizard } from 'react-albus';
+import styled from 'styled-components';
 
 import PreviousButton from 'components/PreviousButton';
 import NextButton from 'components/NextButton';
+import { Spinner as AscSpinner, themeSpacing, themeColor } from '@datapunt/asc-ui';
 import './style.scss';
+
+const Spinner = styled(AscSpinner)`
+  margin-left: ${themeSpacing(2)};
+  & svg {
+    path {
+      fill: ${themeColor('tint', 'level1')};
+    }
+  }
+`;
 
 const IncidentNavigation = ({ controls, meta: { wizard, submitting, handleSubmit } }) => {
   const hideSubmit = controls?.hide_navigation_buttons?.meta ? controls.hide_navigation_buttons.meta.isVisible : false;
@@ -39,11 +50,7 @@ const IncidentNavigation = ({ controls, meta: { wizard, submitting, handleSubmit
               {!hideSubmit && wizardStep.nextButtonLabel && (
                 <NextButton onClick={e => handleSubmit(e, next, wizardStep.formAction)} data-testid="nextButton">
                   <span className="value">{wizardStep.nextButtonLabel}</span>
-                  {submitting && (
-                    <span className="working">
-                      <div className="progress-indicator progress-white"></div>
-                    </span>
-                  )}
+                  {submitting && <Spinner size="25" />}
                 </NextButton>
               )}
             </div>

--- a/src/signals/incident/components/form/HandlingMessage/index.js
+++ b/src/signals/incident/components/form/HandlingMessage/index.js
@@ -5,7 +5,7 @@ import get from 'lodash.get';
 
 import './style.scss';
 
-const renderText = (key, name, parent) => {
+const renderText = (key = 'incident', name, parent) => {
   const replacedValue = get(parent, `meta.incidentContainer.${key}`);
   if (replacedValue) {
     return replacedValue.split('\n\n').map((item, k) => (

--- a/src/signals/incident/components/form/PlainText/index.js
+++ b/src/signals/incident/components/form/PlainText/index.js
@@ -7,12 +7,12 @@ import get from 'lodash.get';
 import mapDynamicFields from '../../../services/map-dynamic-fields';
 import './style.scss';
 
-function renderText(value, parent) {
+function renderText(key = 'incident', value, parent) {
   if (React.isValidElement(value)) {
     return value;
   }
 
-  return mapDynamicFields(value, { incident: get(parent, 'meta.incidentContainer.incident') });
+  return mapDynamicFields(value, { incident: get(parent, `meta.incidentContainer.${key}`) });
 }
 
 const Label = styled.div`
@@ -23,13 +23,13 @@ const PlainText = ({ meta, parent }) =>
   meta?.isVisible && (
     <div className={`${meta.type || ''} plain-text__box`}>
       <Label>{meta.label}</Label>
-      {meta.value && isString(meta.value) && renderText(meta.value, parent)}
+      {meta.value && isString(meta.value) && renderText(meta.key, meta.value, parent)}
 
       {meta.value &&
         Array.isArray(meta.value) &&
         meta.value.map((paragraph, key) => (
           <div key={`${meta.name}-${key + 1}`} className={`plain-text__box-p plain-text__box-p-${key + 1}`}>
-            {renderText(paragraph, parent)}
+            {renderText(meta.key, paragraph, parent)}
           </div>
         ))}
     </div>

--- a/src/signals/incident/containers/IncidentContainer/reducer.js
+++ b/src/signals/incident/containers/IncidentContainer/reducer.js
@@ -39,6 +39,7 @@ export const initialState = fromJS({
     },
   },
   loadingClassification: false,
+  createdIncident: null,
 });
 
 const getIncidentWithoutExtraProps = (incident, { category, subcategory } = {}) => {
@@ -69,12 +70,12 @@ export default (state = initialState, action) => {
 
     case CREATE_INCIDENT:
       return state
-        .set('loading', true)
+        .set('createdIncident', null)
         .set('error', false)
         .set('incident', state.get('incident').set('id', null));
 
     case CREATE_INCIDENT_SUCCESS:
-      return state.set('loading', false).set('incident', fromJS(action.payload));
+      return state.set('createdIncident', fromJS(action.payload));
 
     case CREATE_INCIDENT_ERROR:
       return state.set('error', true).set('loading', false);

--- a/src/signals/incident/containers/IncidentContainer/reducer.test.js
+++ b/src/signals/incident/containers/IncidentContainer/reducer.test.js
@@ -90,10 +90,10 @@ describe('signals/incident/containers/IncidentContainer/reducer', () => {
         }).toJS()
       ).toEqual({
         error: false,
-        loading: true,
         incident: {
           id: null,
         },
+        createdIncident: null,
       });
     });
   });
@@ -117,8 +117,7 @@ describe('signals/incident/containers/IncidentContainer/reducer', () => {
         }).toJS()
       ).toEqual({
         ...initialState.toJS(),
-        loading: false,
-        incident: {
+        createdIncident: {
           id,
           category,
           handling_message,

--- a/src/signals/incident/containers/IncidentContainer/saga.js
+++ b/src/signals/incident/containers/IncidentContainer/saga.js
@@ -57,7 +57,6 @@ export function* getQuestionsSaga(action) {
 export function* createIncident(action) {
   try {
     const { handling_message, ...postData } = yield call(getPostData, action);
-
     const postResult = yield call(postIncident, postData);
 
     const incident = { ...postResult, handling_message };
@@ -65,18 +64,17 @@ export function* createIncident(action) {
     if (action.payload.incident.images) {
       // perform blocking requests for image uploads
       yield all([
-        ...action.payload.incident.images.map(image =>
-          call(uploadFile, {
-            payload: {
-              file: image,
-              id: incident.signal_id,
-            },
-          })
+        ...action.payload.incident.images.map(image => call(uploadFile, {
+          payload: {
+            file: image,
+            id: incident.signal_id,
+          },
+        })
         ),
       ]);
     }
-
     yield put(createIncidentSuccess(incident));
+    yield put(replace('/incident/bedankt'));
   } catch {
     yield put(createIncidentError());
     yield put(replace('/incident/fout'));
@@ -107,7 +105,6 @@ export function* postIncident(postData) {
  */
 export function* getPostData(action) {
   const { category, subcategory } = action.payload.incident;
-
   const {
     handling_message,
     _links: {

--- a/src/signals/incident/definitions/wizard-step-6-bedankt.js
+++ b/src/signals/incident/definitions/wizard-step-6-bedankt.js
@@ -10,6 +10,7 @@ export default {
           className: 'col-sm-12 col-md-6',
           type: 'bedankt',
           value: 'Uw melding is bij ons bekend onder nummer: {incident.id}.',
+          key: 'createdIncident',
         },
         render: FormComponents.PlainText,
       },
@@ -25,7 +26,7 @@ export default {
         meta: {
           className: 'col-sm-12 col-md-6',
           type: 'bedankt',
-          key: 'incident.handling_message',
+          key: 'createdIncident.handling_message',
         },
         render: FormComponents.HandlingMessage,
       },


### PR DESCRIPTION
This PR 
- Shows an loading indicator on the send button during submitting an incident. 
- This ensures that the user doesn't navigate away during creation of the incident. 
- When navigating away to fast there was a chance that not all the attached photo's to be uploaded while this is a separate upload process. 
- To achive this a new object createdIncident was added to the incident container. This object is filled with the results of the create incident call. Till now the results override the incident object what is not correct because the result object has an entirely different structure.

