### PR TITLE
Remove reference to Amsterdam.

### DIFF
--- a/src/signals/incident-management/definitions/typesList.js
+++ b/src/signals/incident-management/definitions/typesList.js
@@ -15,7 +15,7 @@ export default [
     value: 'Vraag',
     info: 'Een verzoek om informatie (van wie is die camera, waarom zijn de paaltjes weggehaald, etc).',
   },
-  { key: 'COM', value: 'Klacht', info: 'Een uiting van ongenoegen over het handelen van de gemeente Amsterdam.' },
+  { key: 'COM', value: 'Klacht', info: 'Een uiting van ongenoegen over het handelen van de gemeente.' },
   {
     key: 'MAI',
     value: 'Groot onderhoud',


### PR DESCRIPTION
closes Signalen/frontend#72

Remove reference to Amsterdam which was still left in the description of a type.