### PR TITLE
(Chore) Skip Cypress binary install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ COPY .gitignore \
       /app/
 
 # Install NPM dependencies, cleaning cache afterwards:
-RUN npm --production=false --unsafe-perm --no-progress ci && npm cache clean --force
+RUN CYPRESS_INSTALL_BINARY=0 npm --production=false --unsafe-perm --no-progress ci && npm cache clean --force
 
 COPY src /app/src
 


### PR DESCRIPTION
This PR makes sure that the Cypres binary is not installed when `npm i` is run in the Dockerfile