### PR TITLE
[FE#81] Move site address reference to configuration

### DIFF
--- a/app.base.json
+++ b/app.base.json
@@ -25,6 +25,7 @@
     "headerTitle": "",
     "phoneNumber": "14 020",
     "shortTitle": "SIA",
+    "siteAddress": "meldingen.amsterdam.nl",
     "siteTitle": "SIA - Signalen Informatievoorziening Amsterdam",
     "smallHeaderTitle": "SIA",
     "title": "Signalen Informatievoorziening Amsterdam",

--- a/internals/schemas/app.schema.json
+++ b/internals/schemas/app.schema.json
@@ -183,7 +183,7 @@
           "type": "string"
         },
         "siteAddress": {
-          "description": "The site's address, for having a means of referencing the site by it's address",
+          "description": "The site's address, for having a means of referencing the site by its address",
           "type": "string"
         },
         "siteTitle": {

--- a/internals/schemas/app.schema.json
+++ b/internals/schemas/app.schema.json
@@ -182,6 +182,10 @@
           "description": "PWA `short_name` property value. Should not exceed 12 characters. See https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/short_name for reference",
           "type": "string"
         },
+        "siteAddress": {
+          "description": "The site's address, for having a means of referencing the site by it's address",
+          "type": "string"
+        },
         "siteTitle": {
           "description": "Application title showing up in the title bar and search results",
           "type": "string"
@@ -208,6 +212,7 @@
         "headerTitle",
         "phoneNumber",
         "shortTitle",
+        "siteAddress",
         "siteTitle",
         "smallHeaderTitle",
         "title",

--- a/src/components/Map/index.js
+++ b/src/components/Map/index.js
@@ -98,7 +98,7 @@ const Map = ({
                   dispatch(
                     showGlobalNotification({
                       variant: VARIANT_NOTICE,
-                      title: 'meldingen.amsterdam.nl heeft geen toestemming om uw locatie te gebruiken.',
+                      title: `${configuration.language.siteAddress} heeft geen toestemming om uw locatie te gebruiken.`,
                       message: 'Dit kunt u wijzigen in de voorkeuren of instellingen van uw browser of systeem.',
                       type: TYPE_LOCAL,
                     })


### PR DESCRIPTION
closes Signalen/frontend#81

There was a reference left in the code to Amsterdam by means of the site's address. This PR moves this to the language section of the configuration `language.siteAddress`.

**Update to `app.base.json`**

`language.siteAddress`
The site's address, for having a means of referencing the site by its address.
Default value: `meldingen.amsterdam.nl`.