### PR TITLE
[SIG-3484] Remove icon url when posting incident

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -17,10 +17,10 @@ module.exports = {
   ],
   coverageThreshold: {
     global: {
-      statements: 99.38,
-      branches: 96.01,
-      functions: 98.64,
-      lines: 99.4,
+      statements: 99.39,
+      branches: 96.03,
+      functions: 98.66,
+      lines: 99.41,
     },
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'json'],

--- a/src/signals/incident/components/IncidentPreview/components/ContainerListPreview/ContainerListPreview.test.tsx
+++ b/src/signals/incident/components/IncidentPreview/components/ContainerListPreview/ContainerListPreview.test.tsx
@@ -1,21 +1,31 @@
 import React from 'react';
 import { render } from '@testing-library/react';
-import type { Container } from 'shared/types/incident';
-
 import ContainerList from '../../../form/ContainerSelect/components/ContainerList';
 
+import type { ContainerListPreviewProps } from './ContainerListPreview';
 import ContainerListPreview from './ContainerListPreview';
+import type { FeatureType } from 'signals/incident/components/form/ContainerSelect/types';
 
-jest.mock('signals/incident/components/form/ContainerSelect/components/ContainerList', () => jest.fn().mockImplementation(() => null));
+jest.mock('signals/incident/components/form/ContainerSelect/components/ContainerList', () =>
+  jest.fn().mockImplementation(() => null)
+);
 
 describe('ContainerListPreview', () => {
   it('should render ContainerList with props', () => {
-    const props: {value: Container[]} = {
-      value: [{ id: 'id', type: 'type', description: 'description', iconUrl: 'iconUrl' }],
+    const props: ContainerListPreviewProps = {
+      value: [{ id: 'id', type: 'type', description: 'description' }],
+      featureTypes: [
+        {
+          typeField: 'type',
+          icon: {
+            iconSvg: 'svg',
+          },
+        } as FeatureType,
+      ],
     };
 
-    render(<ContainerListPreview value={props.value} />);
+    render(<ContainerListPreview value={props.value} featureTypes={props.featureTypes} />);
 
-    expect(ContainerList).toHaveBeenCalledWith({ selection: props.value }, {});
+    expect(ContainerList).toHaveBeenCalledWith({ selection: props.value, featureTypes: props.featureTypes }, {});
   });
 });

--- a/src/signals/incident/components/IncidentPreview/components/ContainerListPreview/ContainerListPreview.tsx
+++ b/src/signals/incident/components/IncidentPreview/components/ContainerListPreview/ContainerListPreview.tsx
@@ -1,11 +1,14 @@
 import React from 'react';
-import type { Item } from 'signals/incident/components/form/ContainerSelect/types';
+import type { FeatureType, Item } from 'signals/incident/components/form/ContainerSelect/types';
 import ContainerList from '../../../form/ContainerSelect/components/ContainerList';
 
 interface ContainerListPreviewProps {
   value: Item[];
+  featureTypes: FeatureType[];
 }
 
-const ContainerListPreview: React.FC<ContainerListPreviewProps> = ({ value }) => <ContainerList selection={value} />;
+const ContainerListPreview: React.FC<ContainerListPreviewProps> = ({ value, featureTypes }) => (
+  <ContainerList selection={value} featureTypes={featureTypes} />
+);
 
 export default ContainerListPreview;

--- a/src/signals/incident/components/IncidentPreview/components/ContainerListPreview/ContainerListPreview.tsx
+++ b/src/signals/incident/components/IncidentPreview/components/ContainerListPreview/ContainerListPreview.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import type { FeatureType, Item } from 'signals/incident/components/form/ContainerSelect/types';
 import ContainerList from '../../../form/ContainerSelect/components/ContainerList';
 
-interface ContainerListPreviewProps {
+export interface ContainerListPreviewProps {
   value: Item[];
   featureTypes: FeatureType[];
 }

--- a/src/signals/incident/components/form/ContainerSelect/__tests__/context.test.tsx
+++ b/src/signals/incident/components/form/ContainerSelect/__tests__/context.test.tsx
@@ -17,7 +17,6 @@ export const contextValue: ContainerSelectValue = {
       id: 'PL734',
       type: 'plastic',
       description: 'Plastic container',
-      iconUrl: '',
     },
   ],
   location: [0, 0],

--- a/src/signals/incident/components/form/ContainerSelect/components/ContainerList/__tests__/index.test.tsx
+++ b/src/signals/incident/components/form/ContainerSelect/components/ContainerList/__tests__/index.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import type { Item } from 'signals/incident/components/form/ContainerSelect/types';
+import { controls } from 'signals/incident/definitions/wizard-step-2-vulaan/afval';
 import { withAppContext } from 'test/utils';
 
 import ContainerList from '..';
@@ -11,30 +12,27 @@ describe('signals/incident/components/form/ContainerSelect/ContainerList', () =>
       id: 'PL734',
       type: 'plastic',
       description: 'Plastic container',
-      iconUrl: '',
     },
     {
       id: 'GLA00137',
       type: 'glas',
       description: 'Glas container',
-      iconUrl: '',
     },
     {
       id: 'BR0234',
       type: 'brood',
       description: 'Brood container',
-      iconUrl: '',
     },
     {
       id: 'PP0234',
       type: 'papier',
       description: 'Papier container',
-      iconUrl: '',
     },
   ];
+  const { featureTypes } = controls.extra_container.meta;
 
   it('should render', () => {
-    render(withAppContext(<ContainerList selection={selection}></ContainerList>));
+    render(withAppContext(<ContainerList selection={selection} featureTypes={featureTypes}></ContainerList>));
 
     expect(screen.getByTestId('containerList')).toBeInTheDocument();
     selection.forEach(({ id }) => {
@@ -44,7 +42,7 @@ describe('signals/incident/components/form/ContainerSelect/ContainerList', () =>
   });
 
   it('should render an empty list', () => {
-    render(withAppContext(<ContainerList selection={[]}></ContainerList>));
+    render(withAppContext(<ContainerList selection={[]} featureTypes={featureTypes}></ContainerList>));
 
     expect(screen.getByTestId('containerList')).toBeInTheDocument();
     expect(screen.queryAllByRole('listitem').length).toBe(0);

--- a/src/signals/incident/components/form/ContainerSelect/components/ContainerList/index.tsx
+++ b/src/signals/incident/components/form/ContainerSelect/components/ContainerList/index.tsx
@@ -1,19 +1,33 @@
 import React from 'react';
 import IconList from 'components/IconList/IconList';
-import type { Item } from 'signals/incident/components/form/ContainerSelect/types';
+import type { FeatureType, Item } from 'signals/incident/components/form/ContainerSelect/types';
 
 export interface ContainerListProps {
   selection: Item[];
-  size?: number;
   className?: string;
+  featureTypes: FeatureType[];
 }
 
-const ContainerList: React.FC<ContainerListProps> = ({ selection, size, className }) =>
-  <IconList
-    className={className}
-    id="containerList"
-    size={size}
-    items={selection.map(({ id, description, iconUrl }) => ({ iconUrl, label: `${description} - ${id}`, id }))}
-  />;
+const ContainerList: React.FC<ContainerListProps> = ({ selection, className, featureTypes }) => {
+  const selectedItems = selection.map(({ id, type }) => {
+    const { description, icon }: Partial<FeatureType> =
+      featureTypes.find(({ typeValue }) => typeValue === type) ?? {};
+
+    return {
+      id,
+      label: `${description} - ${id}`,
+      iconUrl: icon ? `data:image/svg+xml;base64,${btoa(icon.iconSvg)}` : '',
+    };
+  });
+
+
+  return (
+    <IconList
+      className={className}
+      id="containerList"
+      items={selectedItems}
+    />
+  );
+};
 
 export default ContainerList;

--- a/src/signals/incident/components/form/ContainerSelect/components/Selector/components/WfsLayer/components/ContainerLayer/index.tsx
+++ b/src/signals/incident/components/form/ContainerSelect/components/Selector/components/WfsLayer/components/ContainerLayer/index.tsx
@@ -70,7 +70,6 @@ export const ContainerLayer: FunctionComponent<DataLayerProps> = ({ featureTypes
               id: feature.properties[idField] as string,
               type: typeValue,
               description,
-              iconUrl: `data:image/svg+xml;base64,${btoa(featureType.icon.iconSvg)}`,
             };
 
             const updateSelection = selected ? selection.filter(({ id }) => id !== item.id) : [...selection, item];

--- a/src/signals/incident/components/form/ContainerSelect/components/Selector/index.tsx
+++ b/src/signals/incident/components/form/ContainerSelect/components/Selector/index.tsx
@@ -147,14 +147,13 @@ const Selector = () => {
 
       // We use here a fixed list for now
       const selectedItems: Item[] = SELECTED_ITEMS.map(({ id, type }) => {
-        const { description, icon }: Partial<FeatureType> =
+        const { description }: Partial<FeatureType> =
           featureTypes.find(({ typeValue }) => typeValue === type) ?? {};
 
         return {
           id,
           type,
           description,
-          iconUrl: icon ? `data:image/svg+xml;base64,${btoa(icon.iconSvg)}` : '',
         };
       });
 
@@ -198,7 +197,7 @@ const Selector = () => {
                   <StyledButton onClick={addContainer}>Containers toevoegen</StyledButton>
                   <StyledButton onClick={removeContainer}>Containers verwijderen</StyledButton>
                   {selection.length ? (
-                    <ContainerList selection={selection} size={40} />
+                    <ContainerList selection={selection} featureTypes={meta.featureTypes} />
                   ) : (
                     <Paragraph as="h6">Maak een keuze op de kaart</Paragraph>
                   )}
@@ -215,7 +214,7 @@ const Selector = () => {
                 onClose={handleLegendCloseButton}
                 variant={panelVariant}
                 title="Legenda"
-                items={meta.featureTypes.map(featureType => ({
+                items={meta.featureTypes.filter(({ label }) => label !== 'Onbekend').map(featureType => ({
                   label: featureType.label,
                   iconUrl: `data:image/svg+xml;base64,${btoa(featureType.icon.iconSvg)}`,
                   id: featureType.typeValue,

--- a/src/signals/incident/components/form/ContainerSelect/components/Summary/__tests__/index.test.js
+++ b/src/signals/incident/components/form/ContainerSelect/components/Summary/__tests__/index.test.js
@@ -11,9 +11,22 @@ const contextValue = {
       id: 'PL734',
       type: 'plastic',
       description: 'Plastic container',
-      iconUrl: '',
     },
   ],
+  meta: {
+    featureTypes: [
+      {
+        label: 'Plastic',
+        description: 'Plastic container',
+        icon: {
+          iconSvg: 'svg',
+        },
+        idField: 'id_nummer',
+        typeField: 'fractie_omschrijving',
+        typeValue: 'Plastic',
+      },
+    ],
+  },
   update: jest.fn(),
   edit: jest.fn(),
   close: jest.fn(),

--- a/src/signals/incident/components/form/ContainerSelect/components/Summary/index.js
+++ b/src/signals/incident/components/form/ContainerSelect/components/Summary/index.js
@@ -19,12 +19,14 @@ const StyledContainerList = styled(ContainerList)`
 `;
 
 const Summary = () => {
-  const { selection, edit } = useContext(ContainerSelectContext);
+  const { selection, meta, edit } = useContext(ContainerSelectContext);
 
   return (
     <Wrapper data-testid="containerSelectSummary">
-      <StyledContainerList selection={selection}></StyledContainerList>
-      <StyledLink onClick={edit} variant="inline" tabIndex={0}>Wijzigen</StyledLink>
+      <StyledContainerList selection={selection} featureTypes={meta.featureTypes}></StyledContainerList>
+      <StyledLink onClick={edit} variant="inline" tabIndex={0}>
+        Wijzigen
+      </StyledLink>
     </Wrapper>
   );
 };

--- a/src/signals/incident/components/form/ContainerSelect/types.ts
+++ b/src/signals/incident/components/form/ContainerSelect/types.ts
@@ -7,7 +7,6 @@ export interface Item {
   id: string;
   type: string;
   description?: string;
-  iconUrl: string;
 }
 
 export interface FeatureType {

--- a/src/signals/incident/definitions/__tests__/wizard-step-5-samenvatting.test.js
+++ b/src/signals/incident/definitions/__tests__/wizard-step-5-samenvatting.test.js
@@ -76,6 +76,7 @@ describe('signals/incident/definitions/wizard-step-5-samenvatting', () => {
         category: 'afval',
         subcategory: 'subcategory',
       });
+
       const expected = expect.objectContaining({
         vulaan: {
           extra_afval: {
@@ -86,7 +87,7 @@ describe('signals/incident/definitions/wizard-step-5-samenvatting', () => {
           extra_container: {
             label: 'Container(s)',
             optional: true,
-            render: PreviewComponents.ContainerListPreview,
+            render: expect.any(Function),
           },
         },
       });

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/afval.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/afval.ts
@@ -138,6 +138,17 @@ export const controls = {
           typeField: 'fractie_omschrijving',
           typeValue: 'Brood',
         },
+        {
+          description: 'De container staat niet op de kaart',
+          label: 'Onbekend',
+          icon: {
+            iconSvg: afvalIcons.unknown,
+            selectedIconSvg: afvalIcons.select,
+          },
+          idField: 'id',
+          typeField: 'type',
+          typeValue: 'not-on-map',
+        },
       ],
     },
     options: {

--- a/src/signals/incident/definitions/wizard-step-5-samenvatting.js
+++ b/src/signals/incident/definitions/wizard-step-5-samenvatting.js
@@ -20,7 +20,6 @@ export const Null = () => null;
 const mapFieldNameToComponent = key => FormComponents[key];
 
 export const renderPreview = ({ render: renderFunc, meta }) => {
-  const Preview = props => PreviewComponents.ContainerListPreview({ ...props, featureTypes: meta.featureTypes });
   switch (renderFunc.name) {
     case 'RadioInputGroup':
     case 'SelectInput':
@@ -45,8 +44,7 @@ export const renderPreview = ({ render: renderFunc, meta }) => {
       return Label;
 
     case 'ContainerSelectRenderer':
-      return Preview;
-      // return props => PreviewComponents.ContainerListPreview({ ...props, featureTypes: meta.featureTypes });
+      return props => PreviewComponents.ContainerListPreview({ ...props, featureTypes: meta.featureTypes });
 
     default:
       return Null;

--- a/src/signals/incident/definitions/wizard-step-5-samenvatting.js
+++ b/src/signals/incident/definitions/wizard-step-5-samenvatting.js
@@ -20,6 +20,7 @@ export const Null = () => null;
 const mapFieldNameToComponent = key => FormComponents[key];
 
 export const renderPreview = ({ render: renderFunc, meta }) => {
+  const Preview = props => PreviewComponents.ContainerListPreview({ ...props, featureTypes: meta.featureTypes });
   switch (renderFunc.name) {
     case 'RadioInputGroup':
     case 'SelectInput':
@@ -44,7 +45,8 @@ export const renderPreview = ({ render: renderFunc, meta }) => {
       return Label;
 
     case 'ContainerSelectRenderer':
-      return props => PreviewComponents.ContainerListPreview({ ...props, featureTypes: meta.featureTypes });
+      return Preview;
+      // return props => PreviewComponents.ContainerListPreview({ ...props, featureTypes: meta.featureTypes });
 
     default:
       return Null;

--- a/src/signals/incident/definitions/wizard-step-5-samenvatting.js
+++ b/src/signals/incident/definitions/wizard-step-5-samenvatting.js
@@ -44,7 +44,7 @@ export const renderPreview = ({ render: renderFunc, meta }) => {
       return Label;
 
     case 'ContainerSelectRenderer':
-      return PreviewComponents.ContainerListPreview;
+      return props => PreviewComponents.ContainerListPreview({ ...props, featureTypes: meta.featureTypes });
 
     default:
       return Null;


### PR DESCRIPTION
This PR restructures the item structure by removing the iconUrl property as this is not expected by the api.