### PR TITLE
[SIG-2975] Handle failing PDOK response

### DIFF
--- a/src/components/MapInput/__tests__/reverseGeocoderService.test.js
+++ b/src/components/MapInput/__tests__/reverseGeocoderService.test.js
@@ -83,4 +83,12 @@ describe('reverseGeocoderService', () => {
 
     expect(result).toEqual(testResult);
   });
+
+  it('should handle failed requests', async () => {
+    fetch.mockReject(() => Promise.reject(new Error('something bad happened')));
+
+    const result = await reverseGeocoderService(testLocation);
+
+    expect(result).toBeUndefined();
+  });
 });

--- a/src/components/MapInput/services/reverseGeocoderService.js
+++ b/src/components/MapInput/services/reverseGeocoderService.js
@@ -15,8 +15,15 @@ const reverseGeocoderService = async location => {
     latitude: location.lat,
   };
   const url = formatRequest(serviceURL, wgs84point);
-  const result = await fetch(url).then(res => res.json());
-  return formatPDOKResponse(result)[0];
+
+  const result = await fetch(url)
+    .then(res => res.json())
+    // make sure to catch any error responses from the geocoder service
+    .catch(() => ({}));
+
+  const formattedResponse = formatPDOKResponse(result);
+
+  return formattedResponse[0];
 };
 
 export default reverseGeocoderService;

--- a/src/shared/services/map-location/index.js
+++ b/src/shared/services/map-location/index.js
@@ -119,8 +119,8 @@ export const pdokResponseFieldList = [
   'centroide_ll',
 ];
 
-export const formatPDOKResponse = ({ response }) =>
-  response.docs?.map(result => {
+export const formatPDOKResponse = request =>
+  request?.response?.docs?.map(result => {
     const { id, weergavenaam, centroide_ll } = result;
     return {
       id,
@@ -130,7 +130,7 @@ export const formatPDOKResponse = ({ response }) =>
         address: serviceResultToAddress(result),
       },
     };
-  });
+  }) || [];
 
 export const pointWithinBounds = (coordinates, bounds = configuration.map.options.maxBounds) => {
   const latWithinBounds = coordinates[0] > bounds[0][0] && coordinates[0] < bounds[1][0];

--- a/src/shared/services/map-location/index.test.js
+++ b/src/shared/services/map-location/index.test.js
@@ -253,6 +253,12 @@ describe('formatPDOKResponse', () => {
       },
     ]);
   });
+
+  it('return an empty array', () => {
+    expect(formatPDOKResponse({})).toEqual([]);
+    expect(formatPDOKResponse(undefined)).toEqual([]);
+    expect(formatPDOKResponse(null)).toEqual([]);
+  });
 });
 
 describe('pointWithinBounds', () => {

--- a/src/signals/incident-management/containers/IncidentDetail/components/Detail/components/Location/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/Detail/components/Location/index.js
@@ -98,14 +98,14 @@ const Location = ({ location }) => {
             </MapTile>
           )}
 
+          {location.stadsdeel && (
+            <div data-testid="location-value-address-stadsdeel">
+              Stadsdeel: {getListValueByKey(stadsdeelList, location.stadsdeel)}
+            </div>
+          )}
+
           {location.address_text ? (
             <div>
-              {location.stadsdeel && (
-                <div data-testid="location-value-address-stadsdeel">
-                  Stadsdeel: {getListValueByKey(stadsdeelList, location.stadsdeel)}
-                </div>
-              )}
-
               <div data-testid="location-value-address-street">
                 {location.address.openbare_ruimte} {location.address.huisnummer}
                 {location.address.huisletter}

--- a/src/signals/incident-management/containers/IncidentDetail/components/Detail/components/Location/index.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/Detail/components/Location/index.test.js
@@ -123,9 +123,9 @@ describe('<Location />', () => {
       const pinned = await findByTestId('location-value-pinned');
 
       expect(pinned).toHaveTextContent(/^Locatie is gepind op de kaart$/);
-      expect(queryByTestId('location-value-address-stadsdeel')).toBeNull();
-      expect(queryByTestId('location-value-address-street')).toBeNull();
-      expect(queryByTestId('location-value-address-city')).toBeNull();
+      expect(queryByTestId('location-value-address-stadsdeel')).toBeInTheDocument();
+      expect(queryByTestId('location-value-address-street')).not.toBeInTheDocument();
+      expect(queryByTestId('location-value-address-city')).not.toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
This PR contains a fix for when the PDOK service returns with a `500` response. The result of that is that an incident doesn't have a resolved address, just GPS coordinates. Since the backend resolves the 'stadsdeel', a change was necessary in the `Location` component of the `IncidentDetail` container to be able to show the resolved stadsdeel.