### PR TITLE
[SIG-3462] Removes the ADW/Grip button references

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -19,7 +19,7 @@ module.exports = {
     global: {
       statements: 99.33,
       branches: 95.91,
-      functions: 98.61,
+      functions: 98.6,
       lines: 99.35,
     },
   },

--- a/src/components/LoginPage/index.js
+++ b/src/components/LoginPage/index.js
@@ -39,19 +39,9 @@ const LoginPage = () => (
               }}
               type="button"
             >
-              <span className="value">Inloggen Keycloak</span>
+              <span className="value">Inloggen ADW</span>
             </Button>
           )}
-
-          <Button
-            variant="secondary"
-            onClick={() => {
-              login('grip');
-            }}
-            type="button"
-          >
-            <span className="value">Inloggen ADW</span>
-          </Button>
         </ButtonBar>
       </Notification>
     </Column>

--- a/src/components/LoginPage/index.test.js
+++ b/src/components/LoginPage/index.test.js
@@ -22,13 +22,12 @@ describe('components/LoginPage', () => {
     expect(screen.getByText('Om deze pagina te zien dient u ingelogd te zijn.')).toBeInTheDocument();
     expect(screen.getByText('Inloggen')).toBeInTheDocument();
     expect(screen.getByText('Inloggen ADW')).toBeInTheDocument();
-    expect(screen.getByText('Inloggen Keycloak')).toBeInTheDocument();
   });
 
   it('should render correctly without Keycloak', () => {
     render(withAppContext(<LoginPage />));
 
-    expect(screen.queryByText('Inloggen Keycloak')).not.toBeInTheDocument();
+    expect(screen.queryByText('Inloggen ADW')).not.toBeInTheDocument();
   });
 
   it('should login on datapunt when Inloggen button is clicked', () => {
@@ -43,23 +42,11 @@ describe('components/LoginPage', () => {
     expect(loginSpy).toHaveBeenCalledWith('datapunt');
   });
 
-  it('should login on datapunt when Inloggen ADW button is clicked', () => {
-    const loginSpy = jest.spyOn(auth, 'login');
-    render(withAppContext(<LoginPage />));
-    const button = screen.getByText('Inloggen ADW').parentNode;
-
-    expect(button.getAttribute('type')).toEqual('button');
-
-    fireEvent.click(button);
-
-    expect(loginSpy).toHaveBeenCalledWith('grip');
-  });
-
-  it('should login on keycloak when Inloggen Keycloak button is clicked', () => {
+  it('should login on keycloak when Inloggen ADW button is clicked', () => {
     configuration.keycloak = {};
     const loginSpy = jest.spyOn(auth, 'login');
     render(withAppContext(<LoginPage />));
-    const button = screen.getByText('Inloggen Keycloak').parentNode;
+    const button = screen.getByText('Inloggen ADW').parentNode;
 
     expect(button.getAttribute('type')).toEqual('button');
 

--- a/src/containers/App/saga.test.ts
+++ b/src/containers/App/saga.test.ts
@@ -103,20 +103,6 @@ describe('containers/App/saga', () => {
       testSaga(callLogout).next().call(logout).next().put(push('/login')).next().isDone();
     });
 
-    it('should grip success', () => {
-      jest.spyOn(global.localStorage, 'getItem').mockImplementationOnce(key => {
-        switch (key) {
-          case 'oauthDomain':
-            return 'grip';
-          default:
-            return '';
-        }
-      });
-
-      testSaga(callLogout).next();
-      expect(window.open).toHaveBeenCalledWith('https://auth.grip-on-it.com/v2/logout?tenantId=rjsfm52t', '_blank');
-    });
-
     it('should dispatch error', async () => {
       const message = 'no remove';
       jest.spyOn(global.localStorage, 'removeItem').mockImplementationOnce(() => {

--- a/src/containers/App/saga.ts
+++ b/src/containers/App/saga.ts
@@ -23,7 +23,7 @@ import {
   getSourcesFailed,
   getSourcesSuccess,
 } from './actions';
-import { logout, getOauthDomain } from '../../shared/services/auth/auth';
+import { logout } from '../../shared/services/auth/auth';
 
 import fileUploadChannel from '../../shared/services/file-upload-channel';
 import type { User, DataResult, ApiError, UploadFile } from './types';
@@ -32,11 +32,6 @@ const CONFIGURATION = configuration as typeof endpointDefinitions;
 
 export function* callLogout() {
   try {
-    // This forces the remove of the grip cookies.
-    if (getOauthDomain() === 'grip') {
-      window.open('https://auth.grip-on-it.com/v2/logout?tenantId=rjsfm52t', '_blank')?.close();
-    }
-
     yield call(logout);
     yield put(push('/login'));
   } catch (error: unknown) {


### PR DESCRIPTION
This PR removes the ADW button and references. The existing `Inloggen Keycloak` button is renamed to `Inloggen ADW`