### PR TITLE
[SIG-3092] Bugfix preset the incident classification 

### DIFF
--- a/src/containers/App/index.js
+++ b/src/containers/App/index.js
@@ -22,7 +22,6 @@ import KtoContainer from 'signals/incident/containers/KtoContainer';
 import useLocationReferrer from 'hooks/useLocationReferrer';
 import useIsFrontOffice from 'hooks/useIsFrontOffice';
 
-import IncidentClassification from 'signals/incident/components/IncidentClassification';
 import { getSources } from './actions';
 import AppContext from './context';
 import reducer from './reducer';
@@ -103,7 +102,7 @@ export const AppContainer = () => {
               <Route path="/instellingen" component={SettingsModule} />
               <Route path="/incident" component={IncidentContainer} />
               <Route path="/kto/:satisfactionIndication/:uuid" component={KtoContainer} />
-              <Route path="/categorie/:category/:subcategory" component={IncidentClassification} />
+              <Route path="/categorie/:category/:subcategory" component={IncidentContainer} />
               <Route component={NotFoundPage} />
             </Switch>
           </ContentContainer>

--- a/src/containers/App/index.js
+++ b/src/containers/App/index.js
@@ -102,7 +102,7 @@ export const AppContainer = () => {
               <Route path="/instellingen" component={SettingsModule} />
               <Route path="/incident" component={IncidentContainer} />
               <Route path="/kto/:satisfactionIndication/:uuid" component={KtoContainer} />
-              <Route path="/categorie/:category/:subcategory" component={IncidentContainer} />
+              <Route exact path="/categorie/:category/:subcategory" component={IncidentContainer} />
               <Route component={NotFoundPage} />
             </Switch>
           </ContentContainer>

--- a/src/signals/incident/containers/IncidentContainer/index.js
+++ b/src/signals/incident/containers/IncidentContainer/index.js
@@ -9,34 +9,44 @@ import { isAuthenticated } from 'shared/services/auth/auth';
 import injectSaga from 'utils/injectSaga';
 import injectReducer from 'utils/injectReducer';
 
+import { useLocation } from 'react-router-dom';
 import wizardDefinition from '../../definitions/wizard';
 import { getClassification, updateIncident, createIncident } from './actions';
 import { makeSelectIncidentContainer } from './selectors';
 import reducer from './reducer';
 import saga from './saga';
-import './style.scss';
-
 import IncidentWizard from '../../components/IncidentWizard';
+import IncidentClassification from '../../components/IncidentClassification';
+import './style.scss';
 
 export const IncidentContainerComponent = ({
   createIncidentAction,
   getClassificationAction,
   incidentContainer,
   updateIncidentAction,
-}) => (
-  <Row>
-    <Column span={12}>
-      <IncidentWizard
-        wizardDefinition={wizardDefinition}
-        getClassification={getClassificationAction}
-        updateIncident={updateIncidentAction}
-        createIncident={createIncidentAction}
-        incidentContainer={incidentContainer}
-        isAuthenticated={isAuthenticated()}
-      />
-    </Column>
-  </Row>
-);
+}) => {
+  const { pathname } = useLocation();
+  const presetClassification = pathname.startsWith('/categorie');
+
+  return (
+    <Row>
+      <Column span={12}>
+        {presetClassification ? (
+          <IncidentClassification />
+        ) : (
+          <IncidentWizard
+            wizardDefinition={wizardDefinition}
+            getClassification={getClassificationAction}
+            updateIncident={updateIncidentAction}
+            createIncident={createIncidentAction}
+            incidentContainer={incidentContainer}
+            isAuthenticated={isAuthenticated()}
+          />
+        )}
+      </Column>
+    </Row>
+  );
+};
 
 IncidentContainerComponent.propTypes = {
   createIncidentAction: PropTypes.func.isRequired,

--- a/src/signals/incident/containers/IncidentContainer/index.test.js
+++ b/src/signals/incident/containers/IncidentContainer/index.test.js
@@ -1,14 +1,24 @@
 import React from 'react';
 import { render } from '@testing-library/react';
+import * as reactRouterDom from 'react-router-dom';
 
 import { withAppContext } from 'test/utils';
 import { IncidentContainerComponent } from '.';
+
+jest.mock('react-router-dom', () => ({
+  __esModule: true,
+  ...jest.requireActual('react-router-dom'),
+}));
 
 jest.mock('shared/services/auth/auth', () => ({
   __esModule: true,
   ...jest.requireActual('shared/services/auth/auth'),
   isAuthenticated: () => true,
 }));
+
+jest.mock('signals/incident/components/IncidentClassification', () => () => (
+  <span data-testid="incidentClassification" />
+));
 jest.mock('signals/incident/components/IncidentWizard', () => () => <span data-testid="incidentWizard" />);
 
 describe('signals/incident/containers/IncidentContainer', () => {
@@ -19,9 +29,22 @@ describe('signals/incident/containers/IncidentContainer', () => {
     createIncidentAction: jest.fn(),
   };
 
-  it('should render correctly', () => {
-    const { getByTestId } = render(withAppContext(<IncidentContainerComponent {...props} />));
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
 
-    expect(getByTestId('incidentWizard')).toBeInTheDocument();
+  it('should render correctly', () => {
+    const { queryByTestId } = render(withAppContext(<IncidentContainerComponent {...props} />));
+
+    expect(queryByTestId('incidentWizard')).toBeInTheDocument();
+    expect(queryByTestId('incidentClassification')).not.toBeInTheDocument();
+  });
+
+  it('should render correctly when category should be set', () => {
+    jest.spyOn(reactRouterDom, 'useLocation').mockImplementation(() => ({ pathname: '/categorie/cat/sub' }));
+    const { queryByTestId } = render(withAppContext(<IncidentContainerComponent {...props} />));
+
+    expect(queryByTestId('incidentWizard')).not.toBeInTheDocument();
+    expect(queryByTestId('incidentClassification')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
This PR fixes an issue that was found in acceptance. The problem was that the category was not preset and the prediction tool was not disabled when the correct presset link was used. In production mode, initialization of the incident container reducer was done after the InidentClassification events were triggered. The solution was to move the IncidentClassification component to the IncidentContainer in order to ensure the correct handling of the redux events. 