### PR TITLE
[SIG-3286] Revert "#1221 from Amsterdam/SIG-3283-hide-split-button"

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/components/DetailHeader/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/DetailHeader/index.js
@@ -71,7 +71,6 @@ const StyledHeading = styled(Heading)`
 `;
 
 const ButtonLink = styled(Button)`
-  display: none;
   color: ${themeColor('tint', 'level7')};
   text-decoration: none;
 
@@ -142,16 +141,14 @@ const DetailHeader = () => {
 
       <ButtonContainer>
         {showSplitButton && (
-          <div hidden>
-            <ButtonLink
-              variant="application"
-              forwardedAs={Link}
-              to={`${INCIDENT_URL}/${incident.id}/split`}
-              data-testid="detail-header-button-split"
-            >
-              Delen
-            </ButtonLink>
-          </div>
+          <ButtonLink
+            variant="application"
+            forwardedAs={Link}
+            to={`${INCIDENT_URL}/${incident.id}/split`}
+            data-testid="detail-header-button-split"
+          >
+            Delen
+          </ButtonLink>
         )}
 
         {canThor && (


### PR DESCRIPTION
This PR reverts #1221 and makes the incident split button visible again. 