### PR TITLE
[SIG-2851] Autocomplete shadow margin fix

### DIFF
--- a/src/components/AutoSuggest/index.js
+++ b/src/components/AutoSuggest/index.js
@@ -16,6 +16,10 @@ const Wrapper = styled.div`
 
 const StyledInput = styled(Input)`
   outline: 2px solid rgb(0,0,0,0.1);
+
+  & > * {
+    margin: 0;
+  }
 `;
 
 const AbsoluteList = styled(SuggestList)`


### PR DESCRIPTION
This PR fixes an issue where, in Safari, the `AutoSuggest` component has margin between the input element and its outline.