### PR TITLE
[SIG-3154] Deelmelding attachments

### DIFF
--- a/src/signals/incident-management/containers/IncidentSplitContainer/IncidentSplitContainer.js
+++ b/src/signals/incident-management/containers/IncidentSplitContainer/IncidentSplitContainer.js
@@ -56,10 +56,20 @@ const IncidentSplitContainer = ({ FormComponent }) => {
      * @param {string} formData[].type
      */
     formData => {
-      const { extra_properties, incident_date_end, incident_date_start, location, reporter, source, text_extra } = data;
+      const {
+        attachments,
+        extra_properties,
+        incident_date_end,
+        incident_date_start,
+        location,
+        reporter,
+        source,
+        text_extra,
+      } = data;
       const { stadsdeel, buurt_code, address, geometrie } = location;
 
       const parentData = {
+        attachments,
         extra_properties,
         incident_date_end,
         incident_date_start,

--- a/src/signals/incident-management/containers/IncidentSplitContainer/__tests__/IncidentSplitContainer.test.js
+++ b/src/signals/incident-management/containers/IncidentSplitContainer/__tests__/IncidentSplitContainer.test.js
@@ -141,6 +141,7 @@ describe('signals/incident-management/containers/IncidentSplitContainer', () => 
     const { stadsdeel, buurt_code, address, geometrie } = incidentFixture.location;
 
     const parentData = {
+      attachments: incidentFixture.attachments,
       extra_properties: incidentFixture.extra_properties,
       incident_date_end: incidentFixture.incident_date_end,
       incident_date_start: incidentFixture.incident_date_start,


### PR DESCRIPTION
This PR copies the `attachments` prop from the original incident into the created 'deelmeldingen' on split form post.