### PR TITLE
(Chore) serviceworker installation condition

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -91,7 +91,7 @@ store.dispatch(authenticateUser(credentials));
 // Install ServiceWorker and AppCache in the end since
 // it's not most important operation and if main code fails,
 // we do not want it installed
-if (process.env.ENABLE_SERVICEWORKER === '1') {
+if ('serviceWorker' in navigator && process.env.ENABLE_SERVICEWORKER === '1') {
   // eslint-disable-next-line global-require
   const runtime = require('offline-plugin/runtime');
 


### PR DESCRIPTION
This minor change makes sure that `Uncaught (in promise) DOMException: Failed to register a ServiceWorker for scope ('https://meldingen.amsterdam.nl/') with script ('https://meldingen.amsterdam.nl/sw.js'): An unknown error occurred when fetching the script.` errors won't be popping up in Sentry logs.