### PR TITLE
[SIG-3094] Phone/email label visibility

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/components/Detail/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/Detail/index.js
@@ -77,19 +77,15 @@ const Detail = ({ attachments }) => {
 
         {memoIncident.extra_properties && <ExtraProperties items={memoIncident.extra_properties} />}
 
-        {incident.reporter.phone && (
-          <Fragment>
-            <dt data-testid="detail-phone-definition">Telefoon melder</dt>
-            <dd data-testid="detail-phone-value">{incident.reporter.phone}</dd>
-          </Fragment>
-        )}
+        <Fragment>
+          <dt data-testid="detail-phone-definition">Telefoon melder</dt>
+          <dd data-testid="detail-phone-value">{incident.reporter.phone}</dd>
+        </Fragment>
 
-        {incident.reporter.email && (
-          <Fragment>
-            <dt data-testid="detail-email-definition">E-mail melder</dt>
-            <dd data-testid="detail-email-value">{incident.reporter.email}</dd>
-          </Fragment>
-        )}
+        <Fragment>
+          <dt data-testid="detail-email-definition">E-mail melder</dt>
+          <dd data-testid="detail-email-value">{incident.reporter.email}</dd>
+        </Fragment>
 
         <dt data-testid="detail-sharing-definition">Toestemming contactgegevens delen</dt>
         <dd data-testid="detail-sharing-value">{incident.reporter.sharing_allowed ? 'Ja' : 'Nee'}</dd>

--- a/src/signals/incident-management/containers/IncidentDetail/components/Detail/index.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/Detail/index.test.js
@@ -69,7 +69,7 @@ describe('<Detail />', () => {
 
     await findByTestId('detail-title');
 
-    expect(queryByTestId('detail-phone-definition')).not.toBeInTheDocument();
+    expect(queryByTestId('detail-phone-definition')).toBeInTheDocument();
     expect(queryByTestId('detail-email-definition')).toBeInTheDocument();
 
     unmount();
@@ -91,6 +91,6 @@ describe('<Detail />', () => {
     await findByTestId('detail-title');
 
     expect(queryByTestId('detail-phone-definition')).toBeInTheDocument();
-    expect(queryByTestId('detail-email-definition')).not.toBeInTheDocument();
+    expect(queryByTestId('detail-email-definition')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
This PR ensures that both phone and email labels in the incident detail page are always visible, regardless of presence of value for those fields.