### PR TITLE
[SIG-2884] Show a warning when the state of the child incidents is not closed

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/__tests__/StatusForm.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/__tests__/StatusForm.test.js
@@ -3,7 +3,7 @@ import { render, fireEvent, act, cleanup } from '@testing-library/react';
 
 import { withAppContext } from 'test/utils';
 import incidentFixture from 'utils/__tests__/fixtures/incident.json';
-import { changeStatusOptionList } from '../../../../../definitions/statusList';
+import { changeStatusOptionList, GEMELD, INGEPLAND, AFGEHANDELD, GEANNULEERD } from 'signals/incident-management/definitions/statusList';
 
 import { PATCH_TYPE_STATUS } from '../../../constants';
 import IncidentDetailContext from '../../../context';
@@ -14,6 +14,7 @@ import {
   AFGEHANDELD_EXPLANATION,
   GEANNULEERD_EXPLANATION,
   DEELMELDING_EXPLANATION,
+  DEELMELDINGEN_STILL_OPEN,
 } from '../constants';
 
 const defaultTexts = [
@@ -39,10 +40,10 @@ const defaultTexts = [
 const close = jest.fn();
 const update = jest.fn();
 
-const renderWithContext = (incident = incidentFixture) =>
+const renderWithContext = (incident = incidentFixture, childIncidents) =>
   withAppContext(
     <IncidentDetailContext.Provider value={{ incident, update, close }}>
-      <StatusForm defaultTexts={defaultTexts} />
+      <StatusForm defaultTexts={defaultTexts} childIncidents={childIncidents} />
     </IncidentDetailContext.Provider>
   );
 
@@ -398,5 +399,47 @@ describe('signals/incident-management/containers/IncidentDetail/components/Statu
 
     // verify that explanation with text DEELMELDING_EXPLANATION is visible
     expect(getByTestId('statusExplanation').textContent).toEqual(DEELMELDING_EXPLANATION);
+  });
+
+  it('shows a warning when there are child incidents still open', async () => {
+    const childIncidents = [GEMELD, INGEPLAND].map(({ key }) => ({
+      status: { state: key },
+    }));
+    const { container, queryByTestId, getByTestId } = render(renderWithContext(incidentFixture, childIncidents));
+
+    expect(queryByTestId('statusHasChildrenOpen')).not.toBeInTheDocument();
+
+    fireEvent.click(container.querySelector(`input[value="${AFGEHANDELD.key}"]`));
+
+    expect(getByTestId('statusHasChildrenOpen').textContent).toEqual(DEELMELDINGEN_STILL_OPEN);
+
+    fireEvent.click(container.querySelector(`input[value="${INGEPLAND.key}"]`));
+
+    expect(queryByTestId('statusHasChildrenOpen')).not.toBeInTheDocument();
+
+    fireEvent.click(container.querySelector(`input[value="${GEANNULEERD.key}"]`));
+    expect(getByTestId('statusHasChildrenOpen').textContent).toEqual(DEELMELDINGEN_STILL_OPEN);
+  });
+
+  it('shows NO warning when the child incidents are closed', async () => {
+    const childIncidents = [AFGEHANDELD, GEANNULEERD].map(({ key }) => ({
+      status: { state: key },
+    }));
+
+    const { container, queryByTestId } = render(renderWithContext(incidentFixture, childIncidents));
+
+    expect(queryByTestId('statusHasChildrenOpen')).not.toBeInTheDocument();
+
+    fireEvent.click(container.querySelector(`input[value="${AFGEHANDELD.key}"]`));
+
+    expect(queryByTestId('statusHasChildrenOpen')).not.toBeInTheDocument();
+
+    fireEvent.click(container.querySelector(`input[value="${INGEPLAND.key}"]`));
+
+    expect(queryByTestId('statusHasChildrenOpen')).not.toBeInTheDocument();
+
+    fireEvent.click(container.querySelector(`input[value="${GEANNULEERD.key}"]`));
+
+    expect(queryByTestId('statusHasChildrenOpen')).not.toBeInTheDocument();
   });
 });

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/constants.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/constants.js
@@ -5,3 +5,4 @@ export const GEANNULEERD_EXPLANATION =
 export const MELDING_CHECKBOX_DESCRIPTION =
   'Stuur deze toelichting naar de melder. Let dus op de schrijfstijl. De e-mail bevat al een aanhef en afsluiting.';
 export const DEELMELDING_EXPLANATION = 'De melder ontvangt deze toelichting niet.';
+export const DEELMELDINGEN_STILL_OPEN = 'Let op! Er zijn deelmeldingen nog niet afgehandeld.';

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/index.js
@@ -118,7 +118,7 @@ const StatusForm = ({ defaultTexts, childIncidents }) => {
 
             {isStatusClosed(state.status.key) && hasOpenChildren && (
               <Notification warning data-testid="statusHasChildrenOpen">
-                Let op! Er zijn deelmeldingen nog niet afgehandeld.
+                {constants.DEELMELDINGEN_STILL_OPEN}
               </Notification>
             )}
           </OptionsArea>

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/styled.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/styled.js
@@ -32,6 +32,8 @@ export const HeaderArea = styled.div`
 
 export const OptionsArea = styled.div`
   grid-area: options;
+  display: grid;
+  grid-row-gap: ${themeSpacing(4)};
 `;
 
 export const TextsArea = styled.div`

--- a/src/signals/incident-management/containers/IncidentDetail/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/index.js
@@ -253,7 +253,7 @@ const IncidentDetail = () => {
 
         {(state.preview || state.edit) && (
           <Preview>
-            {state.edit === 'status' && <StatusForm defaultTexts={state.defaultTexts} error={state.error} />}
+            {state.edit === 'status' && <StatusForm defaultTexts={state.defaultTexts} childIncidents={state.children?.results} />}
 
             {state.preview === 'location' && <LocationPreview />}
 

--- a/src/signals/incident-management/definitions/statusList.js
+++ b/src/signals/incident-management/definitions/statusList.js
@@ -1,4 +1,4 @@
-const GEMELD = {
+export const GEMELD = {
   key: 'm',
   value: 'Gemeld',
   color: 'red',
@@ -6,7 +6,7 @@ const GEMELD = {
   shows_remaining_sla_days: true,
 };
 
-const AFWACHTING = {
+export const AFWACHTING = {
   key: 'i',
   value: 'In afwachting van behandeling',
   color: 'purple',
@@ -14,7 +14,7 @@ const AFWACHTING = {
   shows_remaining_sla_days: true,
 };
 
-const BEHANDELING = {
+export const BEHANDELING = {
   key: 'b',
   value: 'In behandeling',
   color: 'blue',
@@ -22,7 +22,7 @@ const BEHANDELING = {
   shows_remaining_sla_days: true,
 };
 
-const AFGEHANDELD = {
+export const AFGEHANDELD = {
   key: 'o',
   value: 'Afgehandeld',
   color: 'lightgreen',
@@ -30,7 +30,7 @@ const AFGEHANDELD = {
   shows_remaining_sla_days: false,
 };
 
-const GESPLITST = {
+export const GESPLITST = {
   key: 's',
   value: 'Gesplitst',
   color: 'lightgreen',
@@ -38,7 +38,7 @@ const GESPLITST = {
   shows_remaining_sla_days: false,
 };
 
-const INGEPLAND = {
+export const INGEPLAND = {
   key: 'ingepland',
   value: 'Ingepland',
   color: 'grey',
@@ -46,7 +46,7 @@ const INGEPLAND = {
   shows_remaining_sla_days: true,
 };
 
-const GEANNULEERD = {
+export const GEANNULEERD = {
   key: 'a',
   value: 'Geannuleerd',
   color: 'darkgrey',
@@ -54,7 +54,7 @@ const GEANNULEERD = {
   shows_remaining_sla_days: false,
 };
 
-const VERZOEK_TOT_HEROPENEN = {
+export const VERZOEK_TOT_HEROPENEN = {
   key: 'reopen requested',
   value: 'Verzoek tot heropenen',
   color: 'orange',
@@ -62,7 +62,7 @@ const VERZOEK_TOT_HEROPENEN = {
   shows_remaining_sla_days: false,
 };
 
-const HEROPEND = {
+export const HEROPEND = {
   key: 'reopened',
   value: 'Heropend',
   color: 'orange',
@@ -70,35 +70,35 @@ const HEROPEND = {
   shows_remaining_sla_days: true,
 };
 
-const TE_VERZENDEN = {
+export const TE_VERZENDEN = {
   key: 'ready to send',
   value: 'Extern: te verzenden',
   email_sent_when_set: false,
   shows_remaining_sla_days: true,
 };
 
-const VERZONDEN = {
+export const VERZONDEN = {
   key: 'sent',
   value: 'Extern: verzonden',
   email_sent_when_set: false,
   shows_remaining_sla_days: true,
 };
 
-const VERZENDEN_MISLUKT = {
+export const VERZENDEN_MISLUKT = {
   key: 'send failed',
   value: 'Extern: mislukt',
   email_sent_when_set: false,
   shows_remaining_sla_days: true,
 };
 
-const VERZOEK_TOT_AFHANDELING = {
+export const VERZOEK_TOT_AFHANDELING = {
   key: 'closure requested',
   value: 'Extern: verzoek tot afhandeling',
   email_sent_when_set: false,
   shows_remaining_sla_days: true,
 };
 
-const AFGEHANDELD_EXTERN = {
+export const AFGEHANDELD_EXTERN = {
   key: 'done external',
   value: 'Extern: afgehandeld',
   email_sent_when_set: false,

--- a/src/signals/incident-management/definitions/statusList.js
+++ b/src/signals/incident-management/definitions/statusList.js
@@ -135,6 +135,6 @@ export const changeStatusOptionList = [
   GEANNULEERD,
 ];
 
-export const isStatusClosed = status => [AFGEHANDELD, GEANNULEERD].map(({ key }) => key).some(s => s === status);
+export const isStatusClosed = status => [AFGEHANDELD, GEANNULEERD].map(({ key }) => key).some(value => value === status);
 
 export const defaultTextsOptionList = [...changeStatusOptionList];

--- a/src/signals/incident-management/definitions/statusList.js
+++ b/src/signals/incident-management/definitions/statusList.js
@@ -135,4 +135,6 @@ export const changeStatusOptionList = [
   GEANNULEERD,
 ];
 
+export const isStatusClosed = status => [AFGEHANDELD, GEANNULEERD].map(({ key }) => key).some(s => s === status);
+
 export const defaultTextsOptionList = [...changeStatusOptionList];


### PR DESCRIPTION
This PR shows a warning when the state of a parent incident is changed to Closed (`afgehandeld` or `geannuleerd`) and one of its children is not yet Closed. 