### PR TITLE
Update leaflet map thumbnail on location change

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/components/Detail/components/Location/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/Detail/components/Location/index.js
@@ -95,7 +95,7 @@ const Location = ({ location }) => {
               {configuration.useStaticMapServer ? (
                 <MapStatic boundsScaleFactor={0.25} height={mapHeight} markerSize={20} width={mapWidth} {...geometry} />
               ) : (
-                <StyledMap value={location} icon={smallMarkerIcon} zoom={mapZoom} />
+                <StyledMap key={`${latitude},${longitude}`} value={location} icon={smallMarkerIcon} zoom={mapZoom} />
               )}
             </MapTile>
           )}


### PR DESCRIPTION
closes Signalen/frontend#85

Fixes the bug described in the issue mentioned above.

It makes sure the leaflet map, for the location thumbnail on the incident detail page, updates afther the location has been edited. This is done by adding a `key` prop to the `MapDetail` with the lat/lng value of the location.

This is the map that is being used for other municipalities than Amsterdam. Amsterdam has a static map server for serving images of a map. For other municipalities a leaflet map is being used. We might switch to a static map server for other municipalities in the future as well.