### PR TITLE
[FE#98] Fix fetch questions on manual category selection

### DIFF
--- a/src/signals/incident/containers/IncidentContainer/services.js
+++ b/src/signals/incident/containers/IncidentContainer/services.js
@@ -50,3 +50,13 @@ export const resolveQuestions = questions =>
     }),
     {}
   );
+
+export const getIncidentClassification = (state, incidentPart) => {
+  const previousClassification = state.incident.classification;
+  const classificationPrediction = state.classificationPrediction;
+  const canChange =
+    classificationPrediction === null ||
+    previousClassification === null ||
+    previousClassification?.slug === classificationPrediction?.slug;
+  return canChange ? incidentPart : {};
+};

--- a/src/signals/incident/containers/IncidentContainer/services.test.js
+++ b/src/signals/incident/containers/IncidentContainer/services.test.js
@@ -1,4 +1,4 @@
-import { resolveQuestions } from './services';
+import { getIncidentClassification, resolveQuestions } from './services';
 
 const mockedQuestions = [
   {
@@ -30,65 +30,115 @@ const mockedQuestions = [
   },
 ];
 
-describe('The resolve questions service', () => {
-  it('should return empty object without questions', () => {
-    const result = resolveQuestions([]);
-    expect(result).toEqual({});
-  });
+describe('Incident container services', () => {
+  describe('resolveQuestions', () => {
+    it('should return empty object without questions', () => {
+      const result = resolveQuestions([]);
+      expect(result).toEqual({});
+    });
 
-  it('should return the questions mapped to their key property', () => {
-    const result = resolveQuestions(mockedQuestions);
-    expect(result).toHaveProperty('key1');
-    expect(result).toHaveProperty('key2');
-    expect(result).toHaveProperty('key3');
-    expect(result).toHaveProperty('key4');
-    expect(Object.keys(result).length).toBe(4);
-  });
+    it('should return the questions mapped to their key property', () => {
+      const result = resolveQuestions(mockedQuestions);
+      expect(result).toHaveProperty('key1');
+      expect(result).toHaveProperty('key2');
+      expect(result).toHaveProperty('key3');
+      expect(result).toHaveProperty('key4');
+      expect(Object.keys(result).length).toBe(4);
+    });
 
-  it('should pass meta prop', () => {
-    const result = resolveQuestions(mockedQuestions);
-    expect(result.key1).toMatchObject({
-      meta: {
-        metaProp: 'metaProp',
-        pathMerge: 'extra_properties',
-      },
+    it('should pass meta prop', () => {
+      const result = resolveQuestions(mockedQuestions);
+      expect(result.key1).toMatchObject({
+        meta: {
+          metaProp: 'metaProp',
+          pathMerge: 'extra_properties',
+        },
+      });
+      expect(result.key2).toMatchObject({
+        meta: {},
+      });
     });
-    expect(result.key2).toMatchObject({
-      meta: {},
+
+    it('should add render prop', () => {
+      const result = resolveQuestions(mockedQuestions);
+      expect(result.key1).toMatchObject({
+        render: 'CheckboxInput',
+      });
+      expect(result.key2).toMatchObject({
+        render: 'RadioInputGroup',
+      });
+    });
+
+    it('should add options prop with validators', () => {
+      const result = resolveQuestions(mockedQuestions);
+      expect(result.key1).toMatchObject({
+        options: {
+          validators: [],
+        },
+      });
+      expect(result.key2).toMatchObject({
+        options: {
+          validators: ['required', ['maxLength', 100]],
+        },
+      });
+      expect(result.key3).toMatchObject({
+        options: {
+          validators: ['required'],
+        },
+      });
+      expect(result.key4).toMatchObject({
+        options: {
+          validators: ['required', ['maxLength', 100]],
+        },
+      });
     });
   });
+  describe('getIncidentClassification', () => {
+    it('should return incidentPart without classifications', () => {
+      const incidentPart = { category: 'incidentPart' };
+      const expected = incidentPart;
+      const actual = getIncidentClassification({ incident: {} }, incidentPart);
+      expect(actual).toEqual(expected);
+    });
 
-  it('should add render prop', () => {
-    const result = resolveQuestions(mockedQuestions);
-    expect(result.key1).toMatchObject({
-      render: 'CheckboxInput',
+    it('should return incidentPart when classificationPrediction is null', () => {
+      const incidentPart = { category: 'incidentPart' };
+      const expected = incidentPart;
+      const actual = getIncidentClassification(
+        { classificationPrediction: null, incident: { classification: { slug: 'slug' } } },
+        incidentPart
+      );
+      expect(actual).toEqual(expected);
     });
-    expect(result.key2).toMatchObject({
-      render: 'RadioInputGroup',
-    });
-  });
 
-  it('should add options prop with validators', () => {
-    const result = resolveQuestions(mockedQuestions);
-    expect(result.key1).toMatchObject({
-      options: {
-        validators: [],
-      },
+    it('should return incidentPart when incident classification is null', () => {
+      const incidentPart = { category: 'incidentPart' };
+      const expected = incidentPart;
+      const actual = getIncidentClassification(
+        { classificationPrediction: { slug: 'slug' }, incident: { classification: null } },
+        incidentPart
+      );
+      expect(actual).toEqual(expected);
     });
-    expect(result.key2).toMatchObject({
-      options: {
-        validators: ['required', ['maxLength', 100]],
-      },
+
+    it('should return incidentPart when classificationPrediction and incident classification are equal', () => {
+      const incidentPart = { category: 'incidentPart' };
+      const expected = incidentPart;
+      const actual = getIncidentClassification(
+        { classificationPrediction: { slug: 'slug' }, incident: { classification: { slug: 'slug' } } },
+        incidentPart
+      );
+      expect(actual).toEqual(expected);
     });
-    expect(result.key3).toMatchObject({
-      options: {
-        validators: ['required'],
-      },
-    });
-    expect(result.key4).toMatchObject({
-      options: {
-        validators: ['required', ['maxLength', 100]],
-      },
+
+    it('should return empty object otherwise', () => {
+      const incidentPart = { category: 'incidentPart' };
+      const expected = {};
+      const actual = getIncidentClassification(
+        { classificationPrediction: { slug: 'slug' }, incident: { classification: { slug: 'other' } } },
+        incidentPart
+      );
+      expect(actual).toEqual(expected);
     });
   });
 });


### PR DESCRIPTION
closes Signalen/frontend#98

When logged in, the questions were not fetched from the backend (`fetchQuestionsFromBackend`) in case of manual selection (override) of the category. This has been fixed in this PR.