### PR TITLE
[SIG-3260] Adds scroll to split incident when added

### DIFF
--- a/internals/testing/test-bundler.js
+++ b/internals/testing/test-bundler.js
@@ -49,5 +49,3 @@ global.URL.revokeObjectURL = jest.fn();
 
 const noop = () => {};
 Object.defineProperty(global.window, 'scrollTo', { value: noop, writable: true });
-
-global.window.HTMLElement.prototype.scrollIntoView = jest.fn();

--- a/internals/testing/test-bundler.js
+++ b/internals/testing/test-bundler.js
@@ -49,3 +49,5 @@ global.URL.revokeObjectURL = jest.fn();
 
 const noop = () => {};
 Object.defineProperty(global.window, 'scrollTo', { value: noop, writable: true });
+
+global.window.HTMLElement.prototype.scrollIntoView = jest.fn();

--- a/src/signals/incident-management/containers/IncidentSplitContainer/components/IncidentSplitForm/__tests__/IncidentSplitForm.test.js
+++ b/src/signals/incident-management/containers/IncidentSplitContainer/components/IncidentSplitForm/__tests__/IncidentSplitForm.test.js
@@ -39,6 +39,8 @@ describe('IncidentSplitForm', () => {
 
   it('should handle submit', async () => {
     const { findByTestId, getByTestId } = render(withAppContext(<IncidentSplitForm {...props} />));
+    // scrollIntoView is called in <IncidentSplitFormIncident /> when split button is clicked.
+    global.window.HTMLElement.prototype.scrollIntoView = jest.fn();
 
     fireEvent.click(getByTestId('incidentSplitFormIncidentSplitButton'));
     fireEvent.submit(getByTestId('incidentSplitFormSubmitButton'));

--- a/src/signals/incident-management/containers/IncidentSplitContainer/components/IncidentSplitFormIncident/__tests__/IncidentSplitFormIncident.test.js
+++ b/src/signals/incident-management/containers/IncidentSplitContainer/components/IncidentSplitFormIncident/__tests__/IncidentSplitFormIncident.test.js
@@ -20,6 +20,7 @@ describe('IncidentSplitFormIncident', () => {
   });
 
   it('should split incidents until limit is reached then it should hide incident split button', () => {
+    global.window.HTMLElement.prototype.scrollIntoView = jest.fn();
     const { getByTestId, queryAllByTestId, queryByTestId } = render(withAppContext(
       <IncidentSplitFormIncident {...props} />)
     );
@@ -39,6 +40,7 @@ describe('IncidentSplitFormIncident', () => {
     expect(queryByTestId('incidentSplitFormIncidentSplitButton')).not.toBeInTheDocument();
 
     expect(queryAllByTestId('incidentSplitFormIncidentTitle')[9]).toHaveTextContent(/^Deelmelding 10$/);
+    delete global.window.HTMLElement.prototype.scrollIntoView;
   });
 
   it('should render incident split form when parent already has split incidents', () => {

--- a/src/signals/incident-management/containers/IncidentSplitContainer/components/IncidentSplitFormIncident/__tests__/IncidentSplitFormIncident.test.js
+++ b/src/signals/incident-management/containers/IncidentSplitContainer/components/IncidentSplitFormIncident/__tests__/IncidentSplitFormIncident.test.js
@@ -8,23 +8,7 @@ import parentIncidentFixture from '../../../__tests__/parentIncidentFixture.json
 
 import IncidentSplitFormIncident from '..';
 
-const scrollIntoView = jest.fn();
-
 describe('IncidentSplitFormIncident', () => {
-  let originalScrollIntoView;
-  beforeAll(() => {
-    originalScrollIntoView = global.window.HTMLElement.prototype.scrollIntoView;
-    global.window.HTMLElement.prototype.scrollIntoView = scrollIntoView;
-  });
-
-  beforeEach(() => {
-    scrollIntoView.mockReset();
-  });
-
-  afterAll(() => {
-    global.window.HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
-  });
-
   const register = jest.fn();
   const props = { parentIncident: parentIncidentFixture, subcategories, register };
 
@@ -69,6 +53,9 @@ describe('IncidentSplitFormIncident', () => {
   });
 
   it('should scroll new incident into view', () => {
+    const originalScrollIntoView = global.window.HTMLElement.prototype.scrollIntoView;
+    const scrollIntoView = jest.fn();
+    global.window.HTMLElement.prototype.scrollIntoView = scrollIntoView;
     render(withAppContext(<IncidentSplitFormIncident {...props} />));
 
     expect(scrollIntoView).not.toHaveBeenCalled();
@@ -77,5 +64,7 @@ describe('IncidentSplitFormIncident', () => {
     fireEvent.click(addIncidentButton);
 
     expect(scrollIntoView).toHaveBeenCalledTimes(1);
+
+    global.window.HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
   });
 });

--- a/src/signals/incident-management/containers/IncidentSplitContainer/components/IncidentSplitFormIncident/__tests__/IncidentSplitFormIncident.test.js
+++ b/src/signals/incident-management/containers/IncidentSplitContainer/components/IncidentSplitFormIncident/__tests__/IncidentSplitFormIncident.test.js
@@ -8,7 +8,21 @@ import parentIncidentFixture from '../../../__tests__/parentIncidentFixture.json
 
 import IncidentSplitFormIncident from '..';
 
+const scrollIntoView = jest.fn();
+
 describe('IncidentSplitFormIncident', () => {
+  beforeAll(() => {
+    window.HTMLElement.prototype.scrollIntoView = scrollIntoView;
+  });
+
+  beforeEach(() => {
+    scrollIntoView.mockReset();
+  });
+
+  afterAll(() => {
+    delete window.HTMLElement.prototype.scrollIntoView;
+  });
+
   const register = jest.fn();
   const props = { parentIncident: parentIncidentFixture, subcategories, register };
 
@@ -50,5 +64,16 @@ describe('IncidentSplitFormIncident', () => {
 
     expect(screen.getAllByRole('heading', { name: /^Deelmelding \d+$/ })).toHaveLength(1);
     expect(screen.getByRole('heading', { name: 'Deelmelding 4' })).toBeInTheDocument();
+  });
+
+  it('should scroll new incident into view', () => {
+    render(withAppContext(<IncidentSplitFormIncident {...props} />));
+
+    expect(scrollIntoView).not.toHaveBeenCalled();
+
+    const addIncidentButton = screen.getByRole('button', { name: 'Extra deelmelding toevoegen' });
+    fireEvent.click(addIncidentButton);
+
+    expect(scrollIntoView).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/signals/incident-management/containers/IncidentSplitContainer/components/IncidentSplitFormIncident/__tests__/IncidentSplitFormIncident.test.js
+++ b/src/signals/incident-management/containers/IncidentSplitContainer/components/IncidentSplitFormIncident/__tests__/IncidentSplitFormIncident.test.js
@@ -53,7 +53,6 @@ describe('IncidentSplitFormIncident', () => {
   });
 
   it('should scroll new incident into view', () => {
-    const originalScrollIntoView = global.window.HTMLElement.prototype.scrollIntoView;
     const scrollIntoView = jest.fn();
     global.window.HTMLElement.prototype.scrollIntoView = scrollIntoView;
     render(withAppContext(<IncidentSplitFormIncident {...props} />));
@@ -65,6 +64,6 @@ describe('IncidentSplitFormIncident', () => {
 
     expect(scrollIntoView).toHaveBeenCalledTimes(1);
 
-    global.window.HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+    delete global.window.HTMLElement.prototype.scrollIntoView;
   });
 });

--- a/src/signals/incident-management/containers/IncidentSplitContainer/components/IncidentSplitFormIncident/__tests__/IncidentSplitFormIncident.test.js
+++ b/src/signals/incident-management/containers/IncidentSplitContainer/components/IncidentSplitFormIncident/__tests__/IncidentSplitFormIncident.test.js
@@ -11,8 +11,10 @@ import IncidentSplitFormIncident from '..';
 const scrollIntoView = jest.fn();
 
 describe('IncidentSplitFormIncident', () => {
+  let originalScrollIntoView;
   beforeAll(() => {
-    window.HTMLElement.prototype.scrollIntoView = scrollIntoView;
+    originalScrollIntoView = global.window.HTMLElement.prototype.scrollIntoView;
+    global.window.HTMLElement.prototype.scrollIntoView = scrollIntoView;
   });
 
   beforeEach(() => {
@@ -20,7 +22,7 @@ describe('IncidentSplitFormIncident', () => {
   });
 
   afterAll(() => {
-    delete window.HTMLElement.prototype.scrollIntoView;
+    global.window.HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
   });
 
   const register = jest.fn();

--- a/src/signals/incident-management/containers/IncidentSplitContainer/components/IncidentSplitFormIncident/index.js
+++ b/src/signals/incident-management/containers/IncidentSplitContainer/components/IncidentSplitFormIncident/index.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useState, Fragment } from 'react';
+import React, { useCallback, useState, Fragment, useEffect, createRef, useMemo } from 'react';
 import PropTypes from 'prop-types';
 
 import { priorityList, typesList } from 'signals/incident-management/definitions';
@@ -27,10 +27,18 @@ const IncidentSplitFormIncident = ({ parentIncident, subcategories, register }) 
     []
   );
 
+  const incidentSplitFormIncidentRefs = useMemo(() => Array(splitCount).fill().map(() => createRef()), [splitCount]);
+
+  useEffect(() => {
+    if (splitCount === 1) return;
+
+    incidentSplitFormIncidentRefs[splitCount - 1].current.scrollIntoView({ behavior: 'smooth' });
+  }, [splitCount, incidentSplitFormIncidentRefs]);
+
   return (
     <Fragment>
-      {[...Array(splitCount + 1).keys()].slice(1).map(splitNumber => (
-        <fieldset key={`incident-splitform-incident-${splitNumber}`}>
+      {[...Array(splitCount + 1).keys()].slice(1).map((splitNumber, index) => (
+        <fieldset key={`incident-splitform-incident-${splitNumber}`} ref={incidentSplitFormIncidentRefs[index]}>
           <StyledGrid>
             <StyledHeading forwardedAs="h2" data-testid="incidentSplitFormIncidentTitle">
               Deelmelding {splitNumber + parentIncident.childrenCount}

--- a/src/signals/incident-management/containers/IncidentSplitContainer/components/IncidentSplitFormIncident/index.js
+++ b/src/signals/incident-management/containers/IncidentSplitContainer/components/IncidentSplitFormIncident/index.js
@@ -27,18 +27,18 @@ const IncidentSplitFormIncident = ({ parentIncident, subcategories, register }) 
     []
   );
 
-  const incidentSplitFormIncidentRefs = useMemo(() => Array(splitCount).fill().map(() => createRef()), [splitCount]);
+  const incidentRefs = useMemo(() => Array(splitCount).fill().map(() => createRef()), [splitCount]);
 
   useEffect(() => {
     if (splitCount === 1) return;
 
-    incidentSplitFormIncidentRefs[splitCount - 1].current.scrollIntoView({ behavior: 'smooth' });
-  }, [splitCount, incidentSplitFormIncidentRefs]);
+    incidentRefs[splitCount - 1].current.scrollIntoView({ behavior: 'smooth' });
+  }, [splitCount, incidentRefs]);
 
   return (
     <Fragment>
       {[...Array(splitCount + 1).keys()].slice(1).map((splitNumber, index) => (
-        <fieldset key={`incident-splitform-incident-${splitNumber}`} ref={incidentSplitFormIncidentRefs[index]}>
+        <fieldset key={`incident-splitform-incident-${splitNumber}`} ref={incidentRefs[index]}>
           <StyledGrid>
             <StyledHeading forwardedAs="h2" data-testid="incidentSplitFormIncidentTitle">
               Deelmelding {splitNumber + parentIncident.childrenCount}

--- a/src/signals/incident-management/containers/IncidentSplitContainer/components/IncidentSplitFormIncident/index.js
+++ b/src/signals/incident-management/containers/IncidentSplitContainer/components/IncidentSplitFormIncident/index.js
@@ -9,7 +9,7 @@ import Button from 'components/Button';
 import Label from 'components/Label';
 import TextArea from 'components/TextArea';
 
-import { StyledGrid, StyledHeading } from '../../styled';
+import { StyledGrid, StyledHeading, StyledFieldset } from '../../styled';
 
 import IncidentSplitRadioInput from '../IncidentSplitRadioInput';
 import IncidentSplitSelectInput from '../IncidentSplitSelectInput';
@@ -34,7 +34,7 @@ const IncidentSplitFormIncident = ({ parentIncident, subcategories, register }) 
   return (
     <Fragment>
       {[...Array(splitCount + 1).keys()].slice(1).map((splitNumber, index) => (
-        <fieldset
+        <StyledFieldset
           key={`incident-splitform-incident-${splitNumber}`}
           ref={index === indexWithIncidentRef ? incidentRef : null}
         >
@@ -89,7 +89,7 @@ const IncidentSplitFormIncident = ({ parentIncident, subcategories, register }) 
               />
             </div>
           </StyledGrid>
-        </fieldset>
+        </StyledFieldset>
       ))}
 
       {splitCount < INCIDENT_SPLIT_LIMIT - parentIncident.childrenCount && (

--- a/src/signals/incident-management/containers/IncidentSplitContainer/components/IncidentSplitFormIncident/index.js
+++ b/src/signals/incident-management/containers/IncidentSplitContainer/components/IncidentSplitFormIncident/index.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useState, Fragment, useEffect, createRef, useMemo } from 'react';
+import React, { useCallback, useState, Fragment, useEffect, useRef, useMemo } from 'react';
 import PropTypes from 'prop-types';
 
 import { priorityList, typesList } from 'signals/incident-management/definitions';
@@ -18,27 +18,26 @@ export const INCIDENT_SPLIT_LIMIT = 10;
 
 const IncidentSplitFormIncident = ({ parentIncident, subcategories, register }) => {
   const [splitCount, setSplitCount] = useState(1);
+  const incidentRef = useRef(null);
 
-  const addIncident = useCallback(
-    event => {
-      event.preventDefault();
-      setSplitCount(previousSplitCount => previousSplitCount + 1);
-    },
-    []
-  );
+  const addIncident = useCallback(event => {
+    event.preventDefault();
+    setSplitCount(previousSplitCount => previousSplitCount + 1);
+  }, []);
 
-  const incidentRefs = useMemo(() => Array(splitCount).fill().map(() => createRef()), [splitCount]);
+  const indexWithIncidentRef = useMemo(() => (splitCount === 1 ? null : splitCount - 1), [splitCount]);
 
   useEffect(() => {
-    if (splitCount === 1) return;
-
-    incidentRefs[splitCount - 1].current.scrollIntoView({ behavior: 'smooth' });
-  }, [splitCount, incidentRefs]);
+    incidentRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [splitCount, incidentRef]);
 
   return (
     <Fragment>
       {[...Array(splitCount + 1).keys()].slice(1).map((splitNumber, index) => (
-        <fieldset key={`incident-splitform-incident-${splitNumber}`} ref={incidentRefs[index]}>
+        <fieldset
+          key={`incident-splitform-incident-${splitNumber}`}
+          ref={index === indexWithIncidentRef ? incidentRef : null}
+        >
           <StyledGrid>
             <StyledHeading forwardedAs="h2" data-testid="incidentSplitFormIncidentTitle">
               Deelmelding {splitNumber + parentIncident.childrenCount}

--- a/src/signals/incident-management/containers/IncidentSplitContainer/styled.js
+++ b/src/signals/incident-management/containers/IncidentSplitContainer/styled.js
@@ -55,6 +55,10 @@ export const StyledLabel = styled(Label)`
   }
 `;
 
+export const StyledFieldset = styled.fieldset`
+  scroll-margin-top: ${themeSpacing(15)};
+`;
+
 export const StyledHeading = styled(Heading)`
   margin-bottom: 0;
 `;


### PR DESCRIPTION
When clicking the button 'Extra deelmelding toevoegen', the view should scroll to the newly added incident split form. 
