### PR TITLE
(Chore) Replace Imutable.Map with {} as initialState in tests

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -40,7 +40,7 @@ if (dsn) {
 }
 
 // Create redux store with history
-const initialState = Immutable.Map();
+const initialState = {};
 const store = configureStore(initialState, history);
 const MOUNT_NODE = document.getElementById('app');
 

--- a/src/configureStore.test.js
+++ b/src/configureStore.test.js
@@ -9,7 +9,7 @@ describe('configureStore', () => {
   let store;
 
   beforeAll(() => {
-    store = configureStore(Immutable.Map(), browserHistory);
+    store = configureStore({}, browserHistory);
   });
 
   describe('injectedReducers', () => {

--- a/src/test/utils.js
+++ b/src/test/utils.js
@@ -47,7 +47,7 @@ export const getContext = state => {
   return { store };
 };
 
-export const store = configureStore(Immutable.Map(), history);
+export const store = configureStore({ }, history);
 
 loadModels(store);
 

--- a/src/utils/reducerInjectors.test.js
+++ b/src/utils/reducerInjectors.test.js
@@ -29,7 +29,7 @@ describe('reducer injectors', () => {
 
   describe('getInjectors', () => {
     beforeEach(() => {
-      store = configureStore(Immutable.Map(), memoryHistory);
+      store = configureStore({}, memoryHistory);
     });
 
     it('should return injectors', () => {
@@ -49,7 +49,7 @@ describe('reducer injectors', () => {
 
   describe('injectReducer helper', () => {
     beforeEach(() => {
-      store = configureStore(Immutable.Map(), memoryHistory);
+      store = configureStore({}, memoryHistory);
       injectReducer = injectReducerFactory(store, true);
     });
 

--- a/src/utils/sagaInjectors.test.js
+++ b/src/utils/sagaInjectors.test.js
@@ -25,7 +25,7 @@ describe('injectors', () => {
 
   describe('getInjectors', () => {
     beforeEach(() => {
-      store = configureStore(Immutable.Map(), memoryHistory);
+      store = configureStore({}, memoryHistory);
     });
 
     it('should return injectors', () => {
@@ -46,7 +46,7 @@ describe('injectors', () => {
 
   describe('ejectSaga helper', () => {
     beforeEach(() => {
-      store = configureStore(Immutable.Map(), memoryHistory);
+      store = configureStore({}, memoryHistory);
       injectSaga = injectSagaFactory(store, true);
       ejectSaga = ejectSagaFactory(store, true);
     });
@@ -121,7 +121,7 @@ describe('injectors', () => {
 
   describe('injectSaga helper', () => {
     beforeEach(() => {
-      store = configureStore(Immutable.Map(), memoryHistory);
+      store = configureStore({}, memoryHistory);
       injectSaga = injectSagaFactory(store, true);
       ejectSaga = ejectSagaFactory(store, true);
     });


### PR DESCRIPTION
This PR fixes a error that occured in the tests after the changing the state base structure from immutable to plain JS object