### PR TITLE
[SIG-3283] Hides split button

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/components/DetailHeader/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/DetailHeader/index.js
@@ -71,6 +71,7 @@ const StyledHeading = styled(Heading)`
 `;
 
 const ButtonLink = styled(Button)`
+  display: none;
   color: ${themeColor('tint', 'level7')};
   text-decoration: none;
 
@@ -141,14 +142,16 @@ const DetailHeader = () => {
 
       <ButtonContainer>
         {showSplitButton && (
-          <ButtonLink
-            variant="application"
-            forwardedAs={Link}
-            to={`${INCIDENT_URL}/${incident.id}/split`}
-            data-testid="detail-header-button-split"
-          >
-            Delen
-          </ButtonLink>
+          <div hidden>
+            <ButtonLink
+              variant="application"
+              forwardedAs={Link}
+              to={`${INCIDENT_URL}/${incident.id}/split`}
+              data-testid="detail-header-button-split"
+            >
+              Delen
+            </ButtonLink>
+          </div>
         )}
 
         {canThor && (


### PR DESCRIPTION
This PR prevents the 'delen' button to be shown. 

Background info:
The incident split functionality was developed and accepted, but the customer is not yet ready to make use of it in the coming release. This commit will be reverted when the customer is ready. 

Concerning the e2e tests, @arjandata is aware of this change, and the periodic e2e tests will succeed because the deelmeldingen tests are not (yet) enabled. 