### PR TITLE
[SIG-3333] Container selection component

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -17,10 +17,10 @@ module.exports = {
   ],
   coverageThreshold: {
     global: {
-      statements: 99,
-      branches: 97.87,
-      functions: 98.86,
-      lines: 99.05,
+      statements: 99.02,
+      branches: 97.9,
+      functions: 98.87,
+      lines: 99.07,
     },
   },
   moduleDirectories: ['node_modules', 'src'],

--- a/src/signals/incident/components/form/ContainerSelect/ContainerList/ContainerList.js
+++ b/src/signals/incident/components/form/ContainerSelect/ContainerList/ContainerList.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { themeSpacing } from '@amsterdam/asc-ui';
+
+const List = styled.ul`
+  border-top: 0;
+  padding: 0;
+  margin-bottom: 4px;
+  margin-top: 0;
+`;
+
+const ListItem = styled.li`
+  line-height: ${themeSpacing(4)};
+  padding: ${themeSpacing(1, 0)};
+  display: flex;
+  align-items:center;
+
+  &:focus {
+    outline-style: none;
+  }
+`;
+
+const StyledIcon = styled.div`
+  margin: 0 ${themeSpacing(2)} 0 0;
+  display: inline-block;
+  background-image: url(${({ url }) => url}) ;
+  background-size: cover;
+  width: ${({ size }) => size}px;
+  height:${({ size }) => size}px;
+`;
+
+const ContainerList = ({ selection }) => (
+  <List data-testid="containerList">
+    {selection &&
+      selection.map(({ id, description, iconUrl }) => (
+        <ListItem id={id} data-testid={id} key={id} tabIndex={-1}>
+          <React.Fragment>
+            <StyledIcon size={40} url={iconUrl}>
+            </StyledIcon>
+            {`${description} - ${id}`}
+          </React.Fragment>
+        </ListItem>
+      ))}
+  </List>
+);
+
+ContainerList.propTypes = {
+  selection: PropTypes.array,
+};
+
+export default ContainerList;

--- a/src/signals/incident/components/form/ContainerSelect/ContainerList/ContainerList.test.js
+++ b/src/signals/incident/components/form/ContainerSelect/ContainerList/ContainerList.test.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import ContainerList from './ContainerList';
+
+import { ContainerSelectProvider } from '../context';
+import { withAppContext } from 'test/utils';
+
+describe('signals/incident/components/form/ContainerSelect/ContainerList', () => {
+  const selection = [
+    {
+      id: 'PL734',
+      type: 'plastic',
+      description: 'Plastic container',
+      iconUrl: '',
+    },
+    {
+      id: 'GLA00137',
+      type: 'glas',
+      description: 'Glas container',
+      iconUrl: '',
+    },
+    {
+      id: 'BR0234',
+      type: 'brood',
+      description: 'Brood container',
+      iconUrl: '',
+    },
+    {
+      id: 'PP0234',
+      type: 'papier',
+      description: 'Papier container',
+      iconUrl: '',
+    },
+  ];
+
+  it('should render', () => {
+    render(withAppContext(<ContainerList selection={selection}></ContainerList>));
+
+    expect(screen.getByTestId('containerList')).toBeInTheDocument();
+    selection.forEach(({ id }) => expect(screen.getByTestId(id)).toBeInTheDocument());
+    expect(screen.getAllByRole('listitem').length).toBe(selection.length);
+  });
+
+  it('should render an empty list', () => {
+    render(withAppContext(<ContainerList ></ContainerList>));
+
+    expect(screen.getByTestId('containerList')).toBeInTheDocument();
+    expect(screen.queryAllByRole('listitem').length).toBe(0);
+  });
+});

--- a/src/signals/incident/components/form/ContainerSelect/ContainerList/index.js
+++ b/src/signals/incident/components/form/ContainerSelect/ContainerList/index.js
@@ -1,0 +1,3 @@
+import ContainerList from './ContainerList';
+
+export default ContainerList;

--- a/src/signals/incident/components/form/ContainerSelect/ContainerSelect.js
+++ b/src/signals/incident/components/form/ContainerSelect/ContainerSelect.js
@@ -1,13 +1,11 @@
-import React, { useCallback, useMemo, useState } from 'react';
-import styled from 'styled-components';
+import React, { useCallback, useState } from 'react';
 import PropTypes from 'prop-types';
-import { Paragraph } from '@amsterdam/asc-ui';
 import { ContainerSelectProvider } from './context';
 import Intro from './Intro';
 import Selector from './Selector';
 import Summary from './Summary';
 
-const ContainerSelect = ({ handler, parent }) => {
+const ContainerSelect = ({ handler, meta, parent }) => {
   const { value } = handler();
   const [showMap, setShowMap] = useState(false);
 
@@ -37,20 +35,20 @@ const ContainerSelect = ({ handler, parent }) => {
   );
 
   return (
-    <ContainerSelectProvider value={{ value, location, update, edit, close }}>
+    <ContainerSelectProvider value={{ selection: value, location, meta, update, edit, close }}>
       {!showMap && !value && <Intro />}
 
       {showMap && <Selector />}
 
       {!showMap && value && <Summary />}
 
-      <Paragraph as="h6">Geselecteerd: {value ? value : '<geen>'}</Paragraph>
     </ContainerSelectProvider>
   );
 };
 
 ContainerSelect.propTypes = {
   handler: PropTypes.func,
+  meta: PropTypes.object,
   parent: PropTypes.object,
 };
 

--- a/src/signals/incident/components/form/ContainerSelect/ContainerSelect.test.js
+++ b/src/signals/incident/components/form/ContainerSelect/ContainerSelect.test.js
@@ -56,7 +56,14 @@ describe('signals/incident/components/form/ContainerSelect', () => {
           {...{
             ...props,
             handler: () => ({
-              value: 'test',
+              value: [
+                {
+                  id: 'PL734',
+                  type: 'plastic',
+                  description: 'Plastic container',
+                  iconUrl: '',
+                },
+              ],
             }),
           }}
         />

--- a/src/signals/incident/components/form/ContainerSelect/Intro/Intro.js
+++ b/src/signals/incident/components/form/ContainerSelect/Intro/Intro.js
@@ -8,7 +8,6 @@ import Map from 'components/Map';
 
 const Wrapper = styled.div`
   position: relative;
-  border: 1px dotted ${themeColor('tint', 'level3')};
   height: ${themeSpacing(40)};
 `;
 
@@ -49,7 +48,7 @@ const Intro = () => {
       )}
 
       <ButtonBar>
-        <Button onClick={edit}>Kies op kaart</Button>
+        <Button data-testid="chooseOnMap" onClick={edit} variant="primary">Kies op kaart</Button>
       </ButtonBar>
     </Wrapper>
   );

--- a/src/signals/incident/components/form/ContainerSelect/Intro/Intro.test.js
+++ b/src/signals/incident/components/form/ContainerSelect/Intro/Intro.test.js
@@ -5,7 +5,7 @@ import Intro from './Intro';
 import { ContainerSelectProvider } from '../context';
 import { withAppContext } from 'test/utils';
 
-const contextValue = { value: null, location: null, update: jest.fn(), edit: jest.fn(), close: jest.fn() };
+const contextValue = { selection: null, location: null, update: jest.fn(), edit: jest.fn(), close: jest.fn() };
 
 export const withContext = (Component, context = contextValue) =>
   withAppContext(<ContainerSelectProvider value={context}>{Component}</ContainerSelectProvider>);
@@ -19,26 +19,26 @@ describe('signals/incident/components/form/ContainerSelect/Intro', () => {
   });
 
   it('should render the component without the map', () => {
-    const { container, rerender } = render(withContext(<Intro />));
+    render(withContext(<Intro />));
 
     expect(screen.queryByTestId('containerSelectIntro')).toBeInTheDocument();
     expect(screen.queryByTestId('mapLocation')).not.toBeInTheDocument();
-    expect(screen.queryByText(/kies op kaart/i)).toBeInTheDocument();
+    expect(screen.queryByTestId('chooseOnMap')).toBeInTheDocument();
   });
 
   it('should render the component with the map', () => {
-    const { container, rerender } = render(withContext(<Intro />, { ...contextValue, location: [1, 1] }));
+    render(withContext(<Intro />, { ...contextValue, location: [1, 1] }));
 
     expect(screen.queryByTestId('containerSelectIntro')).toBeInTheDocument();
     expect(screen.queryByTestId('mapLocation')).toBeInTheDocument();
-    expect(screen.queryByText(/kies op kaart/i)).toBeInTheDocument();
+    expect(screen.queryByTestId('chooseOnMap')).toBeInTheDocument();
   });
 
   it('should call edit', () => {
     render(withContext(<Intro />));
     expect(contextValue.edit).not.toHaveBeenCalled();
 
-    const element = screen.queryByText(/kies op kaart/i);
+    const element = screen.queryByTestId('chooseOnMap');
     fireEvent.click(element);
     expect(contextValue.edit).toHaveBeenCalled();
   });

--- a/src/signals/incident/components/form/ContainerSelect/Selector/Selector.test.js
+++ b/src/signals/incident/components/form/ContainerSelect/Selector/Selector.test.js
@@ -5,7 +5,20 @@ import Selector from './Selector';
 import { ContainerSelectProvider } from '../context';
 import { withAppContext } from 'test/utils';
 
-const contextValue = { value: null, update: jest.fn(), edit: jest.fn(), close: jest.fn() };
+const contextValue = {
+  selection: [
+    {
+      id: 'PL734',
+      type: 'plastic',
+      description: 'Plastic container',
+      iconUrl: '',
+    },
+  ],
+  meta: null,
+  update: jest.fn(),
+  edit: jest.fn(),
+  close: jest.fn(),
+};
 
 export const withContext = (Component, context = contextValue) =>
   withAppContext(<ContainerSelectProvider value={context}>{Component}</ContainerSelectProvider>);
@@ -30,7 +43,7 @@ describe('signals/incident/components/form/ContainerSelect/Selector', () => {
 
     const element = screen.queryByText(/container toevoegen/i);
     fireEvent.click(element);
-    expect(contextValue.update).toHaveBeenCalledWith(expect.any(String));
+    expect(contextValue.update).toHaveBeenCalledWith(expect.any(Array));
   });
 
   it('should call update when removing container', () => {

--- a/src/signals/incident/components/form/ContainerSelect/Summary/Summary.js
+++ b/src/signals/incident/components/form/ContainerSelect/Summary/Summary.js
@@ -1,32 +1,26 @@
-import React, { useCallback, useState, useContext } from 'react';
+import React, { useContext } from 'react';
 import styled from 'styled-components';
-import Button from 'components/Button';
-import { themeColor, themeSpacing } from '@amsterdam/asc-ui';
+import { Link } from '@amsterdam/asc-ui';
 import ContainerSelectContext from '../context';
+import ContainerList from '../ContainerList';
 
 const Wrapper = styled.div`
   position: relative;
-  border: 1px dotted ${themeColor('tint', 'level3')};
-  height: ${themeSpacing(40)};
 `;
 
-const ButtonBar = styled.div`
-  margin: 0;
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
+const StyledLink = styled(Link)`
+  text-decoration: underline;
+  font-size: 16px;
+  cursor: pointer;
 `;
-
 
 const Summary = () => {
-  const { edit } = useContext(ContainerSelectContext);
+  const { selection, edit } = useContext(ContainerSelectContext);
 
   return (
     <Wrapper data-testid="containerSelectSummary">
-      <ButtonBar>
-        <Button onClick={edit}>Wijzigen</Button>
-      </ButtonBar>
+      <ContainerList selection={selection}></ContainerList>
+      <StyledLink onClick={edit} variant="inline" tabIndex={0}>Wijzigen</StyledLink>
     </Wrapper>
   );
 };

--- a/src/signals/incident/components/form/ContainerSelect/Summary/Summary.test.js
+++ b/src/signals/incident/components/form/ContainerSelect/Summary/Summary.test.js
@@ -5,7 +5,19 @@ import Summary from './Summary';
 import { ContainerSelectProvider } from '../context';
 import { withAppContext } from 'test/utils';
 
-const contextValue = { value: null, update: jest.fn(), edit: jest.fn(), close: jest.fn() };
+const contextValue = {
+  selection: [
+    {
+      id: 'PL734',
+      type: 'plastic',
+      description: 'Plastic container',
+      iconUrl: '',
+    },
+  ],
+  update: jest.fn(),
+  edit: jest.fn(),
+  close: jest.fn(),
+};
 
 export const withContext = (Component, context = contextValue) =>
   withAppContext(<ContainerSelectProvider value={context}>{Component}</ContainerSelectProvider>);
@@ -19,6 +31,7 @@ describe('signals/incident/components/form/ContainerSelect/Summary', () => {
     render(withContext(<Summary />));
 
     expect(screen.queryByTestId('containerSelectSummary')).toBeInTheDocument();
+    expect(screen.queryByTestId('containerList')).toBeInTheDocument();
     expect(screen.queryByText(/wijzigen/i)).toBeInTheDocument();
   });
 

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/afval-icons.js
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/afval-icons.js
@@ -1,0 +1,109 @@
+export const bread = `<svg width="40px" height="40px" viewBox="0 0 40 40" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<title>icon-bread</title>
+<g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+    <g id="icon/brood" stroke="#FFFFFF" stroke-width="2">
+        <g id="icon-bread">
+            <circle id="Oval-2-Copy-21" fill="#A00078" cx="20" cy="20" r="19"></circle>
+            <path d="M19.978905,12 C15.5015587,12 12,14.0243654 12,16.4461046 C12,18.0605974 12.8785071,19.2350482 14.6355212,19.9694571 L14.6355212,27 L25.4245643,27 L25.4245643,19.9694571 C27.1415214,19.2916517 28,18.1172009 28,16.4461046 C28,13.9394601 24.4562513,12 19.978905,12 Z"></path>
+        </g>
+    </g>
+</g>
+</svg>`;
+
+export const gft = `<svg width="40px" height="40px" viewBox="0 0 40 40" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<title>icon-gft</title>
+<g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+    <g id="icon-gft">
+        <circle id="Oval-2-Copy-16" stroke="#FFFFFF" stroke-width="2" fill="#BED200" cx="20" cy="20" r="19"></circle>
+        <g transform="translate(12.000000, 13.000000)" fill="#000000" fill-rule="nonzero" id="Path">
+            <path d="M4.68697544,1.49315728 C0.89188324,3.6952282 1.10972721,7.28200835 1.24039388,8.60912891 C6.14218112,2.80260409 13.4742095,3.08419275 13.4742095,3.08419275 C13.4742095,3.08419275 3.08084779,6.64932749 0.02825204,13.7984623 C-0.212825976,14.3628311 1.1593726,15.0967885 1.47253572,14.4295544 C2.40725913,12.4413559 3.70975559,10.9502069 3.70975559,10.9502069 C5.63142935,11.6652991 8.95568467,12.5033133 11.3118549,10.8453559 C14.4415003,8.64288777 14.1215853,3.76056153 18.5892733,1.38334168 C19.6328195,0.828306213 9.83202509,-1.49251648 4.68697544,1.49315728 Z"></path>
+        </g>
+    </g>
+</g>
+</svg>`;
+
+export const glas = `<svg width="40px" height="40px" viewBox="0 0 40 40" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<title>icon-glas</title>
+<g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+    <g id="icon-glas">
+        <circle id="Oval-2-Copy-20" stroke="#FFFFFF" stroke-width="2" fill="#FEC813" cx="20" cy="20" r="19"></circle>
+        <g transform="translate(15.000000, 9.000000)" fill="#000000" fill-rule="nonzero" id="Shape">
+            <path d="M9.00000001,19.5 C9.00000001,21 7.49501038,21 7.49501038,21 L1.50000001,21 C1.20831299,21 6.91943569e-09,20.8062744 6.91943569e-09,19.5 L6.91943569e-09,18 L6.00000001,18 L6.00000001,10.5015 L6.91943569e-09,10.5027466 L6.91943569e-09,7.50274657 C6.91943569e-09,6 3.00000001,6 3.00000001,4.5 L3.00000001,-6.82121026e-13 L6.00000001,-6.82121026e-13 L6.00000001,4.5 C6.00000001,6 9.00000001,6 9.00000001,7.50274657 L9.00000001,19.5 Z M4.5,12 L4.5,16.5 L0,16.5 L0,12 L4.5,12 Z"></path>
+        </g>
+    </g>
+</g>
+</svg>`;
+
+export const paper = `<svg width="40px" height="40px" viewBox="0 0 40 40" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<title>icon-paper</title>
+<g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+    <g id="icon-paper">
+        <circle id="Oval-2-Copy-18" stroke="#FFFFFF" stroke-width="2" fill="#009DEC" cx="20" cy="20" r="19"></circle>
+        <g transform="translate(13.000000, 10.000000)" fill="#FFFFFF" fill-rule="nonzero" id="Combined-Shape">
+            <path d="M15,0 L15,21 L0,21 L0,0 L15,0 Z M13.5,18 L1.5,18 L1.5,19.5 L13.5,19.5 L13.5,18 Z M13.5,15 L1.5,15 L1.5,16.5 L13.5,16.5 L13.5,15 Z M13.5,12 L1.5,12 L1.5,13.5 L13.5,13.5 L13.5,12 Z M13.5,9 L1.5,9 L1.5,10.5 L13.5,10.5 L13.5,9 Z M13.5,6 L1.5,6 L1.5,7.5 L13.5,7.5 L13.5,6 Z M9,1.5 L1.5,1.5 L1.5,3 L9,3 L9,1.5 Z"></path>
+        </g>
+    </g>
+</g>
+</svg>`;
+
+export const plastic = `<svg width="40px" height="40px" viewBox="0 0 40 40" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<title>icon-plastic</title>
+<g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+    <g id="icon-plastic">
+        <circle id="Oval-2-Copy-19" stroke="#FFFFFF" stroke-width="2" fill="#FF9100" cx="20" cy="20" r="19"></circle>
+        <g transform="translate(16.000000, 9.000000)" fill="#000000" fill-rule="nonzero" id="Combined-Shape">
+            <path d="M9,16.5 L9,19.5646362 L7.5,21 L1.52050782,21 L0,19.5646362 L0,16.5 L9,16.5 Z M9,13.5 L9,15 L0,15 L0,13.5 L9,13.5 Z M9,10.5 L9,12 L0,12 L0,10.5 L9,10.5 Z M6,3 L9,6.00274657 L9,9.00274657 L0,9.00274657 L0,6.00274657 L3,3 L6,3 Z M6,0 L6,1.5 L3,1.5 L3,0 L6,0 Z"></path>
+        </g>
+    </g>
+</g>
+</svg>`;
+
+export const rest = `<svg width="40px" height="40px" viewBox="0 0 40 40" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<title>icon-rest</title>
+<g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+    <g id="icon-rest">
+        <circle id="Oval-2-Copy-17" stroke="#FFFFFF" stroke-width="2" fill="#323232" cx="20" cy="20" r="19"></circle>
+        <g transform="translate(11.000000, 10.000000)" fill="#FFFFFF" fill-rule="nonzero" id="Combined-Shape">
+            <path d="M6,19.5 C6,20.328427 5.32842713,21 4.5,21 C3.67157287,21 3,20.328427 3,19.5 L6,19.5 Z M15,19.5 C15,20.328427 14.3284271,21 13.5,21 C12.6715729,21 12,20.328427 12,19.5 L15,19.5 Z M16.5,6 L15,18 L3,18 L1.4932251,6 L16.5,6 Z M6,7.5 L4.5,7.5 L4.5,16.5 L13.5,16.5 L13.5,7.5 L12,7.5 L12,15 L6,15 L6,7.5 Z M12,0 L12,3 L18,3 L18,4.5 L0,4.5 L0,3 L6,3 L6,0 L12,0 Z M10.5,1.5 L7.5,1.5 L7.5,3 L10.5,3 L10.5,1.5 Z"></path>
+        </g>
+    </g>
+</g>
+</svg>`;
+
+export const select = `<svg width="40px" height="40px" viewBox="0 0 40 40" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<title>icon-select</title>
+<g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+    <g id="icon-select">
+        <circle id="Oval-2-Copy-21" stroke="#EC0000" stroke-width="4" fill="#FFFFFF" cx="20" cy="20" r="18"></circle>
+        <circle id="Oval-Copy" fill="#EC0000" cx="20" cy="20" r="6"></circle>
+    </g>
+</g>
+</svg>`;
+
+export const textile = `<svg width="40px" height="40px" viewBox="0 0 40 40" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<title>icon-textile</title>
+<g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+    <g id="icon-textile">
+        <circle id="Oval-2-Copy-21" stroke="#FFFFFF" stroke-width="2" fill="#00A03C" cx="20" cy="20" r="19"></circle>
+        <g transform="translate(10.000000, 13.000000)" fill="#FFFFFF" fill-rule="nonzero" id="Shape">
+            <path d="M20.7426406,4.24264068 L16.5,8.48528138 L16.5,15 L4.5,15 L4.5,8.48528138 L0.257359312,4.24264068 L4.5,0 L9,0 C9,0.828427125 9.67157287,1.5 10.5,1.5 C11.3284271,1.5 12,0.828427125 12,0 L16.5,0 L20.7426406,4.24264068 Z M15,1.5 L13.0977178,1.50161625 C12.578774,2.39742692 11.6097562,3 10.5,3 C9.39024375,3 8.42122599,2.39742692 7.90228221,1.50161625 L6,1.5 L6,13.5 L15,13.5 L15,1.5 Z M4.49935932,2.121 L2.37867966,4.24264068 L4.49935932,6.363 L4.49935932,2.121 Z M16.4993593,2.121 L16.4993593,6.363 L18.6213204,4.24264068 L16.4993593,2.121 Z"></path>
+        </g>
+    </g>
+</g>
+</svg>`;
+
+export const unknown = `<svg width="40px" height="40px" viewBox="0 0 40 40" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<title>icon-unknown</title>
+<g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+    <g id="icon/onbekend" stroke-width="2">
+        <g id="icon-unknown">
+            <circle id="Oval-2-Copy-23" stroke="#FFFFFF" fill="#B4B4B4" cx="20" cy="20" r="19"></circle>
+            <g transform="translate(10.000000, 10.000000)" stroke="#000000">
+                <circle id="Oval" cx="10" cy="10" r="9"></circle>
+                <line x1="13" y1="7" x2="7" y2="13" id="Line-3" stroke-linecap="square"></line>
+                <line x1="13" y1="13" x2="7" y2="7" id="Line-3-Copy" stroke-linecap="square"></line>
+            </g>
+        </g>
+    </g>
+</g>
+</svg>`;

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/afval.js
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/afval.js
@@ -1,6 +1,14 @@
 import { Validators } from 'react-reactive-form';
 import FormComponents from '../../components/form';
 import IncidentNavigation from '../../components/IncidentNavigation';
+import * as afvalIcons from './afval-icons';
+
+export const ICON_SIZE = 40;
+
+const options = {
+  className: 'object-marker',
+  iconSize: [ICON_SIZE, ICON_SIZE],
+};
 
 const intro = {
   custom_text: {
@@ -43,6 +51,93 @@ export const controls = {
       label: 'Kies de container waar het om gaat',
       shortLabel: 'Containers',
       pathMerge: 'extra_properties',
+      endpoint: '',
+      featureTypes: [
+        {
+          label: 'Restafval',
+          description: 'Restafval container',
+          icon: {
+            options,
+            iconSvg: afvalIcons.rest,
+            selectedIconSvg: afvalIcons.select,
+          },
+          idField: 'id',
+          typeField: 'type',
+          typeValue: 'restafval',
+        },
+        {
+          label: 'Papier',
+          description: 'Papier container',
+          icon: {
+            options,
+            iconSvg: afvalIcons.paper,
+            selectedIconSvg: afvalIcons.select,
+          },
+          idField: 'id',
+          typeField: 'type',
+          typeValue: 'papier',
+        },
+        {
+          label: 'Glas',
+          description: 'Glas container',
+          icon: {
+            options,
+            iconSvg: afvalIcons.glas,
+            selectedIconSvg: afvalIcons.select,
+          },
+          idField: 'id',
+          typeField: 'type',
+          typeValue: 'glas',
+        },
+        {
+          label: 'Plastic',
+          description: 'Plastic container',
+          icon: {
+            options,
+            iconSvg: afvalIcons.plastic,
+            selectedIconSvg: afvalIcons.select,
+          },
+          idField: 'id',
+          typeField: 'type',
+          typeValue: 'plastic',
+        },
+        {
+          label: 'Textiel',
+          description: 'Textiel container',
+          icon: {
+            options,
+            iconSvg: afvalIcons.textile,
+            selectedIconSvg: afvalIcons.select,
+          },
+          idField: 'id',
+          typeField: 'type',
+          typeValue: 'textiel',
+        },
+        {
+          label: 'Groente- fruit- en tuinafvaal',
+          description: 'Groente- fruit- en tuinafvaal container',
+          icon: {
+            options,
+            iconSvg: afvalIcons.gft,
+            selectedIconSvg: afvalIcons.select,
+          },
+          idField: 'id',
+          typeField: 'type',
+          typeValue: 'gft',
+        },
+        {
+          label: 'Brood',
+          description: 'Brood container',
+          icon: {
+            options,
+            iconSvg: afvalIcons.bread,
+            selectedIconSvg: afvalIcons.select,
+          },
+          idField: 'id',
+          typeField: 'type',
+          typeValue: 'brood',
+        },
+      ],
     },
     options: {
       validators: [Validators.required],


### PR DESCRIPTION
This PR:
- adds a generic definition for the map items
- adds the metadata configuration for the ContainerSelect
- adds svg icons for the specific implementations (will later be moved to the backoffice)
- add temporary (test) functionality for adding containers
- renders the added containers in the Summary component