### PR TITLE
[SIG-3324] Reset the edit mode when the incident is changed

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/components/ChangeValue/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/ChangeValue/index.js
@@ -53,11 +53,12 @@ const ChangeValue = ({
   const [showForm, setShowForm] = useState(false);
   const [info, setInfo] = useState('');
 
+  useEffect(() => setShowForm(false), [incident?.id]);
+
   const form = useMemo(
-    () =>
-      FormBuilder.group({
-        input: [rawDataToKey(get(incident, valuePath)), Validators.required],
-      }),
+    () => FormBuilder.group({
+      input: [rawDataToKey(get(incident, valuePath)), Validators.required],
+    }),
     [incident, rawDataToKey, valuePath]
   );
 
@@ -133,6 +134,7 @@ const ChangeValue = ({
   }, [incident, rawDataToKey, valuePath, path, showInfo, form]);
 
   useEffect(() => {
+    setShowForm(false);
     document.addEventListener('keyup', handleKeyUp);
 
     return () => {

--- a/src/signals/incident-management/containers/IncidentDetail/components/ChangeValue/index.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/ChangeValue/index.test.js
@@ -47,12 +47,13 @@ const props = {
 };
 
 const update = jest.fn();
+const incidentData = { ...incidentFixture, someValue: otherKey, value: { path: rawKey } };
 
-const renderWithContext = (componentProps = props) =>
+const renderWithContext = (componentProps = props, incident = incidentData) =>
   withAppContext(
     <IncidentDetailContext.Provider
       value={{
-        incident: { ...incidentFixture, someValue: otherKey, value: { path: rawKey } },
+        incident,
         update,
         nonExistingValue: 'nonExistingValue',
       }}
@@ -324,5 +325,18 @@ describe('ChangeValue', () => {
     render(renderWithContext({ ...props, valueClass }));
 
     expect(screen.getByTestId('meta-list-mockType-value').className).toBe(valueClass);
+  });
+
+  it('should reset the edit state when the incident is changed', async () => {
+    const renderProps = render(renderWithContext());
+
+    await expectInitialState();
+
+    fireEvent.click(renderProps.getByTestId(editTestId));
+
+    await expectEditState();
+
+    renderProps.rerender(renderWithContext(props, { ...incidentData, id: incidentData.id + 1 }));
+    await expectInitialState();
   });
 });


### PR DESCRIPTION
This PR initializes the ChangeValue state each time the incident changes. This fixes a bug where bij navigation to a different incident, the edit state of a change value remained open.