### PR TITLE
(Chore) Fix the new linting rules after package update

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -49,8 +49,14 @@ module.exports = {
             ignoreStatic: true,
           },
         ],
-        '@typescript-eslint/object-curly-spacing': 'off',
         '@typescript-eslint/sort-type-union-intersection-members': 'off',
+      },
+    },
+    {
+      files: ['**/*.test.js', '**/*.test.ts', '**/*.test.tsx'],
+      extends: ['plugin:amsterdam/react'],
+      rules: {
+        'react/jsx-no-constructed-context-values': 'off',
       },
     },
   ],
@@ -69,10 +75,7 @@ module.exports = {
     'no-unused-vars': 'off',
     'prefer-const': 'off',
     'promise/prefer-await-to-then': 'off',
-    'react/display-name': 'off',
-    'react/forbid-component-props': 'off',
     'react/jsx-key': 'off',
-    'react/jsx-no-bind': 'off',
     'react/no-did-mount-set-state': 'off',
     'react/no-unused-prop-types': 'off',
     'react/require-optimization': 'off',
@@ -149,6 +152,5 @@ module.exports = {
     'jest/valid-expect': 'off',
     'jest/valid-title': 'off',
     'react/jsx-newline': 'off',
-    'react/jsx-no-constructed-context-values': 'off',
   },
 };

--- a/eslint-plugin-amsterdam/react.js
+++ b/eslint-plugin-amsterdam/react.js
@@ -44,6 +44,10 @@ module.exports = {
     'react/self-closing-comp': 'off',
     'react/sort-comp': 'off',
     'react/sort-prop-types': 'off',
+    'react/jsx-no-bind': 'off',
+    'react/forbid-component-props': 'off',
+    'react/display-name': 'off',
+
 
     // jsx-a11y
     'jsx-a11y/alt-text': 'error',
@@ -86,7 +90,6 @@ module.exports = {
     // rules
     'react/boolean-prop-naming': 'error',
     'react/button-has-type': 'error',
-    'react/display-name': 'error',
     'react/forbid-foreign-prop-types': ['error', { allowInPropTypes: true }],
     'react/function-component-definition': ['error', { namedComponents: 'arrow-function', unnamedComponents: 'arrow-function' }],
     'react/jsx-closing-bracket-location': ['error', 'tag-aligned'],

--- a/eslint-plugin-amsterdam/typescript.js
+++ b/eslint-plugin-amsterdam/typescript.js
@@ -68,6 +68,8 @@ module.exports = {
         // 'space-before-function-paren': 'off',
 
         '@typescript-eslint/no-explicit-any': 'warn',
+        '@typescript-eslint/object-curly-spacing': ['error', 'always'],
+        '@typescript-eslint/sort-type-union-intersection-members': 'off',
       },
     },
   ],

--- a/src/components/AutoSuggest/__tests__/AutoSuggest.test.js
+++ b/src/components/AutoSuggest/__tests__/AutoSuggest.test.js
@@ -379,6 +379,7 @@ describe('src/components/AutoSuggest', () => {
         withAppContext(
           <Fragment>
             <AutoSuggest {...props} />
+
             <input type="text" name="foo" />
           </Fragment>
         )
@@ -415,6 +416,7 @@ describe('src/components/AutoSuggest', () => {
         withAppContext(
           <form onSubmit={mockedOnSubmit}>
             <AutoSuggest {...props} />
+
             <input type="text" name="foo" />
           </form>
         )

--- a/src/components/Label/Label.test.tsx
+++ b/src/components/Label/Label.test.tsx
@@ -11,6 +11,7 @@ describe('signals/incident-management/components/Label', () => {
       withAppContext(
         <div>
           <Label htmlFor="someOtherElementId">This is my label text</Label>
+
           <input type="text" id="someOtherElementId" />
         </div>
       )
@@ -24,6 +25,7 @@ describe('signals/incident-management/components/Label', () => {
     render(
       <Fragment>
         <Label inline>Label 1</Label>
+
         <Label>Label 2</Label>
       </Fragment>
     );
@@ -37,6 +39,7 @@ describe('signals/incident-management/components/Label', () => {
       withAppContext(
         <Fragment>
           <Label isGroupHeader>Label 1</Label>
+
           <Label>Label 2</Label>
         </Fragment>
       )

--- a/src/containers/App/index.test.tsx
+++ b/src/containers/App/index.test.tsx
@@ -29,7 +29,7 @@ jest.useFakeTimers();
 describe('<App />', () => {
   let listenSpy: jest.SpyInstance<UnregisterCallback, [listener: History.LocationListener<unknown>]>;
   let spyScrollTo: jest.Mock;
-  let props: JSX.IntrinsicAttributes & {resetIncidentAction: jest.Mock};
+  let props: JSX.IntrinsicAttributes & { resetIncidentAction: jest.Mock };
 
   afterAll(() => {
     jest.restoreAllMocks();

--- a/src/containers/App/index.tsx
+++ b/src/containers/App/index.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useEffect, lazy, Suspense } from 'react';
+import React, { Fragment, useEffect, lazy, Suspense, useMemo } from 'react';
 import styled from 'styled-components';
 import { Switch, Route, Redirect, useHistory } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
@@ -28,7 +28,7 @@ const FooterContainer = styled.div`
   max-width: 1400px;
 `;
 
-const ContentContainer = styled.div<{headerIsTall: boolean}>`
+const ContentContainer = styled.div<{ headerIsTall: boolean }>`
   background-color: #ffffff;
   flex: 1 0 auto;
   margin: 0 auto;
@@ -54,9 +54,10 @@ export const AppContainer = () => {
   const loading = useSelector(makeSelectLoading());
   const sources = useSelector(makeSelectSources);
   const history = useHistory();
-  const location = useLocationReferrer() as {referrer: string};
+  const location = useLocationReferrer() as { referrer: string };
   const isFrontOffice = useIsFrontOffice();
   const headerIsTall = isFrontOffice && !isAuthenticated();
+  const contextValue = useMemo(() => ({ loading, sources }), [loading, sources]);
 
   useEffect(() => {
     const { referrer } = location;
@@ -88,7 +89,7 @@ export const AppContainer = () => {
 
   return (
     <ThemeProvider>
-      <AppContext.Provider value={{ loading, sources }}>
+      <AppContext.Provider value={contextValue}>
         <Fragment>
           <SiteHeaderContainer />
 

--- a/src/containers/App/saga.ts
+++ b/src/containers/App/saga.ts
@@ -5,12 +5,7 @@ import { authCall } from 'shared/services/api/api';
 import configuration from 'shared/services/configuration/configuration';
 import { VARIANT_ERROR, TYPE_GLOBAL } from 'containers/Notification/constants';
 import type endpointDefinitions from 'shared/services/configuration/endpoint-definitions';
-import {
-  SET_SEARCH_QUERY,
-  LOGOUT,
-  AUTHENTICATE_USER,
-  GET_SOURCES,
-} from 'containers/App/constants';
+import { SET_SEARCH_QUERY, LOGOUT, AUTHENTICATE_USER, GET_SOURCES } from 'containers/App/constants';
 
 import type { AuthenticateUserAction } from './actions';
 import {
@@ -78,7 +73,7 @@ export function* callAuthorize(action: AuthenticateUserAction) {
   }
 }
 
-export function* uploadFile(action: {payload: UploadFile}) {
+export function* uploadFile(action: { payload: UploadFile }) {
   const id = action.payload?.id ?? '';
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const channel = yield call(

--- a/src/containers/MapContext/index.js
+++ b/src/containers/MapContext/index.js
@@ -1,4 +1,4 @@
-import React, { useReducer, memo } from 'react';
+import React, { useReducer, memo, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import Context from './context';
 import reducer, { initialState } from './reducer';
@@ -6,8 +6,9 @@ import reducer, { initialState } from './reducer';
 const MapContext = ({ children }) => {
   const [state, dispatch] = useReducer(reducer, initialState);
 
+  const contextValue = useMemo(() => ({ state, dispatch }), [state]);
   return (
-    <Context.Provider value={{ state, dispatch }}>
+    <Context.Provider value={contextValue}>
       {children}
     </Context.Provider>
   );

--- a/src/signals/incident-management/containers/IncidentDetail/IncidentDetail.js
+++ b/src/signals/incident-management/containers/IncidentDetail/IncidentDetail.js
@@ -207,13 +207,13 @@ const IncidentDetail = () => {
     dispatch({ type: CLOSE_ALL });
   }, []);
 
-
   if (!state.incident || !subcategories) return null;
 
   return (
     <IncidentDetailContext.Provider
+      // eslint-disable-next-line react/jsx-no-constructed-context-values
       value={{
-        incident: state.incident,
+        incident: state?.incident,
         update: updateDispatch,
         preview: previewDispatch,
         edit: editDispatch,

--- a/src/signals/incident-management/containers/IncidentDetail/IncidentDetail.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/IncidentDetail.test.js
@@ -85,8 +85,8 @@ describe('signals/incident-management/containers/IncidentDetail', () => {
 
     fetch.mockResponses(
       [JSON.stringify(incidentFixture), { status: 200 }],
-      [JSON.stringify(historyFixture), { status: 200 }],
       [JSON.stringify(statusMessageTemplates), { status: 200 }],
+      [JSON.stringify(historyFixture), { status: 200 }],
       [JSON.stringify(attachments), { status: 200 }],
       [JSON.stringify(childIncidentFixture), { status: 200 }]
     );
@@ -166,8 +166,8 @@ describe('signals/incident-management/containers/IncidentDetail', () => {
 
     fetch.mockResponses(
       [JSON.stringify(incidentWithoutChildren), { status: 200 }],
-      [JSON.stringify(historyFixture), { status: 200 }],
       [JSON.stringify(statusMessageTemplates), { status: 200 }],
+      [JSON.stringify(historyFixture), { status: 200 }],
       [JSON.stringify(attachments), { status: 200 }]
     );
 
@@ -189,8 +189,8 @@ describe('signals/incident-management/containers/IncidentDetail', () => {
 
     fetch.mockResponses(
       [JSON.stringify(incidentFixture), { status: 200 }],
-      [JSON.stringify(historyFixture), { status: 200 }],
       [JSON.stringify(statusMessageTemplates), { status: 200 }],
+      [JSON.stringify(historyFixture), { status: 200 }],
       [JSON.stringify(attachments), { status: 200 }],
       [JSON.stringify(childIncidentFixture), { status: 200 }]
     );

--- a/src/signals/incident-management/containers/IncidentDetail/components/AttachmentViewer/index.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/AttachmentViewer/index.test.js
@@ -142,6 +142,7 @@ describe('<AttachmentViewer />', () => {
       const { queryByTestId } = render(
         <div>
           <input data-testid="input" />
+
           <AttachmentViewer {...props} href={props.attachments[1].location} />
         </div>
       );

--- a/src/signals/incident-management/index.js
+++ b/src/signals/incident-management/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect, lazy, Suspense } from 'react';
+import React, { useEffect, lazy, Suspense, useMemo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { compose } from 'redux';
 import { Route, Switch } from 'react-router-dom';
@@ -38,6 +38,10 @@ const IncidentManagement = () => {
   const searchQuery = useSelector(makeSelectSearchQuery);
   const dispatch = useDispatch();
   const users = useFetch();
+  const contextValue = useMemo(() => ({ districts, users: users.data?.results }), [
+    districts,
+    users.data?.results,
+  ]);
 
   useEffect(() => {
     // prevent continuing (and performing unncessary API calls)
@@ -68,7 +72,7 @@ const IncidentManagement = () => {
   }
 
   return (
-    <IncidentManagementContext.Provider value={{ districts, users: users.data?.results }}>
+    <IncidentManagementContext.Provider value={contextValue}>
       <Suspense fallback={<LoadingIndicator />}>
         <Switch location={location}>
           <Route exact path={routes.incidents} component={IncidentOverviewPage} />

--- a/src/signals/settings/departments/Detail/index.js
+++ b/src/signals/settings/departments/Detail/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useCallback, Fragment } from 'react';
+import React, { useEffect, useCallback, Fragment, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { useParams } from 'react-router-dom';
 import { connect } from 'react-redux';
@@ -54,6 +54,13 @@ export const DepartmentDetailContainer = ({ categories, findByMain, subCategorie
     get(`${CONFIGURATION.DEPARTMENTS_ENDPOINT}${departmentId}`);
   }, [get, departmentId]);
 
+  const contextValue = useMemo(() => ({ categories, department: data, subCategories, findByMain }), [
+    categories,
+    data,
+    findByMain,
+    subCategories,
+  ]);
+
   return (
     <Fragment>
       <PageHeader title={title} BackLink={<BackLink to={routes.departments}>Terug naar overzicht</BackLink>} />
@@ -74,7 +81,7 @@ export const DepartmentDetailContainer = ({ categories, findByMain, subCategorie
           </Row>
 
           {categories && (
-            <DepartmentDetailContext.Provider value={{ categories, department: data, subCategories, findByMain }}>
+            <DepartmentDetailContext.Provider value={contextValue}>
               <CategoryLists onCancel={confirmedCancel} onSubmit={onSubmit} />
             </DepartmentDetailContext.Provider>
           )}

--- a/src/signals/settings/index.js
+++ b/src/signals/settings/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useReducer, lazy, Suspense } from 'react';
+import React, { useEffect, useReducer, lazy, Suspense, useMemo } from 'react';
 import { Route, Redirect, Switch } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 
@@ -41,6 +41,7 @@ const SettingsModule = () => {
   const [state, dispatch] = useReducer(reducer, initialState);
   const userCan = useSelector(makeSelectUserCan);
   const userCanAccess = useSelector(makeSelectUserCanAccess);
+  const contextValue = useMemo(() => ({ state, dispatch }), [state]);
 
   useEffect(() => {
     if (!isAuthenticated()) {
@@ -59,8 +60,9 @@ const SettingsModule = () => {
     return <Redirect to="/manage/incidents" />;
   }
 
+
   return (
-    <SettingsContext.Provider value={{ state, dispatch }}>
+    <SettingsContext.Provider value={contextValue}>
       <Suspense fallback={<LoadingIndicator />}>
         {userCanAccess('groups') && (
           <Switch location={location}>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -15,11 +15,9 @@ export interface ApplicationRootState {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-type-alias
-export type SagaGeneratorType = Generator<CallEffect<EventChannel<unknown>> | TakeEffect | PutEffect<{ type: string }>, void, { progress?: number | undefined; error: boolean; success: boolean}>;
+export type SagaGeneratorType = Generator<CallEffect<EventChannel<unknown>> | TakeEffect | PutEffect<{ type: string }>, void, { progress?: number | undefined; error: boolean; success: boolean }>;
 
 export interface Action<T, ActionType> {
   type: T;
   payload?: ActionType;
 }
-
-


### PR DESCRIPTION
This PR
- Fixes the linting errors that occured after the update of the packages
- Adds a new override section for lint rules specific to tests to the eslint config file
- Promotes few linting rules to the amsterdam plugin