### PR TITLE
[SIG-3262] Add the directing department value from the parent to the split form

### DIFF
--- a/src/models/departments/selectors.js
+++ b/src/models/departments/selectors.js
@@ -7,3 +7,8 @@ export const makeSelectDepartments = createSelector(
   selectDepartmentsDomain,
   state => state.toJS()
 );
+
+export const makeSelectDirectingDepartments = createSelector(
+  makeSelectDepartments,
+  state => state?.list.filter(department => department.can_direct)
+);

--- a/src/shared/types/index.js
+++ b/src/shared/types/index.js
@@ -356,3 +356,10 @@ export const subcategoriesType = PropTypes.arrayOf(
     info: PropTypes.string,
   })
 );
+
+export const directingDepartmentsType = PropTypes.arrayOf(
+  PropTypes.shape({
+    key: PropTypes.string.isRequired,
+    value: PropTypes.string.isRequired,
+  })
+);

--- a/src/signals/incident-management/containers/IncidentSplitContainer/IncidentSplitContainer.js
+++ b/src/signals/incident-management/containers/IncidentSplitContainer/IncidentSplitContainer.js
@@ -32,7 +32,7 @@ const IncidentSplitContainer = ({ FormComponent }) => {
   const [directingDepartment, setDirectingDepartment] = useState([]);
   const departments = useSelector(makeSelectDepartments);
   const directingDepartments = useSelector(makeSelectDirectingDepartments);
-  const directingDepartmentList = useMemo(
+  const directingDepartmentsList = useMemo(
     () => [
       { key: 'null', value: 'Verantwoordelijke afdeling' },
       ...directingDepartments.map(({ code }) => ({ key: code, value: code })),
@@ -50,8 +50,8 @@ const IncidentSplitContainer = ({ FormComponent }) => {
     const department = parentIncident?.directing_departments;
     if (!Array.isArray(department) || department.length !== 1) return 'null';
     const { code } = department[0];
-    return directingDepartmentList.find(({ key }) => key === code) ? code : 'null';
-  }, [parentIncident, directingDepartmentList]);
+    return directingDepartmentsList.find(({ key }) => key === code) ? code : 'null';
+  }, [parentIncident, directingDepartmentsList]);
 
   const updateDepartment = useCallback(
     name => {
@@ -187,6 +187,7 @@ const IncidentSplitContainer = ({ FormComponent }) => {
             directingDepartment: parentDirectingDepartment,
           }}
           subcategories={subcategoryOptions}
+          directingDepartments={directingDepartmentsList}
           onSubmit={onSubmit}
         />
       )}

--- a/src/signals/incident-management/containers/IncidentSplitContainer/IncidentSplitContainer.js
+++ b/src/signals/incident-management/containers/IncidentSplitContainer/IncidentSplitContainer.js
@@ -4,7 +4,7 @@ import { useParams, useHistory } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { makeSelectSubCategories } from 'models/categories/selectors';
-import { makeSelectDepartments } from 'models/departments/selectors';
+import { makeSelectDepartments, makeSelectDirectingDepartments } from 'models/departments/selectors';
 
 import useFetch from 'hooks/useFetch';
 import configuration from 'shared/services/configuration/configuration';
@@ -31,12 +31,27 @@ const IncidentSplitContainer = ({ FormComponent }) => {
   const [parentIncident, setParentIncident] = useState();
   const [directingDepartment, setDirectingDepartment] = useState([]);
   const departments = useSelector(makeSelectDepartments);
-  const subcategories = useSelector(makeSelectSubCategories);
+  const directingDepartments = useSelector(makeSelectDirectingDepartments);
+  const directingDepartmentList = useMemo(
+    () => [
+      { key: 'null', value: 'Verantwoordelijke afdeling' },
+      ...directingDepartments.map(({ code }) => ({ key: code, value: code })),
+    ],
+    [directingDepartments]
+  );
 
+  const subcategories = useSelector(makeSelectSubCategories);
   const subcategoryOptions = useMemo(
     () => subcategories?.map(category => ({ ...category, value: category.extendedName })),
     [subcategories]
   );
+
+  const parentDirectingDepartment = useMemo(() => {
+    const department = parentIncident?.directing_departments;
+    if (!Array.isArray(department) || department.length !== 1) return 'null';
+    const { code } = department[0];
+    return directingDepartmentList.find(({ key }) => key === code) ? code : 'null';
+  }, [parentIncident, directingDepartmentList]);
 
   const updateDepartment = useCallback(
     name => {
@@ -169,6 +184,7 @@ const IncidentSplitContainer = ({ FormComponent }) => {
             subcategoryDisplayName: `${parentIncident.category.sub} (${parentIncident.category.departments})`,
             description: parentIncident.text,
             type: parentIncident.type.code,
+            directingDepartment: parentDirectingDepartment,
           }}
           subcategories={subcategoryOptions}
           onSubmit={onSubmit}

--- a/src/signals/incident-management/containers/IncidentSplitContainer/__tests__/IncidentSplitContainer.test.js
+++ b/src/signals/incident-management/containers/IncidentSplitContainer/__tests__/IncidentSplitContainer.test.js
@@ -114,6 +114,7 @@ describe('signals/incident-management/containers/IncidentSplitContainer', () => 
 
     jest.spyOn(modelSelectors, 'makeSelectSubCategories').mockImplementation(() => subcategories);
     jest.spyOn(departmentsSelectors, 'makeSelectDepartments').mockImplementation(() => departments);
+    jest.spyOn(departmentsSelectors, 'makeSelectDirectingDepartments').mockImplementation(() => [departments.list[0]]);
 
     jest.spyOn(reactRouterDom, 'useParams').mockImplementation(() => ({ id }));
 
@@ -209,7 +210,9 @@ describe('signals/incident-management/containers/IncidentSplitContainer', () => 
       [JSON.stringify({}), { status: 201 }], // post
       [JSON.stringify({}), { status: 201 }] // patch
     );
-    const { container, findByTestId } = await renderAwait(<IncidentSplitContainer FormComponent={Form({ ...submittedFormData, department: null })} />);
+    const { container, findByTestId } = await renderAwait(
+      <IncidentSplitContainer FormComponent={Form({ ...submittedFormData, department: null })} />
+    );
 
     expect(dispatch).not.toHaveBeenCalled();
     expect(push).not.toHaveBeenCalled();
@@ -255,10 +258,12 @@ describe('signals/incident-management/containers/IncidentSplitContainer', () => 
 
   it('should display a global notification on PATCH fail', async () => {
     fetch.resetMocks();
-    fetch.mockResponses(
-      [JSON.stringify(incidentFixture), { status: 200 }], // get
-      [JSON.stringify({}), { status: 201 }], // post
-    ).mockReject(new Error('Whoops!!1!'));
+    fetch
+      .mockResponses(
+        [JSON.stringify(incidentFixture), { status: 200 }], // get
+        [JSON.stringify({}), { status: 201 }] // post
+      )
+      .mockReject(new Error('Whoops!!1!'));
 
     const { container, findByTestId } = await renderAwait(<IncidentSplitContainer FormComponent={Form()} />);
 

--- a/src/signals/incident-management/containers/IncidentSplitContainer/__tests__/parentIncidentFixture.json
+++ b/src/signals/incident-management/containers/IncidentSplitContainer/__tests__/parentIncidentFixture.json
@@ -7,5 +7,6 @@
   "subcategory": "https://acc.api.data.amsterdam.nl/signals/v1/private/categories/145",
   "subcategoryDisplayName": "STW",
   "description": "Het wegdek van de oprit naar ons hotel is kapot. Kunnen jullie dit snel maken?",
-  "type": "SIG"
+  "type": "SIG",
+  "directingDepartment": "null"
 }

--- a/src/signals/incident-management/containers/IncidentSplitContainer/components/IncidentSplitForm/__tests__/IncidentSplitForm.test.js
+++ b/src/signals/incident-management/containers/IncidentSplitContainer/components/IncidentSplitForm/__tests__/IncidentSplitForm.test.js
@@ -4,7 +4,6 @@ import { fireEvent, render } from '@testing-library/react';
 import { withAppContext } from 'test/utils';
 
 import { subcategoriesWithUniqueKeys as subcategories } from 'utils/__tests__/fixtures';
-import directingDepartmentList from 'signals/incident-management/definitions/directingDepartmentList';
 import parentIncidentFixture from '../../../__tests__/parentIncidentFixture.json';
 
 import IncidentSplitForm from '..';
@@ -34,7 +33,7 @@ describe('IncidentSplitForm', () => {
     await findByTestId('incidentSplitForm');
 
     expect(onSubmit).toHaveBeenCalledWith({
-      department: directingDepartmentList[0].key,
+      department: parentIncidentFixture.directingDepartment,
       incidents: [
         undefined,
         {

--- a/src/signals/incident-management/containers/IncidentSplitContainer/components/IncidentSplitForm/__tests__/IncidentSplitForm.test.js
+++ b/src/signals/incident-management/containers/IncidentSplitContainer/components/IncidentSplitForm/__tests__/IncidentSplitForm.test.js
@@ -3,7 +3,7 @@ import React from 'react';
 import { fireEvent, render } from '@testing-library/react';
 import { withAppContext } from 'test/utils';
 
-import { subcategoriesWithUniqueKeys as subcategories } from 'utils/__tests__/fixtures';
+import { subcategoriesWithUniqueKeys as subcategories, departments } from 'utils/__tests__/fixtures';
 import parentIncidentFixture from '../../../__tests__/parentIncidentFixture.json';
 
 import IncidentSplitForm from '..';
@@ -15,13 +15,26 @@ jest.mock('react-router-dom', () => ({
   useHistory: () => ({ push: mockHistoryPush }),
 }));
 
+const directingDepartments = [
+  { key: 'null', value: 'Verantwoordelijke afdeling' },
+  { key: departments.list[0].code, value: departments.list[0].code },
+];
+
 describe('IncidentSplitForm', () => {
   const onSubmit = jest.fn();
-  const props = { parentIncident: parentIncidentFixture, subcategories, onSubmit };
+  const props = { parentIncident: parentIncidentFixture, subcategories, directingDepartments, onSubmit };
 
   it('should render correctly', () => {
-    const { queryAllByText } = render(withAppContext(<IncidentSplitForm {...props} />));
+    const { container, queryAllByText } = render(withAppContext(<IncidentSplitForm {...props} />));
     expect(queryAllByText(parentIncidentFixture.description)).toHaveLength(1);
+    expect(container.querySelector('input[value="null"]').checked).toBe(true);
+  });
+
+  it('should render correctly with selected directing department', () => {
+    const directingDepartment = departments.list[0].code;
+    const parentIncident = { ...props.parentIncident, directingDepartment };
+    const { container } = render(withAppContext(<IncidentSplitForm {...props} parentIncident={parentIncident} />));
+    expect(container.querySelector(`input[value="${directingDepartment}"]`).checked).toBe(true);
   });
 
   it('should handle submit', async () => {

--- a/src/signals/incident-management/containers/IncidentSplitContainer/components/IncidentSplitForm/index.js
+++ b/src/signals/incident-management/containers/IncidentSplitContainer/components/IncidentSplitForm/index.js
@@ -52,7 +52,7 @@ const IncidentSplitForm = ({ parentIncident, subcategories, onSubmit }) => {
           <IncidentSplitRadioInput
             display="Regie"
             register={register}
-            initialValue={directingDepartmentList[0].key}
+            initialValue={parentIncident.directingDepartment}
             name="department"
             id="department"
             data-testid="incidentSplitFormRadioInputDepartment"
@@ -92,6 +92,7 @@ IncidentSplitForm.propTypes = {
     subcategoryDisplayName: PropTypes.string.isRequired,
     description: PropTypes.string.isRequired,
     type: PropTypes.string.isRequired,
+    directingDepartment: PropTypes.string.isRequired,
   }).isRequired,
   subcategories: subcategoriesType.isRequired,
   onSubmit: PropTypes.func.isRequired,

--- a/src/signals/incident-management/containers/IncidentSplitContainer/components/IncidentSplitForm/index.js
+++ b/src/signals/incident-management/containers/IncidentSplitContainer/components/IncidentSplitForm/index.js
@@ -5,9 +5,7 @@ import { useHistory } from 'react-router-dom';
 
 import { Heading } from '@datapunt/asc-ui';
 
-import { subcategoriesType } from 'shared/types';
-
-import directingDepartmentList from 'signals/incident-management/definitions/directingDepartmentList';
+import { directingDepartmentsType, subcategoriesType } from 'shared/types';
 
 import Button from 'components/Button';
 
@@ -21,7 +19,7 @@ import {
 import IncidentSplitFormIncident from '../IncidentSplitFormIncident';
 import IncidentSplitRadioInput from '../IncidentSplitRadioInput';
 
-const IncidentSplitForm = ({ parentIncident, subcategories, onSubmit }) => {
+const IncidentSplitForm = ({ parentIncident, subcategories, directingDepartments, onSubmit }) => {
   const { control, handleSubmit, register } = useForm();
 
   const history = useHistory();
@@ -56,7 +54,7 @@ const IncidentSplitForm = ({ parentIncident, subcategories, onSubmit }) => {
             name="department"
             id="department"
             data-testid="incidentSplitFormRadioInputDepartment"
-            options={directingDepartmentList}
+            options={directingDepartments}
           />
         </fieldset>
 
@@ -95,6 +93,7 @@ IncidentSplitForm.propTypes = {
     directingDepartment: PropTypes.string.isRequired,
   }).isRequired,
   subcategories: subcategoriesType.isRequired,
+  directingDepartments: directingDepartmentsType.isRequired,
   onSubmit: PropTypes.func.isRequired,
 };
 

--- a/src/utils/__tests__/fixtures/departments.json
+++ b/src/utils/__tests__/fixtures/departments.json
@@ -58,7 +58,8 @@
         "Vuurwerkoverlast",
         "Wildplassen / poepen / overgeven",
         "Wrak in het water"
-      ]
+      ],
+      "can_direct": true
     },
     {
       "_links": {

--- a/src/utils/__tests__/fixtures/incident.json
+++ b/src/utils/__tests__/fixtures/incident.json
@@ -139,5 +139,6 @@
       "is_image": true,
       "created_at": "2019-09-25T16: 35: 59.113090+02: 00"
     }
-  ]
+  ],
+  "directing_departments": []
 }


### PR DESCRIPTION
This PR fixes a bug that didn't select by default the directing department from the parent in the split form