### PR TITLE
Make the map tiles subdomains config optional

### DIFF
--- a/internals/schemas/environment.conf.schema.json
+++ b/internals/schemas/environment.conf.schema.json
@@ -580,7 +580,6 @@
       },
       "required": [
         "attribution",
-        "subdomains",
         "tms"
       ],
       "title": "TilesOptions"


### PR DESCRIPTION
The configuration option `map` > `tiles` > `options` > `subdomains` should be optional. Currently only Amsterdam is using it.