### PR TITLE
(Chore) Improve directing department selection

### DIFF
--- a/src/models/departments/useDirectingDepartments.js
+++ b/src/models/departments/useDirectingDepartments.js
@@ -1,0 +1,16 @@
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { makeSelectDirectingDepartments } from './selectors';
+
+const useDirectingDepartments = () => {
+  const directingDepartments = useSelector(makeSelectDirectingDepartments);
+  return useMemo(
+    () => [
+      { key: 'null', value: 'Verantwoordelijke afdeling' },
+      ...directingDepartments.map(({ code }) => ({ key: code, value: code })),
+    ],
+    [directingDepartments]
+  );
+};
+
+export default useDirectingDepartments;

--- a/src/models/departments/useDirectingDepartments.test.js
+++ b/src/models/departments/useDirectingDepartments.test.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react-hooks';
+import * as departmentsSelectors from 'models/departments/selectors';
+import * as reactRedux from 'react-redux';
+import { departments } from 'utils/__tests__/fixtures';
+import useDirectingDepartments from './useDirectingDepartments';
+
+describe('useDirectingDepartments', () => {
+  it('should return the directing departments', async () => {
+    const departmentsList = [departments.list[0]];
+    jest.spyOn(departmentsSelectors, 'makeSelectDirectingDepartments').mockImplementation(() => departmentsList);
+    const store = {
+      subscribe: jest.fn(),
+      dispatch: jest.fn(),
+      getState: jest.fn(),
+    };
+    const { Provider } = reactRedux;
+    const wrapper = ({ children, ...props }) => <Provider {...props} store={store}>{children}</Provider>;
+    const { result } = renderHook(() => useDirectingDepartments(), { wrapper });
+
+    expect(result.current.length).toEqual(departmentsList.length + 1);
+    const departmentCodes = result.current.map(department => department.key);
+    expect(departmentCodes.includes('null')).toBeTruthy();
+    expect(departmentCodes.includes(departmentsList[0].code)).toBeTruthy();
+  });
+});

--- a/src/signals/incident-management/components/FilterForm/__tests__/FilterForm.test.js
+++ b/src/signals/incident-management/components/FilterForm/__tests__/FilterForm.test.js
@@ -9,7 +9,7 @@ import typesList from 'signals/incident-management/definitions/typesList';
 import kindList from 'signals/incident-management/definitions/kindList';
 import dataLists from 'signals/incident-management/definitions';
 import configuration from 'shared/services/configuration/configuration';
-import { departments } from 'utils/__tests__/fixtures';
+import { directingDepartments } from 'utils/__tests__/fixtures';
 
 import categories from 'utils/__tests__/fixtures/categories_structured.json';
 import districts from 'utils/__tests__/fixtures/districts.json';
@@ -209,7 +209,6 @@ describe('signals/incident-management/components/FilterForm', () => {
   });
 
   it('should render a list of directing_department options', () => {
-    const directingDepartments = [departments.list[0]];
     jest.spyOn(departmentsSelectors, 'makeSelectDirectingDepartments').mockImplementation(() => directingDepartments);
     const { container, getByText } = render(withContext(<FilterForm {...formProps} />));
 

--- a/src/signals/incident-management/components/FilterForm/__tests__/FilterForm.test.js
+++ b/src/signals/incident-management/components/FilterForm/__tests__/FilterForm.test.js
@@ -9,10 +9,12 @@ import typesList from 'signals/incident-management/definitions/typesList';
 import kindList from 'signals/incident-management/definitions/kindList';
 import dataLists from 'signals/incident-management/definitions';
 import configuration from 'shared/services/configuration/configuration';
+import { departments } from 'utils/__tests__/fixtures';
 
 import categories from 'utils/__tests__/fixtures/categories_structured.json';
 import districts from 'utils/__tests__/fixtures/districts.json';
 import sources from 'utils/__tests__/fixtures/sources.json';
+import * as departmentsSelectors from 'models/departments/selectors';
 import FilterForm from '..';
 import { SAVE_SUBMIT_BUTTON_LABEL, DEFAULT_SUBMIT_BUTTON_LABEL } from '../constants';
 
@@ -207,10 +209,12 @@ describe('signals/incident-management/components/FilterForm', () => {
   });
 
   it('should render a list of directing_department options', () => {
+    const directingDepartments = [departments.list[0]];
+    jest.spyOn(departmentsSelectors, 'makeSelectDirectingDepartments').mockImplementation(() => directingDepartments);
     const { container, getByText } = render(withContext(<FilterForm {...formProps} />));
 
     expect(getByText('Regie hoofdmelding')).toBeInTheDocument();
-    expect(container.querySelectorAll('input[type="checkbox"][name="directing_department"]')).toHaveLength(dataLists.directing_department.length);
+    expect(container.querySelectorAll('input[type="checkbox"][name="directing_department"]')).toHaveLength(directingDepartments.length + 1);
   });
 
   it('should render a list of source options with feature flag enabled', async () => {

--- a/src/signals/incident-management/components/FilterForm/index.js
+++ b/src/signals/incident-management/components/FilterForm/index.js
@@ -16,7 +16,7 @@ import Input from 'components/Input';
 import Checkbox from 'components/Checkbox';
 import { dateToISOString } from 'shared/services/date-utils';
 
-import { makeSelectDirectingDepartments } from 'models/departments/selectors';
+import useDirectingDepartments from 'models/departments/useDirectingDepartments';
 import { ControlsWrapper, DatesWrapper, Fieldset, FilterGroup, Form, FormFooterWrapper } from './styled';
 import CalendarInput from '../CalendarInput';
 import CategoryGroups from './components/CategoryGroups';
@@ -48,14 +48,7 @@ const FilterForm = ({ filter, onCancel, onClearFilter, onSaveFilter, onSubmit, o
   const { sources } = useContext(AppContext);
   const { districts } = useContext(IncidentManagementContext);
   const categories = useSelector(makeSelectStructuredCategories);
-  const directingDepartments = useSelector(makeSelectDirectingDepartments);
-  const directingDepartmentsList = useMemo(
-    () => [
-      { key: 'null', value: 'Verantwoordelijke afdeling' },
-      ...directingDepartments.map(({ code }) => ({ key: code, value: code })),
-    ],
-    [directingDepartments]
-  );
+  const directingDepartments = useDirectingDepartments();
 
   const [state, dispatch] = useReducer(reducer, filter, init);
 
@@ -382,7 +375,7 @@ const FilterForm = ({ filter, onCancel, onClearFilter, onSaveFilter, onSubmit, o
               name="directing_department"
               onChange={onGroupChange}
               onToggle={onGroupToggle}
-              options={directingDepartmentsList}
+              options={directingDepartments}
             />
 
             <CheckboxGroup

--- a/src/signals/incident-management/components/FilterForm/index.js
+++ b/src/signals/incident-management/components/FilterForm/index.js
@@ -16,6 +16,7 @@ import Input from 'components/Input';
 import Checkbox from 'components/Checkbox';
 import { dateToISOString } from 'shared/services/date-utils';
 
+import { makeSelectDirectingDepartments } from 'models/departments/selectors';
 import { ControlsWrapper, DatesWrapper, Fieldset, FilterGroup, Form, FormFooterWrapper } from './styled';
 import CalendarInput from '../CalendarInput';
 import CategoryGroups from './components/CategoryGroups';
@@ -47,6 +48,15 @@ const FilterForm = ({ filter, onCancel, onClearFilter, onSaveFilter, onSubmit, o
   const { sources } = useContext(AppContext);
   const { districts } = useContext(IncidentManagementContext);
   const categories = useSelector(makeSelectStructuredCategories);
+  const directingDepartments = useSelector(makeSelectDirectingDepartments);
+  const directingDepartmentsList = useMemo(
+    () => [
+      { key: 'null', value: 'Verantwoordelijke afdeling' },
+      ...directingDepartments.map(({ code }) => ({ key: code, value: code })),
+    ],
+    [directingDepartments]
+  );
+
   const [state, dispatch] = useReducer(reducer, filter, init);
 
   const isNewFilter = !filter.name;
@@ -372,7 +382,7 @@ const FilterForm = ({ filter, onCancel, onClearFilter, onSaveFilter, onSubmit, o
               name="directing_department"
               onChange={onGroupChange}
               onToggle={onGroupToggle}
-              options={dataLists.directing_department}
+              options={directingDepartmentsList}
             />
 
             <CheckboxGroup

--- a/src/signals/incident-management/containers/IncidentDetail/components/MetaList/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/MetaList/index.js
@@ -5,12 +5,12 @@ import { Button, themeColor, themeSpacing } from '@datapunt/asc-ui';
 import get from 'lodash.get';
 
 import { makeSelectSubCategories } from 'models/categories/selectors';
-import { typesList, priorityList, directingDepartmentList } from 'signals/incident-management/definitions';
+import { typesList, priorityList } from 'signals/incident-management/definitions';
 
 import RadioInput from 'signals/incident-management/components/RadioInput';
 import SelectInput from 'signals/incident-management/components/SelectInput';
 
-import { makeSelectDepartments } from 'models/departments/selectors';
+import { makeSelectDepartments, makeSelectDirectingDepartments } from 'models/departments/selectors';
 import configuration from 'shared/services/configuration/configuration';
 import { string2date, string2time } from 'shared/services/string-parser';
 import ChangeValue from '../ChangeValue';
@@ -53,6 +53,14 @@ const MetaList = () => {
   const { incident, update, edit } = useContext(IncidentDetailContext);
   const { users } = useContext(IncidentManagementContext);
   const departments = useSelector(makeSelectDepartments);
+  const directingDepartments = useSelector(makeSelectDirectingDepartments);
+  const directingDepartmentsList = useMemo(
+    () => [
+      { key: 'null', value: 'Verantwoordelijke afdeling' },
+      ...directingDepartments.map(({ code }) => ({ key: code, value: code })),
+    ],
+    [directingDepartments]
+  );
 
   const incidentDepartmentNames = useMemo(() => {
     if (!configuration.assignSignalToEmployee) return [];
@@ -88,8 +96,10 @@ const MetaList = () => {
   // eslint-disable-next-line no-shadow
   const getDirectingDepartmentValue = useCallback((incident, path) => {
     const value = get(incident, path);
-    return value?.length === 1 && value[0].code === 'ASC' ? 'ASC' : 'null';
-  }, []);
+    if (!Array.isArray(value) || value.length !== 1) return 'null';
+    const { code } = value[0];
+    return directingDepartmentsList.find(({ key }) => key === code) ? code : 'null';
+  }, [directingDepartmentsList]);
 
   const userOptions = useMemo(
     () =>
@@ -210,7 +220,7 @@ const MetaList = () => {
           <ChangeValue
             component={RadioInput}
             display="Regie"
-            options={directingDepartmentList}
+            options={directingDepartmentsList}
             path="directing_departments"
             type="directing_departments"
             get={getDirectingDepartmentValue}

--- a/src/signals/incident-management/containers/IncidentDetail/components/MetaList/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/MetaList/index.js
@@ -10,9 +10,10 @@ import { typesList, priorityList } from 'signals/incident-management/definitions
 import RadioInput from 'signals/incident-management/components/RadioInput';
 import SelectInput from 'signals/incident-management/components/SelectInput';
 
-import { makeSelectDepartments, makeSelectDirectingDepartments } from 'models/departments/selectors';
+import { makeSelectDepartments } from 'models/departments/selectors';
 import configuration from 'shared/services/configuration/configuration';
 import { string2date, string2time } from 'shared/services/string-parser';
+import useDirectingDepartments from 'models/departments/useDirectingDepartments';
 import ChangeValue from '../ChangeValue';
 
 import Highlight from '../Highlight';
@@ -53,14 +54,7 @@ const MetaList = () => {
   const { incident, update, edit } = useContext(IncidentDetailContext);
   const { users } = useContext(IncidentManagementContext);
   const departments = useSelector(makeSelectDepartments);
-  const directingDepartments = useSelector(makeSelectDirectingDepartments);
-  const directingDepartmentsList = useMemo(
-    () => [
-      { key: 'null', value: 'Verantwoordelijke afdeling' },
-      ...directingDepartments.map(({ code }) => ({ key: code, value: code })),
-    ],
-    [directingDepartments]
-  );
+  const directingDepartments = useDirectingDepartments();
 
   const incidentDepartmentNames = useMemo(() => {
     if (!configuration.assignSignalToEmployee) return [];
@@ -98,8 +92,8 @@ const MetaList = () => {
     const value = get(incident, path);
     if (!Array.isArray(value) || value.length !== 1) return 'null';
     const { code } = value[0];
-    return directingDepartmentsList.find(({ key }) => key === code) ? code : 'null';
-  }, [directingDepartmentsList]);
+    return directingDepartments.find(({ key }) => key === code) ? code : 'null';
+  }, [directingDepartments]);
 
   const userOptions = useMemo(
     () =>
@@ -220,7 +214,7 @@ const MetaList = () => {
           <ChangeValue
             component={RadioInput}
             display="Regie"
-            options={directingDepartmentsList}
+            options={directingDepartments}
             path="directing_departments"
             type="directing_departments"
             get={getDirectingDepartmentValue}

--- a/src/signals/incident-management/containers/IncidentDetail/components/MetaList/index.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/MetaList/index.test.js
@@ -614,6 +614,7 @@ describe('MetaList', () => {
     describe('update directing departmens', () => {
       it('should update for directing department to ASC', async () => {
         jest.spyOn(departmentsSelectors, 'makeSelectDepartments').mockImplementation(() => ({ ...departments }));
+        jest.spyOn(departmentsSelectors, 'makeSelectDirectingDepartments').mockImplementation(() => [departments.list[0]]);
         const { getAllByTestId, getByTestId } = render(renderWithContext(parentIncident));
 
         // priority button data-testid attribute is dynamically generated in the ChangeValue component:
@@ -642,10 +643,10 @@ describe('MetaList', () => {
       });
 
       it('should update for directing department to directing department', async () => {
-        const { id } = departments.list.find(d => d.code === 'ASC');
         jest.spyOn(departmentsSelectors, 'makeSelectDepartments').mockImplementation(() => ({ ...departments }));
+        jest.spyOn(departmentsSelectors, 'makeSelectDirectingDepartments').mockImplementation(() => [departments.list[0]]);
         const { getAllByTestId, getByTestId } = render(
-          renderWithContext({ ...parentIncident, directing_departments: [{ id }] })
+          renderWithContext({ ...parentIncident, directing_departments: [{ id: departments.list[0].id }] })
         );
 
         // priority button data-testid attribute is dynamically generated in the ChangeValue component:

--- a/src/signals/incident-management/containers/IncidentSplitContainer/IncidentSplitContainer.js
+++ b/src/signals/incident-management/containers/IncidentSplitContainer/IncidentSplitContainer.js
@@ -4,7 +4,7 @@ import { useParams, useHistory } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 
 import { makeSelectSubCategories } from 'models/categories/selectors';
-import { makeSelectDepartments, makeSelectDirectingDepartments } from 'models/departments/selectors';
+import { makeSelectDepartments } from 'models/departments/selectors';
 
 import useFetch from 'hooks/useFetch';
 import configuration from 'shared/services/configuration/configuration';
@@ -13,6 +13,7 @@ import { VARIANT_SUCCESS, VARIANT_ERROR, TYPE_LOCAL } from 'containers/Notificat
 import { INCIDENT_URL } from 'signals/incident-management/routes';
 
 import LoadingIndicator from 'components/LoadingIndicator';
+import useDirectingDepartments from 'models/departments/useDirectingDepartments';
 import IncidentSplitForm from './components/IncidentSplitForm';
 
 const IncidentSplitContainer = ({ FormComponent }) => {
@@ -31,14 +32,7 @@ const IncidentSplitContainer = ({ FormComponent }) => {
   const [parentIncident, setParentIncident] = useState();
   const [directingDepartment, setDirectingDepartment] = useState([]);
   const departments = useSelector(makeSelectDepartments);
-  const directingDepartments = useSelector(makeSelectDirectingDepartments);
-  const directingDepartmentsList = useMemo(
-    () => [
-      { key: 'null', value: 'Verantwoordelijke afdeling' },
-      ...directingDepartments.map(({ code }) => ({ key: code, value: code })),
-    ],
-    [directingDepartments]
-  );
+  const directingDepartments = useDirectingDepartments();
 
   const subcategories = useSelector(makeSelectSubCategories);
   const subcategoryOptions = useMemo(
@@ -50,8 +44,8 @@ const IncidentSplitContainer = ({ FormComponent }) => {
     const department = parentIncident?.directing_departments;
     if (!Array.isArray(department) || department.length !== 1) return 'null';
     const { code } = department[0];
-    return directingDepartmentsList.find(({ key }) => key === code) ? code : 'null';
-  }, [parentIncident, directingDepartmentsList]);
+    return directingDepartments.find(({ key }) => key === code) ? code : 'null';
+  }, [parentIncident, directingDepartments]);
 
   const updateDepartment = useCallback(
     name => {
@@ -187,7 +181,7 @@ const IncidentSplitContainer = ({ FormComponent }) => {
             directingDepartment: parentDirectingDepartment,
           }}
           subcategories={subcategoryOptions}
-          directingDepartments={directingDepartmentsList}
+          directingDepartments={directingDepartments}
           onSubmit={onSubmit}
         />
       )}

--- a/src/signals/incident-management/definitions/changedChildrenList.js
+++ b/src/signals/incident-management/definitions/changedChildrenList.js
@@ -1,6 +1,6 @@
-const directingDepartmentList = [
+const changedChildrenList = [
   { key: 'true', value: 'Hoofdmelding met wijziging in deelmelding' },
   { key: 'false', value: 'Hoofdmelding zonder wijziging in deelmelding' },
 ];
 
-export default directingDepartmentList;
+export default changedChildrenList;

--- a/src/signals/incident-management/definitions/directingDepartmentList.js
+++ b/src/signals/incident-management/definitions/directingDepartmentList.js
@@ -1,6 +1,0 @@
-const directingDepartmentList = [
-  { key: 'null', value: 'Verantwoordelijke afdeling' },
-  { key: 'ASC', value: 'ASC' },
-];
-
-export default directingDepartmentList;

--- a/src/signals/incident-management/definitions/index.js
+++ b/src/signals/incident-management/definitions/index.js
@@ -1,6 +1,5 @@
 import changedChildrenList from './changedChildrenList';
 import contactDetailsList from './contactDetailsList';
-import directingDepartmentList from './directingDepartmentList';
 import feedbackList from './feedbackList';
 import kindList from './kindList';
 import priorityList from './priorityList';
@@ -17,13 +16,11 @@ export {
   sourceList,
   contactDetailsList,
   typesList,
-  directingDepartmentList,
 };
 
 export default {
   contact_details: contactDetailsList,
   has_changed_children: changedChildrenList,
-  directing_department: directingDepartmentList,
   feedback: feedbackList,
   kind: kindList,
   priority: priorityList,

--- a/src/utils/__tests__/fixtures/index.js
+++ b/src/utils/__tests__/fixtures/index.js
@@ -1,10 +1,7 @@
 import { fromJS } from 'immutable';
 
-import {
-  makeSelectSubCategories,
-  makeSelectCategories,
-  makeSelectMainCategories,
-} from 'models/categories/selectors';
+import { makeSelectSubCategories, makeSelectCategories, makeSelectMainCategories } from 'models/categories/selectors';
+import { makeSelectDepartments, makeSelectDirectingDepartments } from 'models/departments/selectors';
 
 import categoriesFixture from './categories_private.json';
 import departmentsFixture from './departments.json';
@@ -13,17 +10,16 @@ const state = fromJS({
   categories: categoriesFixture,
 });
 
-export const mainCategories = makeSelectMainCategories.resultFunc(
-  makeSelectCategories.resultFunc(state)
-);
+export const mainCategories = makeSelectMainCategories.resultFunc(makeSelectCategories.resultFunc(state));
 
-export const subCategories = makeSelectSubCategories.resultFunc(
-  makeSelectCategories.resultFunc(state)
-);
+export const subCategories = makeSelectSubCategories.resultFunc(makeSelectCategories.resultFunc(state));
 
 // map subcategories to prevent a warning about non-unique keys rendered by input elements 🙄
-export const subcategoriesWithUniqueKeys = subCategories
-  .map(subcategory => ({ ...subcategory, value: subcategory.name, key: subcategory._links.self.href }));
+export const subcategoriesWithUniqueKeys = subCategories.map(subcategory => ({
+  ...subcategory,
+  value: subcategory.name,
+  key: subcategory._links.self.href,
+}));
 
 export const departments = {
   ...departmentsFixture,
@@ -31,3 +27,7 @@ export const departments = {
   list: departmentsFixture.results,
   results: undefined,
 };
+
+export const directingDepartments = makeSelectDirectingDepartments.resultFunc(
+  makeSelectDepartments.resultFunc(fromJS(departments))
+);


### PR DESCRIPTION
This PR
- Moves the selector for the directing departments to a separate hook
- Uses the departments can_direct prop to determine if a department should be included in the directing departments list.
