### PR TITLE
(Chore) Fix useFetch hook internal handlers

### DIFF
--- a/src/components/MapStatic/index.js
+++ b/src/components/MapStatic/index.js
@@ -85,9 +85,7 @@ const MapStatic = ({
 
   useEffect(() => {
     get(configuration.STATIC_MAP_SERVER_URL, params, { responseType: 'blob' });
-    // only execute on mount; disabling linter
-    // eslint-disable-next-line
-  }, []);
+  }, [get, params]);
 
   useEffect(() => {
     if (!data) return;

--- a/src/signals/incident-management/containers/IncidentOverviewPage/components/Map/index.js
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/components/Map/index.js
@@ -103,14 +103,14 @@ const OverviewMap = ({ showPanelOnInit, ...rest }) => {
   const [layerInstance, setLayerInstance] = useState();
   const [incidentId, setIncidentId] = useState(0);
 
-  const { ...params } = filterParams;
-
-  // fixed query period (24 hours)
-  params.created_after = useMemo(() => format(subDays(new Date(), -1), "yyyy-MM-dd'T'HH:mm:ss"), []);
-  params.created_before = useMemo(() => format(new Date(), "yyyy-MM-dd'T'HH:mm:ss"), []);
-
-  // fixed page size (default is 50; 4000 is 2.5 times the highest daily average)
-  params.page_size = 4000;
+  const params = useMemo(() => ({
+    ...filterParams,
+    // fixed query period (24 hours)
+    created_after: format(subDays(new Date(), -1), "yyyy-MM-dd'T'HH:mm:ss"),
+    created_before: format(new Date(), "yyyy-MM-dd'T'HH:mm:ss"),
+    // fixed page size (default is 50; 4000 is 2.5 times the highest daily average)
+    page_size: 4000,
+  }), [filterParams]);
 
   /**
    * AutoSuggest callback handler
@@ -161,7 +161,7 @@ const OverviewMap = ({ showPanelOnInit, ...rest }) => {
     get(`${configuration.GEOGRAPHY_ENDPOINT}`, params);
     setInitialMount(true);
     // eslint-disable-next-line
-  }, []);
+  }, [get]);
 
   useEffect(() => {
     if (!data || !layerInstance) return () => {};

--- a/src/signals/incident-management/containers/IncidentSplitContainer/services/useFetchIncident/index.js
+++ b/src/signals/incident-management/containers/IncidentSplitContainer/services/useFetchIncident/index.js
@@ -26,11 +26,10 @@ const useFetchIncident = id => {
 
   useEffect(() => {
     if (!id) return;
+
     getIncident(`${CONFIGURATION.INCIDENTS_ENDPOINT}${id}`);
     getIncidentAttachments(`${CONFIGURATION.INCIDENTS_ENDPOINT}${id}/attachments`);
-    // Disable linter to prevent infinite loop; only need to execute on `id` change;
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [id]);
+  }, [id, getIncident, getIncidentAttachments]);
 
   return { isLoading, incident, attachments: attachments?.results?.slice(0, 3) };
 };


### PR DESCRIPTION
This PR fixes a couple of issues with regards of the use of the `useFetch` hook by components.

First of all, the `AbortController` in the `useFetch` hook could not be used as a internal hook dependency, because it was regenerated at every render. To overcome this, the `useMemo` hook was used. That also applied to the `requestHeaders` variable.
Memoizing the `AbortController` instance allowed for setting it as a dependency of the `useEffect` hook. This ensures that the correct object instance is called when a component unmounts.

Second, the internal `get` and `modify` methods weren't wrapped in a `useCallback` hook and thus returned a new instance with every consecutive render and could not be used as dependency by components that implemented `useFetch`.

As a bonus, the `PUT` method is implemented and the `useFetch()` hook now return the `get`, `post`, `patch` and `put` functions.