### PR TITLE
(Fix) History alignment

### DIFF
--- a/src/components/History/index.js
+++ b/src/components/History/index.js
@@ -36,7 +36,7 @@ const Time = styled.div`
 
 const Action = styled.div`
   color: ${themeColor('tint', 'level7')};
-  white-space: pre-wrap;
+  white-space: pre-line;
 
   @media (min-width: ${({ theme }) => theme.layouts.medium.max}px) {
     grid-column-start: 3;


### PR DESCRIPTION
This one-liner changes the alignment of the `History` definition list from:
![Screenshot 2020-09-02 at 09 32 52](https://user-images.githubusercontent.com/1062191/91946102-74e1eb80-ecff-11ea-9482-bc5b0701c201.png)

to:
![Screenshot 2020-09-02 at 09 33 53](https://user-images.githubusercontent.com/1062191/91946144-77dcdc00-ecff-11ea-96f3-6703a1dad62f.png)
