### PR TITLE
[SIG-3156] Fetch subcategories at App level

### DIFF
--- a/src/components/Footer/index.js
+++ b/src/components/Footer/index.js
@@ -95,7 +95,7 @@ const Footer = () => (
 
     <Container>
       <Privacy>
-        <StyledLink href={configuration.links.privacy} variant="with-chevron">
+        <StyledLink href={configuration.links.privacy} inList>
           Privacy
         </StyledLink>
       </Privacy>

--- a/src/containers/App/index.js
+++ b/src/containers/App/index.js
@@ -1,17 +1,17 @@
 import React, { Fragment, useEffect } from 'react';
 import styled from 'styled-components';
 import { Switch, Route, Redirect, useHistory } from 'react-router-dom';
-import { compose } from 'redux';
 import { useDispatch, useSelector } from 'react-redux';
 
 import configuration from 'shared/services/configuration/configuration';
 import { authenticate, isAuthenticated } from 'shared/services/auth/auth';
-import ThemeProvider from 'components/ThemeProvider';
-import injectSaga from 'utils/injectSaga';
-import injectReducer from 'utils/injectReducer';
+import { useInjectSaga } from 'utils/injectSaga';
+import { useInjectReducer } from 'utils/injectReducer';
 
+import { fetchCategories as fetchCategoriesAction } from 'models/categories/actions';
 import NotFoundPage from 'components/NotFoundPage';
 import Footer from 'components/Footer';
+import ThemeProvider from 'components/ThemeProvider';
 import SiteHeaderContainer from 'containers/SiteHeader';
 
 import IncidentManagementModule from 'signals/incident-management';
@@ -55,6 +55,9 @@ export const AppContainer = () => {
   const isFrontOffice = useIsFrontOffice();
   const headerIsTall = isFrontOffice && !isAuthenticated();
 
+  useInjectSaga({ key: 'global', saga });
+  useInjectReducer({ key: 'global', reducer });
+
   authenticate();
 
   useEffect(() => {
@@ -80,12 +83,12 @@ export const AppContainer = () => {
     // when the current session has not been authenticated
     if (!isAuthenticated()) return;
 
+    dispatch(fetchCategoriesAction());
+
     if (configuration.fetchSourcesFromBackend) {
       dispatch(getSources());
     }
-    // disabling linter; no deps needed, only execute on mount
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [dispatch]);
 
   return (
     <ThemeProvider>
@@ -118,7 +121,4 @@ export const AppContainer = () => {
   );
 };
 
-const withReducer = injectReducer({ key: 'global', reducer });
-const withSaga = injectSaga({ key: 'global', saga });
-
-export default compose(withReducer, withSaga)(AppContainer);
+export default AppContainer;

--- a/src/containers/App/index.test.js
+++ b/src/containers/App/index.test.js
@@ -1,10 +1,13 @@
 import React from 'react';
 import { render, act } from '@testing-library/react';
 import * as reactRedux from 'react-redux';
+
 import { withAppContext, history } from 'test/utils';
 import * as auth from 'shared/services/auth/auth';
 import configuration from 'shared/services/configuration/configuration';
 import { resetIncident } from 'signals/incident/containers/IncidentContainer/actions';
+import { fetchCategories as fetchCategoriesAction } from 'models/categories/actions';
+
 import App, { AppContainer } from '.';
 import { getSources } from './actions';
 
@@ -178,13 +181,13 @@ describe('<App />', () => {
 
       render(withAppContext(<AppContainer {...props} />));
 
-      expect(dispatch).not.toHaveBeenCalled();
+      expect(dispatch).not.toHaveBeenCalledWith(getSources());
 
       jest.spyOn(auth, 'isAuthenticated').mockImplementation(() => true);
 
       render(withAppContext(<AppContainer {...props} />));
 
-      expect(dispatch).not.toHaveBeenCalled();
+      expect(dispatch).not.toHaveBeenCalledWith(getSources());
     });
 
     it('should request sources on mount with feature flag enabled', () => {
@@ -194,14 +197,27 @@ describe('<App />', () => {
 
       render(withAppContext(<AppContainer {...props} />));
 
-      expect(dispatch).not.toHaveBeenCalled();
+      expect(dispatch).not.toHaveBeenCalledWith(getSources());
 
       jest.spyOn(auth, 'isAuthenticated').mockImplementation(() => true);
 
       render(withAppContext(<AppContainer {...props} />));
 
-      expect(dispatch).toHaveBeenCalledTimes(1);
       expect(dispatch).toHaveBeenCalledWith(getSources());
+    });
+
+    it('should request subcategories on mount for authenticated users', () => {
+      jest.spyOn(auth, 'isAuthenticated').mockImplementation(() => false);
+
+      render(withAppContext(<AppContainer {...props} />));
+
+      expect(dispatch).not.toHaveBeenCalledWith(fetchCategoriesAction());
+
+      jest.spyOn(auth, 'isAuthenticated').mockImplementation(() => true);
+
+      render(withAppContext(<AppContainer {...props} />));
+
+      expect(dispatch).toHaveBeenCalledWith(fetchCategoriesAction());
     });
   });
 });

--- a/src/signals/incident-management/__tests__/index.test.js
+++ b/src/signals/incident-management/__tests__/index.test.js
@@ -22,7 +22,6 @@ describe('signals/incident-management', () => {
 
   beforeEach(() => {
     props = {
-      fetchCategoriesAction: jest.fn(),
       getDistrictsAction: jest.fn(),
       getFiltersAction: jest.fn(),
       requestIncidentsAction: jest.fn(),
@@ -58,9 +57,6 @@ describe('signals/incident-management', () => {
 
     expect(containerProps.searchIncidentsAction).toBeDefined();
     expect(typeof containerProps.searchIncidentsAction).toEqual('function');
-
-    expect(containerProps.fetchCategoriesAction).toBeDefined();
-    expect(typeof containerProps.fetchCategoriesAction).toEqual('function');
   });
 
   it('should render correctly', () => {
@@ -119,20 +115,6 @@ describe('signals/incident-management', () => {
       render(withAppContext(<IncidentManagementModuleComponent {...props} />));
 
       expect(props.getFiltersAction).toHaveBeenCalledTimes(1);
-    });
-
-    it('should request categories on mount', () => {
-      isAuthenticated.mockImplementation(() => false);
-
-      render(withAppContext(<IncidentManagementModuleComponent {...props} />));
-
-      expect(props.fetchCategoriesAction).not.toHaveBeenCalled();
-
-      isAuthenticated.mockImplementation(() => true);
-
-      render(withAppContext(<IncidentManagementModuleComponent {...props} />));
-
-      expect(props.fetchCategoriesAction).toHaveBeenCalledTimes(1);
     });
 
     it('should request incidents on mount', () => {

--- a/src/signals/incident-management/index.js
+++ b/src/signals/incident-management/index.js
@@ -9,7 +9,6 @@ import configuration from 'shared/services/configuration/configuration';
 import { isAuthenticated } from 'shared/services/auth/auth';
 import injectReducer from 'utils/injectReducer';
 import injectSaga from 'utils/injectSaga';
-import { fetchCategories } from 'models/categories/actions';
 import useLocationReferrer from 'hooks/useLocationReferrer';
 import { makeSelectSearchQuery } from 'containers/App/selectors';
 
@@ -28,7 +27,6 @@ import routes from './routes';
 import { makeSelectDistricts } from './selectors';
 
 export const IncidentManagementModuleComponent = ({
-  fetchCategoriesAction,
   getDistrictsAction,
   getFiltersAction,
   requestIncidentsAction,
@@ -54,9 +52,7 @@ export const IncidentManagementModuleComponent = ({
     }
 
     getFiltersAction();
-    fetchCategoriesAction();
   }, [
-    fetchCategoriesAction,
     getDistrictsAction,
     getFiltersAction,
     requestIncidentsAction,
@@ -82,7 +78,6 @@ export const IncidentManagementModuleComponent = ({
 };
 
 IncidentManagementModuleComponent.propTypes = {
-  fetchCategoriesAction: PropTypes.func.isRequired,
   getDistrictsAction: PropTypes.func.isRequired,
   getFiltersAction: PropTypes.func.isRequired,
   requestIncidentsAction: PropTypes.func.isRequired,
@@ -97,7 +92,6 @@ const mapStateToProps = createStructuredSelector({
 const mapDispatchToProps = dispatch =>
   bindActionCreators(
     {
-      fetchCategoriesAction: fetchCategories,
       getDistrictsAction: getDistricts,
       getFiltersAction: getFilters,
       requestIncidentsAction: requestIncidents,

--- a/src/signals/settings/__tests__/index.test.js
+++ b/src/signals/settings/__tests__/index.test.js
@@ -1,12 +1,16 @@
 import React from 'react';
-import { mount } from 'enzyme';
 import { render, waitFor } from '@testing-library/react';
 import { act } from 'react-dom/test-utils';
-import * as auth from 'shared/services/auth/auth';
 import * as reactRouterDom from 'react-router-dom';
+import * as reactRedux from 'react-redux';
 
+import * as appSelectors from 'containers/App/selectors'; // { makeSelectUserCanAccess, makeSelectUserCan }
+import * as auth from 'shared/services/auth/auth';
+
+import { fetchRoles as fetchRolesAction, fetchPermissions as fetchPermissionsAction } from 'models/roles/actions';
+import { fetchDepartments as fetchDepartmentsAction } from 'models/departments/actions';
 import { withAppContext, history } from 'test/utils';
-import SettingsModule, { SettingsModule as Module } from '..';
+import SettingsModule from '..';
 import { USERS_URL, ROLES_URL } from '../routes';
 
 jest.mock('react-router-dom', () => ({
@@ -14,18 +18,21 @@ jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
 }));
 
-const actionProps = {
-  onFetchDepartments: jest.fn(),
-  onFetchPermissions: jest.fn(),
-  fetchCategoriesAction: jest.fn(),
-  onFetchRoles: jest.fn(),
-  userCan: jest.fn(() => true),
-  userCanAccess: jest.fn(() => true),
-};
+jest.mock('containers/App/selectors', () => ({
+  __esModule: true,
+  ...jest.requireActual('containers/App/selectors'),
+}));
+
+const dispatch = jest.fn();
+jest.spyOn(reactRedux, 'useDispatch').mockImplementation(() => dispatch);
 
 describe('signals/settings', () => {
   beforeEach(() => {
+    dispatch.mockReset();
+
     jest.spyOn(reactRouterDom, 'useLocation');
+    jest.spyOn(appSelectors, 'makeSelectUserCan').mockImplementation(() => () => true);
+    jest.spyOn(appSelectors, 'makeSelectUserCanAccess').mockImplementation(() => () => true);
   });
 
   afterEach(() => {
@@ -33,165 +40,82 @@ describe('signals/settings', () => {
     reactRouterDom.useLocation.mockRestore();
   });
 
-  it('should have props from structured selector', () => {
-    const tree = mount(withAppContext(<SettingsModule />));
-
-    const props = tree.find(Module).props();
-
-    expect(props.userCan).not.toBeUndefined();
-    expect(props.userCanAccess).not.toBeUndefined();
-  });
-
-  it('should have props from action creator', () => {
-    const tree = mount(withAppContext(<SettingsModule />));
-
-    const containerProps = tree.find(Module).props();
-
-    expect(containerProps.onFetchDepartments).toBeDefined();
-    expect(typeof containerProps.onFetchDepartments).toEqual('function');
-
-    expect(containerProps.onFetchPermissions).toBeDefined();
-    expect(typeof containerProps.onFetchPermissions).toEqual('function');
-
-    expect(containerProps.onFetchRoles).toBeDefined();
-    expect(typeof containerProps.onFetchRoles).toEqual('function');
-  });
-
   it('should initiate fetches on mount', () => {
     jest.spyOn(auth, 'isAuthenticated').mockImplementation(() => true);
 
-    const onFetchDepartments = jest.fn();
-    const onFetchPermissions = jest.fn();
-    const onFetchRoles = jest.fn();
+    expect(dispatch).not.toHaveBeenCalled();
 
-    render(
-      withAppContext(
-        <Module
-          {...actionProps}
-          onFetchDepartments={onFetchDepartments}
-          onFetchPermissions={onFetchPermissions}
-          onFetchRoles={onFetchRoles}
-        />
-      )
-    );
+    render(withAppContext(<SettingsModule />));
 
-    expect(onFetchDepartments).toHaveBeenCalled();
-    expect(onFetchPermissions).toHaveBeenCalled();
-    expect(onFetchRoles).toHaveBeenCalled();
+    expect(dispatch).toHaveBeenCalledWith(fetchRolesAction());
+    expect(dispatch).toHaveBeenCalledWith(fetchPermissionsAction());
+    expect(dispatch).toHaveBeenCalledWith(fetchDepartmentsAction());
   });
 
   it('should NOT initiate fetches on mount when session has not been authenticated', () => {
     jest.spyOn(auth, 'isAuthenticated').mockImplementation(() => false);
 
-    const onFetchDepartments = jest.fn();
-    const onFetchPermissions = jest.fn();
-    const onFetchRoles = jest.fn();
+    expect(dispatch).not.toHaveBeenCalled();
 
-    render(
-      withAppContext(
-        <Module
-          {...actionProps}
-          onFetchDepartments={onFetchDepartments}
-          onFetchPermissions={onFetchPermissions}
-          onFetchRoles={onFetchRoles}
-        />
-      )
-    );
+    render(withAppContext(<SettingsModule />));
 
-    expect(onFetchDepartments).not.toHaveBeenCalled();
-    expect(onFetchPermissions).not.toHaveBeenCalled();
-    expect(onFetchRoles).not.toHaveBeenCalled();
+    expect(dispatch).not.toHaveBeenCalled();
   });
 
   it('should render login page', () => {
     jest.spyOn(auth, 'isAuthenticated').mockImplementation(() => false);
 
-    const { queryByTestId, getByTestId, rerender } = render(
-      withAppContext(<Module {...actionProps} />)
-    );
+    const { queryByTestId, getByTestId, rerender } = render(withAppContext(<SettingsModule />));
 
     expect(getByTestId('loginPage')).toBeInTheDocument();
 
     jest.spyOn(auth, 'isAuthenticated').mockImplementation(() => true);
 
-    rerender(withAppContext(<Module {...actionProps} />));
+    rerender(withAppContext(<SettingsModule />));
 
     expect(queryByTestId('loginPage')).toBeNull();
   });
 
   it('should redirect to manage overview page', async () => {
+    jest.spyOn(appSelectors, 'makeSelectUserCanAccess').mockImplementation(() => () => false);
     jest.spyOn(auth, 'isAuthenticated').mockImplementation(() => true);
 
-    render(withAppContext(<Module {...actionProps} userCanAccess={() => false} />));
+    render(withAppContext(<SettingsModule />));
 
-    expect(
-      reactRouterDom.useLocation.mock.results.pop().value.pathname
-    ).toEqual('/manage/incidents');
+    expect(reactRouterDom.useLocation.mock.results.pop().value.pathname).toEqual('/manage/incidents');
   });
 
   it('should allow routing to users pages', async () => {
     jest.spyOn(auth, 'isAuthenticated').mockImplementation(() => true);
+    jest.spyOn(appSelectors, 'makeSelectUserCanAccess').mockImplementation(() => section => section !== 'groups');
 
-    await act(async () =>
-      render(
-        withAppContext(
-          <Module
-            {...actionProps}
-            userCanAccess={section => section !== 'groups'}
-          />
-        )
-      )
-    );
+    render(withAppContext(<SettingsModule />));
 
     // load users overview page
-    await act(async () => history.push(USERS_URL));
+    act(() => history.push(USERS_URL));
 
-    await waitFor(() =>
-      expect(
-        reactRouterDom.useLocation.mock.results.pop().value.pathname
-      ).toEqual(USERS_URL)
-    );
+    await waitFor(() => expect(reactRouterDom.useLocation.mock.results.pop().value.pathname).toEqual(USERS_URL));
 
     // load roles overview page (should not be allowed)
-    await act(async () => history.push(ROLES_URL));
+    act(() => history.push(ROLES_URL));
 
-    await waitFor(() =>
-      expect(
-        reactRouterDom.useLocation.mock.results.pop().value.pathname
-      ).not.toEqual(ROLES_URL)
-    );
+    await waitFor(() => expect(reactRouterDom.useLocation.mock.results.pop().value.pathname).not.toEqual(ROLES_URL));
   });
 
   it('should allow routing to groups pages', async () => {
     jest.spyOn(auth, 'isAuthenticated').mockImplementation(() => true);
+    jest.spyOn(appSelectors, 'makeSelectUserCanAccess').mockImplementation(() => section => section !== 'users');
 
-    await act(async () =>
-      render(
-        withAppContext(
-          <Module
-            {...actionProps}
-            userCanAccess={section => section !== 'users'}
-          />
-        )
-      )
-    );
+    render(withAppContext(<SettingsModule />));
 
     // load roles overview page
-    await act(async () => history.push(ROLES_URL));
+    act(() => history.push(ROLES_URL));
 
-    await waitFor(() =>
-      expect(
-        reactRouterDom.useLocation.mock.results.pop().value.pathname
-      ).toEqual(ROLES_URL)
-    );
+    await waitFor(() => expect(reactRouterDom.useLocation.mock.results.pop().value.pathname).toEqual(ROLES_URL));
 
     // load users overview page (should not be allowed)
-    await act(async () => history.push(USERS_URL));
+    act(() => history.push(USERS_URL));
 
-    await waitFor(() =>
-      expect(
-        reactRouterDom.useLocation.mock.results.pop().value.pathname
-      ).not.toEqual(USERS_URL)
-    );
+    await waitFor(() => expect(reactRouterDom.useLocation.mock.results.pop().value.pathname).not.toEqual(USERS_URL));
   });
 });

--- a/src/signals/settings/index.js
+++ b/src/signals/settings/index.js
@@ -1,30 +1,17 @@
-import React, { memo, useEffect, useReducer } from 'react';
-import PropTypes from 'prop-types';
+import React, { useEffect, useReducer } from 'react';
 import { Route, Redirect, Switch } from 'react-router-dom';
-import { createStructuredSelector } from 'reselect';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import { isAuthenticated } from 'shared/services/auth/auth';
 
 import LoginPage from 'components/LoginPage';
-import {
-  makeSelectUserCanAccess,
-  makeSelectUserCan,
-} from 'containers/App/selectors';
+import { makeSelectUserCanAccess, makeSelectUserCan } from 'containers/App/selectors';
 
-import { fetchRoles, fetchPermissions } from 'models/roles/actions';
-import { fetchDepartments } from 'models/departments/actions';
+import { fetchRoles as fetchRolesAction, fetchPermissions as fetchPermissionsAction } from 'models/roles/actions';
+import { fetchDepartments as fetchDepartmentsAction } from 'models/departments/actions';
 import useLocationReferrer from 'hooks/useLocationReferrer';
-import { fetchCategories } from 'models/categories/actions';
 
-import routes, {
-  USERS_PAGED_URL,
-  USER_URL,
-  ROLE_URL,
-  CATEGORIES_PAGED_URL,
-  CATEGORY_URL,
-} from './routes';
+import routes, { USERS_PAGED_URL, USER_URL, ROLE_URL, CATEGORIES_PAGED_URL, CATEGORY_URL } from './routes';
 import UsersOverviewContainer from './users/Overview';
 import RolesListContainer from './roles/containers/RolesListContainer';
 import RoleFormContainer from './roles/containers/RoleFormContainer';
@@ -37,32 +24,22 @@ import CategoryDetailContainer from './categories/Detail';
 import SettingsContext from './context';
 import reducer, { initialState } from './reducer';
 
-export const SettingsModule = ({
-  onFetchDepartments,
-  onFetchPermissions,
-  onFetchRoles,
-  fetchCategoriesAction,
-  userCan,
-  userCanAccess,
-}) => {
+export const SettingsModule = () => {
+  const storeDispatch = useDispatch();
   const location = useLocationReferrer();
   const [state, dispatch] = useReducer(reducer, initialState);
+  const userCan = useSelector(makeSelectUserCan);
+  const userCanAccess = useSelector(makeSelectUserCanAccess);
 
   useEffect(() => {
     if (!isAuthenticated()) {
       return;
     }
 
-    onFetchDepartments();
-    onFetchRoles();
-    onFetchPermissions();
-    fetchCategoriesAction();
-  }, [
-    onFetchDepartments,
-    onFetchPermissions,
-    onFetchRoles,
-    fetchCategoriesAction,
-  ]);
+    storeDispatch(fetchDepartmentsAction());
+    storeDispatch(fetchRolesAction());
+    storeDispatch(fetchPermissionsAction());
+  }, [storeDispatch]);
 
   if (!isAuthenticated()) {
     return <Route component={LoginPage} />;
@@ -78,12 +55,8 @@ export const SettingsModule = ({
         <Switch location={location}>
           <Route exact path={routes.roles} component={RolesListContainer} />
 
-          {userCanAccess('groupForm') && (
-            <Route exact path={routes.role} component={RoleFormContainer} />
-          )}
-          {userCan('add_group') && (
-            <Route exact path={ROLE_URL} component={RoleFormContainer} />
-          )}
+          {userCanAccess('groupForm') && <Route exact path={routes.role} component={RoleFormContainer} />}
+          {userCan('add_group') && <Route exact path={ROLE_URL} component={RoleFormContainer} />}
         </Switch>
       )}
 
@@ -94,35 +67,19 @@ export const SettingsModule = ({
            * in the UsersOverviewContainer component
            */}
           <Redirect exact from={routes.users} to={`${USERS_PAGED_URL}/1`} />
-          <Route
-            exact
-            path={routes.usersPaged}
-            component={UsersOverviewContainer}
-          />
+          <Route exact path={routes.usersPaged} component={UsersOverviewContainer} />
 
-          {userCanAccess('userForm') && (
-            <Route exact path={routes.user} component={UsersDetailContainer} />
-          )}
-          {userCan('add_user') && (
-            <Route exact path={USER_URL} component={UsersDetailContainer} />
-          )}
+          {userCanAccess('userForm') && <Route exact path={routes.user} component={UsersDetailContainer} />}
+          {userCan('add_user') && <Route exact path={USER_URL} component={UsersDetailContainer} />}
         </Switch>
       )}
 
       {userCanAccess('departments') && (
         <Switch location={location}>
-          <Route
-            exact
-            path={routes.departments}
-            component={DepartmentsOverviewContainer}
-          />
+          <Route exact path={routes.departments} component={DepartmentsOverviewContainer} />
 
           {userCanAccess('departmentForm') && (
-            <Route
-              exact
-              path={routes.department}
-              component={DepartmentsDetailContainer}
-            />
+            <Route exact path={routes.department} component={DepartmentsDetailContainer} />
           )}
         </Switch>
       )}
@@ -133,62 +90,15 @@ export const SettingsModule = ({
            * always redirect from /gebruikers to /gebruikers/page/1 to avoid having complexity
            * in the UsersOverviewContainer component
            */}
-          <Redirect
-            exact
-            from={routes.categories}
-            to={`${CATEGORIES_PAGED_URL}/1`}
-          />
-          <Route
-            exact
-            path={routes.categoriesPaged}
-            component={CategoriesOverviewContainer}
-          />
+          <Redirect exact from={routes.categories} to={`${CATEGORIES_PAGED_URL}/1`} />
+          <Route exact path={routes.categoriesPaged} component={CategoriesOverviewContainer} />
 
-          {userCanAccess('categoryForm') && (
-            <Route
-              exact
-              path={routes.category}
-              component={CategoryDetailContainer}
-            />
-          )}
-          {userCan('add_category') && (
-            <Route
-              exact
-              path={CATEGORY_URL}
-              component={CategoryDetailContainer}
-            />
-          )}
+          {userCanAccess('categoryForm') && <Route exact path={routes.category} component={CategoryDetailContainer} />}
+          {userCan('add_category') && <Route exact path={CATEGORY_URL} component={CategoryDetailContainer} />}
         </Switch>
       )}
     </SettingsContext.Provider>
   );
 };
 
-SettingsModule.propTypes = {
-  fetchCategoriesAction: PropTypes.func.isRequired,
-  onFetchDepartments: PropTypes.func.isRequired,
-  onFetchPermissions: PropTypes.func.isRequired,
-  onFetchRoles: PropTypes.func.isRequired,
-  userCan: PropTypes.func.isRequired,
-  userCanAccess: PropTypes.func.isRequired,
-};
-
-const mapStateToProps = createStructuredSelector({
-  userCan: makeSelectUserCan,
-  userCanAccess: makeSelectUserCanAccess,
-});
-
-export const mapDispatchToProps = dispatch =>
-  bindActionCreators(
-    {
-      fetchCategoriesAction: fetchCategories,
-      onFetchDepartments: fetchDepartments,
-      onFetchPermissions: fetchPermissions,
-      onFetchRoles: fetchRoles,
-    },
-    dispatch
-  );
-
-const withConnect = connect(mapStateToProps, mapDispatchToProps);
-
-export default memo(withConnect(SettingsModule));
+export default SettingsModule;


### PR DESCRIPTION
This PR moves the fetch of subcategories to the `App` container level. Previously, subcategories were retrieved in the `incident-management` and `settings` modules. Since subcategories are also required in the `incident` modules, it makes sense to move the responsibility of retrieving the data to the highest level in the application.