### PR TITLE
[FE#80] Auto load first subcategory in the list

### DIFF
--- a/src/signals/incident-management/containers/DefaultTextsAdmin/components/DefaultTextsForm/index.js
+++ b/src/signals/incident-management/containers/DefaultTextsAdmin/components/DefaultTextsForm/index.js
@@ -55,7 +55,15 @@ const fields = [...new Array(DEFAULT_TEXT_FIELDS).keys()].reduce(
 );
 
 const DefaultTextsForm = ({ categoryUrl, state, defaultTexts, subCategories, onSubmitTexts, onOrderDefaultTexts }) => {
-  const form = useMemo(() => FormBuilder.group(fields), []);
+  const form = useMemo(
+    () =>
+      FormBuilder.group({
+        ...fields,
+        categoryUrl: null,
+        state: null,
+      }),
+    []
+  );
   const items = Object.keys(form.controls).slice(0, -2);
 
   const handleSubmit = useCallback(

--- a/src/signals/incident-management/containers/DefaultTextsAdmin/components/SelectForm/index.js
+++ b/src/signals/incident-management/containers/DefaultTextsAdmin/components/SelectForm/index.js
@@ -11,19 +11,13 @@ import RadioInput from '../../../../components/RadioInput';
 import HiddenInput from '../../../../components/HiddenInput';
 
 const form = FormBuilder.group({
-  category_url: [
-    'https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/asbest-accu',
-  ],
-  state: ['o'],
-  sub_slug: ['asbest-accu'],
-  main_slug: ['afval'],
+  category_url: null,
+  state: 'o',
+  sub_slug: null,
+  main_slug: null,
 });
 
-const SelectForm = ({
-  subCategories,
-  defaultTextsOptionList,
-  onFetchDefaultTexts,
-}) => {
+const SelectForm = ({ subCategories, defaultTextsOptionList, onFetchDefaultTexts }) => {
   const handleChange = useCallback(
     changed => {
       const newValues = {
@@ -38,13 +32,7 @@ const SelectForm = ({
 
   useEffect(() => {
     form.controls.category_url.valueChanges.subscribe(category_url => {
-      const found = subCategories.find(
-        sub =>
-          sub._links &&
-          sub._links.self &&
-          sub._links.self.public &&
-          sub._links.self.public === category_url
-      );
+      const found = category_url && subCategories.find(sub => sub?._links?.self?.public === category_url);
 
       /* istanbul ignore else */
       if (found) {
@@ -63,8 +51,12 @@ const SelectForm = ({
       handleChange({ state });
     });
 
-    form.updateValueAndValidity();
-    handleChange({});
+    const firstCategoryUrl = subCategories[0]?._links?.self?.public;
+    if (firstCategoryUrl) {
+      form.patchValue({
+        category_url: firstCategoryUrl,
+      });
+    }
 
     return () => {
       form.controls.category_url.valueChanges.unsubscribe();
@@ -99,16 +91,8 @@ const SelectForm = ({
             control={form.get('state')}
           />
 
-          <FieldControlWrapper
-            render={HiddenInput}
-            name="sub_slug"
-            control={form.get('sub_slug')}
-          />
-          <FieldControlWrapper
-            render={HiddenInput}
-            name="main_slug"
-            control={form.get('main_slug')}
-          />
+          <FieldControlWrapper render={HiddenInput} name="sub_slug" control={form.get('sub_slug')} />
+          <FieldControlWrapper render={HiddenInput} name="main_slug" control={form.get('main_slug')} />
         </form>
       )}
     />

--- a/src/signals/incident-management/containers/DefaultTextsAdmin/components/SelectForm/index.test.js
+++ b/src/signals/incident-management/containers/DefaultTextsAdmin/components/SelectForm/index.test.js
@@ -13,8 +13,9 @@ store.dispatch(fetchCategoriesSuccess(categoriesPrivate));
 
 const subCategories = makeSelectSubCategories(store.getState());
 
-describe('<SelectForm />', () => {
-  const category_url = 'https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/asbest-accu';
+describe('SelectForm', () => {
+  const category_url = categoriesPrivate.results[1]._links.self.public;
+  const name = categoriesPrivate.results[1].name;
   let props;
 
   beforeEach(() => {
@@ -37,7 +38,7 @@ describe('<SelectForm />', () => {
     expect(queryByTestId('selectFormForm')).not.toBeNull();
 
     expect(queryByText('Subcategorie')).not.toBeNull();
-    expect(getByDisplayValue('Asbest / accu')).not.toBeNull();
+    expect(getByDisplayValue(name)).not.toBeNull();
 
     expect(queryByText('Status')).not.toBeNull();
     expect(queryByText('Afgehandeld')).not.toBeNull();
@@ -45,36 +46,32 @@ describe('<SelectForm />', () => {
     expect(queryByText('Ingepland')).not.toBeNull();
     expect(queryByText('Heropend')).not.toBeNull();
 
-    expect(queryByDisplayValue('afval')).not.toBeNull();
-    expect(queryByDisplayValue('asbest-accu')).not.toBeNull();
+    expect(queryByDisplayValue('civiele-constructies')).not.toBeNull();
+    expect(queryByDisplayValue('afwatering-brug')).not.toBeNull();
   });
 
   describe('events', () => {
     it('should trigger fetch default texts on load', () => {
-      render(
-        withAppContext(<SelectForm {...props} />)
-      );
+      render(withAppContext(<SelectForm {...props} />));
 
       expect(props.onFetchDefaultTexts).toHaveBeenCalledWith({
         category_url,
         state: 'o',
-        sub_slug: 'asbest-accu',
-        main_slug: 'afval',
+        sub_slug: 'afwatering-brug',
+        main_slug: 'civiele-constructies',
       });
     });
 
     it('should trigger fetch default texts when a new status has been selected', () => {
-      const { getByDisplayValue } = render(
-        withAppContext(<SelectForm {...props} />)
-      );
+      const { getByDisplayValue } = render(withAppContext(<SelectForm {...props} />));
       const newStatus = 'ingepland';
       fireEvent.click(getByDisplayValue(newStatus));
 
       expect(props.onFetchDefaultTexts).toHaveBeenCalledWith({
         category_url,
         state: newStatus,
-        sub_slug: 'asbest-accu',
-        main_slug: 'afval',
+        sub_slug: 'afwatering-brug',
+        main_slug: 'civiele-constructies',
       });
     });
 
@@ -88,20 +85,19 @@ describe('<SelectForm />', () => {
         withAppContext(<SelectForm {...props} subCategories={invalidSubCategories} />)
       );
 
-      expect(props.onFetchDefaultTexts).toHaveBeenCalledTimes(1);
+      expect(props.onFetchDefaultTexts).not.toHaveBeenCalled();
 
       const newStatus = 'ingepland';
       fireEvent.click(getByDisplayValue(newStatus));
 
-      expect(props.onFetchDefaultTexts).toHaveBeenCalledTimes(1);
+      expect(props.onFetchDefaultTexts).not.toHaveBeenCalled();
     });
 
     it('should trigger fetch default texts when a new category has been selected', () => {
-      const { getByTestId } = render(
-        withAppContext(<SelectForm {...props} />)
-      );
+      const { getByTestId } = render(withAppContext(<SelectForm {...props} />));
 
-      const newCategory = 'https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/openbaar-groen-en-water/sub_categories/boom';
+      const newCategory =
+        'https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/openbaar-groen-en-water/sub_categories/boom';
       const event = {
         target: {
           value: newCategory,

--- a/src/signals/incident-management/containers/DefaultTextsAdmin/index.js
+++ b/src/signals/incident-management/containers/DefaultTextsAdmin/index.js
@@ -16,11 +16,7 @@ import injectReducer from 'utils/injectReducer';
 import SelectForm from './components/SelectForm';
 import DefaultTextsForm from './components/DefaultTextsForm';
 
-import {
-  fetchDefaultTexts,
-  storeDefaultTexts,
-  orderDefaultTexts,
-} from './actions';
+import { fetchDefaultTexts, storeDefaultTexts, orderDefaultTexts } from './actions';
 import makeSelectDefaultTextsAdmin from './selectors';
 import reducer from './reducer';
 import saga from './saga';
@@ -35,12 +31,7 @@ export const DefaultTextsAdminContainer = ({
   onFetchDefaultTexts,
   onSubmitTexts,
   onOrderDefaultTexts,
-  defaultTextsAdmin: {
-    defaultTexts,
-    defaultTextsOptionList,
-    categoryUrl,
-    state,
-  },
+  defaultTextsAdmin: { defaultTexts, defaultTextsOptionList, categoryUrl, loading, error, state },
 }) => (
   <Row>
     <Column span={12}>
@@ -60,7 +51,7 @@ export const DefaultTextsAdminContainer = ({
     </Column>
 
     <Column span={8}>
-      {subCategories && (
+      {subCategories && categoryUrl && !loading && !error && (
         <DefaultTextsForm
           defaultTexts={defaultTexts}
           categoryUrl={categoryUrl}
@@ -78,7 +69,7 @@ DefaultTextsAdminContainer.defaultProps = {
   defaultTextsAdmin: {
     defaultTexts: [],
     defaultTextsOptionList: [],
-    categoryUrl: 'https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/asbest-accu',
+    categoryUrl: null,
     state: 'o',
   },
 };
@@ -89,6 +80,8 @@ DefaultTextsAdminContainer.propTypes = {
     defaultTextsOptionList: dataListType,
     categoryUrl: PropTypes.string,
     state: PropTypes.string,
+    loading: PropTypes.bool,
+    error: PropTypes.bool,
   }),
   subCategories: dataListType,
 
@@ -97,30 +90,24 @@ DefaultTextsAdminContainer.propTypes = {
   onOrderDefaultTexts: PropTypes.func.isRequired,
 };
 
-export const mapDispatchToProps = dispatch => bindActionCreators(
-  {
-    onFetchDefaultTexts: fetchDefaultTexts,
-    onSubmitTexts: storeDefaultTexts,
-    onOrderDefaultTexts: orderDefaultTexts,
-  },
-  dispatch,
-);
+export const mapDispatchToProps = dispatch =>
+  bindActionCreators(
+    {
+      onFetchDefaultTexts: fetchDefaultTexts,
+      onSubmitTexts: storeDefaultTexts,
+      onOrderDefaultTexts: orderDefaultTexts,
+    },
+    dispatch
+  );
 
 const mapStateToProps = createStructuredSelector({
   defaultTextsAdmin: makeSelectDefaultTextsAdmin(),
   subCategories: makeSelectSubCategories,
 });
 
-const withConnect = connect(
-  mapStateToProps,
-  mapDispatchToProps,
-);
+const withConnect = connect(mapStateToProps, mapDispatchToProps);
 
 const withReducer = injectReducer({ key: 'defaultTextsAdmin', reducer });
 const withSaga = injectSaga({ key: 'defaultTextsAdmin', saga });
 
-export default compose(
-  withReducer,
-  withSaga,
-  withConnect,
-)(DefaultTextsAdminContainer);
+export default compose(withReducer, withSaga, withConnect)(DefaultTextsAdminContainer);

--- a/src/signals/incident-management/containers/DefaultTextsAdmin/index.test.js
+++ b/src/signals/incident-management/containers/DefaultTextsAdmin/index.test.js
@@ -13,12 +13,15 @@ describe('<DefaultTextsAdmin />', () => {
   beforeEach(() => {
     props = {
       defaultTextsAdmin: {
-        defaultTexts: [{
-          title: 'Accu',
-          text: 'accutekst',
-        }],
+        defaultTexts: [
+          {
+            title: 'Accu',
+            text: 'accutekst',
+          },
+        ],
         defaultTextsOptionList,
-        categoryUrl: 'https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/asbest-accu',
+        categoryUrl:
+          'https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/asbest-accu',
         state: 'o',
       },
       categories: {},
@@ -55,25 +58,79 @@ describe('<DefaultTextsAdmin />', () => {
 
   describe('rendering', () => {
     it('should render correctly', () => {
-      const { queryByTestId, rerender } = render(
-        withAppContext(<DefaultTextsAdminContainer {...props} />)
-      );
+      const { queryByTestId, rerender } = render(withAppContext(<DefaultTextsAdminContainer {...props} />));
 
       expect(queryByTestId('loadingIndicator')).toBeInTheDocument();
       expect(queryByTestId('defaultTextFormForm')).not.toBeInTheDocument();
       expect(queryByTestId('selectFormForm')).not.toBeInTheDocument();
 
-      rerender(
+      rerender(withAppContext(<DefaultTextsAdminContainer {...props} subCategories={subCategories} />));
+
+      expect(queryByTestId('loadingIndicator')).not.toBeInTheDocument();
+      expect(queryByTestId('defaultTextFormForm')).toBeInTheDocument();
+      expect(queryByTestId('selectFormForm')).toBeInTheDocument();
+    });
+
+    it('should not render the texts form without categoryUrl', () => {
+      const { queryByTestId } = render(
         withAppContext(
           <DefaultTextsAdminContainer
-            {...props}
+            {...{
+              ...props,
+              defaultTextsAdmin: {
+                ...props.defaultTextsAdmin,
+                categoryUrl: '',
+              },
+            }}
             subCategories={subCategories}
           />
         )
       );
 
       expect(queryByTestId('loadingIndicator')).not.toBeInTheDocument();
-      expect(queryByTestId('defaultTextFormForm')).toBeInTheDocument();
+      expect(queryByTestId('defaultTextFormForm')).not.toBeInTheDocument();
+      expect(queryByTestId('selectFormForm')).toBeInTheDocument();
+    });
+
+    it('should not render the texts form when loading', () => {
+      const { queryByTestId } = render(
+        withAppContext(
+          <DefaultTextsAdminContainer
+            {...{
+              ...props,
+              defaultTextsAdmin: {
+                ...props.defaultTextsAdmin,
+                loading: true,
+              },
+            }}
+            subCategories={subCategories}
+          />
+        )
+      );
+
+      expect(queryByTestId('loadingIndicator')).not.toBeInTheDocument();
+      expect(queryByTestId('defaultTextFormForm')).not.toBeInTheDocument();
+      expect(queryByTestId('selectFormForm')).toBeInTheDocument();
+    });
+
+    it('should not render the texts on error', () => {
+      const { queryByTestId } = render(
+        withAppContext(
+          <DefaultTextsAdminContainer
+            {...{
+              ...props,
+              defaultTextsAdmin: {
+                ...props.defaultTextsAdmin,
+                error: true,
+              },
+            }}
+            subCategories={subCategories}
+          />
+        )
+      );
+
+      expect(queryByTestId('loadingIndicator')).not.toBeInTheDocument();
+      expect(queryByTestId('defaultTextFormForm')).not.toBeInTheDocument();
       expect(queryByTestId('selectFormForm')).toBeInTheDocument();
     });
   });


### PR DESCRIPTION
closes Signalen/frontend#80

The bug is explained in the issue mentioned above.

There is no hard-coded default value set anymore for the subcategory, to fetch the default texts for, on load. Instead, the first subcategory in the list will be programmatically selected and used.