### PR TITLE
[SIG-2866] Regie filter block

### DIFF
--- a/src/signals/incident-management/components/CheckboxList/index.js
+++ b/src/signals/incident-management/components/CheckboxList/index.js
@@ -1,7 +1,9 @@
 import React, { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
-import { Checkbox, themeSpacing } from '@datapunt/asc-ui';
+import { themeSpacing } from '@datapunt/asc-ui';
+
+import Checkbox from 'components/Checkbox';
 import * as types from 'shared/types';
 
 const FilterGroup = styled.div`
@@ -45,6 +47,8 @@ const StyledCheckbox = styled(Checkbox)`
 `;
 
 const Wrapper = styled.div`
+  padding: 6px 14px 6px 0;
+
   ${({ disabled }) =>
     disabled &&
     css`

--- a/src/signals/incident-management/components/FilterForm/__tests__/FilterForm.test.js
+++ b/src/signals/incident-management/components/FilterForm/__tests__/FilterForm.test.js
@@ -206,6 +206,13 @@ describe('signals/incident-management/components/FilterForm', () => {
     expect(container.querySelectorAll('input[type="checkbox"][name="source"]')).toHaveLength(dataLists.source.length);
   });
 
+  it('should render a list of directing_department options', () => {
+    const { container, getByText } = render(withContext(<FilterForm {...formProps} />));
+
+    expect(getByText('Regie hoofdmelding')).toBeInTheDocument();
+    expect(container.querySelectorAll('input[type="checkbox"][name="directing_department"]')).toHaveLength(dataLists.directing_department.length);
+  });
+
   it('should render a list of source options with feature flag enabled', async () => {
     configuration.fetchSourcesFromBackend = true;
     const { container, findByTestId } = render(withContext(<FilterForm {...formProps} />, null, sources));

--- a/src/signals/incident-management/components/FilterForm/index.js
+++ b/src/signals/incident-management/components/FilterForm/index.js
@@ -364,6 +364,18 @@ const FilterForm = ({ filter, onCancel, onClearFilter, onSaveFilter, onSubmit, o
             options={dataLists.kind}
           />
 
+          <Fieldset isSection>
+            <CheckboxGroup
+              defaultValue={state.options.directing_department}
+              hasToggle={false}
+              label="Regie hoofdmelding"
+              name="directing_department"
+              onChange={onGroupChange}
+              onToggle={onGroupToggle}
+              options={dataLists.directing_department}
+            />
+          </Fieldset>
+
           <FilterGroup>
             <Label htmlFor="filter_date" isGroupHeader>
               Datum

--- a/src/signals/incident-management/components/FilterForm/styled.js
+++ b/src/signals/incident-management/components/FilterForm/styled.js
@@ -1,7 +1,7 @@
 import FormFooter from 'components/FormFooter';
 
 import styled, { css } from 'styled-components';
-import { themeSpacing } from '@datapunt/asc-ui';
+import { themeSpacing, themeColor } from '@datapunt/asc-ui';
 
 export const Form = styled.form`
   column-count: 2;
@@ -31,6 +31,11 @@ export const Fieldset = styled.fieldset`
   border: 0;
   padding: 0;
 
+  &:not(:first-of-type),
+  &:first-of-type:last-of-type {
+    margin: ${themeSpacing(7, 0)};
+  }
+
   legend {
     border: 0;
     clip: rect(0 0 0 0);
@@ -51,8 +56,8 @@ export const Fieldset = styled.fieldset`
   }
 
   ${({ isSection }) => isSection && css`
-    background-color: #f5f5f5;
-    padding: 15px 20px;
+    background-color: ${themeColor('tint', 'level2')};
+    padding: 15px 21px;
   `}
 `;
 

--- a/src/signals/incident-management/containers/FilterTagList/__tests__/FilterTagList.test.js
+++ b/src/signals/incident-management/containers/FilterTagList/__tests__/FilterTagList.test.js
@@ -253,5 +253,7 @@ describe('signals/incident-management/containers/FilterTagList', () => {
   it('should map keys', () => {
     expect(mapKeys('source')).toEqual('bron');
     expect(mapKeys('any_key')).toEqual('any_key');
+    expect(mapKeys('contact_details')).toEqual('contact');
+    expect(mapKeys('directing_department')).toEqual('verantwoordelijke afdeling');
   });
 });

--- a/src/signals/incident-management/containers/FilterTagList/index.js
+++ b/src/signals/incident-management/containers/FilterTagList/index.js
@@ -41,6 +41,9 @@ export const mapKeys = key => {
     case 'contact_details':
       return 'contact';
 
+    case 'directing_department':
+      return 'verantwoordelijke afdeling';
+
     default:
       return key;
   }

--- a/src/signals/incident-management/definitions/directingDepartmentList.js
+++ b/src/signals/incident-management/definitions/directingDepartmentList.js
@@ -1,0 +1,6 @@
+const directingDepartmentList = [
+  { key: 'null', value: 'Verantwoordelijke afdeling' },
+  { key: 'ASC', value: 'ASC' },
+];
+
+export default directingDepartmentList;

--- a/src/signals/incident-management/definitions/index.js
+++ b/src/signals/incident-management/definitions/index.js
@@ -1,4 +1,5 @@
 import contactDetailsList from './contactDetailsList';
+import directingDepartmentList from './directingDepartmentList';
 import feedbackList from './feedbackList';
 import kindList from './kindList';
 import priorityList from './priorityList';
@@ -11,6 +12,7 @@ export { feedbackList, priorityList, stadsdeelList, statusList, sourceList, cont
 
 export default {
   contact_details: contactDetailsList,
+  directing_department: directingDepartmentList,
   feedback: feedbackList,
   kind: kindList,
   priority: priorityList,

--- a/src/signals/shared/filter/parse.js
+++ b/src/signals/shared/filter/parse.js
@@ -9,6 +9,7 @@ const arrayFields = [
   'area',
   'category_slug',
   'contact_details',
+  'directing_department',
   'kind',
   'maincategory_slug',
   'priority',
@@ -46,14 +47,15 @@ export const parseOutputFormData = options =>
       case 'maincategory_slug':
         entryValue = value.map(({ slug }) => slug);
         break;
+      case 'area':
       case 'contact_details':
+      case 'directing_department':
+      case 'kind':
       case 'priority':
       case 'source':
-      case 'area':
       case 'stadsdeel':
       case 'status':
       case 'type':
-      case 'kind':
         entryValue = value.map(({ key: itemKey }) => itemKey);
         break;
       case 'created_after':


### PR DESCRIPTION
This PR adds the following block to the `FilterForm` component:
![Screenshot 2020-09-09 at 07 52 59](https://user-images.githubusercontent.com/1062191/92559801-9009a980-f271-11ea-8791-4b7b496f5d93.png)

Note that the `Checkbox` component in the `CheckboxList` component has been replaced with our own component (which, in turn, also uses the asc-ui `Checkbox` component), because our own component shows a checkbox with a white background instead of a transparent background.