### PR TITLE
[SIG-2160] Adds an extra check to prevent resetting the incident

### DIFF
--- a/src/containers/App/index.js
+++ b/src/containers/App/index.js
@@ -52,9 +52,10 @@ export const AppContainer = ({ resetIncidentAction }) => {
   authenticate();
 
   useEffect(() => {
-    const { referrer } = location;
+    const { pathname, referrer } = location;
 
-    if (referrer === '/incident/bedankt') {
+    // The incident will be reset if we navigate from `/incident/bedankt` but NOT when an error occurs
+    if (referrer === '/incident/bedankt' && pathname !== '/incident/fout') {
       resetIncidentAction();
     }
   }, [location, resetIncidentAction]);

--- a/src/containers/App/index.test.js
+++ b/src/containers/App/index.test.js
@@ -84,6 +84,40 @@ describe('<App />', () => {
     expect(resetIncidentAction).toHaveBeenCalled();
   });
 
+  it('should not reset incident on fault', () => {
+    act(() => {
+      history.push('/');
+    });
+
+    const resetIncidentAction = jest.fn();
+
+    const { rerender, unmount } = render(withAppContext(<AppContainer resetIncidentAction={resetIncidentAction} />));
+
+    expect(resetIncidentAction).not.toHaveBeenCalled();
+
+    act(() => {
+      history.push('/incident/bedankt');
+    });
+
+    unmount();
+
+    resetIncidentAction.mockReset();
+    rerender(withAppContext(<AppContainer resetIncidentAction={resetIncidentAction} />));
+
+    expect(resetIncidentAction).not.toHaveBeenCalled();
+
+    act(() => {
+      history.push('/incident/fault');
+    });
+
+    unmount();
+
+    resetIncidentAction.mockReset();
+    rerender(withAppContext(<AppContainer resetIncidentAction={resetIncidentAction} />));
+
+    expect(resetIncidentAction).not.toHaveBeenCalled();
+  });
+
   it('should render correctly', () => {
     jest.spyOn(auth, 'isAuthenticated').mockImplementation(() => false);
 


### PR DESCRIPTION
This PR prevents the resetting of the incident data by introducing an extra check so that when the current page is `inicdent/fout`, the incident data is not resset