### PR TITLE
(Chore) Fix the build configuration for amsterdam

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,7 @@ COPY start.sh /usr/local/bin/start.sh
 RUN chmod +x /usr/local/bin/start.sh
 
 COPY app.base.json /app.base.json
+COPY app.amsterdam.json /app.amsterdam.json
 COPY internals/schemas/app.schema.json /internals/schemas/app.schema.json
 COPY internals/scripts/validate-config.js /internals/scripts/validate-config.js
 COPY internals/scripts/inject-config.js /internals/scripts/inject-config.js


### PR DESCRIPTION
This PR adds the app.amsterdam.json to the docker container. This was missing and generated a crash in the build pipeline.