### PR TITLE
Fix split incident form opening with multiple incident forms

### DIFF
--- a/src/signals/incident-management/containers/IncidentSplitContainer/components/IncidentSplitFormIncident/__tests__/IncidentSplitFormIncident.test.js
+++ b/src/signals/incident-management/containers/IncidentSplitContainer/components/IncidentSplitFormIncident/__tests__/IncidentSplitFormIncident.test.js
@@ -41,13 +41,14 @@ describe('IncidentSplitFormIncident', () => {
     expect(queryAllByTestId('incidentSplitFormIncidentTitle')[9]).toHaveTextContent(/^Deelmelding 10$/);
   });
 
-  it('should render incremented incident count for new split incidents', () => {
+  it('should render incident split form when parent already has split incidents', () => {
     const parentIncidentWithChildCount = {
       ...parentIncidentFixture,
       childrenCount: 3,
     };
     render(withAppContext(<IncidentSplitFormIncident {...props} parentIncident={parentIncidentWithChildCount} />));
 
+    expect(screen.getAllByRole('heading', { name: /^Deelmelding \d+$/ })).toHaveLength(1);
     expect(screen.getByRole('heading', { name: 'Deelmelding 4' })).toBeInTheDocument();
   });
 });

--- a/src/signals/incident-management/containers/IncidentSplitContainer/components/IncidentSplitFormIncident/index.js
+++ b/src/signals/incident-management/containers/IncidentSplitContainer/components/IncidentSplitFormIncident/index.js
@@ -17,7 +17,7 @@ import IncidentSplitSelectInput from '../IncidentSplitSelectInput';
 export const INCIDENT_SPLIT_LIMIT = 10;
 
 const IncidentSplitFormIncident = ({ parentIncident, subcategories, register }) => {
-  const [splitCount, setSplitCount] = useState(parentIncident.childrenCount || 1);
+  const [splitCount, setSplitCount] = useState(1);
 
   const addIncident = useCallback(
     event => {


### PR DESCRIPTION
## Signalen

Fixes bug where, if the incident was previously splitted _X_ times, the incident split form would open with _X_ forms. 