### PR TITLE
(Chore) Add outline to file upload element when focused

### DIFF
--- a/src/signals/incident/components/form/FileInput/index.js
+++ b/src/signals/incident/components/form/FileInput/index.js
@@ -151,13 +151,6 @@ const FileInput = ({ handler, parent, meta }) => {
 
         {previews.length < maxNumberOfFiles && (
           <FileInputUploadButton data-testid="fileInputUploadButton">
-            <label htmlFor="formUpload">
-              <AddButton aria-label="Toevoegen foto">
-                <AddIcon size={22}>
-                  <Enlarge />
-                </AddIcon>
-              </AddButton>
-            </label>
             <input
               type="file"
               id="formUpload"
@@ -166,6 +159,13 @@ const FileInput = ({ handler, parent, meta }) => {
               onChange={handleChange}
               multiple
             />
+            <label htmlFor="formUpload">
+              <AddButton aria-label="Toevoegen foto">
+                <AddIcon size={22}>
+                  <Enlarge />
+                </AddIcon>
+              </AddButton>
+            </label>
           </FileInputUploadButton>
         )}
 

--- a/src/signals/incident/components/form/FileInput/styles.js
+++ b/src/signals/incident/components/form/FileInput/styles.js
@@ -28,6 +28,13 @@ export const FileInputUploadButton = styled(FileInputEmptyBox)`
     opacity: 0;
     width: 0;
     height: 0;
+
+    &:focus + label {
+      outline-color: red;
+      outline-style: solid;
+      outline-width: 2px;
+      outline-offset: 4px;
+    }
   }
 
   & > label {


### PR DESCRIPTION
### Fixes

- Adds outline to file upload button when element is focused

Previously, when using `Tab` to navigate to the file upload button, it was unclear that it was focused (the file input is a hidden input). Now, the element depicting the upload button will show an outline. 

