### PR TITLE
[SIG-2295] Field order

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/components/Detail/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/Detail/index.js
@@ -1,4 +1,4 @@
-import React, { useMemo, useContext } from 'react';
+import React, { Fragment, useMemo, useContext } from 'react';
 import styled from 'styled-components';
 import { themeColor, themeSpacing, Heading } from '@datapunt/asc-ui';
 
@@ -78,11 +78,19 @@ const Detail = ({ attachments }) => {
 
         {memoIncident.extra_properties && <ExtraProperties items={memoIncident.extra_properties} />}
 
-        <dt data-testid="detail-email-definition">E-mail melder</dt>
-        <dd data-testid="detail-email-value">{incident.reporter.email}</dd>
+        {incident.reporter.phone && (
+          <Fragment>
+            <dt data-testid="detail-phone-definition">Telefoon melder</dt>
+            <dd data-testid="detail-phone-value">{incident.reporter.phone}</dd>
+          </Fragment>
+        )}
 
-        <dt data-testid="detail-phone-definition">Telefoon melder</dt>
-        <dd data-testid="detail-phone-value">{incident.reporter.phone}</dd>
+        {incident.reporter.email && (
+          <Fragment>
+            <dt data-testid="detail-email-definition">E-mail melder</dt>
+            <dd data-testid="detail-email-value">{incident.reporter.email}</dd>
+          </Fragment>
+        )}
 
         <dt data-testid="detail-sharing-definition">Toestemming contactgegevens delen</dt>
         <dd data-testid="detail-sharing-value">{incident.reporter.sharing_allowed ? 'Ja' : 'Nee'}</dd>

--- a/src/signals/incident-management/containers/IncidentDetail/components/Detail/index.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/Detail/index.test.js
@@ -51,4 +51,46 @@ describe('<Detail />', () => {
     expect(getByTestId('attachmentsDefinition')).toBeInTheDocument();
     expect(getByTestId('detail-location')).toBeInTheDocument();
   });
+
+  it('should only render elements that have data', async () => {
+    const reporterNoPhone = {
+      reporter: {
+        email: 'foo@bar.com',
+      },
+    };
+
+    const { queryByTestId, findByTestId, unmount, rerender } = render(
+      withAppContext(
+        <IncidentDetailContext.Provider value={{ incident: { ...incidentFixture, ...reporterNoPhone } }}>
+          <Detail {...props} />
+        </IncidentDetailContext.Provider>
+      )
+    );
+
+    await findByTestId('detail-title');
+
+    expect(queryByTestId('detail-phone-definition')).not.toBeInTheDocument();
+    expect(queryByTestId('detail-email-definition')).toBeInTheDocument();
+
+    unmount();
+
+    const reporterNoEmail = {
+      reporter: {
+        phone: '14020',
+      },
+    };
+
+    rerender(
+      withAppContext(
+        <IncidentDetailContext.Provider value={{ incident: { ...incidentFixture, ...reporterNoEmail } }}>
+          <Detail {...props} />
+        </IncidentDetailContext.Provider>
+      )
+    );
+
+    await findByTestId('detail-title');
+
+    expect(queryByTestId('detail-phone-definition')).toBeInTheDocument();
+    expect(queryByTestId('detail-email-definition')).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
This PR changes the order of the `phone` and `email` field values in the incident detail page. It also makes them conditionally visible.