### PR TITLE
[SIG-3103] Fix incident date filter

### DIFF
--- a/src/signals/shared/filter/__tests__/parse.test.js
+++ b/src/signals/shared/filter/__tests__/parse.test.js
@@ -4,12 +4,37 @@ import categories from 'utils/__tests__/fixtures/categories_private.json';
 import { filterForSub, filterForMain } from 'models/categories/selectors';
 import dataLists from 'signals/incident-management/definitions';
 
-import { parseOutputFormData, parseInputFormData, parseToAPIData } from '../parse';
+import { parseDate, parseOutputFormData, parseInputFormData, parseToAPIData } from '../parse';
 
 const filteredSubCategories = categories.results.filter(filterForSub);
 const filteredMainCategories = categories.results.filter(filterForMain);
 
 describe('signals/shared/filter/parse', () => {
+  describe('parseDate', () => {
+    const dateString = '2019-12-10';
+    const timeString = '00:00:00';
+    const dateWithTimeString = `${dateString}T${timeString}`;
+
+    const emptyValues = ['', null, false, undefined];
+    const invalidDateStrings = [...emptyValues, '2019-12-100', 'invalid date', '1923'];
+
+    it('should parse date without time string', () => {
+      expect(parseDate(dateString, timeString)).toEqual(dateWithTimeString);
+    });
+
+    it('should parse date with time string', () => {
+      expect(parseDate(dateWithTimeString, timeString)).toEqual(dateWithTimeString);
+    });
+
+    it('should return `null` on an invalid date or empty time string', () => {
+      invalidDateStrings.forEach(invalidDate => expect(parseDate(invalidDate, timeString)).toEqual(null));
+    });
+
+    it('should return `null` on an empty time string', () => {
+      emptyValues.forEach(emptyTimeString => expect(parseDate(dateString, emptyTimeString)).toEqual(null));
+    });
+  });
+
   describe('parseOutputFormData', () => {
     it('should parse output FormData', () => {
       const mainCategories = filteredMainCategories.filter(

--- a/src/signals/shared/filter/parse.js
+++ b/src/signals/shared/filter/parse.js
@@ -17,6 +17,16 @@ const arrayFields = [
   'type',
 ];
 
+export const parseDate = (dateString, timeString) => {
+  if (!dateString || !timeString) return null;
+
+  const strippedDateString = dateString.replace(new RegExp(`T${timeString}$`), '');
+  const parsedDate = parse(strippedDateString, 'yyyy-MM-dd', new Date());
+  if (isValid(parsedDate)) return `${format(parsedDate, 'yyyy-MM-dd')}T${timeString}`;
+
+  return null;
+};
+
 /**
  * Parse form data for consumption by global store actions
  *
@@ -35,7 +45,6 @@ export const parseOutputFormData = options =>
       case 'maincategory_slug':
         entryValue = value.map(({ slug }) => slug);
         break;
-
       case 'contact_details':
       case 'priority':
       case 'source':
@@ -45,21 +54,12 @@ export const parseOutputFormData = options =>
       case 'type':
         entryValue = value.map(({ key: itemKey }) => itemKey);
         break;
-
       case 'created_after':
-        if (isValid(parse(options.created_after, 'yyyy-MM-dd', new Date()))) {
-          entryValue = `${format(parse(options.created_after, 'yyyy-MM-dd', new Date()), 'yyyy-MM-dd')}T00:00:00`;
-        }
-
+        entryValue = parseDate(options.created_after, '00:00:00');
         break;
-
       case 'created_before':
-        if (isValid(parse(options.created_before, 'yyyy-MM-dd', new Date()))) {
-          entryValue = `${format(parse(options.created_before, 'yyyy-MM-dd', new Date()), 'yyyy-MM-dd')}T23:59:59`;
-        }
-
+        entryValue = parseDate(options.created_before, '23:59:59');
         break;
-
       default:
         entryValue = value;
     }


### PR DESCRIPTION
IMHO the backend should accept dates without the timestamps so we don't need this prone to error logic on the front-end.

When the dates from the filter form are stored the reducer will append time strings to the dates.

When a user re-opens the filter form when dates are stored, the reducer assumes dates without time string,s this pull request fixes this by stripping the time string before the date gets further processed by the reducer.