### PR TITLE
[SIG-3288] Show an icon for the child incidents in the overview

### DIFF
--- a/src/signals/incident-management/containers/IncidentOverviewPage/components/List/index.js
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/components/List/index.js
@@ -93,7 +93,7 @@ const ParentIconStyle = styled.span`
   flex-direction: row;
 
   & span:nth-child(2) {
-    margin-left: -5px;
+    margin-left: -5px; // specific value. Ensures the parent icon composition icons are near each other.
   }
 `;
 

--- a/src/signals/incident-management/containers/IncidentOverviewPage/components/List/index.js
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/components/List/index.js
@@ -89,9 +89,6 @@ Td.propTypes = {
 };
 
 const ParentIconStyle = styled.span`
-  display: flex;
-  flex-direction: row;
-
   & span:nth-child(2) {
     margin-left: -5px; // specific value. Ensures the parent icon composition icons are near each other.
   }
@@ -199,7 +196,7 @@ const List = ({
               <tr key={incident.id}>
                 <Td detailLink={detailLink}>
                   {incident.has_children && <ParentIcon />}
-                  {(incident.has_parent && <ChildIcon />) || null}
+                  {incident.has_parent && <ChildIcon />}
                 </Td>
                 <Td detailLink={detailLink}>{incident.id}</Td>
                 <Td detailLink={detailLink} data-testid="incidentDaysOpen">

--- a/src/signals/incident-management/containers/IncidentOverviewPage/components/List/index.js
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/components/List/index.js
@@ -1,10 +1,10 @@
-import React, { useCallback, useContext } from 'react';
+import React, { useCallback, useContext, Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import parseISO from 'date-fns/parseISO';
 import differenceInCalendarDays from 'date-fns/differenceInCalendarDays';
-import { FastForward, ChevronUp, ChevronDown } from '@amsterdam/asc-assets';
-import { Icon, themeSpacing } from '@amsterdam/asc-ui';
+import { FastForward, ChevronUp, ChevronDown, Play } from '@amsterdam/asc-assets';
+import { Icon, themeColor, themeSpacing } from '@amsterdam/asc-ui';
 import styled from 'styled-components';
 
 import { string2date, string2time } from 'shared/services/string-parser';
@@ -87,6 +87,32 @@ Td.propTypes = {
   detailLink: PropTypes.string.isRequired,
   children: PropTypes.node,
 };
+
+const ParentIconStyle = styled.span`
+  display: flex;
+  flex-direction: row;
+
+  & span:nth-child(2) {
+    margin-left: -5px;
+  }
+`;
+
+const ParentIcon = () => (
+  <ParentIconStyle role="img" aria-label="Hoofdmelding">
+    <Icon size={14}>
+      <Play />
+    </Icon>
+    <Icon size={14}>
+      <Play />
+    </Icon>
+  </ParentIconStyle>
+);
+
+const ChildIcon = () => (
+  <Icon size={14} role="img" aria-label="Deelmelding" color={themeColor('tint', 'level4')}>
+    <Play />
+  </Icon>
+);
 
 const List = ({
   className = '',
@@ -172,11 +198,8 @@ const List = ({
             return (
               <tr key={incident.id}>
                 <Td detailLink={detailLink}>
-                  {incident.has_children && (
-                    <Icon size={14} role="img" aria-label="Hoofdmelding">
-                      <FastForward />
-                    </Icon>
-                  )}
+                  {incident.has_children && <ParentIcon />}
+                  {(incident.has_parent && <ChildIcon />) || null}
                 </Td>
                 <Td detailLink={detailLink}>{incident.id}</Td>
                 <Td detailLink={detailLink} data-testid="incidentDaysOpen">

--- a/src/signals/incident-management/containers/IncidentOverviewPage/components/List/index.test.js
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/components/List/index.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
 import configuration from 'shared/services/configuration/configuration';
 import { priorityList, statusList, stadsdeelList } from 'signals/incident-management/definitions';
 import { withAppContext } from 'test/utils';
@@ -173,9 +173,21 @@ describe('List', () => {
       const incidentList = [incidentWithChildren, ...props.incidents.slice(1)];
       const parentsCount = incidentList.filter(incident => incident.has_children).length;
 
-      const { queryAllByRole } = render(withContext(<List {...props} incidents={incidentList} />));
+      render(withContext(<List {...props} incidents={incidentList} />));
 
-      expect(queryAllByRole('img').length).toEqual(parentsCount);
+      expect(screen.queryAllByRole('img').length).toEqual(parentsCount);
+      expect(screen.queryByRole('img')).toHaveAttribute('aria-label', 'Hoofdmelding');
+    });
+
+    it('should render an icon for each child incident', () => {
+      const incidentWithChildren = { ...props.incidents[0], has_parent: true };
+      const incidentList = [incidentWithChildren, ...props.incidents.slice(1)];
+      const childCount = incidentList.filter(incident => incident.parent).length;
+
+      render(withContext(<List {...props} incidents={incidentList} />));
+
+      expect(screen.queryAllByRole('img').length).toEqual(childCount);
+      expect(screen.queryByRole('img')).toHaveAttribute('aria-label', 'Deelmelding');
     });
   });
 });

--- a/src/signals/incident-management/containers/IncidentOverviewPage/components/List/index.test.js
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/components/List/index.test.js
@@ -182,7 +182,7 @@ describe('List', () => {
     it('should render an icon for each child incident', () => {
       const incidentWithChildren = { ...props.incidents[0], has_parent: true };
       const incidentList = [incidentWithChildren, ...props.incidents.slice(1)];
-      const childCount = incidentList.filter(incident => incident.parent).length;
+      const childCount = incidentList.filter(incident => incident.has_parent).length;
 
       render(withContext(<List {...props} incidents={incidentList} />));
 


### PR DESCRIPTION
This PR marks with a grey `play` icon all the child incidents in the overview list