### PR TITLE
Adds category_url to value of extra questions

### DIFF
--- a/src/signals/incident/services/map-paths/index.js
+++ b/src/signals/incident/services/map-paths/index.js
@@ -1,11 +1,14 @@
 import forEach from 'lodash.foreach';
 import set from 'lodash.set';
 
+import configuration from 'shared/services/configuration/configuration';
 import getStepControls from '../get-step-controls';
 import convertValue from '../convert-value';
 
 const mapPaths = (params, incident, wizard) => {
-  const category_url = incident && incident.subcategory_link ? new URL(incident.subcategory_link).pathname : '';
+  const category_url = incident
+    ? new URL(`${configuration.CATEGORIES_ENDPOINT}${incident.category}/sub_categories/${incident.subcategory}`).pathname
+    : '';
 
   forEach(wizard, step => {
     const controls = getStepControls(step, incident);
@@ -21,7 +24,7 @@ const mapPaths = (params, incident, wizard) => {
           mapMerge = {
             ...mapMerge,
             [meta.pathMerge]: [
-              ...mapMerge[meta.pathMerge] || [],
+              ...(mapMerge[meta.pathMerge] || []),
               {
                 id: name,
                 label: meta.shortLabel || meta.label || '',

--- a/src/signals/incident/services/map-paths/index.test.js
+++ b/src/signals/incident/services/map-paths/index.test.js
@@ -7,7 +7,6 @@ jest.mock('../get-step-controls');
 jest.mock('../convert-value');
 
 describe('The map paths service', () => {
-  const category_url = '/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/straatverlichting-openbare-klok';
   const wizard = {
     step: {
       form: {
@@ -68,9 +67,10 @@ describe('The map paths service', () => {
   };
 
   const incident = {
-    subcategory_link: 'https://api.data.amsterdam.nl/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/straatverlichting-openbare-klok',
     description: 'free text',
     value_0: 0,
+    category: 'wegen-verkeer-straatmeubilair',
+    subcategory: 'straatverlichting-openbare-klok',
     checkbox_false: {
       label: 'Gebeurt het vaker?',
       value: false,
@@ -83,13 +83,16 @@ describe('The map paths service', () => {
       id: 'foo',
       label: 'Foo',
     },
-    array: [{
-      id: 'bar',
-      label: 'Bar',
-    }, {
-      id: 'baz',
-      label: 'Baz',
-    }],
+    array: [
+      {
+        id: 'bar',
+        label: 'Bar',
+      },
+      {
+        id: 'baz',
+        label: 'Baz',
+      },
+    ],
   };
 
   it('should map status by default', () => {
@@ -108,57 +111,68 @@ describe('The map paths service', () => {
       .mockImplementationOnce(() => incident.array);
 
     expect(mapPaths({}, incident, wizard)).toMatchObject({
-      extra_properties: [{
-        id: 'description',
-        label: 'Omschr.',
-        answer: 'free text',
-        category_url,
-      },
-      {
-        id: 'value_0',
-        label: '',
-        answer: 0,
-        category_url,
-      },
-      {
-        id: 'checkbox_false',
-        label: 'Checkbox unchecked',
-        answer: {
-          label: 'Gebeurt het vaker?',
-          value: false,
+      extra_properties: [
+        {
+          id: 'description',
+          label: 'Omschr.',
+          answer: 'free text',
+          category_url:
+            '/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/straatverlichting-openbare-klok',
         },
-        category_url,
-      },
-      {
-        id: 'checkbox_true',
-        label: 'Checkbox checked',
-        answer: {
-          label: 'Heeft u het gezien?',
-          value: true,
+        {
+          id: 'value_0',
+          label: '',
+          answer: 0,
+          category_url:
+            '/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/straatverlichting-openbare-klok',
         },
-        category_url,
-      },
-      {
-        id: 'object',
-        label: 'Selectbox of Radio',
-        answer: {
-          id: 'foo',
-          label: 'Foo',
+        {
+          id: 'checkbox_false',
+          label: 'Checkbox unchecked',
+          answer: {
+            label: 'Gebeurt het vaker?',
+            value: false,
+          },
+          category_url:
+            '/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/straatverlichting-openbare-klok',
         },
-        category_url,
-      },
-      {
-        id: 'array',
-        label: 'Multi checkbox',
-        answer: [{
-          id: 'bar',
-          label: 'Bar',
-        }, {
-          id: 'baz',
-          label: 'Baz',
-        }],
-        category_url,
-      }],
+        {
+          id: 'checkbox_true',
+          label: 'Checkbox checked',
+          answer: {
+            label: 'Heeft u het gezien?',
+            value: true,
+          },
+          category_url:
+            '/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/straatverlichting-openbare-klok',
+        },
+        {
+          id: 'object',
+          label: 'Selectbox of Radio',
+          answer: {
+            id: 'foo',
+            label: 'Foo',
+          },
+          category_url:
+            '/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/straatverlichting-openbare-klok',
+        },
+        {
+          id: 'array',
+          label: 'Multi checkbox',
+          answer: [
+            {
+              id: 'bar',
+              label: 'Bar',
+            },
+            {
+              id: 'baz',
+              label: 'Baz',
+            },
+          ],
+          category_url:
+            '/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/straatverlichting-openbare-klok',
+        },
+      ],
     });
   });
 });


### PR DESCRIPTION
This PR adds the category_url of the incident to the answer of every extra question. 

Functionally, this means that the backend is able to relate questions/answers on an incident to a specific (sub)category. This allows for filtering where only users with rights to specific categories can see the answers to those questions.