### PR TITLE
[SIG-3417] Fix 'Enter' behaviour for filtering on Firefox/Safari on Mac

### DIFF
--- a/src/signals/incident-management/components/CheckboxList/CheckboxList.js
+++ b/src/signals/incident-management/components/CheckboxList/CheckboxList.js
@@ -185,7 +185,7 @@ const CheckboxList = ({
       const { checked: targetIsChecked, id } = target;
 
       // Firefox & Safari on Mac do not hold focus for non-input elements when clicked
-      // Force focus so that 'Enter' will submit the checkbox selection
+      // Force focus so that 'Enter' will submit the current selection
       document.getElementById(id).focus();
 
       setChecked(state => {
@@ -257,7 +257,7 @@ const CheckboxList = ({
           indent={Boolean(title)}
           tabIndex={0}
           htmlFor={groupName}
-          onClick={groupName ? null : handleToggle}
+          onClick={handleToggle}
           onKeyDown={handleKeyDown}
         >
           {toggled ? toggleNothingLabel : toggleAllLabel}

--- a/src/signals/incident-management/components/CheckboxList/CheckboxList.js
+++ b/src/signals/incident-management/components/CheckboxList/CheckboxList.js
@@ -186,7 +186,7 @@ const CheckboxList = ({
 
       // Firefox & Safari on Mac do not hold focus for non-input elements when clicked
       // Force focus so that 'Enter' will submit the current selection
-      document.getElementById(id).focus();
+      target.focus();
 
       setChecked(state => {
         const modifiedState = new Set(state);

--- a/src/signals/incident-management/components/CheckboxList/CheckboxList.js
+++ b/src/signals/incident-management/components/CheckboxList/CheckboxList.js
@@ -182,7 +182,11 @@ const CheckboxList = ({
    */
   const handleIndividualCheck = useCallback(
     ({ target }) => {
-      const { checked: targetIsChecked } = target;
+      const { checked: targetIsChecked, id } = target;
+
+      // Firefox & Safari on Mac do not hold focus for non-input elements when clicked
+      // Force focus so that 'Enter' will submit the checkbox selection
+      document.getElementById(id).focus();
 
       setChecked(state => {
         const modifiedState = new Set(state);

--- a/src/signals/incident-management/components/CheckboxList/CheckboxList.test.js
+++ b/src/signals/incident-management/components/CheckboxList/CheckboxList.test.js
@@ -409,6 +409,9 @@ describe('signals/incident-management/components/CheckboxList', () => {
 
     expect(randomCheckbox.checked).toEqual(false);
 
+    const focusedCheckbox = container.querySelector('input[type="checkbox"]:focus');
+    expect(focusedCheckbox).toBeInTheDocument();
+
     expect(getByText(toggleAllLabel)).toBeInTheDocument();
     expect(queryByText(toggleNothingLabel)).not.toBeInTheDocument();
 

--- a/src/signals/incident-management/components/CheckboxList/CheckboxList.test.js
+++ b/src/signals/incident-management/components/CheckboxList/CheckboxList.test.js
@@ -180,7 +180,7 @@ describe('signals/incident-management/components/CheckboxList', () => {
     const groupId = 'barbazbaz';
     const toggleAllLabel = 'Select all';
     const toggleNothingLabel = 'Select none';
-    const { container, getByText, queryByText } = render(
+    const { container } = render(
       withAppContext(
         <CheckboxList
           groupId={groupId}
@@ -197,26 +197,26 @@ describe('signals/incident-management/components/CheckboxList', () => {
 
     expect(onToggleMock).not.toHaveBeenCalled();
 
-    // loop over all checkboxes but one and check them manually
-    const nodeListIterator = container.querySelectorAll('input[type="checkbox"]:not(:last-of-type)').values();
+    const checkboxes = screen.getAllByRole('checkbox');
 
-    for (const checkbox of nodeListIterator) {
+    // loop over all checkboxes but one and check them manually
+    checkboxes.slice(1).forEach(checkbox => {
       act(() => {
         fireEvent.click(checkbox);
       });
-    }
+    });
 
-    expect(getByText(toggleAllLabel)).toBeInTheDocument();
-    expect(queryByText(toggleNothingLabel)).not.toBeInTheDocument();
+    expect(screen.getByText(toggleAllLabel)).toBeInTheDocument();
+    expect(screen.queryByText(toggleNothingLabel)).not.toBeInTheDocument();
 
     act(() => {
-      fireEvent.click(container.querySelector('input[type="checkbox"]:last-of-type'));
+      fireEvent.click(checkboxes[0]);
     });
 
     expect(onToggleMock).toHaveBeenCalledTimes(1);
 
-    expect(queryByText(toggleAllLabel)).not.toBeInTheDocument();
-    expect(getByText(toggleNothingLabel)).toBeInTheDocument();
+    expect(screen.queryByText(toggleAllLabel)).not.toBeInTheDocument();
+    expect(screen.getByText(toggleNothingLabel)).toBeInTheDocument();
   });
 
   it('should update correctly when defaultValue prop value changes', () => {

--- a/src/signals/incident-management/components/CheckboxList/CheckboxList.test.js
+++ b/src/signals/incident-management/components/CheckboxList/CheckboxList.test.js
@@ -409,8 +409,7 @@ describe('signals/incident-management/components/CheckboxList', () => {
 
     expect(randomCheckbox.checked).toEqual(false);
 
-    const focusedCheckbox = container.querySelector('input[type="checkbox"]:focus');
-    expect(focusedCheckbox).toBeInTheDocument();
+    expect(document.activeElement).toBe(randomCheckbox);
 
     expect(getByText(toggleAllLabel)).toBeInTheDocument();
     expect(queryByText(toggleNothingLabel)).not.toBeInTheDocument();

--- a/src/signals/incident-management/components/FilterForm/components/CategoryGroups.js
+++ b/src/signals/incident-management/components/FilterForm/components/CategoryGroups.js
@@ -5,7 +5,7 @@ import * as types from 'shared/types';
 import Label from 'components/Label';
 import CheckboxList from '../../CheckboxList';
 
-const CategoryGroups = ({ categories, filterSlugs, onChange, onToggle }) =>
+const CategoryGroups = ({ categories, filterSlugs, onChange, onToggle, onSubmit }) =>
   Object.entries(categories).map(([slug, { name, sub, key }]) => {
     const defaultValue = filterSlugs.filter(({ _links: { self }, id }) =>
       new RegExp(`/terms/categories/${slug}`).test(self.public || id)
@@ -22,6 +22,7 @@ const CategoryGroups = ({ categories, filterSlugs, onChange, onToggle }) =>
         name={`${slug}_category_slug`}
         onChange={onChange}
         onToggle={onToggle}
+        onSubmit={onSubmit}
         options={sub}
         title={<Label as="span">{name}</Label>}
       />
@@ -37,6 +38,7 @@ CategoryGroups.propTypes = {
   filterSlugs: types.dataListType,
   onChange: PropTypes.func,
   onToggle: PropTypes.func,
+  onSubmit: PropTypes.func,
 };
 
 export default memo(CategoryGroups);

--- a/src/signals/incident-management/components/FilterForm/index.js
+++ b/src/signals/incident-management/components/FilterForm/index.js
@@ -468,6 +468,7 @@ const FilterForm = ({ filter, onCancel, onClearFilter, onSaveFilter, onSubmit, o
               filterSlugs={filterSlugs}
               onChange={onChangeCategories}
               onToggle={onMainCategoryToggle}
+              onSubmit={onSubmitForm}
             />
           )}
         </Fieldset>


### PR DESCRIPTION
### Fixes

- Clicking on a checkbox and then pressing 'Enter' did not submit the filter selection
- Clicking on 'Alles selecteren' or 'Niets selecteren' for Category filters did not work
- Clicking on 'Alles selecteren' or 'Niets selecteren' and then pressing 'Enter' did not submit the filter selection