### PR TITLE
[SIG-3003] Adds default text capabilities for all statuses

### DIFF
--- a/src/signals/incident-management/definitions/statusList.js
+++ b/src/signals/incident-management/definitions/statusList.js
@@ -143,4 +143,4 @@ export const changeStatusOptionList = [
   GEANNULEERD,
 ];
 
-export const defaultTextsOptionList = [AFGEHANDELD, INGEPLAND, HEROPEND];
+export const defaultTextsOptionList = [...changeStatusOptionList];


### PR DESCRIPTION
This PR enables the definition of a default text for all statuses that can be selected in change status page