### PR TITLE
Fix cat and subcat sent to questions endpoint

### DIFF
--- a/src/signals/incident/containers/IncidentContainer/saga.js
+++ b/src/signals/incident/containers/IncidentContainer/saga.js
@@ -27,25 +27,26 @@ export function* getClassification(action) {
       text: action.payload,
     });
 
-    const { category, subcategory } = resolveClassification(result);
-    const classification = yield call(
+    const resolved = resolveClassification(result);
+    const { category, subcategory } = resolved;
+    const categoryData = yield call(
       request,
       `${configuration.CATEGORIES_ENDPOINT}${category}/sub_categories/${subcategory}`
     );
 
-    yield put(getClassificationSuccess(getClassificationData(category, subcategory, classification)));
+    yield put(getClassificationSuccess(getClassificationData(category, subcategory, categoryData)));
 
     if (configuration.fetchQuestionsFromBackend) {
-      yield put(getQuestions(classification));
+      yield put(getQuestions(resolved));
     }
   } catch {
     const { category, subcategory } = resolveClassification();
-    const classification = yield call(
+    const categoryData = yield call(
       request,
       `${configuration.CATEGORIES_ENDPOINT}${category}/sub_categories/${subcategory}`
     );
 
-    yield put(getClassificationError(getClassificationData(category, subcategory, classification)));
+    yield put(getClassificationError(getClassificationData(category, subcategory, categoryData)));
   }
 }
 

--- a/src/signals/incident/containers/IncidentContainer/saga.test.js
+++ b/src/signals/incident/containers/IncidentContainer/saga.test.js
@@ -167,7 +167,7 @@ describe('IncidentContainer saga', () => {
         ])
         .call(request, `${configuration.CATEGORIES_ENDPOINT}${category}/sub_categories/${subcategory}`)
         .put.actionType(constants.GET_CLASSIFICATION_SUCCESS)
-        .put.actionType(constants.GET_QUESTIONS)
+        .put({ type: constants.GET_QUESTIONS, payload: { category, subcategory } })
         .run();
     });
 


### PR DESCRIPTION
Due to a previous change, the parameters `category` and `subcategory` weren't sent to the `questions` endpoint anymore. This change fixes that bug.

Unit test has been updated to catch this in the future.