### PR TITLE
Allow Sentry and Matomo configuration flag to be null

### DIFF
--- a/internals/schemas/environment.conf.schema.json
+++ b/internals/schemas/environment.conf.schema.json
@@ -13,10 +13,16 @@
           "$ref": "#/definitions/Logo"
         },
         "sentry": {
-          "$ref": "#/definitions/Sentry"
+          "oneOf": [
+            { "type": "null" },
+            { "$ref": "#/definitions/Sentry" }
+          ]
         },
         "matomo": {
-          "$ref": "#/definitions/Matomo"
+          "oneOf": [
+            { "type": "null" },
+            { "$ref": "#/definitions/Matomo" }
+          ]
         },
         "language": {
           "$ref": "#/definitions/Language"


### PR DESCRIPTION
Used in review apps and end-to-end test environments.