### PR TITLE
(Chore) Docs overview on configuring questions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,41 +1,23 @@
 # Documentation
 
-## Architectural decision records
+## [Architectural decision records](./adr/README.md)
 
-All important architectural decisions that have been made, along with their context and consequences, are documented [here](./adr/README.md).
-See https://github.com/joelparkerhenderson/architecture_decision_record for reference on creating ADRs.
+All important architectural decisions that have been made, along with their context and consequences, are documented.
+
+See this [reference on creating ADRs](https://github.com/joelparkerhenderson/architecture_decision_record).
 
 ## Schemas
 
-### Configuration schema
+### [Configuration schema](./schemas/README.md)
 
-The application is split into multiple parts where the functionality lives in this repository and the corresponding configuration in another. Each configuration property is listed and described [here](./schemas/README.md).
+The application is split into multiple parts where the functionality lives in this repository and the corresponding configuration in another. Each configuration property is listed and described.
 
-## Setting up a serviceworker proxy
+## [Serviceworker proxy](./serviceworker-proxy.md)
 
 It can sometimes be useful to mock requests in the browser in order to test different UI presentations. For instance when a user's permission should dictate which menu items should be shown.
 
 This behaviour can be accomplished by invoking a serviceworker that acts as a proxy that can return specific content for certain requests.
 
-The [serviceworker](../src/sw-proxy.js) takes [an array of request/response configurations](../src/sw-proxy-config.js). A config object can have the following properties:
+## [Additional questions](./additional-questions.md)
 
-- `request`: Object (required)
-- `request.headers`: Object (optional), key/value pairs of HTTP headers
-- `request.method`: String (required), HTTP method (GET, POST, PUT or DELETE)
-- `request.url`: String (required), fully qualified URL of the request to be proxied. Can be a regexp.
-
-- `response`: Object (required)
-- `response.body`: Object/String (optional): response body
-- `response.delay`: Number (optional): delay in milliseconds for the response to return
-- `response.file`: String (optional), path to file to be served, relative to root folder of the application. Must be accessible to the web server and will be ignored if `body` is present
-- `response.headers`: Object (optional), key/value pairs of HTTP headers
-- `response.status`: Number (optional), HTTP status code
-- `response.statusText`: String (optional), HTTP status text
-
-To run the application with the proxied serviceworker:
-
-```
-HTTPS=true PROXY=true npm start
-```
-
-After each change of the [array of request/response configurations](../src/sw-proxy-config.js), the serviceworker doens't automatically pick up the changes. A hard refresh or clearing the application's data in the browser will fix that.
+The second step of the incident wizard shows any additional questions available. These questions will be fetched from the backend with the feature flag `fetchQuestionsFromBackend` enabled. How to configure these questions is explained in detail.

--- a/docs/additional-questions.md
+++ b/docs/additional-questions.md
@@ -1,0 +1,50 @@
+# Additional questions
+
+## Question properties
+
+| Property | Description
+| - | -
+| **Key** | This doesn't do anything, just give it a name.
+| **Field type** | The type of form field for the visitor to anser the question with. Detailed below.
+| **Meta** | This gives extra control over more specified properties. Detailed below.
+| **Required** | The visitor is required to answer the question when this is checked. Otherwise the question is optional.
+
+## Field type
+
+Possible field types.
+
+| Field type | Description
+| - | -
+| **PlainText** | This is not really a question to answer. It simply shows some information to the visitor.
+| **TextInput** | A text field for one line of text.
+| **CheckboxInput** | Could be either of the following. A *single* checkbox to allow the visitor to check or uncheck a specific option. A *list* of checkboxes to allow the visitor to choose multiple values from a fixed set of options.
+| **RadioInput** | Radio boxes to allow the visitor to choose one value from a fixed set of options.
+| **SelectInput** | Dropdown box to allow the visitor to choose one value from a fixed set of options.
+| **TextareaInput** | A bigger text field for multiple lines of text.
+
+## Meta
+
+This defines a set of properties written in [JSON](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Objects/JSON).
+
+Possible properties are listed below. The 'Field types' column lists the possible field types the property can be used for, in case the property is not possible for all field types.
+
+| Property | Description | Field types
+| - | - | -
+| **label** | The label acompanying the input field, proposing the question.
+| **subtitle** | Extra information needed to explain the question (e.g. possible values, or how to find what is being asked for).
+| **shortLabel** | A short label to indicate the meaning of the answer. This is shown next to the answer in the back-office.
+| **placeholder** | An example answer to help the visitor determine how to answer the question and how to write down that answer. | TextInput, TextareaInput
+| **type** | Allows to specify more specifically the type of form field. Detailed below. | PlainText
+| **autoRemove** | Automatically removes the specified value from the answer. | TextInput, TextareaInput
+| **value** | The text to display to the visitor. | PlainText, CheckboxInput (single)
+| **values** | The possible options in key-value pairs. | CheckboxInput (list), RadioInput, SelectInput
+| **maxLength** | Displays, underneath the text area, the amount of characters typed into the text area versus the total amount of characters allowed (as specified with this property). | TextareaInput
+
+### Type
+
+The type attribute on the meta value is possible on a few input types, specifying more specifically how to display the form field, or how it should behave. Possibilities are listed below.
+
+| Field type | Description
+| - | -
+| **PlainText** | Possible values: `citation`, `caution`, `alert`.
+| **TextInput** | [MDN](https://developer.mozilla.org) lists [all possible input types](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input) in the table under '\<input\> types'.

--- a/docs/serviceworker-proxy.md
+++ b/docs/serviceworker-proxy.md
@@ -1,0 +1,24 @@
+# Setting up a serviceworker Proxy
+
+The [serviceworker](../src/sw-proxy.js) takes [an array of request/response configurations](../src/sw-proxy-config.js). A config object can have the following properties:
+
+- `request`: Object (required)
+- `request.headers`: Object (optional), key/value pairs of HTTP headers
+- `request.method`: String (required), HTTP method (GET, POST, PUT or DELETE)
+- `request.url`: String (required), fully qualified URL of the request to be proxied. Can be a regexp.
+
+- `response`: Object (required)
+- `response.body`: Object/String (optional): response body
+- `response.delay`: Number (optional): delay in milliseconds for the response to return
+- `response.file`: String (optional), path to file to be served, relative to root folder of the application. Must be accessible to the web server and will be ignored if `body` is present
+- `response.headers`: Object (optional), key/value pairs of HTTP headers
+- `response.status`: Number (optional), HTTP status code
+- `response.statusText`: String (optional), HTTP status text
+
+To run the application with the proxied serviceworker:
+
+```
+HTTPS=true PROXY=true npm start
+```
+
+After each change of the [array of request/response configurations](../src/sw-proxy-config.js), the serviceworker doens't automatically pick up the changes. A hard refresh or clearing the application's data in the browser will fix that.


### PR DESCRIPTION
For now, the additional questions coming from the backend can be configured in the Jango admin. This PR creates documentation to give a simple overview of how to configure those questions and what the possible options are.