### PR TITLE
[SIG-3424] 'Melden' link as a client-side route

### DIFF
--- a/src/components/SiteHeader/index.js
+++ b/src/components/SiteHeader/index.js
@@ -217,7 +217,7 @@ const MenuItems = ({ onLogOut, showItems }) => {
         </Fragment>
       )}
       <MenuItem element="span">
-        <StyledMenuButton forwardedAs="a" href="/incident/beschrijf">
+        <StyledMenuButton forwardedAs={NavLink} to="/incident/beschrijf">
           Melden
         </StyledMenuButton>
       </MenuItem>


### PR DESCRIPTION
### Fixes

- Changes 'Melden' link in header to be a client-side route