### PR TITLE
(Chore) Make it possible to run Jest outside the project root directory

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -12,7 +12,7 @@ extends:
 globals:
   L: true
 overrides:
-  - files: [./eslint-plugin-amsterdam/**/*, ./internals/**/*, ./server/**/*]
+  - files: [./eslint-plugin-amsterdam/**/*, jest.config.*, ./internals/**/*, ./server/**/*]
     extends: [plugin:amsterdam/node]
     rules:
       node/shebang: 'off'

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 module.exports = {
   collectCoverageFrom: [
     'src/*.js',
@@ -28,12 +30,8 @@ module.exports = {
     '.*\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
       '<rootDir>/internals/mocks/image.js',
   },
-  setupFilesAfterEnv: [
-    '<rootDir>/internals/testing/test-bundler.js',
-  ],
-  transform: {
-    '^.+\\.js$': 'babel-jest',
-  },
+  setupFilesAfterEnv: ['<rootDir>/internals/testing/test-bundler.js'],
+  transform: { '^.+\\.js$': ['babel-jest', { configFile: path.resolve(__dirname, 'babel.config.js') }] },
   testRegex: '.*\\.test\\.js$',
   snapshotSerializers: ['enzyme-to-json/serializer'],
 };


### PR DESCRIPTION
This enables the possibility to run Jest (from node_modules, system or npx) from everywhere

For example:
```
cd ~/ga/signals-frontend/src/hooks
npx jest --coverage --watch src
jest --coverage --watch IncidentSplitContainer
```

Or 😎 :
```
node /home/jpoppe/ga/signals-frontend/node_modules/.bin/jest \
 --config /home/jpoppe/ga/signals-frontend/jest.config.js \
 --runTestsByPath /home/jpoppe/ga/signals-frontend/src/components/ChildIncidents/__tests__/ChildIncidents.test.js \
 --watch
```

- also added jest.config.js to Node module overrides in the ESLint configuration