### PR TITLE
Use more intuitive solr syntax for suggest request

### DIFF
--- a/src/components/PDOKAutoSuggest/__tests__/PDOKAutoSuggest.test.js
+++ b/src/components/PDOKAutoSuggest/__tests__/PDOKAutoSuggest.test.js
@@ -10,8 +10,7 @@ import PDOKAutoSuggest, { formatResponseFunc } from '..';
 const mockResponse = JSON.stringify(JSONResponse);
 
 const onSelect = jest.fn();
-const municipalityName = 'gemeentenaam:';
-const municipalityQs = 'fq=';
+const municipalityQs = 'fq=gemeentenaam:';
 const fieldListQs = 'fl=';
 
 const renderAndSearch = async (value = 'Dam', props = {}) => {
@@ -72,7 +71,7 @@ describe('components/PDOKAutoSuggest', () => {
     it('should call fetch without municipality by default', async () => {
       await renderAndSearch();
       expect(fetch).toHaveBeenCalledWith(
-        expect.not.stringContaining(`${municipalityQs}${municipalityName}`),
+        expect.not.stringContaining(municipalityQs),
         expect.objectContaining({ method: 'GET' })
       );
     });
@@ -80,7 +79,7 @@ describe('components/PDOKAutoSuggest', () => {
     it('should call fetch with municipality', async () => {
       await renderAndSearch('Dam', { municipality: 'amsterdam' });
       expect(fetch).toHaveBeenCalledWith(
-        expect.stringContaining(`${municipalityQs}${municipalityName}"amsterdam"`),
+        expect.stringContaining(`${municipalityQs}("amsterdam")`),
         expect.objectContaining({ method: 'GET' })
       );
     });
@@ -88,7 +87,7 @@ describe('components/PDOKAutoSuggest', () => {
     it('should work with an array for municipality', async () => {
       await renderAndSearch('Dam', { municipality: ['utrecht', 'amsterdam'] });
       expect(fetch).toHaveBeenCalledWith(
-        expect.stringContaining(`${municipalityQs}${municipalityName}"utrecht"${municipalityName}"amsterdam"`),
+        expect.stringContaining(`${municipalityQs}("utrecht" "amsterdam")`),
         expect.objectContaining({ method: 'GET' })
       );
     });

--- a/src/components/PDOKAutoSuggest/index.js
+++ b/src/components/PDOKAutoSuggest/index.js
@@ -23,8 +23,8 @@ export const formatResponseFunc = ({ response }) =>
 
 const PDOKAutoSuggest = ({ className, fieldList, municipality, onSelect, formatResponse, value, ...rest }) => {
   const municipalityArray = Array.isArray(municipality) ? municipality : [municipality].filter(Boolean);
-  const municipalityString = municipalityArray.map(item => `${municipalityFilterName}:"${item}"`).join('');
-  const fq = municipality ? [['fq', municipalityString]] : [];
+  const municipalityString = municipalityArray.map(item => `"${item}"`).join(' ');
+  const fq = municipality ? [['fq', `${municipalityFilterName}:(${municipalityString})`]] : [];
   // ['fl', '*'], // undocumented; requests all available field values from the API
   const fl = [['fl', [...pdokResponseFieldList, ...fieldList].join(',')]];
   const params = [...fq, ...fl, ...serviceParams];


### PR DESCRIPTION
Use the more intuitive solr syntax for the request to the PDOK suggest service. As explained in Amsterdam/signals#628.

Use

```
gemeentenaam:("den bosch" "boxtel" "altena")
```

instead of

```
gemeentenaam:"den bosch" gemeentenaam:"boxtel" gemeentenaam:"altena"
```
