### PR TITLE
[SIG-3268] Enable Christmas lights message

### DIFF
--- a/src/signals/incident/components/form/PlainText/style.scss
+++ b/src/signals/incident/components/form/PlainText/style.scss
@@ -18,12 +18,16 @@
     &.alert {
       color: #ec0000;
       border: 2px solid #ec0000;
-      padding:  9px 20px 0;
+      padding:  9px 20px;
       @include avenirnextdemi();
     }
 
     &-p {
       margin-bottom: 16px;
+
+      &:last-child {
+        margin-bottom: 0;
+      }
     }
 
     ul {
@@ -35,4 +39,5 @@
       }
     }
   }
+
 }

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/wegen-verkeer-straatmeubilair.js
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/wegen-verkeer-straatmeubilair.js
@@ -20,14 +20,19 @@ const intro = {
 };
 
 export const controls = {
-  // This element will be enabled each year near the christmass. Just comment it out and not remove it.
   extra_kerstverlichting: {
     meta: {
       label: '',
       type: 'alert',
-      value: 'Doet de sierverlichting in een winkelstraat het niet? Of hebt u last van de kerstverlichting? Neem dan contact op met de winkeliersvereniging. De gemeente gaat hier helaas niet over.',
+      value:
+        'Doet de sierverlichting in een winkelstraat het niet? Of hebt u last van de kerstverlichting? Neem dan contact op met de winkeliersvereniging. De gemeente gaat hier helaas niet over.',
       ifAllOf: {
-        subcategory: 'lantaarnpaal-straatverlichting',
+        subcategory: [
+          'lantaarnpaal-straatverlichting',
+          // This element will be enabled each year near the christmass.
+          // Comment/Uncomment next line to show/hide it.
+          // 'do-not-show-this-message',
+        ],
       },
     },
     render: FormComponents.PlainText,

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/wegen-verkeer-straatmeubilair.js
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/wegen-verkeer-straatmeubilair.js
@@ -20,6 +20,19 @@ const intro = {
 };
 
 export const controls = {
+  // This element will be enabled each year near the christmass. Just comment it out and not remove it.
+  extra_kerstverlichting: {
+    meta: {
+      label: '',
+      type: 'alert',
+      value: 'Doet de sierverlichting in een winkelstraat het niet? Of hebt u last van de kerstverlichting? Neem dan contact op met de winkeliersvereniging. De gemeente gaat hier helaas niet over.',
+      ifAllOf: {
+        subcategory: 'lantaarnpaal-straatverlichting',
+      },
+    },
+    render: FormComponents.PlainText,
+  },
+
   extra_brug: {
     meta: {
       ifAllOf: {
@@ -125,7 +138,7 @@ export const controls = {
         ],
       },
       type: 'alert',
-      value: [`Bel direct ${configuration.language.phoneNumber}. U hoeft dit formulier niet meer verder in te vullen.`],
+      value: `Bel direct ${configuration.language.phoneNumber}. U hoeft dit formulier niet meer verder in te vullen.`,
     },
     render: FormComponents.PlainText,
   },
@@ -236,7 +249,7 @@ export const controls = {
         ],
       },
       type: 'alert',
-      value: [`Bel direct ${configuration.language.phoneNumber}. U hoeft dit formulier niet meer verder in te vullen.`],
+      value: `Bel direct ${configuration.language.phoneNumber}. U hoeft dit formulier niet meer verder in te vullen.`,
     },
     render: FormComponents.PlainText,
   },
@@ -369,7 +382,7 @@ export const controls = {
         ],
       },
       type: 'alert',
-      value: [`Bel direct ${configuration.language.phoneNumber}. U hoeft dit formulier niet meer verder in te vullen.`],
+      value: `Bel direct ${configuration.language.phoneNumber}. U hoeft dit formulier niet meer verder in te vullen.`,
     },
     render: FormComponents.PlainText,
   },

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/wegen-verkeer-straatmeubilair.js
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/wegen-verkeer-straatmeubilair.js
@@ -20,6 +20,8 @@ const intro = {
 };
 
 export const controls = {
+  // This element will be enabled each year near the christmass.
+  // Comment/Uncomment next block to show/hide it.
   extra_kerstverlichting: {
     meta: {
       label: '',
@@ -27,12 +29,7 @@ export const controls = {
       value:
         'Doet de sierverlichting in een winkelstraat het niet? Of hebt u last van de kerstverlichting? Neem dan contact op met de winkeliersvereniging. De gemeente gaat hier helaas niet over.',
       ifAllOf: {
-        subcategory: [
-          'lantaarnpaal-straatverlichting',
-          // This element will be enabled each year near the christmass.
-          // Comment/Uncomment next line to show/hide it.
-          // 'do-not-show-this-message',
-        ],
+        subcategory: ['lantaarnpaal-straatverlichting'],
       },
     },
     render: FormComponents.PlainText,

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/wonen.js
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/wonen.js
@@ -441,7 +441,7 @@ const woningkwaliteit = {
         extra_wonen_woonkwaliteit_direct_gevaar: 'ja',
       },
       type: 'alert',
-      value: ['Bel 112 en vul dit formulier niet verder in'],
+      value: 'Bel 112 en vul dit formulier niet verder in',
     },
     render: FormComponents.PlainText,
   },


### PR DESCRIPTION
This PR 
- adds a temporary message about the Christmas lights in the `straatverlichting` additional questions. 
- fixes a small style issue on displaying the PlainText component with `alert` type
- adds a not existing category to make possible disabling of this message when required