### PR TITLE
[SIG-3494] Fix style in checkbox label

### DIFF
--- a/src/components/Input/index.js
+++ b/src/components/Input/index.js
@@ -2,7 +2,7 @@ import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import {
-  Label as FieldLabel,
+  Label,
   styles,
   themeColor,
   Typography,
@@ -47,7 +47,7 @@ const Error = styled(Typography).attrs({
   margin: ${themeSpacing(2)} 0;
 `;
 
-export const Label = styled(FieldLabel)`
+export const StyledLabel = styled(Label)`
   display: block;
   font-family: Avenir Next LT W01 Demi, arial, sans-serif;
   ${({ hasHint }) =>
@@ -66,7 +66,7 @@ const Wrapper = styled.div`
 
 const Input = forwardRef(({ className, hint, label, id, error, ...rest }, ref) => (
   <Wrapper className={className} showError={Boolean(error)}>
-    {label && <Label hasHint={Boolean(hint)} htmlFor={id} label={label} />}
+    {label && <StyledLabel hasHint={Boolean(hint)} htmlFor={id} label={label} />}
     {hint && <Hint>{hint}</Hint>}
     {error && <Error>{error}</Error>}
     <StyledInput id={id} showError={Boolean(error)} ref={ref} {...rest} />

--- a/src/signals/incident-management/components/CheckboxList/CheckboxList.js
+++ b/src/signals/incident-management/components/CheckboxList/CheckboxList.js
@@ -287,7 +287,7 @@ const CheckboxList = ({
 
         return (
           <Wrapper disabled={defaultOption.disabled} key={optionId}>
-            <Label htmlFor={optionId} label={label} disabled={defaultOption.disabled}>
+            <Label htmlFor={optionId} label={label} disabled={defaultOption.disabled} noActiveState>
               <Checkbox
                 checked={isChecked(groupId) || isChecked(uid)}
                 data-testid={`checkbox-${optionId}`}

--- a/src/signals/incident-management/components/FilterForm/index.js
+++ b/src/signals/incident-management/components/FilterForm/index.js
@@ -481,7 +481,7 @@ const FilterForm = ({ filter, onCancel, onClearFilter, onSaveFilter, onSubmit, o
                 Toegewezen aan
               </Label>
               <div>
-                <AscLabel htmlFor="filter_not_assigned" label="Niet toegewezen">
+                <AscLabel htmlFor="filter_not_assigned" label="Niet toegewezen" noActiveState>
                   <Checkbox
                     data-testid="filterNotAssigned"
                     checked={state.options.assigned_user_email === 'null'}

--- a/src/signals/incident-management/components/RadioInput/index.js
+++ b/src/signals/incident-management/components/RadioInput/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
-import { RadioGroup, Label as AscLabel, themeSpacing } from '@amsterdam/asc-ui';
+import { RadioGroup, Label, themeSpacing } from '@amsterdam/asc-ui';
 
 import InfoText from 'components/InfoText';
 import Radio from 'components/RadioButton';
@@ -11,7 +11,7 @@ const Wrapper = styled.div`
   margin-bottom: ${themeSpacing(6)};
 `;
 
-const StyledLabel = styled(AscLabel)`
+const StyledLabel = styled(Label)`
   align-self: baseline;
 
   * {
@@ -32,7 +32,7 @@ const RadioInput = ({ name, display, values }) => {
     return (
       <Wrapper>
         <div className="mode_input text rij_verplicht">
-          {display && <AscLabel htmlFor={`form${name}`} label={<strong>{display}</strong>} />}
+          {display && <Label htmlFor={`form${name}`} label={<strong>{display}</strong>} />}
 
           <RadioGroup name={name}>
             {values?.map(({ key, value }) => (

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/index.js
@@ -165,6 +165,7 @@ const StatusForm = ({ defaultTexts, childIncidents }) => {
                 disabled={state.check.disabled}
                 htmlFor="send_email"
                 label={constants.MELDING_CHECKBOX_DESCRIPTION}
+                noActiveState
               >
                 <Checkbox
                   checked={state.check.checked}

--- a/src/signals/incident/components/form/CheckboxInput/index.js
+++ b/src/signals/incident/components/form/CheckboxInput/index.js
@@ -30,7 +30,7 @@ const CheckboxInput = ({ handler, touched, hasError, meta, parent, getError, val
           <input type="hidden" {...handler()} />
 
           {map(meta.values, (value, key) => (
-            <Label htmlFor={`${meta.name}-${key + 1}`} label={value}>
+            <Label htmlFor={`${meta.name}-${key + 1}`} label={value} noActiveState>
               <Checkbox
                 id={`${meta.name}-${key + 1}`}
                 name={`${meta.name}-${key + 1}`}
@@ -42,7 +42,7 @@ const CheckboxInput = ({ handler, touched, hasError, meta, parent, getError, val
           ))}
         </Fragment>
       ) : (
-        <Label htmlFor={meta.name} label={meta.value}>
+        <Label htmlFor={meta.name} label={meta.value} noActiveState>
           <Checkbox
             id={meta.name}
             name={meta.name}

--- a/src/signals/incident/containers/KtoContainer/components/KtoForm/index.js
+++ b/src/signals/incident/containers/KtoContainer/components/KtoForm/index.js
@@ -169,7 +169,7 @@ const KtoForm = ({ options, isSatisfied, onSubmit }) => {
           Mogen wij contact met u opnemen naar aanleiding van uw feedback? <Optional>(optioneel)</Optional>
         </Label>
         <div />
-        <Label inline htmlFor="allows_contact">
+        <Label inline htmlFor="allows_contact" >
           <Checkbox
             data-testid="ktoAllowsContact"
             id="allows_contact"

--- a/src/signals/settings/roles/containers/RoleFormContainer/components/RoleForm/index.js
+++ b/src/signals/settings/roles/containers/RoleFormContainer/components/RoleForm/index.js
@@ -2,7 +2,7 @@ import React, { useEffect, useCallback, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useHistory } from 'react-router-dom';
 import styled from 'styled-components';
-import { Label as FieldLabel, themeSpacing } from '@amsterdam/asc-ui';
+import { Label, themeSpacing } from '@amsterdam/asc-ui';
 import useFormValidation from 'hooks/useFormValidation';
 
 import Checkbox from 'components/Checkbox';
@@ -15,7 +15,7 @@ const StyledForm = styled.form`
   margin-bottom: ${themeSpacing(15)};
 `;
 
-const Label = styled(FieldLabel)`
+const GroupLabel = styled(Label)`
   display: block;
   font-family: Avenir Next LT W01 Demi, arial, sans-serif;
   margin-bottom: ${themeSpacing(3)};
@@ -97,17 +97,17 @@ export const RoleForm = ({ role, permissions, onPatchRole, onSaveRole, readOnly 
           type="text"
         />
 
-        <Label label="Rechten" />
+        <GroupLabel label="Rechten" />
         {permissions.map(permission => (
           <div key={permission.id}>
-            <FieldLabel disabled={readOnly} htmlFor={`permission${permission.id}`} label={permission.name}>
+            <Label disabled={readOnly} htmlFor={`permission${permission.id}`} label={permission.name} noActiveState>
               <Checkbox
                 data-testid={`checkbox-permissions_${permission.id}`}
                 id={`permission${permission.id}`}
                 checked={rolePermissions.find(item => item.id === permission.id)}
                 onChange={handleChange(permission.id)}
               />
-            </FieldLabel>
+            </Label>
           </div>
         ))}
 


### PR DESCRIPTION
This PR 
- Ensures that the checkbox labels don't get bold when the checkbox is selected
- Implements the naming conventions that a 3td party component will not be renamed unless there are name conflicts with another component. When only a `style` is applied, the `Styled<ComponentName>` will be used for consistency.