### PR TITLE
[SIG-3370] Hide attribution on screen readers

### DIFF
--- a/app.amsterdam.json
+++ b/app.amsterdam.json
@@ -71,7 +71,7 @@
         "https://{s}.data.amsterdam.nl/topo_rd/{z}/{x}/{y}.png"
       ],
       "options": {
-        "attribution": "Kaartgegevens CC-BY-4.0 Gemeente Amsterdam",
+        "attribution": "<span aria-hidden='true'>Kaartgegevens CC-BY-4.0 Gemeente Amsterdam</span>",
         "subdomains": [
           "t1",
           "t2",

--- a/src/components/MapInput/index.js
+++ b/src/components/MapInput/index.js
@@ -66,6 +66,13 @@ const MapInput = ({ className, hasGPSControl, value, onChange, mapOptions, event
    */
   const hasInitalViewRef = useRef(true);
 
+  useEffect(() => {
+    if (!map) return;
+
+    map.attributionControl._container.setAttribute('aria-hidden', 'true');
+    map.attributionControl.setPrefix('<a aria-hidden="true" tabindex=-1 href="https://leafletjs.com" title="A JS library for interactive maps">Leaflet</a>');
+  }, [map]);
+
   const clickFunc = useCallback(
     async event => {
       hasInitalViewRef.current = false;

--- a/src/components/MapInput/index.js
+++ b/src/components/MapInput/index.js
@@ -70,7 +70,7 @@ const MapInput = ({ className, hasGPSControl, value, onChange, mapOptions, event
     if (!map) return;
 
     map.attributionControl._container.setAttribute('aria-hidden', 'true');
-    map.attributionControl.setPrefix('<a aria-hidden="true" tabindex=-1 href="https://leafletjs.com" title="A JS library for interactive maps">Leaflet</a>');
+    map.attributionControl.setPrefix('');
   }, [map]);
 
   const clickFunc = useCallback(


### PR DESCRIPTION
This PR hides the map attribution text for the screen readers