### PR TITLE
[SIG-3455] Revert "Changes 'melden' link to a client-side route"

### DIFF
--- a/src/components/SiteHeader/index.js
+++ b/src/components/SiteHeader/index.js
@@ -217,6 +217,7 @@ const MenuItems = ({ onLogOut, showItems }) => {
         </Fragment>
       )}
       <MenuItem element="span">
+        {/* Full page load to trigger refresh of incident form data */}
         <StyledMenuButton forwardedAs="a" href="/incident/beschrijf">
           Melden
         </StyledMenuButton>

--- a/src/components/SiteHeader/index.js
+++ b/src/components/SiteHeader/index.js
@@ -217,7 +217,7 @@ const MenuItems = ({ onLogOut, showItems }) => {
         </Fragment>
       )}
       <MenuItem element="span">
-        <StyledMenuButton forwardedAs={NavLink} to="/incident/beschrijf">
+        <StyledMenuButton forwardedAs="a" href="/incident/beschrijf">
           Melden
         </StyledMenuButton>
       </MenuItem>


### PR DESCRIPTION
### Fix

- Remove client-side route to trigger reset of incident form data