### PR TITLE
Validate base config on pre commit hook

### DIFF
--- a/internals/scripts/validate-base-config.js
+++ b/internals/scripts/validate-base-config.js
@@ -1,0 +1,14 @@
+const { validator } = require('@exodus/schemasafe');
+
+const { baseConfig } = require('./helpers/config');
+const schema = require('../schemas/app.schema.json');
+
+const validate = validator(schema, { includeErrors: true, allErrors: true });
+const valid = validate(baseConfig);
+
+if (!valid) {
+  /* eslint-disable no-console */
+  console.log('Configuration is not valid according to app.schema.json');
+  console.table(validate.errors);
+  process.exit(1);
+}

--- a/package.json
+++ b/package.json
@@ -39,14 +39,15 @@
     "test:update": "cross-env NODE_ENV=test jest --updateSnapshot --coverage --verbose false",
     "test:watch": "cross-env NODE_ENV=test jest --watchAll --coverage --verbose false",
     "test": "cross-env NODE_ENV=test jest --coverage",
-    "validate-config": "node ./internals/scripts/validate-config.js"
+    "validate-config": "node ./internals/scripts/validate-config.js",
+    "validate-base-config": "node ./internals/scripts/validate-base-config.js"
   },
   "lint-staged": {
     "*.js": "eslint --ignore-pattern internals/scripts --ignore-pattern e2e-tests"
   },
   "pre-commit": [
     "lint:staged",
-    "validate-config"
+    "validate-base-config"
   ],
   "dependencies": {
     "@datapunt/amsterdam-react-maps": "^0.1.2",


### PR DESCRIPTION
The pre-commit hook validated the configuration in `app.base.json`, including any extended configuration in `app.json`. It only needs to validate `app.base.json` however, since `app.json` won't be committed as it's ignored.

This makes it easier to keep some extended configuration in `app.json` in development, while switching branches.

`validate-base-config.js` in this PR is a copy of `validate-config.js` with the only difference that it does `const { baseConfig } = require('./helpers/config');` instead of `const { config } = require('./helpers/config');`.