### PR TITLE
Fix PDOK suggest for multiple municipalities

### DIFF
--- a/src/components/PDOKAutoSuggest/__tests__/PDOKAutoSuggest.test.js
+++ b/src/components/PDOKAutoSuggest/__tests__/PDOKAutoSuggest.test.js
@@ -4,15 +4,15 @@ import { withAppContext } from 'test/utils';
 
 import JSONResponse from 'utils/__tests__/fixtures/PDOKResponseData.json';
 import { INPUT_DELAY } from 'components/AutoSuggest';
-import { formatPDOKResponse } from 'shared/services/map-location';
+import { formatPDOKResponse, pdokResponseFieldList } from 'shared/services/map-location';
 import PDOKAutoSuggest, { formatResponseFunc } from '..';
 
 const mockResponse = JSON.stringify(JSONResponse);
 
 const onSelect = jest.fn();
-const municipalityQs = 'fq=gemeentenaam:';
+const municipalityName = 'gemeentenaam:';
+const municipalityQs = 'fq=';
 const fieldListQs = 'fl=';
-const defaultFieldsQs = 'id,weergavenaam';
 
 const renderAndSearch = async (value = 'Dam', props = {}) => {
   const result = render(withAppContext(<PDOKAutoSuggest onSelect={onSelect} {...props} />));
@@ -72,7 +72,7 @@ describe('components/PDOKAutoSuggest', () => {
     it('should call fetch without municipality by default', async () => {
       await renderAndSearch();
       expect(fetch).toHaveBeenCalledWith(
-        expect.not.stringContaining(municipalityQs),
+        expect.not.stringContaining(`${municipalityQs}${municipalityName}`),
         expect.objectContaining({ method: 'GET' })
       );
     });
@@ -80,7 +80,7 @@ describe('components/PDOKAutoSuggest', () => {
     it('should call fetch with municipality', async () => {
       await renderAndSearch('Dam', { municipality: 'amsterdam' });
       expect(fetch).toHaveBeenCalledWith(
-        expect.stringContaining(`${municipalityQs}"amsterdam"`),
+        expect.stringContaining(`${municipalityQs}${municipalityName}"amsterdam"`),
         expect.objectContaining({ method: 'GET' })
       );
     });
@@ -88,7 +88,7 @@ describe('components/PDOKAutoSuggest', () => {
     it('should work with an array for municipality', async () => {
       await renderAndSearch('Dam', { municipality: ['utrecht', 'amsterdam'] });
       expect(fetch).toHaveBeenCalledWith(
-        expect.stringContaining(`${municipalityQs}"utrecht" "amsterdam"`),
+        expect.stringContaining(`${municipalityQs}${municipalityName}"utrecht"${municipalityName}"amsterdam"`),
         expect.objectContaining({ method: 'GET' })
       );
     });
@@ -98,7 +98,7 @@ describe('components/PDOKAutoSuggest', () => {
     it('should call fetch with default field list', async () => {
       await renderAndSearch();
       expect(fetch).toHaveBeenCalledWith(
-        expect.stringContaining(`${fieldListQs}${defaultFieldsQs}`),
+        expect.stringContaining(`${fieldListQs}${pdokResponseFieldList}`),
         expect.objectContaining({ method: 'GET' })
       );
     });
@@ -106,7 +106,7 @@ describe('components/PDOKAutoSuggest', () => {
     it('should call fetch with extra fields', async () => {
       await renderAndSearch('Dam', { fieldList: ['name', 'type'] });
       expect(fetch).toHaveBeenCalledWith(
-        expect.stringContaining(`${fieldListQs}name,type,${defaultFieldsQs}`),
+        expect.stringContaining(`${fieldListQs}${pdokResponseFieldList},name,type`),
         expect.objectContaining({ method: 'GET' })
       );
     });

--- a/src/components/PDOKAutoSuggest/index.js
+++ b/src/components/PDOKAutoSuggest/index.js
@@ -8,8 +8,6 @@ const municipalityFilterName = 'gemeentenaam';
 const serviceParams = [
   ['fq', 'bron:BAG'],
   ['fq', 'type:adres'],
-  // ['fl', '*'], // undocumented; requests all available field values from the API
-  ['fl', pdokResponseFieldList.join(',')],
   ['q', ''],
 ];
 const serviceUrl = 'https://geodata.nationaalgeoregister.nl/locatieserver/v3/suggest?';
@@ -22,11 +20,13 @@ export const formatResponseFunc = ({ response }) =>
  *
  * @see {@link https://www.pdok.nl/restful-api/-/article/pdok-locatieserver#/paths/~1suggest/get}
  */
+
 const PDOKAutoSuggest = ({ className, fieldList, municipality, onSelect, formatResponse, value, ...rest }) => {
   const municipalityArray = Array.isArray(municipality) ? municipality : [municipality].filter(Boolean);
-  const municipalityString = municipalityArray.map(item => `"${item}"`).join(' ');
-  const fq = municipality ? [['fq', `${municipalityFilterName}:${municipalityString}`]] : [];
-  const fl = [['fl', fieldList.concat(['id', 'weergavenaam']).join(',')]];
+  const municipalityString = municipalityArray.map(item => `${municipalityFilterName}:"${item}"`).join('');
+  const fq = municipality ? [['fq', municipalityString]] : [];
+  // ['fl', '*'], // undocumented; requests all available field values from the API
+  const fl = [['fl', [...pdokResponseFieldList, ...fieldList].join(',')]];
   const params = [...fq, ...fl, ...serviceParams];
   const queryParams = params.map(([key, val]) => `${key}=${val}`).join('&');
   const url = `${serviceUrl}${queryParams}`;


### PR DESCRIPTION
closes Signalen/backend#73

With multiple municipalities configured in `map.municipality` in `app.json`, the results of the PDOK suggest service was unpredictable. Some cities within a municipality configured would not show up in the suggest results. While other municipalities not configured would show up in the suggest results.

It turns out that calling the PDOK suggest service with the following parameter is not giving the expected results:

```
fq=gemeentenaam:"boxtel" "altena"
```

When we write this parameter as follows, we do get the expected results:

```
fq=gemeentenaam:"boxtel"gemeentenaam:"altena"
```

This should be updated accordingly in the backend as well.

## Steps to reproduce

### Unexpected results

The following request will give you the expected results of the `Mezenlaan` in `Boxtel`.

```
➜ curl https://geodata.nationaalgeoregister.nl/locatieserver/v3/suggest\?fq\=gemeentenaam:%22boxtel%22%20%22altena%22\&fq\=bron:BAG\&fq\=type:adres\&fl\=id,weergavenaam,straatnaam,postcode,woonplaatsnaam,gemeentenaam\&q\=mezen
```

The following request, however, will give you no results, while you would expect results of the `Jettebosstraat` in `Woudrichem` which falls under the municipality of `Altena`.

```
➜ curl https://geodata.nationaalgeoregister.nl/locatieserver/v3/suggest\?fq\=gemeentenaam:%22boxtel%22%20%22altena%22\&fq\=bron:BAG\&fq\=type:adres\&fl\=id,weergavenaam,straatnaam,postcode,woonplaatsnaam,gemeentenaam\&q\=jett
```

### Expected results

The following request will still give you the expected results of the `Mezenlaan` in `Boxtel`.

```
➜ curl https://geodata.nationaalgeoregister.nl/locatieserver/v3/suggest\?fq\=gemeentenaam:%22boxtel%22gemeentenaam:%22altena%22\&fq\=bron:BAG\&fq\=type:adres\&fl\=id,weergavenaam,straatnaam,postcode,woonplaatsnaam,gemeentenaam\&q\=mezen
```

The following request will now give you the expected results of the `Jeetebosstraat` in `Woudrichem` which falls under the municipality of `Altena`.
```
➜ curl https://geodata.nationaalgeoregister.nl/locatieserver/v3/suggest\?fq\=gemeentenaam:%22boxtel%22gemeentenaam:%22altena%22\&fq\=bron:BAG\&fq\=type:adres\&fl\=id,weergavenaam,straatnaam,postcode,woonplaatsnaam,gemeentenaam\&q\=jett
```
