### PR TITLE
[SIG-3339] Container map drawer

### DIFF
--- a/src/components/IconList/IconList.tsx
+++ b/src/components/IconList/IconList.tsx
@@ -23,7 +23,7 @@ const ListItem = styled.li`
 
 const StyledIcon = styled.span<{ url: string; size: number }>`
   margin-right: ${themeSpacing(2)};
-  display: inline-block;
+  flex-shrink: 0;
   background-image: url(${({ url }) => url});
   background-size: cover;
   width: ${({ size }) => size}px;

--- a/src/signals/incident/components/form/ContainerSelect/components/Selector/components/LegendPanel/index.tsx
+++ b/src/signals/incident/components/form/ContainerSelect/components/Selector/components/LegendPanel/index.tsx
@@ -1,9 +1,13 @@
-import React, { Fragment } from 'react';
-import { createGlobalStyle } from 'styled-components';
+import React from 'react';
 import { MapPanelContent } from '@amsterdam/arm-core';
+import styled from 'styled-components';
 
 import IconList from 'components/IconList/IconList';
 import type { IconListItem } from 'components/IconList/IconList';
+
+const StyledMapPanelContent = styled(MapPanelContent)`
+  width: initial; // Prevents content from overlapping the panel shadow
+`;
 
 export interface LegendPanelProps {
   variant: 'panel' | 'drawer';
@@ -12,21 +16,17 @@ export interface LegendPanelProps {
   onClose: () => void;
 }
 
-// Prevent scrollBar on iOS due to navigation bar
-const GlobalStyle = createGlobalStyle`
-  body {
-    touch-action: none;
-    overflow: hidden;
-  }
-`;
-
 const LegendPanel: React.FC<LegendPanelProps> = ({ items = [], title, variant, onClose }) => (
-  <Fragment>
-    <GlobalStyle />
-    <MapPanelContent data-testid="legend-panel" stackOrder={1} onClose={onClose} variant={variant} title={title}>
-      <IconList id="legend-icons" items={items} />
-    </MapPanelContent>
-  </Fragment>
+  <StyledMapPanelContent
+    animate
+    data-testid="legend-panel"
+    stackOrder={1}
+    onClose={onClose}
+    variant={variant}
+    title={title}
+  >
+    <IconList id="legend-icons" items={items} />
+  </StyledMapPanelContent>
 );
 
 export default LegendPanel;

--- a/src/signals/incident/components/form/ContainerSelect/components/Selector/components/LegendToggleButton/__tests__/index.test.tsx
+++ b/src/signals/incident/components/form/ContainerSelect/components/Selector/components/LegendToggleButton/__tests__/index.test.tsx
@@ -29,8 +29,7 @@ describe('LegendToggleButton', () => {
       )
     );
 
-    expect(screen.getByRole('button')).toBeInTheDocument();
-    expect(screen.getByRole('button').textContent).not.toBe('Legenda');
+    expect(screen.getByRole('button').textContent).toBe('Legenda');
   });
 
   it('should render drawer variant', () => {
@@ -42,7 +41,8 @@ describe('LegendToggleButton', () => {
       )
     );
 
-    expect(screen.getByRole('button').textContent).toBe('Legenda');
+    expect(screen.getByRole('button')).toBeInTheDocument();
+    expect(screen.getByRole('button').textContent).not.toBe('Legenda');
   });
 
   it('should handle click when panel is closed', () => {

--- a/src/signals/incident/components/form/ContainerSelect/components/Selector/components/LegendToggleButton/index.tsx
+++ b/src/signals/incident/components/form/ContainerSelect/components/Selector/components/LegendToggleButton/index.tsx
@@ -3,8 +3,8 @@ import styled from 'styled-components';
 
 import { MapPanelContext } from '@amsterdam/arm-core';
 import { MapLayers } from '@amsterdam/asc-assets';
-import { Button } from '@amsterdam/asc-ui';
 import { SnapPoint } from '@amsterdam/arm-core/lib/components/MapPanel/constants';
+import Button from 'components/Button';
 
 const ICON_SIZE = 20;
 
@@ -16,13 +16,18 @@ export interface LegendToggleButtonProps {
 const StyledButton = styled(Button)`
   box-sizing: border-box; // Override box-sizing: content-box set by Leaflet
   min-width: 0;
+  box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.1);
+
+  svg path {
+    fill: currentColor;
+  }
 `;
 
 const LegendToggleButton: React.FC<LegendToggleButtonProps> = ({ onClick, isRenderingLegendPanel }) => {
   const { setPositionFromSnapPoint, matchPositionWithSnapPoint, variant } = useContext(MapPanelContext);
 
   const isDrawerOpen = !matchPositionWithSnapPoint(SnapPoint.Closed);
-  const icon = { [variant === 'drawer' ? 'iconLeft' : 'icon']: <MapLayers /> };
+  const icon = { [variant === 'panel' ? 'iconLeft' : 'icon']: <MapLayers /> };
   const isLegendPanelOpen = isDrawerOpen && isRenderingLegendPanel;
   const buttonVariant = isLegendPanelOpen ? 'secondary' : 'blank';
 

--- a/src/signals/incident/components/form/ContainerSelect/components/Selector/components/ViewerContainer/__tests__/index.test.tsx
+++ b/src/signals/incident/components/form/ContainerSelect/components/Selector/components/ViewerContainer/__tests__/index.test.tsx
@@ -9,7 +9,7 @@ import ViewerContainer from '..';
 describe('ViewerContainer', () => {
   const button = <button type="button">Legend</button>;
 
-  it('should render drawer (desktop) variant of viewer container', () => {
+  it('should render drawer (mobile) variant of viewer container', () => {
     render(
       withAppContext(
         <MapPanelProvider variant="drawer" initialPosition={SnapPoint.Closed}>
@@ -19,12 +19,12 @@ describe('ViewerContainer', () => {
     );
 
     const viewerContainer = screen.getByTestId('viewer-container');
-    expect(viewerContainer).toHaveStyle('left: calc(100% - 70px)');
-    expect(viewerContainer).toHaveStyle('height: 100%');
+    expect(viewerContainer).toHaveStyle('left: 0');
+    expect(viewerContainer).toHaveStyle('height: calc(100% - 70px)');
     expect(screen.getByRole('button')).toBeInTheDocument();
   });
 
-  it('should render panel (mobile) variant of viewer container', () => {
+  it('should render panel (desktop) variant of viewer container', () => {
     render(
       withAppContext(
         <MapPanelProvider variant="panel" initialPosition={SnapPoint.Closed}>
@@ -34,8 +34,8 @@ describe('ViewerContainer', () => {
     );
 
     const viewerContainer = screen.getByTestId('viewer-container');
-    expect(viewerContainer).toHaveStyle('left: 0');
-    expect(viewerContainer).toHaveStyle('height: 30px');
+    expect(viewerContainer).toHaveStyle('left: 30px');
+    expect(viewerContainer).toHaveStyle('height: 100%');
     expect(screen.getByRole('button')).toBeInTheDocument();
   });
 });

--- a/src/signals/incident/components/form/ContainerSelect/components/Selector/components/ViewerContainer/index.tsx
+++ b/src/signals/incident/components/form/ContainerSelect/components/Selector/components/ViewerContainer/index.tsx
@@ -1,6 +1,6 @@
-import React, { useContext } from 'react';
+import React, { Fragment, useContext } from 'react';
 import type { ReactNode } from 'react';
-import styled from 'styled-components';
+import styled, { createGlobalStyle } from 'styled-components';
 
 import { MapPanelContext, ViewerContainer as AscViewerContainer } from '@amsterdam/arm-core';
 
@@ -18,7 +18,15 @@ interface StyledViewerContainerProps {
   height: string;
 }
 
-const StyledViewerContainer = styled(AscViewerContainer) <StyledViewerContainerProps>`
+// Prevent scrollBar on iOS due to navigation bar
+const GlobalPanelStyle = createGlobalStyle`
+  body {
+    touch-action: none;
+    overflow: hidden;
+  }
+`;
+
+const StyledViewerContainer = styled(AscViewerContainer)<StyledViewerContainerProps>`
   left: ${({ leftOffset }) => leftOffset};
   height: ${({ height }) => height};
   z-index: 400;
@@ -27,18 +35,16 @@ const StyledViewerContainer = styled(AscViewerContainer) <StyledViewerContainerP
 
 const ViewerContainer: React.FC<ViewerContainerProps> = props => {
   const { drawerPosition, variant } = useContext(MapPanelContext);
-  const isDrawerVariant = variant === 'drawer';
+  const isDrawerVariant = variant === 'panel';
 
   const height = isDrawerVariant ? '100%' : drawerPosition;
   const leftOffset = isDrawerVariant ? drawerPosition : '0';
 
   return (
-    <StyledViewerContainer
-      {...props}
-      data-testid="viewer-container"
-      height={height}
-      leftOffset={leftOffset}
-    />
+    <Fragment>
+      <GlobalPanelStyle />
+      <StyledViewerContainer {...props} data-testid="viewer-container" height={height} leftOffset={leftOffset} />
+    </Fragment>
   );
 };
 

--- a/src/signals/incident/components/form/ContainerSelect/components/Selector/index.tsx
+++ b/src/signals/incident/components/form/ContainerSelect/components/Selector/index.tsx
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 import styled from 'styled-components';
 import type { MapOptions } from 'leaflet';
 
-import { Paragraph, themeColor } from '@amsterdam/asc-ui';
+import { Paragraph, themeColor, themeSpacing } from '@amsterdam/asc-ui';
 import { MapPanel, MapPanelContent, MapPanelDrawer, MapPanelProvider } from '@amsterdam/arm-core';
 import { SnapPoint } from '@amsterdam/arm-core/lib/components/MapPanel/constants';
 import { useMatchMedia } from '@amsterdam/asc-ui/lib/utils/hooks';
@@ -25,14 +25,14 @@ import { Close } from '@amsterdam/asc-assets';
 import ContainerList from '../ContainerList';
 
 const MAP_PANEL_DRAWER_SNAP_POSITIONS = {
-  [SnapPoint.Closed]: '30px',
-  [SnapPoint.Halfway]: '400px',
-  [SnapPoint.Full]: '100%',
-};
-const MAP_PANEL_SNAP_POSITIONS = {
   [SnapPoint.Closed]: '90%',
   [SnapPoint.Halfway]: '50%',
   [SnapPoint.Full]: '0',
+};
+const MAP_PANEL_SNAP_POSITIONS = {
+  [SnapPoint.Closed]: '30px',
+  [SnapPoint.Halfway]: '400px',
+  [SnapPoint.Full]: '100%',
 };
 
 const ButtonBar = styled.div`
@@ -43,6 +43,11 @@ const ButtonBar = styled.div`
 
 const StyledButton = styled(Button)`
   box-sizing: border-box;
+`;
+
+const MapButton = styled(Button)`
+  box-sizing: border-box;
+  box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.1);
 `;
 
 const Wrapper = styled.div`
@@ -74,6 +79,10 @@ const StyledMap = styled(Map)`
       line-height: 34px;
     }
   }
+`;
+
+const StyledContainerList = styled(ContainerList)`
+  margin-bottom: ${themeSpacing(8)};
 `;
 
 const unknownFeatureType: FeatureType = {
@@ -109,8 +118,8 @@ const Selector = () => {
   const { Panel, panelVariant } = useMemo<{ Panel: React.FC; panelVariant: Variant }>(
     () =>
       showDesktopVariant
-        ? { Panel: MapPanel, panelVariant: 'drawer' }
-        : { Panel: MapPanelDrawer, panelVariant: 'panel' },
+        ? { Panel: MapPanel, panelVariant: 'panel' }
+        : { Panel: MapPanelDrawer, panelVariant: 'drawer' },
     [showDesktopVariant]
   );
 
@@ -178,33 +187,29 @@ const Selector = () => {
           mapPanelSnapPositions={MAP_PANEL_SNAP_POSITIONS}
           mapPanelDrawerSnapPositions={MAP_PANEL_DRAWER_SNAP_POSITIONS}
           variant={panelVariant}
-          initialPosition={SnapPoint.Closed}
+          initialPosition={SnapPoint.Halfway}
         >
           <ViewerContainer
             topLeft={<LegendToggleButton onClick={toggleLegend} isRenderingLegendPanel={showLegendPanel} />}
             topRight={
-              <StyledButton data-testid="selector-close" variant="blank" onClick={close} size={44} icon={<Close />} />
+              <MapButton data-testid="selector-close" variant="blank" onClick={close} size={44} icon={<Close />} />
             }
           />
           <Panel data-testid={`panel-${showDesktopVariant ? 'desktop' : 'mobile'}`}>
             {showSelectionPanel && (
-              <MapPanelContent
-                variant={panelVariant}
-                title="Kies de container"
-                subTitle="U kunt meer dan 1 keuze maken"
-                data-testid="selection-panel"
-              >
+              <MapPanelContent variant={panelVariant} title="Kies de container" data-testid="selection-panel">
+                <Paragraph>U kunt meer dan 1 keuze maken</Paragraph>
                 <ButtonBar>
                   <StyledButton onClick={addContainer}>Containers toevoegen</StyledButton>
                   <StyledButton onClick={removeContainer}>Containers verwijderen</StyledButton>
                   {selection.length ? (
-                    <ContainerList selection={selection} size={40} />
+                    <StyledContainerList selection={selection} size={40} />
                   ) : (
                     <Paragraph as="h6">Maak een keuze op de kaart</Paragraph>
                   )}
                 </ButtonBar>
                 <ButtonBar>
-                  <StyledButton onClick={close} variant="primary" disabled={selection.length === 0}>
+                  <StyledButton onClick={close} variant="primary">
                     Meld deze container{selection.length > 1 ? 's' : ''}
                   </StyledButton>
                 </ButtonBar>


### PR DESCRIPTION
This PR fixes UX and styling based on a review by our designer

### Fixes

- Map drawer should be open by default
- Map drawer subtitle should be shown as a paragraph in the content area
- Selection submit button should be active always
- Remove vertical scroll on map
- Fix map buttons shadow and font
- Add slide-in animation to legend
- Prevent icons shrinking when labels in icon list are long