### PR TITLE
(Chore) Removes duplicated conversion code for departments

### DIFF
--- a/src/signals/settings/departments/Overview/__tests__/Overview.test.js
+++ b/src/signals/settings/departments/Overview/__tests__/Overview.test.js
@@ -3,20 +3,13 @@ import { render, fireEvent, waitFor, act } from '@testing-library/react';
 import * as reactRouterDom from 'react-router-dom';
 
 import { withAppContext } from 'test/utils';
-import departmentsJson from 'utils/__tests__/fixtures/departments.json';
+import { departments } from 'utils/__tests__/fixtures';
 import { DEPARTMENT_URL } from 'signals/settings/routes';
 
 import * as modelSelectors from 'models/departments/selectors';
 import * as appSelectors from 'containers/App/selectors';
 
 import DepartmentOverview from '..';
-
-const departments = {
-  ...departmentsJson,
-  count: departmentsJson.count,
-  list: departmentsJson.results,
-  results: undefined,
-};
 
 jest.mock('react-router-dom', () => ({
   __esModule: true,
@@ -87,7 +80,7 @@ describe('signals/settings/departments/Overview', () => {
   it('should push on list item click', async () => {
     jest.spyOn(appSelectors, 'makeSelectUserCan').mockImplementation(() => () => true);
 
-    const { id } = departmentsJson.results[12];
+    const { id } = departments.list[12];
     const { container } = render(withAppContext(<DepartmentOverview />));
 
     let row;
@@ -129,7 +122,7 @@ describe('signals/settings/departments/Overview', () => {
 
   it('should not push on list item click when permissions are insufficient', async () => {
     jest.spyOn(appSelectors, 'makeSelectUserCan').mockImplementation(() => () => false);
-    const { id } = departmentsJson.results[9];
+    const { id } = departments.list[9];
     const { container } = render(withAppContext(<DepartmentOverview />));
 
     let row;

--- a/src/signals/settings/users/Detail/__tests__/Detail.test.js
+++ b/src/signals/settings/users/Detail/__tests__/Detail.test.js
@@ -11,7 +11,7 @@ import routes from 'signals/settings/routes';
 import userFixture from 'utils/__tests__/fixtures/user.json';
 import historyFixture from 'utils/__tests__/fixtures/history.json';
 import rolesFixture from 'utils/__tests__/fixtures/roles.json';
-import departmentsFixture from 'utils/__tests__/fixtures/departments.json';
+import { departments } from 'utils/__tests__/fixtures';
 import inputCheckboxRolesSelectorJson from 'utils/__tests__/fixtures/inputCheckboxRolesSelector.json';
 
 import * as rolesSelectors from 'models/roles/selectors';
@@ -19,13 +19,6 @@ import * as modelSelectors from 'models/departments/selectors';
 import * as appSelectors from 'containers/App/selectors';
 
 import UserDetail from '..';
-
-const departments = {
-  ...departmentsFixture,
-  count: departmentsFixture.count,
-  list: departmentsFixture.results,
-  results: undefined,
-};
 
 jest.mock('react-router-dom', () => ({
   __esModule: true,

--- a/src/signals/settings/users/Detail/components/UserForm/__tests__/UserForm.test.js
+++ b/src/signals/settings/users/Detail/components/UserForm/__tests__/UserForm.test.js
@@ -3,7 +3,7 @@ import { act, fireEvent, render } from '@testing-library/react';
 import { mount } from 'enzyme';
 import { withAppContext } from 'test/utils';
 
-import departmentsJson from 'utils/__tests__/fixtures/departments.json';
+import { departments } from 'utils/__tests__/fixtures';
 import inputCheckboxRolesSelectorJson from
   'utils/__tests__/fixtures/inputCheckboxRolesSelector.json';
 
@@ -11,12 +11,6 @@ import * as modelSelectors from 'models/departments/selectors';
 import * as rolesSelectors from 'models/roles/selectors';
 
 import UserForm from '..';
-
-const departments = {
-  ...departmentsJson,
-  list: departmentsJson.results,
-  results: undefined,
-};
 
 jest.mock('models/departments/selectors', () => ({
   __esModule: true,
@@ -50,10 +44,10 @@ describe('signals/settings/users/containers/Detail/components/UserForm', () => {
     expect(container.querySelectorAll('[name="is_active"]')[1].value).toBe('false');
     expect(container.querySelectorAll('[name="is_active"]')[1].checked).toBe(false);
 
-    expect(container.querySelectorAll('[name="departments"]')).toHaveLength(departmentsJson.count);
+    expect(container.querySelectorAll('[name="departments"]')).toHaveLength(departments.count);
 
-    const uncheckedDepartmentIndex = departmentsJson.results.indexOf(
-      departmentsJson.results.find(({ name }) => name === 'Port of Amsterdam')
+    const uncheckedDepartmentIndex = departments.list.indexOf(
+      departments.list.find(({ name }) => name === 'Port of Amsterdam')
     );
 
     expect(container.querySelectorAll('[name="departments"]')[uncheckedDepartmentIndex].checked)
@@ -136,13 +130,13 @@ describe('signals/settings/users/containers/Detail/components/UserForm', () => {
     expect(container.querySelector('[name="is_active"][value="false"]').checked).toBe(false);
     expect(container.querySelector('[name="note"]').value).toBe(data.profile.note);
 
-    const checkedDepartmentIndex = departmentsJson.results.indexOf(
-      departmentsJson.results.find(({ name }) => name === 'Actie Service Centrum')
+    const checkedDepartmentIndex = departments.list.indexOf(
+      departments.list.find(({ name }) => name === 'Actie Service Centrum')
     );
     expect(container.querySelectorAll('[name="departments"]')[checkedDepartmentIndex].checked).toBe(true);
 
-    const uncheckedDepartmentIndex = departmentsJson.results.indexOf(
-      departmentsJson.results.find(({ name }) => name === 'Port of Amsterdam')
+    const uncheckedDepartmentIndex = departments.list.indexOf(
+      departments.list.find(({ name }) => name === 'Port of Amsterdam')
     );
     expect(container.querySelectorAll('[name="departments"]')[uncheckedDepartmentIndex].checked).toBe(false);
   });


### PR DESCRIPTION
This PR applies DRY rules to the departments fixture. The conversion to the internal format is already done in the `utils/__tests__/fixtures`