### PR TITLE
[FE#95] Fix bottom padding of filters modal

### DIFF
--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -1,14 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
-import {
-  Button,
-  Row,
-  Column,
-  Modal as ASCModal,
-  Heading,
-  themeColor,
-} from '@amsterdam/asc-ui';
+import { Button, Row, Column, Modal as ASCModal, Heading, themeColor } from '@amsterdam/asc-ui';
 import { Close as CloseIcon } from '@amsterdam/asc-assets';
 
 const StyledModal = styled(ASCModal)`
@@ -20,7 +13,7 @@ const StyledModal = styled(ASCModal)`
 `;
 
 const ModalInner = styled.div`
-  height: calc(100vh - (50px + 66px));
+  height: calc(100vh - (60px + 40px));
   max-width: 1800px;
   padding-top: 20px;
   padding-bottom: 20px;

--- a/src/signals/incident-management/components/FilterForm/index.js
+++ b/src/signals/incident-management/components/FilterForm/index.js
@@ -475,16 +475,6 @@ const FilterForm = ({ filter, onCancel, onClearFilter, onSaveFilter, onSubmit, o
             />
           </FilterGroup>
 
-          <CheckboxGroup
-            defaultValue={state.options.source}
-            label="Bron"
-            name="source"
-            onChange={onGroupChange}
-            onToggle={onGroupToggle}
-            onSubmit={onSubmitForm}
-            options={sources}
-          />
-
           {configuration.featureFlags.assignSignalToEmployee && (
             <FilterGroup data-testid="filterAssignedUserEmail">
               <Label htmlFor="filter_assigned_user_email" isGroupHeader>
@@ -515,6 +505,16 @@ const FilterForm = ({ filter, onCancel, onClearFilter, onSaveFilter, onSubmit, o
               />
             </FilterGroup>
           )}
+
+          <CheckboxGroup
+            defaultValue={state.options.source}
+            label="Bron"
+            name="source"
+            onChange={onGroupChange}
+            onToggle={onGroupToggle}
+            onSubmit={onSubmitForm}
+            options={sources}
+          />
         </Fieldset>
       </ControlsWrapper>
 

--- a/src/signals/incident-management/components/FilterForm/styled.js
+++ b/src/signals/incident-management/components/FilterForm/styled.js
@@ -7,6 +7,8 @@ export const Form = styled.form`
   column-count: 2;
   column-gap: 100px;
   width: 100%;
+  padding-bottom: 86px;
+
   column-fill: auto @media (max-width: 1020px) {
     column-gap: 60px;
   }
@@ -71,6 +73,8 @@ export const DatesWrapper = styled.div`
 `;
 
 export const FormFooterWrapper = styled(FormFooter)`
+  z-index: 2;
+
   button[type='reset'] {
     order: 1;
   }


### PR DESCRIPTION
closes Signalen/frontend#95

A few minor changes:

* Fix the bottom padding of the filters modal. With the right column being taller, there was no problem. With the left column being taller there was not enough padding at the bottom, making the last controls disappear below the footer. The padding has been straightened out. For the `ModalInner` `height: calc(100vh - (60px + 40px));` (60 for the header and 40 for the padding). For the `FilterForm` `padding-bottom: 86px;` (66 for the footer plus 20 padding).
* Move the 'assigned to' filter above the 'source' filter. This gives it enough space for the auto-suggest dropdown to appear, without having to scroll down after it folds open.
* Add `z-index: 2;` to the footer to keep it on top of the auto-suggest.

<img width="861" alt="Screenshot 2021-01-13 at 11 20 36" src="https://user-images.githubusercontent.com/2932084/104439596-90081600-5591-11eb-800a-e1cd91664bc6.png">
<img width="866" alt="Screenshot 2021-01-13 at 11 21 01" src="https://user-images.githubusercontent.com/2932084/104439605-926a7000-5591-11eb-8951-7cf44733c5ce.png">
<img width="871" alt="Screenshot 2021-01-13 at 11 21 23" src="https://user-images.githubusercontent.com/2932084/104439614-94ccca00-5591-11eb-942f-b868fe3fac36.png">
