### PR TITLE
[SIG-3183] Keeps the children when updating the incident

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/__tests__/reducer.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/__tests__/reducer.test.js
@@ -67,13 +67,13 @@ describe('signals/incident-management/containers/IncidentDetail/reducer', () => 
       children,
     };
 
-    expect(reducer(intermediateState, { type: SET_INCIDENT, payload: incident })).toEqual({
+    expect(reducer(intermediateState, { type: SET_INCIDENT, payload: { incident } })).toEqual({
       ...intermediateState,
       incident: {
         ...intermediateState.incident,
         ...incident,
       },
-      children: undefined,
+      children,
     });
   });
 

--- a/src/signals/incident-management/containers/IncidentDetail/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/index.js
@@ -140,8 +140,7 @@ const IncidentDetail = () => {
 
   useEffect(() => {
     if (!incident) return;
-
-    dispatch({ type: SET_INCIDENT, payload: incident });
+    dispatch({ type: SET_INCIDENT, payload: { incident } });
 
     retrieveUnderlyingData();
   }, [incident, retrieveUnderlyingData]);

--- a/src/signals/incident-management/containers/IncidentDetail/reducer.js
+++ b/src/signals/incident-management/containers/IncidentDetail/reducer.js
@@ -52,7 +52,7 @@ const reducer = (state, action) => {
       return { ...state, defaultTexts: action.payload };
 
     case SET_INCIDENT:
-      return { ...state, children: undefined, incident: { ...state.incident, ...action.payload } };
+      return { ...state, incident: { ...state.incident, ...action.payload.incident } };
 
     case PATCH_START:
       return { ...state, patching: action.payload };


### PR DESCRIPTION
This PR ensure that when updating an incident (for example changing the priority), the children are not retested. 