### PR TITLE
[SIG-2879] Adds  the has_changed_children filter

### DIFF
--- a/src/signals/incident-management/components/FilterForm/index.js
+++ b/src/signals/incident-management/components/FilterForm/index.js
@@ -374,6 +374,16 @@ const FilterForm = ({ filter, onCancel, onClearFilter, onSaveFilter, onSubmit, o
               onToggle={onGroupToggle}
               options={dataLists.directing_department}
             />
+
+            <CheckboxGroup
+              defaultValue={state.options.has_changed_children}
+              hasToggle={false}
+              label="Wijziging"
+              name="has_changed_children"
+              onChange={onGroupChange}
+              onToggle={onGroupToggle}
+              options={dataLists.has_changed_children}
+            />
           </Fieldset>
 
           <FilterGroup>

--- a/src/signals/incident-management/components/FilterForm/reducer.js
+++ b/src/signals/incident-management/components/FilterForm/reducer.js
@@ -31,6 +31,8 @@ export const initialState = {
     area: [],
     stadsdeel: [],
     status: [],
+    directing_department: [],
+    has_changed_children: [],
   },
 };
 

--- a/src/signals/incident-management/containers/FilterTagList/__tests__/FilterTagList.test.js
+++ b/src/signals/incident-management/containers/FilterTagList/__tests__/FilterTagList.test.js
@@ -256,5 +256,6 @@ describe('signals/incident-management/containers/FilterTagList', () => {
     expect(mapKeys('priority')).toEqual('urgentie');
     expect(mapKeys('contact_details')).toEqual('contact');
     expect(mapKeys('directing_department')).toEqual('verantwoordelijke afdeling');
+    expect(mapKeys('has_changed_children')).toEqual('Wijziging in deelmeldingen');
   });
 });

--- a/src/signals/incident-management/containers/FilterTagList/index.js
+++ b/src/signals/incident-management/containers/FilterTagList/index.js
@@ -45,6 +45,9 @@ export const mapKeys = key => {
     case 'directing_department':
       return 'verantwoordelijke afdeling';
 
+    case 'has_changed_children':
+      return 'Wijziging in deelmeldingen';
+
     default:
       return key;
   }

--- a/src/signals/incident-management/definitions/changedChildrenList.js
+++ b/src/signals/incident-management/definitions/changedChildrenList.js
@@ -1,0 +1,6 @@
+const directingDepartmentList = [
+  { key: 'true', value: 'Hoofdmelding met wijziging in deelmelding' },
+  { key: 'false', value: 'Hoofdmelding zonder wijziging in deelmelding' },
+];
+
+export default directingDepartmentList;

--- a/src/signals/incident-management/definitions/index.js
+++ b/src/signals/incident-management/definitions/index.js
@@ -1,3 +1,4 @@
+import changedChildrenList from './changedChildrenList';
 import contactDetailsList from './contactDetailsList';
 import directingDepartmentList from './directingDepartmentList';
 import feedbackList from './feedbackList';
@@ -12,6 +13,7 @@ export { feedbackList, priorityList, stadsdeelList, statusList, sourceList, cont
 
 export default {
   contact_details: contactDetailsList,
+  has_changed_children: changedChildrenList,
   directing_department: directingDepartmentList,
   feedback: feedbackList,
   kind: kindList,

--- a/src/signals/shared/filter/parse.js
+++ b/src/signals/shared/filter/parse.js
@@ -10,6 +10,7 @@ const arrayFields = [
   'category_slug',
   'contact_details',
   'directing_department',
+  'has_changed_children',
   'kind',
   'maincategory_slug',
   'priority',
@@ -50,6 +51,7 @@ export const parseOutputFormData = options =>
       case 'area':
       case 'contact_details':
       case 'directing_department':
+      case 'has_changed_children':
       case 'kind':
       case 'priority':
       case 'source':


### PR DESCRIPTION
This PR adds the `has_changed_children` filter so the user can filter the main incidents on changes in the children incidents
