### PR TITLE
[SIG-3078] AddNote component validation

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/components/AddNote/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/AddNote/index.js
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState, useRef, useContext } from 'react';
 import styled from 'styled-components';
-import { themeSpacing } from '@datapunt/asc-ui';
+import { themeSpacing, ErrorMessage } from '@datapunt/asc-ui';
 
 import Button from 'components/Button';
 import TextArea from 'components/TextArea';
@@ -16,17 +16,26 @@ const NoteButton = styled(Button)`
   margin: ${themeSpacing(8, 2, 4, 0)};
 `;
 
+const StyledErrorMessage = styled(ErrorMessage)`
+  font-family: Avenir Next LT W01 Demi;
+  font-weight: normal;
+`;
+
 const AddNote = () => {
   const { update } = useContext(IncidentDetailContext);
   const areaRef = useRef(null);
   const [showForm, setShowForm] = useState(false);
   const [note, setNote] = useState('');
+  const [error, setError] = useState();
 
   const handleSubmit = useCallback(
     event => {
       event.preventDefault();
 
-      if (note.trim() === '') return;
+      if (note.trim() === '') {
+        setError('Dit veld is verplicht');
+        return;
+      }
 
       const notes = [{ text: note }];
 
@@ -45,9 +54,13 @@ const AddNote = () => {
     event => {
       const value = event.target.value;
 
+      if (value.trim() !== '') {
+        setError('');
+      }
+
       setNote(value);
     },
-    [setNote]
+    [setNote, setError]
   );
 
   useEffect(() => {
@@ -76,9 +89,11 @@ const AddNote = () => {
       <form action="">
         <Label htmlFor="addNoteText">Notitie toevoegen</Label>
         <TextArea id="addNoteText" ref={areaRef} onChange={onChange} rows={10} data-testid="addNoteText" value={note} />
+
+        {error && <StyledErrorMessage data-testid="error" message={error} />}
+
         <NoteButton
           data-testid="addNoteSaveNoteButton"
-          disabled={!note}
           onClick={handleSubmit}
           type="submit"
           variant="secondary"

--- a/src/signals/incident-management/containers/IncidentDetail/components/AddNote/index.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/AddNote/index.test.js
@@ -74,7 +74,7 @@ describe('<AddNote />', () => {
   });
 
   it('should not call update when note field is empty', async () => {
-    const { getByTestId, findByTestId } = render(renderWithContext());
+    const { getByTestId, queryByTestId, findByTestId } = render(renderWithContext());
 
     act(() => {
       fireEvent.click(getByTestId('addNoteNewNoteButton'));
@@ -88,12 +88,14 @@ describe('<AddNote />', () => {
     });
 
     expect(update).not.toHaveBeenCalled();
+    expect(queryByTestId('error')).not.toBeInTheDocument();
 
     act(() => {
       fireEvent.click(saveNoteButton);
     });
 
     expect(update).not.toHaveBeenCalled();
+    expect(queryByTestId('error')).toBeInTheDocument();
   });
 
   it('should clear the textarea', async () => {


### PR DESCRIPTION
This PR makes the submit button for the `AddNote` component form always clickable. For visual feedback, an error message is shown when the text area is left empty when the form is submitted.