### PR TITLE
[SIG-3465] Expired authentication error when logged in with Keycloak

### DIFF
--- a/src/hooks/__tests__/useFetch.test.js
+++ b/src/hooks/__tests__/useFetch.test.js
@@ -1,8 +1,11 @@
 import { renderHook, act } from '@testing-library/react-hooks';
 import JSONresponse from 'utils/__tests__/fixtures/user.json';
 import { getErrorMessage } from 'shared/services/api/api';
+import { getAuthHeaders } from 'shared/services/auth/auth';
 
 import useFetch from '../useFetch';
+
+jest.mock('shared/services/auth/auth');
 
 const URL = 'https://here-is-my.api/someId/6';
 
@@ -37,6 +40,35 @@ describe('hooks/useFetch', () => {
 
       expect(result.current.isLoading).toEqual(false);
       expect(result.current.data).toEqual(JSONresponse);
+    });
+
+    it('should use correct request headers', () => {
+      const { result, waitForNextUpdate } = renderHook(() => useFetch());
+      const authHeader = { Authorization: 'Bearer token' };
+
+      act(() => {
+        result.current.get(URL);
+      });
+
+      expect(fetch).not.toHaveBeenCalledWith(
+        URL,
+        expect.objectContaining({
+          headers: expect.objectContaining(authHeader),
+        })
+      );
+
+      getAuthHeaders.mockImplementation(() => authHeader);
+
+      act(() => {
+        result.current.get(URL);
+      });
+
+      expect(fetch).toHaveBeenLastCalledWith(
+        URL,
+        expect.objectContaining({
+          headers: expect.objectContaining(authHeader),
+        })
+      );
     });
 
     it('should construct a URL with query params', async () => {

--- a/src/hooks/useFetch.js
+++ b/src/hooks/useFetch.js
@@ -43,7 +43,7 @@ const useFetch = () => {
 
   const controller = useMemo(() => new AbortController(), []);
   const { signal } = controller;
-  const requestHeaders = useMemo(
+  const requestHeaders = useCallback(
     () => ({
       ...getAuthHeaders(),
       'Content-Type': 'application/json',
@@ -77,7 +77,7 @@ const useFetch = () => {
 
       try {
         const fetchResponse = await fetch(requestURL, {
-          headers: requestHeaders,
+          headers: requestHeaders(),
           method: 'GET',
           signal,
           ...requestOptions,
@@ -114,7 +114,7 @@ const useFetch = () => {
 
       try {
         const modifyResponse = await fetch(url, {
-          headers: requestHeaders,
+          headers: requestHeaders(),
           method,
           signal,
           body: JSON.stringify(modifiedData),

--- a/src/shared/services/auth/auth.js
+++ b/src/shared/services/auth/auth.js
@@ -21,7 +21,7 @@ export const getOauthDomain = () => storage.getItem(OAUTH_DOMAIN_KEY);
 export const getAuth = () => (configuration.keycloak && getOauthDomain() === 'keycloak' ? keycloak : authz);
 
 /**
- * Returns the access token from local storage when available.
+ * Returns the access token when available.
  *
  * @returns {string} The access token.
  */


### PR DESCRIPTION
### Fixes

- Bug that caused old access tokens to be used in authenticated requests