### PR TITLE
Bug/50 small map

### DIFF
--- a/environment.conf.json
+++ b/environment.conf.json
@@ -84,6 +84,7 @@
   },
   "fetchQuestionsFromBackend": false,
   "showVulaanControls": true,
+  "useStaticMapServer": true,
   "STATIC_MAP_SERVER_URL": "https://map.data.amsterdam.nl/maps/topografie",
   "AUTH_ME_ENDPOINT": "https://acc.api.data.amsterdam.nl/signals/v1/private/me/",
   "CATEGORIES_ENDPOINT": "https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/",

--- a/internals/schemas/environment.conf.schema.json
+++ b/internals/schemas/environment.conf.schema.json
@@ -35,7 +35,11 @@
           "type": "boolean"
         },
         "showVulaanControls": {
-          "description": "When false, will not show extra questions after the first page of questions in the incident submission form",
+          "description": "When true, will show extra questions after the first page of questions in the incident submission form",
+          "type": "boolean"
+        },
+        "useStaticMapServer": {
+          "description": "When true, will use the static map server difined by [STATIC_MAP_SERVER_URL](#STATIC_MAP_SERVER_URL) to get a png image for a small map preview, otherwise leaflet without controls will be used.",
           "type": "boolean"
         },
         "STATIC_MAP_SERVER_URL": {
@@ -236,7 +240,14 @@
           "description": "Value that sets the color of the tool bar, and may be reflected in the app's preview in task switchers"
         }
       },
-      "required": ["androidIcon", "backgroundColor", "favicon", "iosIcon", "statusBarStyle", "themeColor"],
+      "required": [
+        "androidIcon",
+        "backgroundColor",
+        "favicon",
+        "iosIcon",
+        "statusBarStyle",
+        "themeColor"
+      ],
       "title": "Head"
     },
     "Language": {
@@ -324,7 +335,11 @@
           "format": "uri"
         }
       },
-      "required": ["help", "home", "privacy"],
+      "required": [
+        "help",
+        "home",
+        "privacy"
+      ],
       "title": "Links"
     },
     "Logo": {
@@ -334,26 +349,47 @@
       "properties": {
         "url": {
           "description": "Any URL that will hold the image for the application's logo. Can be a URI or an absolute URL that points to the webroot",
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "width": {
           "description": "Length value that sets the logo image's width. See https://developer.mozilla.org/en-US/docs/Web/CSS/width for reference",
-          "type": ["string", "integer"]
+          "type": [
+            "string",
+            "integer"
+          ]
         },
         "height": {
           "description": "Length value that sets the logo image's height",
-          "type": ["string", "integer"]
+          "type": [
+            "string",
+            "integer"
+          ]
         },
         "smallWidth": {
           "description": "Length value that sets the logo image's width in case the logo is rendered in a site header with limited height",
-          "type": ["string", "integer"]
+          "type": [
+            "string",
+            "integer"
+          ]
         },
         "smallHeight": {
           "description": "Length value that sets the logo image's height in case the logo is rendered in a site header with limited height",
-          "type": ["string", "integer"]
+          "type": [
+            "string",
+            "integer"
+          ]
         }
       },
-      "required": ["height", "smallHeight", "smallWidth", "url", "width"],
+      "required": [
+        "height",
+        "smallHeight",
+        "smallWidth",
+        "url",
+        "width"
+      ],
       "title": "Logo"
     },
     "Map": {
@@ -361,7 +397,10 @@
       "additionalProperties": false,
       "properties": {
         "municipality": {
-          "type": ["string", "array"]
+          "type": [
+            "string",
+            "array"
+          ]
         },
         "options": {
           "$ref": "#/definitions/MapOptions"
@@ -373,7 +412,12 @@
           "$ref": "#/definitions/Tiles"
         }
       },
-      "required": ["municipality", "options", "optionsBackOffice", "tiles"],
+      "required": [
+        "municipality",
+        "options",
+        "optionsBackOffice",
+        "tiles"
+      ],
       "title": "Map"
     },
     "MapOptions": {
@@ -405,7 +449,13 @@
           "type": "integer"
         }
       },
-      "required": ["center", "maxBounds", "maxZoom", "minZoom", "zoom"],
+      "required": [
+        "center",
+        "maxBounds",
+        "maxZoom",
+        "minZoom",
+        "zoom"
+      ],
       "title": "MapOptions"
     },
     "OptionsBackOffice": {
@@ -422,7 +472,11 @@
           "type": "integer"
         }
       },
-      "required": ["maxZoom", "minZoom", "zoom"],
+      "required": [
+        "maxZoom",
+        "minZoom",
+        "zoom"
+      ],
       "title": "OptionsBackOffice"
     },
     "Tiles": {
@@ -441,7 +495,10 @@
           "$ref": "#/definitions/TilesOptions"
         }
       },
-      "required": ["args", "options"],
+      "required": [
+        "args",
+        "options"
+      ],
       "title": "Tiles"
     },
     "TilesOptions": {
@@ -461,7 +518,11 @@
           "type": "boolean"
         }
       },
-      "required": ["attribution", "subdomains", "tms"],
+      "required": [
+        "attribution",
+        "subdomains",
+        "tms"
+      ],
       "title": "TilesOptions"
     },
     "Matomo": {
@@ -478,7 +539,10 @@
           "type": "integer"
         }
       },
-      "required": ["siteId", "urlBase"],
+      "required": [
+        "siteId",
+        "urlBase"
+      ],
       "title": "Matomo"
     },
     "Sentry": {
@@ -491,7 +555,9 @@
           "description": "Sentry data source name value. When omitted, Sentry will not be initialised in the application"
         }
       },
-      "required": ["dsn"],
+      "required": [
+        "dsn"
+      ],
       "title": "Sentry"
     },
     "Theme": {

--- a/internals/schemas/environment.conf.schema.json
+++ b/internals/schemas/environment.conf.schema.json
@@ -206,7 +206,8 @@
         "matomo",
         "sentry",
         "showVulaanControls",
-        "theme"
+        "theme",
+        "useStaticMapServer"
       ],
       "title": "Test"
     },

--- a/src/signals/incident-management/containers/IncidentDetail/components/Detail/components/Location/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/Detail/components/Location/index.js
@@ -6,11 +6,18 @@ import { getListValueByKey } from 'shared/services/list-helper/list-helper';
 import { locationType } from 'shared/types';
 import { stadsdeelList } from 'signals/incident-management/definitions';
 import MapStatic from 'components/MapStatic';
+import { smallMarkerIcon } from 'shared/services/configuration/map-markers';
+import configuration from 'shared/services/configuration/configuration';
 
+import MapDetail from '../../../MapDetail';
 import HighLight from '../../../Highlight';
 import EditButton from '../../../EditButton';
 import IconEdit from '../../../../../../../../shared/images/icon-edit.svg';
 import IncidentDetailContext from '../../../../context';
+
+const mapWidth = 80;
+const mapHeight = 80;
+const mapZoom = 9;
 
 const MapTile = styled.div`
   float: left;
@@ -38,6 +45,12 @@ const StyledHighLight = styled(HighLight)`
   .highlight__children {
     display: flex;
   }
+`;
+
+const StyledMap = styled(MapDetail)`
+  width: ${mapWidth}px;
+  height: ${mapHeight}px;
+  cursor: pointer;
 `;
 
 const Location = ({ location }) => {
@@ -77,7 +90,11 @@ const Location = ({ location }) => {
               }}
               data-testid="previewLocationButton"
             >
-              <MapStatic boundsScaleFactor={0.25} height={80} markerSize={20} width={80} {...geometry} />
+              {configuration.useStaticMapServer ? (
+                <MapStatic boundsScaleFactor={0.25} height={mapHeight} markerSize={20} width={mapWidth} {...geometry} />
+              ) : (
+                <StyledMap value={location} icon={smallMarkerIcon} zoom={mapZoom} />
+              )}
             </MapTile>
           )}
 
@@ -90,15 +107,13 @@ const Location = ({ location }) => {
               )}
 
               <div data-testid="location-value-address-street">
-                {location.address.openbare_ruimte}{' '}
-                {location.address.huisnummer}
+                {location.address.openbare_ruimte} {location.address.huisnummer}
                 {location.address.huisletter}
                 {location.address.huisnummer_toevoeging ? `-${location.address.huisnummer_toevoeging}` : ''}
               </div>
 
               <div data-testid="location-value-address-city">
-                {location.address.postcode}{' '}
-                {location.address.woonplaats}
+                {location.address.postcode} {location.address.woonplaats}
               </div>
             </div>
           ) : (

--- a/src/signals/incident-management/containers/IncidentDetail/components/Detail/components/Location/index.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/Detail/components/Location/index.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, fireEvent, act } from '@testing-library/react';
 
+import configuration from 'shared/services/configuration/configuration';
 import { getListValueByKey } from 'shared/services/list-helper/list-helper';
 import { withAppContext } from 'test/utils';
 
@@ -8,6 +9,7 @@ import IncidentDetailContext from '../../../../context';
 
 import Location from '.';
 
+jest.mock('shared/services/configuration/configuration');
 jest.mock('shared/services/list-helper/list-helper');
 
 const props = {
@@ -52,6 +54,10 @@ describe('<Location />', () => {
     edit.mockReset();
   });
 
+  afterEach(() => {
+    configuration.__reset();
+  });
+
   describe('rendering', () => {
     it('should render correctly', async () => {
       const { findByText, queryByTestId, getByTestId } = render(renderWithContext());
@@ -62,6 +68,28 @@ describe('<Location />', () => {
       expect(queryByTestId('location-value-address-street')).toHaveTextContent(/^Rokin 123A-H$/);
       expect(queryByTestId('location-value-address-city')).toHaveTextContent(/^1012KP Amsterdam$/);
       expect(getByTestId('previewLocationButton')).toBeInTheDocument();
+    });
+
+    describe('location preview', () => {
+      it('should render static map image with useStaticMapServer enabled', async () => {
+        const { findByText, queryByTestId } = render(renderWithContext());
+
+        await findByText('Locatie');
+
+        expect(queryByTestId('mapStaticImage')).toBeInTheDocument();
+        expect(queryByTestId('map-base')).not.toBeInTheDocument();
+      });
+
+      it('should render normal map with useStaticMapServer disabled', async () => {
+        configuration.useStaticMapServer = false;
+
+        const { findByText, queryByTestId } = render(renderWithContext());
+
+        await findByText('Locatie');
+
+        expect(queryByTestId('mapStaticImage')).not.toBeInTheDocument();
+        expect(queryByTestId('map-base')).toBeInTheDocument();
+      });
     });
 
     it('should render correctly without huisnummer_toevoeging', async () => {

--- a/src/signals/incident/components/IncidentPreview/components/Map/index.js
+++ b/src/signals/incident/components/IncidentPreview/components/Map/index.js
@@ -2,13 +2,32 @@ import React, { Fragment, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { themeSpacing } from '@datapunt/asc-ui';
+import { Marker } from '@datapunt/react-maps';
 
+import { markerIcon } from 'shared/services/configuration/map-markers';
+import MAP_OPTIONS from 'shared/services/configuration/map-options';
+import configuration from 'shared/services/configuration/configuration';
 import { formatAddress } from 'shared/services/map-location';
 import MapStatic from 'components/MapStatic';
+
+import Map from 'components/Map';
+
+const mapWidth = 640;
+const mapHeight = 300;
+const mapZoom = 12;
 
 const Address = styled.address`
   margin-bottom: ${themeSpacing(4)};
   font-style: normal;
+`;
+
+const StyledMap = styled(Map)`
+  width: ${mapWidth}px;
+  height: ${mapHeight}px;
+`;
+
+const StyledMarker = styled(Marker)`
+  cursor: none;
 `;
 
 /**
@@ -17,6 +36,12 @@ const Address = styled.address`
 const MapPreview = ({ value }) => {
   const longitude = value?.geometrie?.coordinates[0];
   const latitude = value?.geometrie?.coordinates[1];
+  const options = {
+    ...MAP_OPTIONS,
+    zoom: mapZoom,
+    attributionControl: false,
+    center: [latitude, longitude],
+  };
 
   const geometry = useMemo(
     () => ({
@@ -30,7 +55,15 @@ const MapPreview = ({ value }) => {
     value && (
       <Fragment>
         <Address>{value?.address ? formatAddress(value.address) : 'Geen adres gevonden'}</Address>
-        {latitude && longitude && <MapStatic width={640} {...geometry} />}
+        {latitude &&
+          longitude &&
+          (configuration.useStaticMapServer ? (
+            <MapStatic height={mapHeight} width={mapWidth} {...geometry} />
+          ) : (
+            <StyledMap mapOptions={options} canBeDragged={false}>
+              <StyledMarker args={[{ lat: latitude, lng: longitude }]} options={{ icon: markerIcon }} />
+            </StyledMap>
+          ))}
       </Fragment>
     )
   );

--- a/src/signals/incident/components/IncidentPreview/components/Map/index.test.js
+++ b/src/signals/incident/components/IncidentPreview/components/Map/index.test.js
@@ -1,13 +1,20 @@
 import React from 'react';
 import { render } from '@testing-library/react';
 import { withAppContext } from 'test/utils';
+import configuration from 'shared/services/configuration/configuration';
 
 import MapPreview from '.';
+
+jest.mock('shared/services/configuration/configuration');
 
 describe('signals/incident/components/IncidentPreview/components/Map', () => {
   const geometrie = {
     coordinates: [52, 4],
   };
+
+  afterEach(() => {
+    configuration.__reset();
+  });
 
   it('should show address fallback', async () => {
     const { getByText, findByTestId } = render(withAppContext(<MapPreview value={{ geometrie }} />));
@@ -17,11 +24,21 @@ describe('signals/incident/components/IncidentPreview/components/Map', () => {
     expect(getByText('Geen adres gevonden')).toBeInTheDocument();
   });
 
-  it('should render static map', async () => {
-    const { findByTestId } = render(withAppContext(<MapPreview value={{ geometrie }} />));
+  it('should render static map with useStaticMapServer enabled', async () => {
+    const { findByTestId, queryByTestId } = render(withAppContext(<MapPreview value={{ geometrie }} />));
 
-    const mapStatic = await findByTestId('mapStatic');
+    await findByTestId('mapStatic');
 
-    expect(mapStatic).toBeInTheDocument();
+    expect(queryByTestId('mapStatic')).toBeInTheDocument();
+    expect(queryByTestId('map-base')).not.toBeInTheDocument();
+  });
+
+  it('should render normal map with useStaticMapServer disabled', () => {
+    configuration.useStaticMapServer = false;
+
+    const { queryByTestId } = render(withAppContext(<MapPreview value={{ geometrie }} />));
+
+    expect(queryByTestId('mapStatic')).not.toBeInTheDocument();
+    expect(queryByTestId('map-base')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
The PDOK service we use to show the map outside of Amsterdam doesn't have a service to get a static image for the map layer we are using. Therefore I added a feature flag `useStaticMapServer` to indicate using the service to get a static map image. When disabled, leaflet will be used, without any controls, to show a static map.

closes Signalen/frontend#50