### PR TITLE
[SIG-3092] Updates the description value when the predictions are disabled

### DIFF
--- a/src/signals/incident/components/form/DescriptionWithClassificationInput/index.js
+++ b/src/signals/incident/components/form/DescriptionWithClassificationInput/index.js
@@ -8,8 +8,7 @@ import './style.scss';
 
 function get(e, meta, parent) {
   const { getClassification, updateIncident, incidentContainer: { usePredictions } } = parent?.meta;
-  if (!usePredictions) return;
-  if (e.target.value) getClassification(e.target.value);
+  if (usePredictions && e.target.value) getClassification(e.target.value);
   updateIncident({ [meta.name]: e.target.value });
 }
 

--- a/src/signals/incident/components/form/DescriptionWithClassificationInput/index.test.js
+++ b/src/signals/incident/components/form/DescriptionWithClassificationInput/index.test.js
@@ -141,7 +141,9 @@ describe('Form component <DescriptionWithClassificationInput />', () => {
 
       wrapper.find(TextArea).simulate('blur', { target: { value: 'diabolo' } });
       expect(parent.meta.getClassification).not.toHaveBeenCalled();
-      expect(parent.meta.updateIncident).not.toHaveBeenCalled();
+      expect(parent.meta.updateIncident).toHaveBeenCalledWith({
+        'input-field-name': 'diabolo',
+      });
     });
   });
 });


### PR DESCRIPTION
This bug fixes a bug that prevented updating the description value when the predictions were disabled