### PR TITLE
(Chore) Set GIT_BRANCH build-arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,9 @@ COPY assets /app/assets
 ARG GIT_BRANCH
 ENV GIT_BRANCH ${GIT_BRANCH}
 
+ARG BUILD_ENV
+ENV BUILD_ENV ${BUILD_ENV}
+
 ENV NODE_ENV=production
 RUN echo "run build"
 RUN npm run build

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,10 +34,9 @@ node('BS16 || BS17') {
                     }
 
                     def buildParams = "--shm-size 1G " +
-                        "--build-arg BUILD_NUMBER=${env.BUILD_NUMBER} "
-
-                    buildParams += IS_SEMVER_TAG ? "--build-arg GIT_BRANCH=${BRANCH} " : 'develop'
-                    buildParams += '.'
+                        "--build-arg BUILD_NUMBER=${env.BUILD_NUMBER} " +
+                        "--build-arg GIT_BRANCH=${BRANCH} " +
+                        "."
 
                     def image = docker.build("ois/signalsfrontend:${env.BUILD_NUMBER}", buildParams)
                     image.push()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,9 @@ node('BS16 || BS17') {
                     def buildParams = "--shm-size 1G " +
                         "--build-arg BUILD_NUMBER=${env.BUILD_NUMBER} " +
                         "--build-arg GIT_BRANCH=${BRANCH} " +
-                        "."
+                        '--build-arg BUILD_ENV=' + (IS_SEMVER_TAG ? 'production' : 'acceptance')
+
+                    buildParams += ' .'
 
                     def image = docker.build("ois/signalsfrontend:${env.BUILD_NUMBER}", buildParams)
                     image.push()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,7 @@ node('BS16 || BS17') {
                     def buildParams = "--shm-size 1G " +
                         "--build-arg BUILD_NUMBER=${env.BUILD_NUMBER} "
 
-                    buildParams += IS_SEMVER_TAG ? "--build-arg GIT_BRANCH=${BRANCH} " : ''
+                    buildParams += IS_SEMVER_TAG ? "--build-arg GIT_BRANCH=${BRANCH} " : 'develop'
                     buildParams += '.'
 
                     def image = docker.build("ois/signalsfrontend:${env.BUILD_NUMBER}", buildParams)

--- a/internals/webpack/webpack.base.babel.js
+++ b/internals/webpack/webpack.base.babel.js
@@ -123,6 +123,7 @@ module.exports = options => ({
     new webpack.EnvironmentPlugin({
       NODE_ENV: JSON.stringify(process.env.NODE_ENV),
       GIT_BRANCH: JSON.stringify(process.env.GIT_BRANCH) || 'dummy',
+      BUILD_ENV: JSON.stringify(process.env.BUILD_ENV) || 'development',
     }),
 
     new MiniCssExtractPlugin({

--- a/src/app.js
+++ b/src/app.js
@@ -27,10 +27,10 @@ import './polyfills';
 
 import configureStore from './configureStore';
 
-const environment = process.env.NODE_ENV;
-
+const environment = process.env.BUILD_ENV;
 const dsn = configuration?.sentry?.dsn;
 const release = process.env.GIT_BRANCH;
+
 if (dsn) {
   Sentry.init({
     environment,
@@ -59,7 +59,7 @@ if (urlBase && siteId) {
 }
 
 const render = () => {
-  // eslint-disable-next-line no-undef,no-console
+  // eslint-disable-next-line no-console
   if (release) console.log(`Signals: tag ${release}`);
 
   ReactDOM.render(


### PR DESCRIPTION
This PR fixes an issue where `release` values for tickets in Sentry would contain an invalid, empty value.

Sentry doesn't allow empty values for releases (see for instance the error shown in ticket https://sentry.data.amsterdam.nl/sentry/signals-frontend/issues/12757/?referrer=RegressionActivityEmail).

In addition to that fix, an env var `BUILD_ENV` is exposed to the run-time code so that issues can be filed under either `development`, `acceptance` or `production` where it is always `production` currently.