### PR TITLE
[SIG-3091] Add default text to subcategory select input

### DIFF
--- a/src/signals/incident/components/form/CategorySelect/CategorySelect.js
+++ b/src/signals/incident/components/form/CategorySelect/CategorySelect.js
@@ -11,11 +11,14 @@ const StyledInfoText = styled(InfoText)`
   margin-bottom: 0;
 `;
 
+const defaultOption = { key: '', name: 'Selecteer subcatgorie', value: '' };
+
 const CategorySelect = ({ handler, meta, parent }) => {
   const subcategories = useSelector(makeSelectSubCategories);
   const options = useMemo(() => subcategories?.map(({ slug, name }) => ({ key: slug, name, value: slug })), [
     subcategories,
   ]);
+
   const { value } = handler();
 
   const [info, setInfo] = useState();
@@ -49,7 +52,7 @@ const CategorySelect = ({ handler, meta, parent }) => {
 
   return (
     <div>
-      <Select name={meta.name} value={`${handler().value}`} onChange={handleChange} options={options || []} />
+      <Select name={meta.name} value={`${handler().value}`} onChange={handleChange} options={[defaultOption, ...options || []]} />
       {info && <StyledInfoText text={`${info}`} />}
     </div>
   );

--- a/src/signals/incident/components/form/CategorySelect/CategorySelect.test.js
+++ b/src/signals/incident/components/form/CategorySelect/CategorySelect.test.js
@@ -52,7 +52,7 @@ describe('signals/incident/components/form/CategorySelect', () => {
 
     const element = queryByTestId('categorySelect');
     expect(element).toBeInTheDocument();
-    expect(element.querySelectorAll('option').length).toEqual(subCategories.length);
+    expect(element.querySelectorAll('option').length).toEqual(subCategories.length + 1);
     expect(queryByTestId('infoText')).toBeInTheDocument();
   });
 
@@ -61,7 +61,7 @@ describe('signals/incident/components/form/CategorySelect', () => {
     const { queryByTestId } = render(withAppContext(<CategorySelect {...props} meta={{ ...metaFields }} />));
     const element = queryByTestId('categorySelect');
     expect(element).toBeInTheDocument();
-    expect(element.querySelectorAll('option').length).toEqual(0);
+    expect(element.querySelectorAll('option').length).toEqual(1);
     expect(queryByTestId('infoText')).not.toBeInTheDocument();
   });
 


### PR DESCRIPTION
This PR displays an default text in the CategorySelect component.
