### PR TITLE
[SIG-3029] Uses the extendedName for the subcategory in the category list

### DIFF
--- a/src/models/categories/__tests__/selectors.test.js
+++ b/src/models/categories/__tests__/selectors.test.js
@@ -1,5 +1,8 @@
 import { fromJS } from 'immutable';
-import { mainCategories as mainCategoriesFixture, subCategories as subCategoriesFixture } from 'utils/__tests__/fixtures';
+import {
+  mainCategories as mainCategoriesFixture,
+  subCategories as subCategoriesFixture,
+} from 'utils/__tests__/fixtures';
 
 import categoriesJson from 'utils/__tests__/fixtures/categories_private.json';
 
@@ -169,5 +172,10 @@ describe('models/categories/selectors', () => {
     const [subcategoryGroups, subcategoryOptions] = subcategoriesGroupedByCategories;
     expect(subcategoryGroups.length).toEqual(mainCategoriesFixture.length);
     expect(subcategoryOptions.length).toEqual(subCategoriesFixture.length);
+    subcategoryOptions.forEach(({ name, value, extendedName, category_slug, group }) => {
+      expect(name).toEqual(extendedName);
+      expect(value).toEqual(extendedName);
+      expect(group).toEqual(category_slug);
+    });
   });
 });

--- a/src/models/categories/selectors.js
+++ b/src/models/categories/selectors.js
@@ -157,6 +157,7 @@ export const makeSelectSubcategoriesGroupedByCategories = createSelector(
     const subcategoryGroups = categories?.map(({ slug: value, name }) => ({ name, value }));
     const subcategoryOptions = subcategories?.map(subcategory => ({
       ...subcategory,
+      name: subcategory.extendedName,
       value: subcategory.extendedName,
       group: subcategory.category_slug,
     }));


### PR DESCRIPTION
This PR fixes a bug where in the display name of the subcategory the departments list were missing