### PR TITLE
[FE#87] Use correct logo height on mobile

### DIFF
--- a/internals/schemas/app.schema.json
+++ b/internals/schemas/app.schema.json
@@ -273,7 +273,7 @@
           ]
         },
         "height": {
-          "description": "Length value that sets the logo image's height",
+          "description": "Length value that sets the logo image's height. In pixels, the height should be 56 or less.",
           "type": [
             "string",
             "integer"
@@ -287,7 +287,7 @@
           ]
         },
         "smallHeight": {
-          "description": "Length value that sets the logo image's height in case the logo is rendered in a site header with limited height",
+          "description": "Length value that sets the logo image's height in case the logo is rendered in a site header with limited height. In pixels, the smallHeight should be 32 or less.",
           "type": [
             "string",
             "integer"

--- a/internals/schemas/app.schema.json
+++ b/internals/schemas/app.schema.json
@@ -273,7 +273,7 @@
           ]
         },
         "height": {
-          "description": "Length value that sets the logo image's height. In pixels, the height should be 56 or less.",
+          "description": "Length value that sets the logo image's height. In pixels, the height should be 86 or less.",
           "type": [
             "string",
             "integer"
@@ -287,7 +287,7 @@
           ]
         },
         "smallHeight": {
-          "description": "Length value that sets the logo image's height in case the logo is rendered in a site header with limited height. In pixels, the smallHeight should be 32 or less.",
+          "description": "Length value that sets the logo image's height in case the logo is rendered in a site header with limited height. In pixels, the smallHeight should be 34 or less.",
           "type": [
             "string",
             "integer"

--- a/src/components/Logo/__tests__/Logo.test.js
+++ b/src/components/Logo/__tests__/Logo.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render } from '@testing-library/react';
+import { ascDefaultTheme } from '@datapunt/asc-ui';
 
 import { withAppContext } from 'test/utils';
 import configuration from 'shared/services/configuration/configuration';
@@ -25,20 +26,56 @@ describe('components/Logo', () => {
 
   it('should render correctly', () => {
     const { container, getByTestId } = render(withAppContext(<Logo />));
+    const media = `screen and ${ascDefaultTheme.breakpoints.laptopM('max-width')}`;
 
     expect(container.querySelector(`a[href="${configuration.links.home}"]`)).toBeInTheDocument();
     expect(container.querySelector(`img[src="${configuration.logo.url}"]`)).toBeInTheDocument();
-    expect(getByTestId('logo')).toHaveStyleRule('height', configuration.logo.height.toString());
-    expect(getByTestId('logo')).toHaveStyleRule('width', configuration.logo.width.toString());
+
+    expect(getByTestId('logo-link')).toHaveStyleRule('height', configuration.logo.height);
+    expect(getByTestId('logo-link')).toHaveStyleRule('width', configuration.logo.width);
+    expect(getByTestId('logo-link')).toHaveStyleRule('max-height', '56px');
+    expect(getByTestId('logo-link')).toHaveStyleRule('width', configuration.logo.smallWidth, {
+      media,
+    });
+    expect(getByTestId('logo-link')).toHaveStyleRule('height', configuration.logo.smallHeight, {
+      media,
+    });
+
+    expect(getByTestId('logo')).toHaveStyleRule('height', configuration.logo.height);
+    expect(getByTestId('logo')).toHaveStyleRule('width', configuration.logo.width);
+    expect(getByTestId('logo')).toHaveStyleRule('width', configuration.logo.smallWidth, {
+      media,
+    });
+    expect(getByTestId('logo')).toHaveStyleRule('height', configuration.logo.smallHeight, {
+      media,
+    });
   });
 
   it('should render differently when not tall', () => {
     const { container, getByTestId } = render(withAppContext(<Logo tall={false} />));
+    const media = `screen and ${ascDefaultTheme.breakpoints.laptopM('max-width')}`;
 
     expect(container.querySelector('a[href="/"]')).toBeInTheDocument();
     expect(container.querySelector(`img[src="${configuration.logo.url}"]`)).toBeInTheDocument();
-    expect(getByTestId('logo')).toHaveStyleRule('height', configuration.logo.smallHeight.toString());
-    expect(getByTestId('logo')).toHaveStyleRule('width', configuration.logo.smallWidth.toString());
+
+    expect(getByTestId('logo-link')).toHaveStyleRule('height', configuration.logo.smallHeight);
+    expect(getByTestId('logo-link')).toHaveStyleRule('width', configuration.logo.smallWidth);
+    expect(getByTestId('logo-link')).toHaveStyleRule('max-height', '32px');
+    expect(getByTestId('logo-link')).not.toHaveStyleRule('width', configuration.logo.smallWidth, {
+      media,
+    });
+    expect(getByTestId('logo-link')).not.toHaveStyleRule('height', configuration.logo.smallHeight, {
+      media,
+    });
+
+    expect(getByTestId('logo')).toHaveStyleRule('height', configuration.logo.smallHeight);
+    expect(getByTestId('logo')).toHaveStyleRule('width', configuration.logo.smallWidth);
+    expect(getByTestId('logo')).not.toHaveStyleRule('width', configuration.logo.smallWidth, {
+      media,
+    });
+    expect(getByTestId('logo')).not.toHaveStyleRule('height', configuration.logo.smallHeight, {
+      media,
+    });
   });
 
   it('should render extra props', () => {

--- a/src/components/Logo/__tests__/Logo.test.js
+++ b/src/components/Logo/__tests__/Logo.test.js
@@ -26,7 +26,7 @@ describe('components/Logo', () => {
 
   it('should render correctly', () => {
     const { container, getByTestId } = render(withAppContext(<Logo />));
-    const media = `screen and ${ascDefaultTheme.breakpoints.laptopM('max-width')}`;
+    const media = `screen and ${ascDefaultTheme.breakpoints.tabletS('max-width')}`;
 
     expect(container.querySelector(`a[href="${configuration.links.home}"]`)).toBeInTheDocument();
     expect(container.querySelector(`img[src="${configuration.logo.url}"]`)).toBeInTheDocument();
@@ -53,7 +53,7 @@ describe('components/Logo', () => {
 
   it('should render differently when not tall', () => {
     const { container, getByTestId } = render(withAppContext(<Logo tall={false} />));
-    const media = `screen and ${ascDefaultTheme.breakpoints.laptopM('max-width')}`;
+    const media = `screen and ${ascDefaultTheme.breakpoints.tabletS('max-width')}`;
 
     expect(container.querySelector('a[href="/"]')).toBeInTheDocument();
     expect(container.querySelector(`img[src="${configuration.logo.url}"]`)).toBeInTheDocument();

--- a/src/components/Logo/__tests__/Logo.test.js
+++ b/src/components/Logo/__tests__/Logo.test.js
@@ -33,7 +33,6 @@ describe('components/Logo', () => {
 
     expect(getByTestId('logo-link')).toHaveStyleRule('height', configuration.logo.height);
     expect(getByTestId('logo-link')).toHaveStyleRule('width', configuration.logo.width);
-    expect(getByTestId('logo-link')).toHaveStyleRule('max-height', '56px');
     expect(getByTestId('logo-link')).toHaveStyleRule('width', configuration.logo.smallWidth, {
       media,
     });
@@ -60,7 +59,6 @@ describe('components/Logo', () => {
 
     expect(getByTestId('logo-link')).toHaveStyleRule('height', configuration.logo.smallHeight);
     expect(getByTestId('logo-link')).toHaveStyleRule('width', configuration.logo.smallWidth);
-    expect(getByTestId('logo-link')).toHaveStyleRule('max-height', '32px');
     expect(getByTestId('logo-link')).not.toHaveStyleRule('width', configuration.logo.smallWidth, {
       media,
     });

--- a/src/components/Logo/index.js
+++ b/src/components/Logo/index.js
@@ -14,7 +14,7 @@ const StyledLogo = styled.img`
   ${({ tall }) =>
     tall &&
     css`
-      @media screen and ${breakpoint('max-width', 'laptopM')} {
+      @media screen and ${breakpoint('max-width', 'tabletS')} {
         width: ${configuration.logo.smallWidth};
         height: ${configuration.logo.smallHeight};
       }
@@ -38,7 +38,7 @@ const StyledA = styled.a`
   ${({ tall }) =>
     tall &&
     css`
-      @media screen and ${breakpoint('max-width', 'laptopM')} {
+      @media screen and ${breakpoint('max-width', 'tabletS')} {
         width: ${configuration.logo.smallWidth};
         height: ${configuration.logo.smallHeight};
       }

--- a/src/components/Logo/index.js
+++ b/src/components/Logo/index.js
@@ -38,7 +38,7 @@ const StyledA = styled.a`
   ${({ tall }) =>
     tall &&
     css`
-      @media screen and ${breakpoint('min-width', 'laptopM')} {
+      @media screen and ${breakpoint('max-width', 'laptopM')} {
         width: ${configuration.logo.smallWidth};
         height: ${configuration.logo.smallHeight};
       }
@@ -49,7 +49,7 @@ const StyledA = styled.a`
 `;
 
 export const Logo = ({ tall, ...props }) => (
-  <StyledA href={tall ? configuration.links.home : '/'}>
+  <StyledA data-testid="logo-link" tall={tall} href={tall ? configuration.links.home : '/'}>
     <StyledLogo data-testid="logo" alt="Logo" tall={tall} src={configuration.logo.url} {...props} />
   </StyledA>
 );

--- a/src/components/Logo/index.js
+++ b/src/components/Logo/index.js
@@ -9,7 +9,6 @@ const StyledLogo = styled.img`
   display: block;
   width: ${({ tall }) => (tall ? configuration.logo.width : configuration.logo.smallWidth)};
   height: ${({ tall }) => (tall ? configuration.logo.height : configuration.logo.smallHeight)};
-  max-height: ${({ tall }) => (tall ? '56px' : '32px')};
 
   ${({ tall }) =>
     tall &&
@@ -25,7 +24,6 @@ const StyledA = styled.a`
   display: inline-block;
   width: ${({ tall }) => (tall ? configuration.logo.width : configuration.logo.smallWidth)};
   height: ${({ tall }) => (tall ? configuration.logo.height : configuration.logo.smallHeight)};
-  max-height: ${({ tall }) => (tall ? '56px' : '32px')};
   margin-right: ${themeSpacing(3)};
 
   &&:focus {

--- a/src/components/Logo/index.js
+++ b/src/components/Logo/index.js
@@ -1,20 +1,57 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
+import { breakpoint, themeSpacing, themeColor } from '@datapunt/asc-ui';
 
 import configuration from 'shared/services/configuration/configuration';
 
 const StyledLogo = styled.img`
-  width: ${({ tall }) => tall ? configuration.logo.width : configuration.logo.smallWidth};
-  height: ${({ tall }) => tall ? configuration.logo.height : configuration.logo.smallHeight};
-  max-height: ${({ tall }) => tall ? '56px' : '32px'};
+  display: block;
+  width: ${({ tall }) => (tall ? configuration.logo.width : configuration.logo.smallWidth)};
+  height: ${({ tall }) => (tall ? configuration.logo.height : configuration.logo.smallHeight)};
+  max-height: ${({ tall }) => (tall ? '56px' : '32px')};
+
+  ${({ tall }) =>
+    tall &&
+    css`
+      @media screen and ${breakpoint('max-width', 'laptopM')} {
+        width: ${configuration.logo.smallWidth};
+        height: ${configuration.logo.smallHeight};
+      }
+    `};
+`;
+
+const StyledA = styled.a`
+  display: inline-block;
+  width: ${({ tall }) => (tall ? configuration.logo.width : configuration.logo.smallWidth)};
+  height: ${({ tall }) => (tall ? configuration.logo.height : configuration.logo.smallHeight)};
+  max-height: ${({ tall }) => (tall ? '56px' : '32px')};
+  margin-right: ${themeSpacing(3)};
+
+  &&:focus {
+    outline-color: ${themeColor('support', 'focus')};
+    outline-style: solid;
+    outline-offset: 0px;
+    outline-width: 3px;
+  }
+
+  ${({ tall }) =>
+    tall &&
+    css`
+      @media screen and ${breakpoint('min-width', 'laptopM')} {
+        width: ${configuration.logo.smallWidth};
+        height: ${configuration.logo.smallHeight};
+      }
+      @media screen and ${breakpoint('min-width', 'laptopM')} {
+        margin-right: ${themeSpacing(10)};
+      }
+    `};
 `;
 
 export const Logo = ({ tall, ...props }) => (
-  <a href={tall ? configuration.links.home : '/'}>
+  <StyledA href={tall ? configuration.links.home : '/'}>
     <StyledLogo data-testid="logo" alt="Logo" tall={tall} src={configuration.logo.url} {...props} />
-  </a>
+  </StyledA>
 );
 
 Logo.defaultProps = {


### PR DESCRIPTION
closes Signalen/frontend#87

On smaller screens, non-Amsterdam logo's wouldn't be shown in their smaller version and thus not fit nicely.

![image](https://user-images.githubusercontent.com/5213690/97311915-2f581f80-1865-11eb-94e0-97fc4913203b.png)

This PR fixes that.

@jpoppe I removed the `max-height` on the logo. I see you've added this in the past. I'm not sure for what reason. It messes with the fixed height from the configuration. Let me know if this is okay.