### PR TITLE
[SIG-1848] User history

### DIFF
--- a/src/signals/settings/categories/Detail/__tests__/Detail.test.js
+++ b/src/signals/settings/categories/Detail/__tests__/Detail.test.js
@@ -262,7 +262,7 @@ describe('signals/settings/categories/Detail', () => {
     );
 
     // on patch success, re-request all categories
-    await waitFor(() => getByTestId('detailCategoryForm'));
+    await findByTestId('detailCategoryForm');
 
     expect(dispatch).toHaveBeenCalledWith(fetchCategories());
   });
@@ -278,9 +278,9 @@ describe('signals/settings/categories/Detail', () => {
       categoryId,
     }));
 
-    const { getByTestId } = render(withAppContext(<CategoryDetailContainer />));
+    const { findByTestId, getByTestId } = render(withAppContext(<CategoryDetailContainer />));
 
-    await waitFor(() => getByTestId('detailCategoryForm'));
+    await findByTestId('detailCategoryForm');
     expect(getByTestId('detailCategoryForm')).toBeInTheDocument();
 
     const submitBtn = getByTestId('submitBtn');
@@ -292,7 +292,7 @@ describe('signals/settings/categories/Detail', () => {
     expect(dispatch).not.toHaveBeenCalled();
     expect(push).not.toHaveBeenCalled();
 
-    await waitFor(() => getByTestId('detailCategoryForm'));
+    await findByTestId('detailCategoryForm');
 
     expect(dispatch).toHaveBeenCalledWith(showGlobalNotification(expect.any(Object)));
 
@@ -304,9 +304,9 @@ describe('signals/settings/categories/Detail', () => {
       categoryId: undefined,
     }));
 
-    const { getByTestId } = render(withAppContext(<CategoryDetailContainer />));
+    const { findByTestId } = render(withAppContext(<CategoryDetailContainer />));
 
-    await waitFor(() => getByTestId('detailCategoryForm'));
+    await findByTestId('detailCategoryForm');
 
     expect(fetch).not.toHaveBeenLastCalledWith(expect.stringContaining('/history'), expect.any(Object));
 
@@ -320,7 +320,7 @@ describe('signals/settings/categories/Detail', () => {
 
     render(withAppContext(<CategoryDetailContainer />));
 
-    await waitFor(() => getByTestId('detailCategoryForm'));
+    await findByTestId('detailCategoryForm');
 
     expect(fetch).toHaveBeenLastCalledWith(expect.stringContaining('/history'), expect.any(Object));
   });

--- a/src/signals/settings/categories/Detail/components/CategoryForm/index.js
+++ b/src/signals/settings/categories/Detail/components/CategoryForm/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { themeSpacing, Row, Column, Select } from '@datapunt/asc-ui';
 import styled from 'styled-components';
 
+import { historyType } from 'shared/types';
 import RadioButtonList from 'signals/incident-management/components/RadioButtonList';
 
 import History from 'components/History';
@@ -183,15 +184,7 @@ CategoryForm.propTypes = {
       use_calendar_days: PropTypes.bool,
     }),
   }),
-  history: PropTypes.arrayOf(
-    PropTypes.shape({
-      identifier: PropTypes.string.isRequired,
-      when: PropTypes.string.isRequired,
-      what: PropTypes.string.isRequired,
-      action: PropTypes.string.isRequired,
-      who: PropTypes.string.isRequired,
-    })
-  ),
+  history: historyType,
   onCancel: PropTypes.func,
   onSubmitForm: PropTypes.func,
   /** When true, none of the fields in the form can be edited */

--- a/src/signals/settings/hooks/useFetchResponseNotification.js
+++ b/src/signals/settings/hooks/useFetchResponseNotification.js
@@ -54,10 +54,12 @@ const useFetchResponseNotification = ({ entityName, error, isExisting, isLoading
   }, [entityName, error, isExisting, isLoading, isSuccess, showNotification]);
 
   useEffect(() => {
+    if (isLoading) return;
+
     if (isSuccess && redirectURL) {
       history.push(redirectURL);
     }
-  }, [history, isSuccess, redirectURL]);
+  }, [history, isSuccess, redirectURL, isLoading]);
 };
 
 export default useFetchResponseNotification;

--- a/src/signals/settings/hooks/useFetchResponseNotification.js
+++ b/src/signals/settings/hooks/useFetchResponseNotification.js
@@ -2,11 +2,7 @@ import { useDispatch } from 'react-redux';
 import { useCallback, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 
-import {
-  TYPE_LOCAL,
-  VARIANT_ERROR,
-  VARIANT_SUCCESS,
-} from 'containers/Notification/constants';
+import { TYPE_LOCAL, VARIANT_ERROR, VARIANT_SUCCESS } from 'containers/Notification/constants';
 import { showGlobalNotification } from 'containers/App/actions';
 
 /**
@@ -23,14 +19,7 @@ import { showGlobalNotification } from 'containers/App/actions';
  * @param {String} options.redirectURL - URL to which the push should be directed when isSuccess is truthy
  * @returns {void}
  */
-const useFetchResponseNotification = ({
-  entityName,
-  error,
-  isExisting,
-  isLoading,
-  isSuccess,
-  redirectURL,
-}) => {
+const useFetchResponseNotification = ({ entityName, error, isExisting, isLoading, isSuccess, redirectURL }) => {
   const dispatch = useDispatch();
   const history = useHistory();
   const showNotification = useCallback(
@@ -58,26 +47,17 @@ const useFetchResponseNotification = ({
 
     if (isSuccess) {
       const entityLabel = entityName || 'Gegevens';
-      message = isExisting ?
-        `${entityLabel} bijgewerkt` :
-        `${entityLabel} toegevoegd`;
+      message = isExisting ? `${entityLabel} bijgewerkt` : `${entityLabel} toegevoegd`;
     }
 
     showNotification(variant, message);
+  }, [entityName, error, isExisting, isLoading, isSuccess, showNotification]);
 
+  useEffect(() => {
     if (isSuccess && redirectURL) {
       history.push(redirectURL);
     }
-  }, [
-    entityName,
-    error,
-    history,
-    isExisting,
-    isLoading,
-    isSuccess,
-    redirectURL,
-    showNotification,
-  ]);
+  }, [history, isSuccess, redirectURL]);
 };
 
 export default useFetchResponseNotification;

--- a/src/signals/settings/users/Detail/__tests__/Detail.test.js
+++ b/src/signals/settings/users/Detail/__tests__/Detail.test.js
@@ -420,7 +420,7 @@ describe('signals/settings/users/containers/Detail', () => {
     expect(push).toHaveBeenCalledWith(expect.stringContaining(routes.users));
   });
 
-  it.only('should push to correct URL when cancel button is clicked and form data is pristine', async () => {
+  it('should push to correct URL when cancel button is clicked and form data is pristine', async () => {
     const referrer = '/some-page-we-came-from';
     jest.spyOn(reactRouterDom, 'useLocation').mockImplementation(() => ({ referrer }));
 

--- a/src/signals/settings/users/Detail/__tests__/Detail.test.js
+++ b/src/signals/settings/users/Detail/__tests__/Detail.test.js
@@ -62,6 +62,8 @@ describe('signals/settings/users/containers/Detail', () => {
     jest.spyOn(reactRouterDom, 'useHistory').mockImplementation(() => ({ push }));
     jest.spyOn(appSelectors, 'makeSelectUserCan').mockImplementation(() => () => true);
     jest.spyOn(reactRouterDom, 'useParams').mockImplementation(() => ({ userId: userFixture.id }));
+
+    fetch.mockResponseOnce(JSON.stringify(userFixture)).mockResponseOnce(JSON.stringify(historyFixture));
   });
 
   afterEach(() => {
@@ -70,8 +72,6 @@ describe('signals/settings/users/containers/Detail', () => {
   });
 
   it('should render a backlink', async () => {
-    fetch.mockResponseOnce(JSON.stringify(userFixture)).mockResponseOnce(JSON.stringify(historyFixture));
-
     const referrer = '/some-page-we-came-from';
     const { findByTestId, getByTestId, rerender, unmount } = render(withAppContext(<UserDetail />));
 
@@ -91,8 +91,6 @@ describe('signals/settings/users/containers/Detail', () => {
   });
 
   it('should render the correct title', async () => {
-    fetch.mockResponseOnce(JSON.stringify(userFixture)).mockResponseOnce(JSON.stringify(historyFixture));
-
     jest.spyOn(reactRouterDom, 'useParams').mockImplementation(() => ({ userId: undefined }));
 
     const { findByText, rerender, unmount } = render(withAppContext(<UserDetail />));
@@ -113,8 +111,6 @@ describe('signals/settings/users/containers/Detail', () => {
   });
 
   it('should get user and history data', async () => {
-    fetch.mockResponseOnce(JSON.stringify(userFixture)).mockResponseOnce(JSON.stringify(historyFixture));
-
     const { findByTestId } = render(withAppContext(<UserDetail />));
 
     await findByTestId('userDetailFormContainer');
@@ -131,8 +127,6 @@ describe('signals/settings/users/containers/Detail', () => {
   });
 
   it('should render a loading indicator', async () => {
-    fetch.mockResponseOnce(JSON.stringify(userFixture)).mockResponseOnce(JSON.stringify(historyFixture));
-
     const { findByTestId, getByTestId, queryByTestId } = render(withAppContext(<UserDetail />));
 
     expect(getByTestId('loadingIndicator')).toBeInTheDocument();
@@ -143,8 +137,6 @@ describe('signals/settings/users/containers/Detail', () => {
   });
 
   it('should not render a form when the data from the API is not yet available', async () => {
-    fetch.mockResponseOnce(JSON.stringify(userFixture)).mockResponseOnce(JSON.stringify(historyFixture));
-
     jest.spyOn(reactRouterDom, 'useParams').mockImplementation(() => ({ userId }));
 
     const { findByTestId, queryByTestId } = render(withAppContext(<UserDetail />));
@@ -157,8 +149,6 @@ describe('signals/settings/users/containers/Detail', () => {
   });
 
   it('should render a form when the URL does not contain a user ID', async () => {
-    fetch.mockResponseOnce(JSON.stringify(userFixture)).mockResponseOnce(JSON.stringify(historyFixture));
-
     jest.spyOn(reactRouterDom, 'useParams').mockImplementation(() => ({ userId: undefined }));
 
     const { findByTestId, getByTestId } = render(withAppContext(<UserDetail />));
@@ -169,8 +159,6 @@ describe('signals/settings/users/containers/Detail', () => {
   });
 
   it('should not patch user data on submit when form data has not been altered', async () => {
-    fetch.mockResponseOnce(JSON.stringify(userFixture)).mockResponseOnce(JSON.stringify(historyFixture));
-
     const { findByTestId, getByTestId } = render(withAppContext(<UserDetail />));
 
     await findByTestId('userDetailFormContainer');
@@ -195,8 +183,6 @@ describe('signals/settings/users/containers/Detail', () => {
   });
 
   it('should patch user data on submit', async () => {
-    fetch.mockResponseOnce(JSON.stringify(userFixture)).mockResponseOnce(JSON.stringify(historyFixture));
-
     const { findByTestId, getByTestId } = render(withAppContext(<UserDetail />));
 
     await findByTestId('userDetailFormContainer');
@@ -226,8 +212,6 @@ describe('signals/settings/users/containers/Detail', () => {
   });
 
   it('should NOT patch user data on submit when user does not have permissions', async () => {
-    fetch.mockResponseOnce(JSON.stringify(userFixture)).mockResponseOnce(JSON.stringify(historyFixture));
-
     jest.spyOn(appSelectors, 'makeSelectUserCan').mockImplementation(() => () => false);
 
     const { findByTestId, getByTestId } = render(withAppContext(<UserDetail />));
@@ -261,8 +245,6 @@ describe('signals/settings/users/containers/Detail', () => {
   });
 
   it('should post user data on submit', async () => {
-    fetch.mockResponseOnce(JSON.stringify(userFixture)).mockResponseOnce(JSON.stringify(historyFixture));
-
     jest.spyOn(reactRouterDom, 'useParams').mockImplementation(() => ({ userId: undefined }));
 
     const { findByTestId, getByTestId } = render(withAppContext(<UserDetail />));
@@ -307,8 +289,6 @@ describe('signals/settings/users/containers/Detail', () => {
   });
 
   it('should NOT post user data on submit when user does not have permissions', async () => {
-    fetch.mockResponseOnce(JSON.stringify(userFixture)).mockResponseOnce(JSON.stringify(historyFixture));
-
     jest.spyOn(appSelectors, 'makeSelectUserCan').mockImplementation(() => () => false);
 
     jest.spyOn(reactRouterDom, 'useParams').mockImplementation(() => ({ userId: undefined }));
@@ -331,9 +311,9 @@ describe('signals/settings/users/containers/Detail', () => {
   });
 
   it('should convert stringified booleans to boolean values', async () => {
-    fetch
-      .mockResponseOnce(JSON.stringify({ ...userFixture, is_active: false }))
-      .mockResponseOnce(JSON.stringify(historyFixture));
+    fetch.resetMocks();
+
+    fetch.once(JSON.stringify({ ...userFixture, is_active: false })).once(JSON.stringify(historyFixture));
 
     const { findByTestId, getByTestId } = render(withAppContext(<UserDetail />));
 
@@ -377,8 +357,6 @@ describe('signals/settings/users/containers/Detail', () => {
   it('should direct to the overview page when cancel button is clicked and form data is pristine', async () => {
     jest.spyOn(reactRouterDom, 'useLocation').mockImplementation(() => ({}));
 
-    fetch.mockResponseOnce(JSON.stringify(userFixture)).mockResponseOnce(JSON.stringify(historyFixture));
-
     global.window.confirm = jest.fn();
 
     const { findByTestId, rerender, getByTestId } = render(withAppContext(<UserDetail />));
@@ -412,8 +390,6 @@ describe('signals/settings/users/containers/Detail', () => {
   it('should direct to the overview page when cancel button is clicked and form data is NOT pristine', async () => {
     jest.spyOn(reactRouterDom, 'useLocation').mockImplementation(() => ({}));
 
-    fetch.mockResponseOnce(JSON.stringify(userFixture)).mockResponseOnce(JSON.stringify(historyFixture));
-
     global.window.confirm = jest.fn();
 
     const { findByTestId, getByTestId } = render(withAppContext(<UserDetail />));
@@ -444,11 +420,9 @@ describe('signals/settings/users/containers/Detail', () => {
     expect(push).toHaveBeenCalledWith(expect.stringContaining(routes.users));
   });
 
-  it('should push to correct URL when cancel button is clicked and form data is pristine', async () => {
+  it.only('should push to correct URL when cancel button is clicked and form data is pristine', async () => {
     const referrer = '/some-page-we-came-from';
     jest.spyOn(reactRouterDom, 'useLocation').mockImplementation(() => ({ referrer }));
-
-    fetch.mockResponseOnce(JSON.stringify(userFixture)).mockResponseOnce(JSON.stringify(historyFixture));
 
     global.window.confirm = jest.fn();
 

--- a/src/signals/settings/users/Detail/components/UserForm/index.js
+++ b/src/signals/settings/users/Detail/components/UserForm/index.js
@@ -4,7 +4,7 @@ import { useSelector } from 'react-redux';
 import { themeSpacing, Row, Column } from '@datapunt/asc-ui';
 import styled from 'styled-components';
 
-import { userType } from 'shared/types';
+import { userType, historyType } from 'shared/types';
 
 import { rolesModelSelector, inputCheckboxRolesSelector } from 'models/roles/selectors';
 
@@ -16,6 +16,7 @@ import Input from 'components/Input';
 import Label from 'components/Label';
 import TextArea from 'components/TextArea';
 import FormFooter from 'components/FormFooter';
+import History from 'components/History';
 
 const Form = styled.form`
   width: 100%;
@@ -28,6 +29,10 @@ const StyledColumn = styled(Column).attrs({
 `;
 
 const FieldGroup = styled.div`
+  @media (max-width: ${({ theme }) => theme.layouts.large.min}px) {
+    margin-top: ${themeSpacing(8)};
+  }
+
   & + & {
     margin-top: ${themeSpacing(8)};
   }
@@ -42,27 +47,28 @@ const statusOptions = [
   { key: 'false', value: 'Niet actief' },
 ];
 
+const StyledHistory = styled(History)`
+  h2 {
+    font-size: 16px;
+  }
+`;
+
 const DEFAULT_STATUS_OPTION = 'true';
 
 const reducer = (state, { field, value }) => ({ ...state, [field]: value });
 
-const UserForm = ({ data, onCancel, onSubmit, readOnly }) => {
+const UserForm = ({ data, history, onCancel, onSubmit, readOnly }) => {
   const inputRoles = useSelector(inputCheckboxRolesSelector);
   const roles = useSelector(rolesModelSelector).list;
-
   const departments = useSelector(makeSelectDepartments);
   const departmentList = departments.list.map(({ id, name }) => ({ id: String(id), value: name }));
 
-  const userDepartments = data
-    ?.profile
-    ?.departments
-    ?.map(department => departmentList.find(({ value }) => value === department))
-    .filter(Boolean) || [];
+  const userDepartments =
+    data?.profile?.departments
+      ?.map(department => departmentList.find(({ value }) => value === department))
+      .filter(Boolean) || [];
 
-  const userRoles = data
-    ?.roles
-    ?.map(role => inputRoles.find(({ name }) => name === role.name))
-    .filter(Boolean) || [];
+  const userRoles = data?.roles?.map(role => inputRoles.find(({ name }) => name === role.name)).filter(Boolean) || [];
 
   const [state, dispatch] = React.useReducer(reducer, {
     username: data.username,
@@ -74,13 +80,19 @@ const UserForm = ({ data, onCancel, onSubmit, readOnly }) => {
     roles: userRoles,
   });
 
-  const onChangeEvent = useCallback(event => {
-    onChange(event.target.name, event.target.value);
-  }, [onChange]);
+  const onChangeEvent = useCallback(
+    event => {
+      onChange(event.target.name, event.target.value);
+    },
+    [onChange]
+  );
 
-  const onChange = useCallback((field, value) => {
-    dispatch({ field, value });
-  }, [dispatch]);
+  const onChange = useCallback(
+    (field, value) => {
+      dispatch({ field, value });
+    },
+    [dispatch]
+  );
 
   const getFormData = useCallback(() => {
     const form = { ...data, profile: { ...data.profile } };
@@ -107,106 +119,125 @@ const UserForm = ({ data, onCancel, onSubmit, readOnly }) => {
     return { form, postPatch };
   }, [data, roles, state]);
 
-  const onSubmitForm = useCallback(event => {
-    event.preventDefault();
-    onSubmit(getFormData());
-  }, [getFormData, onSubmit]);
+  const onSubmitForm = useCallback(
+    event => {
+      event.preventDefault();
+      onSubmit(getFormData());
+    },
+    [getFormData, onSubmit]
+  );
 
-  const onCancelForm = useCallback(event => {
-    event.preventDefault();
-    onCancel(getFormData());
-  }, [getFormData, onCancel]);
+  const onCancelForm = useCallback(
+    event => {
+      event.preventDefault();
+      onCancel(getFormData());
+    },
+    [getFormData, onCancel]
+  );
 
   return (
     <Form action="" data-testid="detailUserForm">
       <Row>
         <StyledColumn>
-          <FieldGroup>
-            <Input
-              value={state.username}
-              id="username"
-              name="username"
-              label="E-mailadres"
-              disabled={data.username !== undefined || readOnly}
-              readOnly={readOnly}
-              onChange={onChangeEvent}
-            />
-          </FieldGroup>
+          <div>
+            <FieldGroup>
+              <Input
+                disabled={data.username !== undefined || readOnly}
+                id="username"
+                label="E-mailadres"
+                name="username"
+                onChange={onChangeEvent}
+                readOnly={readOnly}
+                type="text"
+                value={state.username}
+              />
+            </FieldGroup>
 
-          <FieldGroup>
-            <Input
-              value={state.first_name}
-              id="first_name"
-              name="first_name"
-              label="Voornaam"
-              disabled={readOnly}
-              onChange={onChangeEvent}
-            />
-          </FieldGroup>
+            <FieldGroup>
+              <Input
+                disabled={readOnly}
+                id="first_name"
+                label="Voornaam"
+                name="first_name"
+                onChange={onChangeEvent}
+                type="text"
+                value={state.first_name}
+              />
+            </FieldGroup>
 
-          <FieldGroup>
-            <Input
-              value={state.last_name}
-              id="last_name"
-              name="last_name"
-              label="Achternaam"
-              disabled={readOnly}
-              onChange={onChangeEvent}
-            />
-          </FieldGroup>
+            <FieldGroup>
+              <Input
+                disabled={readOnly}
+                id="last_name"
+                label="Achternaam"
+                name="last_name"
+                onChange={onChangeEvent}
+                type="text"
+                value={state.last_name}
+              />
+            </FieldGroup>
 
-          <FieldGroup>
-            <Label as="span">Status</Label>
-            <RadioButtonList
-              defaultValue={state.is_active}
-              groupName="is_active"
-              hasEmptySelectionButton={false}
-              options={statusOptions}
-              disabled={readOnly}
-              onChange={(field, { key: value }) => { onChange(field, value); }}
-            />
-          </FieldGroup>
+            <FieldGroup>
+              <Label as="span">Status</Label>
+              <RadioButtonList
+                defaultValue={state.is_active}
+                groupName="is_active"
+                hasEmptySelectionButton={false}
+                options={statusOptions}
+                disabled={readOnly}
+                onChange={(field, { key: value }) => {
+                  onChange(field, value);
+                }}
+              />
+            </FieldGroup>
 
-          <FieldGroup>
-            <Label as="span">Rollen</Label>
-            <CheckboxList
-              defaultValue={state.roles}
-              disabled={readOnly}
-              groupName="roles"
-              name="roles"
-              options={inputRoles}
-              onChange={(field, value) => { onChange(field, value); }}
-            />
-          </FieldGroup>
+            <FieldGroup>
+              <Label as="span">Rollen</Label>
+              <CheckboxList
+                defaultValue={state.roles}
+                disabled={readOnly}
+                groupName="roles"
+                name="roles"
+                options={inputRoles}
+                onChange={(field, value) => {
+                  onChange(field, value);
+                }}
+              />
+            </FieldGroup>
 
-          <FieldGroup>
-            <Label as="span">Afdeling</Label>
-            <CheckboxList
-              defaultValue={state.departments}
-              disabled={readOnly}
-              groupName="departments"
-              name="departments"
-              options={departmentList}
-              onChange={(field, value) => { onChange(field, value); }}
-            />
-          </FieldGroup>
+            <FieldGroup>
+              <Label as="span">Afdeling</Label>
+              <CheckboxList
+                defaultValue={state.departments}
+                disabled={readOnly}
+                groupName="departments"
+                name="departments"
+                options={departmentList}
+                onChange={(field, value) => {
+                  onChange(field, value);
+                }}
+              />
+            </FieldGroup>
+          </div>
         </StyledColumn>
 
         <StyledColumn push={{ small: 0, medium: 0, big: 0, large: 1, xLarge: 1 }}>
-          <FieldGroup>
-            <Label as="span">Notitie</Label>
-            <TextArea
-              disabled={readOnly}
-              value={state.note}
-              id="note"
-              name="note"
-              rows="8"
-              onChange={onChangeEvent}
-            />
-          </FieldGroup>
-        </StyledColumn>
+          <div>
+            <FieldGroup>
+              <Label as="span">Notitie</Label>
+              <TextArea
+                disabled={readOnly}
+                value={state.note}
+                id="note"
+                name="note"
+                rows="8"
+                onChange={onChangeEvent}
+              />
+            </FieldGroup>
 
-        <Column span={{ small: 0, medium: 0, big: 0, large: 1, xLarge: 1 }} />
+            <FieldGroup>{history && <StyledHistory list={history} />}</FieldGroup>
+          </div>
+        </StyledColumn>
 
         {!readOnly && (
           <StyledFormFooter
@@ -230,6 +261,7 @@ UserForm.defaultProps = {
 
 UserForm.propTypes = {
   data: userType,
+  history: historyType,
   /**
    * Callback handler called whenever form is canceled
    * @param {Object} form data

--- a/src/signals/settings/users/Detail/index.js
+++ b/src/signals/settings/users/Detail/index.js
@@ -30,6 +30,7 @@ const UserDetail = () => {
 
   const isExistingUser = userId !== undefined;
   const { isLoading, isSuccess, error, data, get, patch, post } = useFetch();
+  const history = useFetch();
   const shouldRenderForm = !isExistingUser || (isExistingUser && Boolean(data));
   const redirectURL = location.referrer || routes.users;
   const userCanSubmitForm = (isExistingUser && userCan('change_user')) || (!isExistingUser && userCan('add_user'));
@@ -47,21 +48,23 @@ const UserDetail = () => {
   useEffect(() => {
     if (userId) {
       get(`${configuration.USERS_ENDPOINT}${userId}`);
+      history.get(`${configuration.USERS_ENDPOINT}${userId}/history`);
     }
     // disabling linter; only need to execute on mount
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const onSubmit = useCallback(formData => {
-    if (isEqual(data, formData.form)) return;
+  const onSubmit = useCallback(
+    formData => {
+      if (isEqual(data, formData.form)) return;
 
-    if (isExistingUser) {
-      patch(`${configuration.USERS_ENDPOINT}${userId}`, formData.postPatch);
-    } else {
-      post(configuration.USERS_ENDPOINT, formData.postPatch);
-    }
-  },
-  [data, isExistingUser, patch, post, userId]
+      if (isExistingUser) {
+        patch(`${configuration.USERS_ENDPOINT}${userId}`, formData.postPatch);
+      } else {
+        post(configuration.USERS_ENDPOINT, formData.postPatch);
+      }
+    },
+    [data, isExistingUser, patch, post, userId]
   );
 
   const onCancel = useCallback(
@@ -80,10 +83,11 @@ const UserDetail = () => {
 
       {isLoading && <LoadingIndicator />}
 
-      <FormContainer>
+      <FormContainer data-testid="userDetailFormContainer">
         {shouldRenderForm && (
           <UserForm
             data={data}
+            history={history.data}
             onCancel={onCancel}
             onSubmit={onSubmit}
             readOnly={!userCanSubmitForm}


### PR DESCRIPTION
This PR contains changes that render a user's edit history in the user detail page. For that, this PR:
- Adds an extra request to the `UserDetail` component to retrieve the history
- Applies layout changes to the `UserForm` component so that its children are properly aligned
- Rewrites all the tests for the `UserDetail` component
- Applies a fix to the `useFetchResponseNotification` hook that prevents unnecessary rerenders for every component that uses that hook.