### PR TITLE
Fix incident value injection for Markdown in PlainText

### DIFF
--- a/src/signals/incident/components/form/PlainText/index.js
+++ b/src/signals/incident/components/form/PlainText/index.js
@@ -30,6 +30,9 @@ const Span = styled.span`
         `}
 `;
 
+const injectParent = (value, parent) =>
+  mapDynamicFields(value, { incident: get(parent, 'meta.incidentContainer.incident') });
+
 const renderText = (value, parent) => {
   if (React.isValidElement(value)) {
     return value;
@@ -109,7 +112,7 @@ const PlainText = ({ className, meta, parent }) =>
       {meta.label && <Label>{meta.label}</Label>}
 
       {configuration.featureFlags.fetchQuestionsFromBackend && meta.value && (
-        <ReactMarkdown linkTarget="_blank">{meta.value}</ReactMarkdown>
+        <ReactMarkdown linkTarget="_blank">{injectParent(meta.value, parent)}</ReactMarkdown>
       )}
 
       {!configuration.featureFlags.fetchQuestionsFromBackend && meta.value && isString(meta.value) && (

--- a/src/signals/incident/components/form/PlainText/index.test.js
+++ b/src/signals/incident/components/form/PlainText/index.test.js
@@ -18,13 +18,16 @@ describe('Form component <PlainText />', () => {
     value: 'Lorem Ipsum',
     isVisible: true,
   };
+  const incidentId = 666;
 
   const getProps = (meta = metaProps) => ({
     meta,
     parent: {
       meta: {
-        incident: {
-          id: 666,
+        incidentContainer: {
+          incident: {
+            id: incidentId,
+          },
         },
       },
     },
@@ -172,15 +175,18 @@ describe('Form component <PlainText />', () => {
 
     it('should render markdown when fetchQuestionsFromBackend enabled', () => {
       configuration.featureFlags.fetchQuestionsFromBackend = true;
+      const injection = '{incident.id}';
       const props = getProps({
         ...metaProps,
-        value: '# Header\n[this](https://example.com) link',
+        value: `# Header\n[this](https://example.com) link\nInjected: ${injection}`,
       });
 
       const { queryByTestId, queryByText } = render(withAppContext(<PlainText {...props} />));
       expect(screen.getByRole('heading', { name: 'Header' })).toBeInTheDocument();
       expect(screen.getByRole('link', { name: 'this' })).toBeInTheDocument();
       expect(screen.queryByText('# Header', { exact: false })).not.toBeInTheDocument();
+      expect(screen.getByText(incidentId.toString(), { exact: false })).toBeInTheDocument();
+      expect(screen.queryByText(injection, { exact: false })).not.toBeInTheDocument();
     });
 
     it('should render no plain text when not visible', () => {


### PR DESCRIPTION
Injecting incident values into the `PlainText` value wasn't been done anymore in case of parsing and rendering markdown (#1323). This injection functionality has been added again, in case of markdown, with this PR.