### PR TITLE
Post additional questions through extra_properties

### DIFF
--- a/src/signals/incident/containers/IncidentContainer/services.js
+++ b/src/signals/incident/containers/IncidentContainer/services.js
@@ -46,7 +46,10 @@ export const resolveQuestions = questions => ({
     (acc, question) => ({
       ...acc,
       [question.key]: {
-        meta: question.meta,
+        meta: {
+          ...question.meta,
+          pathMerge: 'extra_properties',
+        },
         options: {
           validators: (question.meta?.validators || []).map(mapValidator),
         },

--- a/src/signals/incident/containers/IncidentContainer/services.js
+++ b/src/signals/incident/containers/IncidentContainer/services.js
@@ -51,7 +51,9 @@ export const resolveQuestions = questions => ({
           pathMerge: 'extra_properties',
         },
         options: {
-          validators: (question.meta?.validators || []).map(mapValidator),
+          validators: [
+            ...new Set([...question.meta?.validators || [], ...question.required ? ['required'] : []]),
+          ].map(mapValidator),
         },
         render: fieldTypeMap[question.field_type],
       },

--- a/src/signals/incident/containers/IncidentContainer/services.test.js
+++ b/src/signals/incident/containers/IncidentContainer/services.test.js
@@ -3,7 +3,9 @@ import { resolveQuestions } from './services';
 const mockedQuestions = [
   {
     key: 'key1',
-    meta: 'meta1',
+    meta: {
+      metaProp: 'metaProp',
+    },
     field_type: 'checkbox_input',
   },
   {
@@ -31,7 +33,10 @@ describe('The resolve questions service', () => {
   it('should pass meta prop', () => {
     const result = resolveQuestions(mockedQuestions);
     expect(result.key1).toMatchObject({
-      meta: 'meta1',
+      meta: {
+        metaProp: 'metaProp',
+        pathMerge: 'extra_properties',
+      },
     });
     expect(result.key2).toMatchObject({
       meta: {},

--- a/src/signals/incident/containers/IncidentContainer/services.test.js
+++ b/src/signals/incident/containers/IncidentContainer/services.test.js
@@ -15,6 +15,19 @@ const mockedQuestions = [
     },
     field_type: 'radio_input',
   },
+  {
+    key: 'key3',
+    field_type: 'select_input',
+    required: true,
+  },
+  {
+    key: 'key4',
+    meta: {
+      validators: ['required', ['max_length', 100]],
+    },
+    field_type: 'select_input',
+    required: true,
+  },
 ];
 
 describe('The resolve questions service', () => {
@@ -24,12 +37,16 @@ describe('The resolve questions service', () => {
     expect(result).toHaveProperty('$field_0');
     expect(Object.keys(result).length).toBe(2);
   });
+
   it('should return the questions mapped to their key property', () => {
     const result = resolveQuestions(mockedQuestions);
     expect(result).toHaveProperty('key1');
     expect(result).toHaveProperty('key2');
-    expect(Object.keys(result).length).toBe(4);
+    expect(result).toHaveProperty('key3');
+    expect(result).toHaveProperty('key4');
+    expect(Object.keys(result).length).toBe(6);
   });
+
   it('should pass meta prop', () => {
     const result = resolveQuestions(mockedQuestions);
     expect(result.key1).toMatchObject({
@@ -42,6 +59,7 @@ describe('The resolve questions service', () => {
       meta: {},
     });
   });
+
   it('should add render prop', () => {
     const result = resolveQuestions(mockedQuestions);
     expect(result.key1).toMatchObject({
@@ -51,6 +69,7 @@ describe('The resolve questions service', () => {
       render: 'RadioInputGroup',
     });
   });
+
   it('should add options prop with validators', () => {
     const result = resolveQuestions(mockedQuestions);
     expect(result.key1).toMatchObject({
@@ -59,6 +78,16 @@ describe('The resolve questions service', () => {
       },
     });
     expect(result.key2).toMatchObject({
+      options: {
+        validators: ['required', ['maxLength', 100]],
+      },
+    });
+    expect(result.key3).toMatchObject({
+      options: {
+        validators: ['required'],
+      },
+    });
+    expect(result.key4).toMatchObject({
       options: {
         validators: ['required', ['maxLength', 100]],
       },


### PR DESCRIPTION
All additional questions (coming from the backend) should have their answer inside the `extra_properties` parameter of the signal in the POST request creating the signal.

This PR makes sure this is done by default and should not have to be configured for every question in the database.

The `required` property on a question (coming from the backend) is now also being picked up. Whenever it's `true`, the `required` validator is being added to the `options.validators` property.