### PR TITLE
[SIG-2160] Adds a loading state to the wizzard

### DIFF
--- a/src/signals/incident/containers/IncidentContainer/saga.js
+++ b/src/signals/incident/containers/IncidentContainer/saga.js
@@ -77,6 +77,7 @@ export function* createIncident(action) {
     }
 
     yield put(createIncidentSuccess(incident));
+    yield put(replace('/incident/bedankt'));
   } catch {
     yield put(createIncidentError());
     yield put(replace('/incident/fout'));

--- a/src/signals/incident/containers/IncidentContainer/saga.test.js
+++ b/src/signals/incident/containers/IncidentContainer/saga.test.js
@@ -389,6 +389,7 @@ describe('IncidentContainer saga', () => {
         .call(getPostData, action)
         .call(postIncidentSaga, postData)
         .put(createIncidentSuccess({ handling_message, ...incident }))
+        .put(replace('/incident/bedankt'))
         .run());
 
     it('should dispatch error', () =>

--- a/src/signals/incident/definitions/wizard.js
+++ b/src/signals/incident/definitions/wizard.js
@@ -12,6 +12,7 @@ export default {
   telefoon,
   email,
   samenvatting,
+  opslaan: {},
   bedankt,
   fout,
 };


### PR DESCRIPTION
This PR 
- Prevents the resetting of the incident data on error by introducing an `opslaan` step to the wizard.
- The navigation to the `incident/bedankt` occurs only when the saving of the incident is successfull
- This is the preferred solution because on slow internet the address will show `incident/bedankt` during save and will switch to `incident/fout`. 
- With this implementation 'incident/opslaan' will be shown in the address bar during the save operation.