### PR TITLE
[SIG-3006] Disabling status form submit button

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/index.js
@@ -5,8 +5,8 @@ import styled, { css } from 'styled-components';
 import { Heading, themeSpacing, Row, Column, themeColor } from '@datapunt/asc-ui';
 import { defaultTextsType } from 'shared/types';
 import statusList, {
-  defaultTextsOptionList,
   changeStatusOptionList,
+  defaultTextsOptionList,
 } from 'signals/incident-management/definitions/statusList';
 
 import Button from 'components/Button';
@@ -108,6 +108,10 @@ const canSendMail = status =>
 const StatusForm = ({ defaultTexts }) => {
   const { incident, update, close } = useContext(IncidentDetailContext);
   const currentStatus = statusList.find(({ key }) => key === incident.status.state);
+  // disable submit button when the current status is a status that cannot be set manually (or, in other words, is not in the list of changeStatusOptionList)
+  const [submitIsDisabled, setSubmitIsDisabled] = useState(
+    changeStatusOptionList.find(({ key }) => key === currentStatus.key) === undefined
+  );
   const [warning, setWarning] = useState('');
   const [showSendMail, setShowSendMail] = useState(canSendMail(currentStatus?.key));
   const isDeelmelding = !!incident?._links?.['sia:parent'];
@@ -128,6 +132,7 @@ const StatusForm = ({ defaultTexts }) => {
 
       const found = statusList.find(s => s.key === status);
 
+      setSubmitIsDisabled(false);
       setShowSendMail(canSendMail(found?.key));
       setWarning(found?.warning);
 
@@ -231,7 +236,12 @@ const StatusForm = ({ defaultTexts }) => {
                   </React.Fragment>
                 )}
 
-                <StyledButton data-testid="statusFormSubmitButton" type="submit" variant="secondary" disabled={invalid}>
+                <StyledButton
+                  data-testid="statusFormSubmitButton"
+                  type="submit"
+                  variant="secondary"
+                  disabled={invalid || submitIsDisabled}
+                >
                   Status opslaan
                 </StyledButton>
 

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/index.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/index.test.js
@@ -3,7 +3,7 @@ import { render, fireEvent, act } from '@testing-library/react';
 
 import { withAppContext } from 'test/utils';
 import incidentFixture from 'utils/__tests__/fixtures/incident.json';
-import { changeStatusOptionList } from '../../../../definitions/statusList';
+import statusList, { changeStatusOptionList } from '../../../../definitions/statusList';
 
 import { PATCH_TYPE_STATUS } from '../../constants';
 import IncidentDetailContext from '../../context';
@@ -303,5 +303,21 @@ describe('signals/incident-management/containers/IncidentDetail/components/Statu
 
       expect(queryByTestId('statusFormSendEmailField')).not.toBeInTheDocument();
     });
+  });
+
+  it('should disable the submit button when the incident status cannot be set manually', () => {
+    const changeStatusOptionListKeys = changeStatusOptionList.map(({ key }) => key);
+    const statusThatIsNotSelectable = statusList.find(({ key }) => changeStatusOptionListKeys.includes(key) === false);
+
+    const incident = {
+      ...incidentFixture,
+      status: {
+        state: statusThatIsNotSelectable.key,
+      },
+    };
+
+    const { getByTestId } = render(renderWithContext(incident));
+
+    expect(getByTestId('statusFormSubmitButton').disabled).toEqual(true);
   });
 });


### PR DESCRIPTION
This PR changes the logic in the `StatusForm` component for disabling the submit button. Prior to this change, the submit button was disabled whenever the form values didn't validate. After the change, the submit button is also disabled when the current incident status is a status that cannot be selected in the status form.