### PR TITLE
(Chore) Remove lodash/debounce

### DIFF
--- a/src/components/AutoSuggest/__tests__/AutoSuggest.test.js
+++ b/src/components/AutoSuggest/__tests__/AutoSuggest.test.js
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
-import { render, fireEvent, waitFor, act } from '@testing-library/react';
-import { withAppContext, resolveAfterMs } from 'test/utils';
+import { render, fireEvent, act } from '@testing-library/react';
+import { withAppContext } from 'test/utils';
 
 import AutoSuggest, { INPUT_DELAY } from '..';
 import JSONResponse from './mockResponse.json';
@@ -23,10 +23,14 @@ describe('src/components/AutoSuggest', () => {
   beforeEach(() => {
     fetch.mockResponse(mockResponse);
     onSelect.mockReset();
+    jest.useFakeTimers();
   });
 
   afterEach(() => {
     fetch.resetMocks();
+
+    jest.runOnlyPendingTimers();
+    jest.useRealTimers();
   });
 
   it('should render a combobox with input field', () => {
@@ -40,7 +44,7 @@ describe('src/components/AutoSuggest', () => {
   });
 
   it('should request external service', async () => {
-    const { container } = render(withAppContext(<AutoSuggest {...props} />));
+    const { container, findByTestId } = render(withAppContext(<AutoSuggest {...props} />));
     const input = container.querySelector('input');
 
     input.focus();
@@ -49,7 +53,11 @@ describe('src/components/AutoSuggest', () => {
       fireEvent.change(input, { target: { value: 'A' } });
     });
 
-    await waitFor(() => resolveAfterMs(INPUT_DELAY));
+    act(() => {
+      jest.advanceTimersByTime(INPUT_DELAY);
+    });
+
+    await findByTestId('autoSuggest');
 
     expect(fetch).not.toHaveBeenCalled();
 
@@ -57,7 +65,11 @@ describe('src/components/AutoSuggest', () => {
       fireEvent.change(input, { target: { value: 'Am' } });
     });
 
-    await waitFor(() => resolveAfterMs(INPUT_DELAY));
+    act(() => {
+      jest.advanceTimersByTime(INPUT_DELAY);
+    });
+
+    await findByTestId('autoSuggest');
 
     expect(fetch).not.toHaveBeenCalled();
 
@@ -65,17 +77,25 @@ describe('src/components/AutoSuggest', () => {
       fireEvent.change(input, { target: { value: 'Ams' } });
     });
 
+    await findByTestId('autoSuggest');
+
     expect(fetch).not.toHaveBeenCalled();
 
-    await waitFor(() => resolveAfterMs(INPUT_DELAY));
+    act(() => {
+      jest.advanceTimersByTime(INPUT_DELAY);
+    });
+
+    await findByTestId('autoSuggest');
 
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(fetch).toHaveBeenCalledWith(`${url}Ams`, expect.anything());
   });
 
-  it('should show a value without sending a request to the external service', () => {
-    const { container, rerender } = render(withAppContext(<AutoSuggest {...props} />));
+  it('should show a value without sending a request to the external service', async () => {
+    const { container, findByTestId, rerender } = render(withAppContext(<AutoSuggest {...props} />));
     const input = container.querySelector('input');
+
+    await findByTestId('autoSuggest');
 
     input.focus();
 
@@ -86,6 +106,8 @@ describe('src/components/AutoSuggest', () => {
     expect(fetch).not.toHaveBeenCalled();
 
     rerender(withAppContext(<AutoSuggest {...props} value={value} />));
+
+    await findByTestId('autoSuggest');
 
     expect(input.value).toEqual(value);
 
@@ -431,7 +453,7 @@ describe('src/components/AutoSuggest', () => {
 
   it('should call onClear', async () => {
     const onClear = jest.fn();
-    const { container } = render(
+    const { container, findByTestId } = render(
       withAppContext(<AutoSuggest {...props} onClear={onClear} />)
     );
     const input = container.querySelector('input');
@@ -440,7 +462,11 @@ describe('src/components/AutoSuggest', () => {
       fireEvent.change(input, { target: { value: 'Rembrandt' } });
     });
 
-    await waitFor(() => resolveAfterMs(INPUT_DELAY));
+    await findByTestId('autoSuggest');
+
+    act(() => {
+      jest.advanceTimersByTime(INPUT_DELAY);
+    });
 
     expect(onClear).not.toHaveBeenCalled();
 
@@ -448,7 +474,11 @@ describe('src/components/AutoSuggest', () => {
       fireEvent.change(input, { target: { value: '' } });
     });
 
-    await waitFor(() => resolveAfterMs(INPUT_DELAY));
+    await findByTestId('autoSuggest');
+
+    act(() => {
+      jest.advanceTimersByTime(INPUT_DELAY);
+    });
 
     expect(onClear).toHaveBeenCalled();
   });

--- a/src/components/AutoSuggest/index.js
+++ b/src/components/AutoSuggest/index.js
@@ -1,8 +1,8 @@
 import React, { useCallback, useEffect, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import debounce from 'lodash/debounce';
 
+import useDebounce from 'hooks/useDebounce';
 import useFetch from 'hooks/useFetch';
 import Input from 'components/Input';
 import SuggestList from './components/SuggestList';
@@ -15,7 +15,7 @@ const Wrapper = styled.div`
 `;
 
 const StyledInput = styled(Input)`
-  outline: 2px solid rgb(0,0,0,0.1);
+  outline: 2px solid rgb(0, 0, 0, 0.1);
 
   & > * {
     margin: 0;
@@ -173,19 +173,12 @@ const AutoSuggest = ({
     setShowList(false);
   }, []);
 
-  // linter complaining about the use of the debounce function
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const delayedCallback = useCallback(
-    debounce(inputValue => serviceRequest(inputValue), INPUT_DELAY),
-    [serviceRequest, url]
-  );
-
   const onChange = useCallback(
     event => {
       event.persist();
-      delayedCallback(event.target.value);
+      debouncedServiceRequest(event.target.value);
     },
-    [delayedCallback]
+    [debouncedServiceRequest]
   );
 
   const serviceRequest = useCallback(
@@ -202,6 +195,8 @@ const AutoSuggest = ({
     },
     [get, onClear, url]
   );
+
+  const debouncedServiceRequest = useDebounce(serviceRequest, INPUT_DELAY);
 
   const onSelectOption = useCallback(
     option => {

--- a/src/components/AutoSuggest/index.js
+++ b/src/components/AutoSuggest/index.js
@@ -173,14 +173,6 @@ const AutoSuggest = ({
     setShowList(false);
   }, []);
 
-  const onChange = useCallback(
-    event => {
-      event.persist();
-      debouncedServiceRequest(event.target.value);
-    },
-    [debouncedServiceRequest]
-  );
-
   const serviceRequest = useCallback(
     inputValue => {
       if (inputValue.length >= 3) {
@@ -197,6 +189,14 @@ const AutoSuggest = ({
   );
 
   const debouncedServiceRequest = useDebounce(serviceRequest, INPUT_DELAY);
+
+  const onChange = useCallback(
+    event => {
+      event.persist();
+      debouncedServiceRequest(event.target.value);
+    },
+    [debouncedServiceRequest]
+  );
 
   const onSelectOption = useCallback(
     option => {

--- a/src/components/Label/__test__/Label.test.js
+++ b/src/components/Label/__test__/Label.test.js
@@ -61,7 +61,7 @@ describe('signals/incident-management/components/Label', () => {
       ),
     );
 
-    expect(container.querySelector('label')).toHaveStyleRule('color', '#ec0000');
+    expect(container.querySelector('label')).not.toHaveStyleRule('color', 'inherit');
 
     rerender(
       withAppContext(
@@ -72,6 +72,6 @@ describe('signals/incident-management/components/Label', () => {
       ),
     );
 
-    expect(container.querySelector('label')).not.toHaveStyleRule('color', '#ec0000');
+    expect(container.querySelector('label')).toHaveStyleRule('color', 'inherit');
   });
 });

--- a/src/components/Label/index.js
+++ b/src/components/Label/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
+import { themeColor } from '@datapunt/asc-ui';
 
 const LabelWrapper = styled.div`
   ${({ isGroupHeader }) => !isGroupHeader &&
@@ -15,12 +16,13 @@ const StyledLabel = styled.label`
   line-height: 25px;
   margin-bottom: 8px;
   display: inline-block;
+  color: inherit;
 
   ${({ isGroupHeader }) =>
     isGroupHeader &&
     css`
     font-size: 18px;
-    color: #ec0000;
+    color: ${themeColor('secondary')};
   `}
 `;
 

--- a/src/components/MapInput/index.js
+++ b/src/components/MapInput/index.js
@@ -102,6 +102,10 @@ const MapInput = ({ className, hasGPSControl, value, onChange, mapOptions, event
     [map, dispatch, onChange]
   );
 
+  const onClear = useCallback(() => {
+    dispatch(resetLocationAction());
+  }, [dispatch]);
+
   const { click, doubleClick } = useDelayedDoubleClick(clickFunc);
 
   /**
@@ -143,7 +147,7 @@ const MapInput = ({ className, hasGPSControl, value, onChange, mapOptions, event
             <StyledAutosuggest
               formatResponse={formatPDOKResponse}
               municipality={configuration.map?.municipality}
-              onClear={() => dispatch(resetLocationAction())}
+              onClear={onClear}
               onSelect={onSelect}
               placeholder="Zoek adres"
               value={addressValue}

--- a/src/components/PDOKAutoSuggest/__tests__/PDOKAutoSuggest.test.js
+++ b/src/components/PDOKAutoSuggest/__tests__/PDOKAutoSuggest.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent, waitFor, act } from '@testing-library/react';
+import { render, fireEvent, act } from '@testing-library/react';
 import { withAppContext } from 'test/utils';
 
 import JSONResponse from 'utils/__tests__/fixtures/PDOKResponseData.json';
@@ -10,7 +10,6 @@ import PDOKAutoSuggest, { formatResponseFunc } from '..';
 const mockResponse = JSON.stringify(JSONResponse);
 
 const onSelect = jest.fn();
-const resolveAfterMs = timeMs => new Promise(resolve => setTimeout(resolve, timeMs));
 const municipalityQs = 'fq=gemeentenaam:';
 const fieldListQs = 'fl=';
 const defaultFieldsQs = 'id,weergavenaam';
@@ -25,7 +24,11 @@ const renderAndSearch = async (value = 'Dam', props = {}) => {
     fireEvent.change(input, { target: { value } });
   });
 
-  await waitFor(() => resolveAfterMs(INPUT_DELAY));
+  act(() => {
+    jest.advanceTimersByTime(INPUT_DELAY);
+  });
+
+  await result.findByTestId('autoSuggest');
 
   return result;
 };
@@ -33,11 +36,14 @@ const renderAndSearch = async (value = 'Dam', props = {}) => {
 describe('components/PDOKAutoSuggest', () => {
   beforeEach(() => {
     fetch.mockResponse(mockResponse);
+    jest.useFakeTimers();
   });
 
   afterEach(() => {
     fetch.mockReset();
     onSelect.mockReset();
+
+    jest.useRealTimers();
   });
 
   it('should render an AutoSuggest', () => {

--- a/src/hooks/__tests__/useDebounce.test.js
+++ b/src/hooks/__tests__/useDebounce.test.js
@@ -1,0 +1,39 @@
+import { renderHook } from '@testing-library/react-hooks';
+
+import useDebounce from '../useDebounce';
+
+describe('hooks/useDebounce', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('calls function parameter', () => {
+    const callable = jest.fn();
+    const { result } = renderHook(() => useDebounce(callable, 200));
+
+    result.current();
+
+    expect(callable).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(199);
+
+    expect(callable).not.toHaveBeenCalled();
+
+    // calling again, should reset timer
+    result.current();
+
+    expect(callable).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(199);
+
+    expect(callable).not.toHaveBeenCalled();
+
+    jest.advanceTimersByTime(1);
+
+    expect(callable).toHaveBeenCalled();
+  });
+});

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,3 +1,4 @@
+export { default as useDebounce } from './useDebounce';
 export { default as useDelayedDoubleClick } from './useDelayedDoubleClick';
 export { default as useEventEmitter } from './useEventEmitter';
 export { default as useFetch } from './useFetch';

--- a/src/hooks/useDebounce.js
+++ b/src/hooks/useDebounce.js
@@ -1,0 +1,18 @@
+import { useRef } from 'react';
+
+const useDebounce = (func, wait) => {
+  const timeout = useRef(null);
+
+  return function (...args) {
+    const that = this;
+
+    if (timeout.current) clearTimeout(timeout.current);
+
+    timeout.current = setTimeout(() => {
+      func.apply(that, args);
+      clearTimeout(timeout.current);
+    }, wait);
+  };
+};
+
+export default useDebounce;

--- a/src/hooks/useDelayedDoubleClick.js
+++ b/src/hooks/useDelayedDoubleClick.js
@@ -1,12 +1,12 @@
 import { useCallback, useRef } from 'react';
-import debounce from 'lodash/debounce';
+import useDebounce from './useDebounce';
 
 /**
  * Timeout by which clicks on the map are delayed so that potential double click can be captured
  * Increasing the value lead to a perceivable delay between click and the placement of the marker. Decreasing the value
  * could lead to a double click never being captured, because of the limited time to have both click registered.
  */
-export const DOUBLE_CLICK_TIMEOUT = 200;
+export const CLICK_TIMEOUT = 200;
 
 const useDelayedDoubleClick = clickFunc => {
   const doubleClicking = useRef(false);
@@ -16,13 +16,13 @@ const useDelayedDoubleClick = clickFunc => {
    *
    * Will prevent click events from being fired until the timeout has expired
    */
-  const doubleClick = useCallback(() => {
+  const debouncedDoubleClick = useCallback(() => {
     doubleClicking.current = true;
 
     const dblClickTimeout = setTimeout(() => {
       doubleClicking.current = false;
       clearTimeout(dblClickTimeout);
-    }, DOUBLE_CLICK_TIMEOUT * 2);
+    }, CLICK_TIMEOUT * 2);
   }, []);
 
   const debouncedClick = useCallback(
@@ -34,12 +34,10 @@ const useDelayedDoubleClick = clickFunc => {
     [clickFunc]
   );
 
-  // linter complaining about the use of the debounce function
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const click = useCallback(debounce(debouncedClick, DOUBLE_CLICK_TIMEOUT), [debouncedClick]);
+  const click = useDebounce(debouncedClick, CLICK_TIMEOUT);
 
   return {
-    doubleClick,
+    doubleClick: debouncedDoubleClick,
     click,
   };
 };

--- a/src/signals/settings/users/Overview/__tests__/Overview.test.js
+++ b/src/signals/settings/users/Overview/__tests__/Overview.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, fireEvent, waitFor, within, act } from '@testing-library/react';
-import { history as memoryHistory, withCustomAppContext, resolveAfterMs } from 'test/utils';
+import { history as memoryHistory, withCustomAppContext } from 'test/utils';
 
 import usersJSON from 'utils/__tests__/fixtures/users.json';
 import inputSelectRolesSelectorJSON from 'utils/__tests__/fixtures/inputSelectRolesSelector.json';
@@ -59,6 +59,8 @@ const usersOverviewWithAppContext = (overrideProps = {}, overrideCfg = {}, state
 
 describe('signals/settings/users/containers/Overview', () => {
   beforeEach(() => {
+    jest.useFakeTimers();
+
     dispatch.mockReset();
 
     jest.spyOn(reactRouter, 'useParams').mockImplementation(() => ({ pageNum: 1 }));
@@ -68,7 +70,6 @@ describe('signals/settings/users/containers/Overview', () => {
 
     const history = { ...memoryHistory, push };
 
-    jest.useRealTimers();
     fetch.resetMocks();
     dispatch.mockReset();
 
@@ -80,6 +81,10 @@ describe('signals/settings/users/containers/Overview', () => {
       push,
       scrollTo,
     };
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   it('should render "add user" button', async () => {
@@ -212,14 +217,12 @@ describe('signals/settings/users/containers/Overview', () => {
   it('should push on list item with an itemId click', async () => {
     jest.spyOn(appSelectors, 'makeSelectUserCan').mockImplementation(() => () => true);
     const { push } = testContext;
-    const { container } = render(usersOverviewWithAppContext());
+    const { container, findByTestId } = render(usersOverviewWithAppContext());
     const itemId = 666;
 
-    let row;
+    await findByTestId('usersOverview');
 
-    await waitFor(() => {
-      row = container.querySelector('tbody tr:nth-child(42)');
-    });
+    const row = container.querySelector('tbody tr:nth-child(42)');
 
     const username = row.querySelector('td:first-of-type');
 
@@ -260,11 +263,9 @@ describe('signals/settings/users/containers/Overview', () => {
     const { push } = testContext;
     const { container, findByTestId } = render(usersOverviewWithAppContext());
 
-    let row;
+    await findByTestId('usersOverview');
 
-    await waitFor(() => {
-      row = container.querySelector('tbody tr:nth-child(42)');
-    });
+    const row = container.querySelector('tbody tr:nth-child(42)');
 
     // Explicitly set an 'itemId'.
     row.dataset.itemId = 666;
@@ -297,11 +298,15 @@ describe('signals/settings/users/containers/Overview', () => {
       fireEvent.change(filterByUserNameInput, { target: { value: filterValue } });
     });
 
-    await waitFor(() => resolveAfterMs(50));
+    act(() => {
+      jest.advanceTimersByTime(50);
+    });
 
     expect(dispatch).not.toHaveBeenCalled();
 
-    await waitFor(() => resolveAfterMs(200));
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
 
     expect(dispatch).toHaveBeenCalledTimes(1);
     expect(dispatch).toHaveBeenCalledWith(setUserFilters({ username: filterValue }));
@@ -320,7 +325,10 @@ describe('signals/settings/users/containers/Overview', () => {
       fireEvent.change(filterByUserNameInput, { target: { value: filterValue } });
     });
 
-    await waitFor(() => resolveAfterMs(300));
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
     expect(dispatch).toHaveBeenCalledTimes(1);
     expect(dispatch).toHaveBeenCalledWith(setUserFilters({ username: filterValue }));
 
@@ -351,7 +359,11 @@ describe('signals/settings/users/containers/Overview', () => {
       });
     });
 
-    await waitFor(() => resolveAfterMs(250));
+    await findByTestId('filterUsersByUsername');
+
+    act(() => {
+      jest.advanceTimersByTime(250);
+    });
 
     expect(dispatch).toHaveBeenCalledTimes(1);
 
@@ -367,7 +379,11 @@ describe('signals/settings/users/containers/Overview', () => {
       });
     });
 
-    await waitFor(() => resolveAfterMs(250));
+    await findByTestId('filterUsersByUsername');
+
+    act(() => {
+      jest.advanceTimersByTime(250);
+    });
 
     expect(dispatch).toHaveBeenCalledTimes(1);
 

--- a/src/signals/settings/users/Overview/index.js
+++ b/src/signals/settings/users/Overview/index.js
@@ -4,8 +4,8 @@ import { useSelector } from 'react-redux';
 
 import { Row, Column, themeSpacing, Button, SearchBar } from '@datapunt/asc-ui';
 import styled from 'styled-components';
-import debounce from 'lodash/debounce';
 
+import useDebounce from 'hooks/useDebounce';
 import { PAGE_SIZE } from 'containers/App/constants';
 import LoadingIndicator from 'components/LoadingIndicator';
 import Pagination from 'components/Pagination';
@@ -92,9 +92,7 @@ const UsersOverviewContainer = () => {
     [filters, setUsernameFilter]
   );
 
-  // linter complaining about the use of the debounce function
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const debouncedOnChangeFilter = useCallback(debounce(createOnChangeFilter('username'), 250), [createOnChangeFilter]);
+  const debouncedOnChangeFilter = useDebounce(createOnChangeFilter('username'), 250);
 
   const selectUserActiveOnChange = useCallback(
     event => {

--- a/src/test/utils.js
+++ b/src/test/utils.js
@@ -90,14 +90,4 @@ export const userObjects = (users = usersJSON) =>
       }, {})
   );
 
-/**
- * Timeboxed promise resolver
- *
- * Particularly useful when when functionality that is debounced with lodash.debounce
- *
- * @param {Number} timeMs
- * @returns {Promise} Resolved promise
- */
-export const resolveAfterMs = timeMs => new Promise(resolve => setTimeout(resolve, timeMs));
-
 export const withMapContext = Component => withAppContext(<MapContext>{Component}</MapContext>);


### PR DESCRIPTION
Numerous tests were breaking unexpectedly across builds. Most of these breaking tests used either the Lodash `debounce` function or were dependent on `useDelayedDoubleClick` hook, which was also depending on `debounce`.  By removing said dependency and replacing `debounce` with a custom hook (`useDebounce`), the issue seems to be solved; tests are passing consistently.

By getting rid of `debounce` and the subsequent `resolveAfterMs` test utility function, there is more fine grained control over components in tests.