### PR TITLE
Update PDF filename

### DIFF
--- a/internals/schemas/app.schema.json
+++ b/internals/schemas/app.schema.json
@@ -188,7 +188,7 @@
           "type": "string"
         },
         "shortTitle": {
-          "description": "PWA `short_name` property value. Should not exceed 12 characters. See https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/short_name for reference",
+          "description": "PWA `short_name` property value. Should not exceed 12 characters. See https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/short_name for reference. This is also being used in the filname of a downloadable PDF of an incident.",
           "type": "string"
         },
         "siteAddress": {

--- a/internals/schemas/app.schema.json
+++ b/internals/schemas/app.schema.json
@@ -188,7 +188,7 @@
           "type": "string"
         },
         "shortTitle": {
-          "description": "PWA `short_name` property value. Should not exceed 12 characters. See https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/short_name for reference. This is also being used in the filname of a downloadable PDF of an incident.",
+          "description": "PWA `short_name` property value. Should not exceed 12 characters. See https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/short_name for reference. This is also being used in the filename of a downloadable PDF of an incident.",
           "type": "string"
         },
         "siteAddress": {

--- a/src/signals/incident-management/containers/IncidentDetail/components/DetailHeader/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/DetailHeader/index.js
@@ -5,6 +5,7 @@ import { themeColor, themeSpacing, Heading, styles } from '@amsterdam/asc-ui';
 
 import BackLink from 'components/BackLink';
 import Button from 'components/Button';
+import configuration from 'shared/services/configuration/configuration';
 import { MAP_URL, INCIDENT_URL, INCIDENTS_URL } from 'signals/incident-management/routes';
 
 import DownloadButton from './components/DownloadButton';
@@ -161,7 +162,7 @@ const DetailHeader = () => {
         <DownloadButton
           label="PDF"
           url={downloadLink}
-          filename={`SIA melding ${incident.id}.pdf`}
+          filename={`${configuration.language.shortTitle}-${incident.id}.pdf`}
           data-testid="detail-header-button-download"
         />
       </ButtonContainer>


### PR DESCRIPTION
The filename of the PDF you can download for an incident needs to be changed.
Now using `configuration.language.shortTitle` in the filename.