### PR TITLE
[SIG-3308] Replace h1 from the logo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,21 +22,28 @@
       }
     },
     "@amsterdam/asc-assets": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/@amsterdam/asc-assets/-/asc-assets-0.26.1.tgz",
-      "integrity": "sha512-u7RwYTJC8ZuxBQMOtwUezcTvyKmrXiWgZCO2lXlgFfCSqDPVCgtPgfw97C20uUOG4hOnUTI8ze6PXnpYUpH9Ow=="
+      "version": "0.26.2-alpha.0",
+      "resolved": "https://registry.npmjs.org/@amsterdam/asc-assets/-/asc-assets-0.26.2-alpha.0.tgz",
+      "integrity": "sha512-qDDe7m0QbxPX2UzY4ChxzWLGgTsMIgImqPry5rzF7erxIyQ5eaS2zf8wbRjyZt1JgxKml/2fN5P4lbbkHwxZUg=="
     },
     "@amsterdam/asc-ui": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/@amsterdam/asc-ui/-/asc-ui-0.26.1.tgz",
-      "integrity": "sha512-QlYMpdafrBaGBFvIxYmDBO+1fL1lVNOrdKLoxj27CNShA9V0MYPbYWxSK5oXSL5eXN+756rXekz46SgCkodQlw==",
+      "version": "0.26.2-alpha.0",
+      "resolved": "https://registry.npmjs.org/@amsterdam/asc-ui/-/asc-ui-0.26.2-alpha.0.tgz",
+      "integrity": "sha512-LDX3cUH32HQ6DBJ1dn4p/qh7doD4Ju5iWYVZdr6oKopru9pcDv90G758MWQ5YvhTWnpn1cIq3uxGgzwYU9ojbA==",
       "requires": {
-        "@amsterdam/asc-assets": "^0.26.1",
+        "@amsterdam/asc-assets": "^0.26.2-alpha.0+c1bb64c",
         "classnames": "^2.2.6",
         "deepmerge": "^4.2.2",
         "objectFitPolyfill": ">=2.3.0",
         "polished": "^4.0.1",
         "react-uid": "^2.3.0"
+      },
+      "dependencies": {
+        "@amsterdam/asc-assets": {
+          "version": "0.26.2-alpha.0",
+          "resolved": "https://registry.npmjs.org/@amsterdam/asc-assets/-/asc-assets-0.26.2-alpha.0.tgz",
+          "integrity": "sha512-qDDe7m0QbxPX2UzY4ChxzWLGgTsMIgImqPry5rzF7erxIyQ5eaS2zf8wbRjyZt1JgxKml/2fN5P4lbbkHwxZUg=="
+        }
       }
     },
     "@amsterdam/react-maps": {
@@ -18551,9 +18558,9 @@
       }
     },
     "polished": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/polished/-/polished-4.0.4.tgz",
-      "integrity": "sha512-P2PAwmvzsGDwf1La7za64s7IPFIT4Ee287sEKV86D5i0JLLSjq9TnapyNyIMXtx2Maoq11cWLdrD8raGfCr7lw==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/polished/-/polished-4.0.5.tgz",
+      "integrity": "sha512-BY2+LVtOHQWBQpGN4GPAKpCdsBePOdSdHTpZegRDRCrvGPkRPTx1DEC+vGjIDPhXS7W2qiBxschnwRWTFdMZag==",
       "requires": {
         "@babel/runtime": "^7.12.5"
       },
@@ -19897,9 +19904,9 @@
       }
     },
     "react-uid": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/react-uid/-/react-uid-2.3.0.tgz",
-      "integrity": "sha512-tsPZ77GR0pISGYmpCLHAbZTabKXZ7zBniKPVqVMMfnXFyo39zq5g/psIlD5vLTKkjQEhWOO8JhqcHnxkwNu6eA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/react-uid/-/react-uid-2.3.1.tgz",
+      "integrity": "sha512-6C5pwNYP1udgp5feQ9MTBZBKD4su9nhD2aYCFY1bB0Bpask8wYKYz0ZhAtAJ4lcmTDC5kY1ByGTQMFDHQW6p0w==",
       "requires": {
         "tslib": "^1.10.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,16 +22,16 @@
       }
     },
     "@amsterdam/asc-assets": {
-      "version": "0.26.2-alpha.0",
-      "resolved": "https://registry.npmjs.org/@amsterdam/asc-assets/-/asc-assets-0.26.2-alpha.0.tgz",
-      "integrity": "sha512-qDDe7m0QbxPX2UzY4ChxzWLGgTsMIgImqPry5rzF7erxIyQ5eaS2zf8wbRjyZt1JgxKml/2fN5P4lbbkHwxZUg=="
+      "version": "0.26.2",
+      "resolved": "https://registry.npmjs.org/@amsterdam/asc-assets/-/asc-assets-0.26.2.tgz",
+      "integrity": "sha512-9aJCJiVbs490IQWcr3fZ1XfrkIn6JiaLB8XLXkYSvrdVy8Lwfq9k0VkhilGrEWXIM37fMaebghwKkX4ttOcWKA=="
     },
     "@amsterdam/asc-ui": {
-      "version": "0.26.2-alpha.0",
-      "resolved": "https://registry.npmjs.org/@amsterdam/asc-ui/-/asc-ui-0.26.2-alpha.0.tgz",
-      "integrity": "sha512-LDX3cUH32HQ6DBJ1dn4p/qh7doD4Ju5iWYVZdr6oKopru9pcDv90G758MWQ5YvhTWnpn1cIq3uxGgzwYU9ojbA==",
+      "version": "0.26.2",
+      "resolved": "https://registry.npmjs.org/@amsterdam/asc-ui/-/asc-ui-0.26.2.tgz",
+      "integrity": "sha512-DIFFMkOTM9PZT0WfXGwLv68xEA95NgAqXeiX8//E53eXdTCjIrSaIlugLO70g+BtK2gPgHDxdw69qgxMsWxwyA==",
       "requires": {
-        "@amsterdam/asc-assets": "^0.26.2-alpha.0+c1bb64c",
+        "@amsterdam/asc-assets": "^0.26.2",
         "classnames": "^2.2.6",
         "deepmerge": "^4.2.2",
         "objectFitPolyfill": ">=2.3.0",
@@ -40,9 +40,9 @@
       },
       "dependencies": {
         "@amsterdam/asc-assets": {
-          "version": "0.26.2-alpha.0",
-          "resolved": "https://registry.npmjs.org/@amsterdam/asc-assets/-/asc-assets-0.26.2-alpha.0.tgz",
-          "integrity": "sha512-qDDe7m0QbxPX2UzY4ChxzWLGgTsMIgImqPry5rzF7erxIyQ5eaS2zf8wbRjyZt1JgxKml/2fN5P4lbbkHwxZUg=="
+          "version": "0.26.2",
+          "resolved": "https://registry.npmjs.org/@amsterdam/asc-assets/-/asc-assets-0.26.2.tgz",
+          "integrity": "sha512-9aJCJiVbs490IQWcr3fZ1XfrkIn6JiaLB8XLXkYSvrdVy8Lwfq9k0VkhilGrEWXIM37fMaebghwKkX4ttOcWKA=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
   ],
   "dependencies": {
     "@amsterdam/arm-core": "^0.4.0",
-    "@amsterdam/asc-assets": "^0.26.1",
-    "@amsterdam/asc-ui": "^0.26.1",
+    "@amsterdam/asc-assets": "^0.26.2-alpha.0",
+    "@amsterdam/asc-ui": "^0.26.2-alpha.0",
     "@amsterdam/react-maps": "^0.11.0",
     "@datapunt/leaflet-geojson-bbox-layer": "0.1.1",
     "@datapunt/matomo-tracker-js": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
   ],
   "dependencies": {
     "@amsterdam/arm-core": "^0.4.0",
-    "@amsterdam/asc-assets": "^0.26.2-alpha.0",
-    "@amsterdam/asc-ui": "^0.26.2-alpha.0",
+    "@amsterdam/asc-assets": "^0.26.2",
+    "@amsterdam/asc-ui": "^0.26.2",
     "@amsterdam/react-maps": "^0.11.0",
     "@datapunt/leaflet-geojson-bbox-layer": "0.1.1",
     "@datapunt/matomo-tracker-js": "^0.3.1",

--- a/src/components/SiteHeader/__tests__/SiteHeader.test.js
+++ b/src/components/SiteHeader/__tests__/SiteHeader.test.js
@@ -102,7 +102,7 @@ describe('components/SiteHeader', () => {
       withAppContext(<SiteHeader permissions={[]} location={{ pathname: '/' }} />)
     );
 
-    expect(container.querySelector('h1 img')).not.toBeInTheDocument();
+    expect(container.querySelector('div img')).not.toBeInTheDocument();
 
     configuration.logo = {
       url: 'logoUrl',
@@ -112,7 +112,7 @@ describe('components/SiteHeader', () => {
 
     rerender(withAppContext(<SiteHeader permissions={[]} location={{ pathname: '/' }} />));
 
-    expect(container.querySelector('h1 img[src="logoUrl"]')).toBeInTheDocument();
+    expect(container.querySelector('div img[src="logoUrl"]')).toBeInTheDocument();
   });
 
   it('should render the correct homeLink', () => {
@@ -125,7 +125,7 @@ describe('components/SiteHeader', () => {
       withAppContext(<SiteHeader permissions={[]} location={{ pathname: '/' }} />)
     );
 
-    expect(container.querySelector(`h1 a[href="${homeLink}"]`)).toBeInTheDocument();
+    expect(container.querySelector(`div a[href="${homeLink}"]`)).toBeInTheDocument();
 
     jest.spyOn(auth, 'isAuthenticated').mockImplementation(() => true);
 
@@ -133,13 +133,13 @@ describe('components/SiteHeader', () => {
 
     rerender(withAppContext(<SiteHeader permissions={[]} location={{ pathname: '/' }} />));
 
-    expect(container.querySelector('h1 a[href="/"]')).toBeInTheDocument();
+    expect(container.querySelector('div a[href="/"]')).toBeInTheDocument();
 
     unmount();
 
     rerender(withAppContext(<SiteHeader permissions={[]} location={{ pathname: '/manage/incidents' }} />));
 
-    expect(container.querySelector('h1 a[href="/"]')).toBeInTheDocument();
+    expect(container.querySelector('div a[href="/"]')).toBeInTheDocument();
   });
 
   it('should render a title', () => {

--- a/src/components/SiteHeader/index.js
+++ b/src/components/SiteHeader/index.js
@@ -16,6 +16,7 @@ import {
   themeColor,
   themeSpacing,
   breakpoint,
+  styles,
 } from '@amsterdam/asc-ui';
 import SearchBar from 'containers/SearchBar';
 import { isAuthenticated } from 'shared/services/auth/auth';
@@ -28,22 +29,24 @@ import AmsterdamLogo from 'components/AmsterdamLogo';
 export const menuBreakpoint = 1170;
 
 const StyledHeader = styled(HeaderComponent)`
-  a:link {
+  ${styles.HeaderTitleStyle} {
+    font-family: Avenir Next LT W01 Demi, arial, sans-serif;
     font-weight: 400;
-    text-decoration: none;
   }
+
   ${({ isFrontOffice, tall }) =>
     isFrontOffice &&
     tall &&
     css`
       & {
         max-width: 960px;
-        h1 {
+
+        & > div {
           margin-left: ${themeSpacing(-5)};
         }
 
         @media screen and ${breakpoint('min-width', 'tabletS')} {
-          h1 a {
+          & > div > a {
             &,
             span {
               width: 153px;
@@ -101,7 +104,7 @@ const HeaderWrapper = styled.div`
     z-index: 2;
   }
 
-  [aria-hidden="true"] {
+  [aria-hidden='true'] {
     display: none;
   }
 
@@ -161,27 +164,27 @@ const HeaderWrapper = styled.div`
           margin: 0;
         }
 
-        > header {
+        & > header {
           flex-wrap: wrap;
-        }
 
-        h1 {
-          padding: 15px 0;
-          @media screen and (max-width: 990px) {
-            margin: 0;
-          }
-
-          a {
-            height: 68px;
-
-            span {
-              background-repeat: no-repeat;
-              background-size: auto 100%;
+          & > div {
+            padding: 15px 0;
+            @media screen and (max-width: 990px) {
+              margin: 0;
             }
 
-            @media screen and (max-width: 539px) {
-              margin-top: -3px;
-              height: 29px;
+            a {
+              height: 68px;
+
+              span {
+                background-repeat: no-repeat;
+                background-size: auto 100%;
+              }
+
+              @media screen and (max-width: 539px) {
+                margin-top: -3px;
+                height: 29px;
+              }
             }
           }
         }
@@ -310,6 +313,7 @@ export const SiteHeader = props => {
           fullWidth={false}
           navigation={tall ? null : navigation}
           logo={configuration.logo?.url ? Logo : AmsterdamLogo}
+          headerLogoTextAs="div"
         />
         {!tall && <Notification />}
       </HeaderWrapper>

--- a/src/components/SiteHeader/index.js
+++ b/src/components/SiteHeader/index.js
@@ -26,7 +26,7 @@ import Logo from 'components/Logo';
 import configuration from 'shared/services/configuration/configuration';
 import AmsterdamLogo from 'components/AmsterdamLogo';
 
-export const menuBreakpoint = 1170;
+export const menuBreakpoint = 1200;
 
 const StyledHeader = styled(HeaderComponent)`
   ${styles.HeaderTitleStyle} {

--- a/src/components/SiteHeader/index.js
+++ b/src/components/SiteHeader/index.js
@@ -94,6 +94,12 @@ const SearchBarMenuItem = styled(MenuItem)`
 
 const StyledSearchBar = styled(SearchBar)`
   margin-top: 5px;
+
+  ${styles.TextFieldStyle} {
+    button {
+      top: 3px;
+    }
+  }
 `;
 
 const HeaderWrapper = styled.div`


### PR DESCRIPTION
This PR:
- updates the `asc` package to the last version
- replaces the `h1` element with a `div` for accessibility
- fixes the focus style of the `select` elements
- fixes the alignment of the clear button in the search text field of the header