### PR TITLE
[FE#100] Bug Auto suggest z-index

### DIFF
--- a/src/components/AutoSuggest/__tests__/AutoSuggest.test.js
+++ b/src/components/AutoSuggest/__tests__/AutoSuggest.test.js
@@ -302,6 +302,48 @@ describe('src/components/AutoSuggest', () => {
       expect(queryByTestId('suggestList')).not.toBeInTheDocument();
     });
 
+    test('Esc without onClear defined', async () => {
+      const { container, findByTestId, queryByTestId } = render(withAppContext(<AutoSuggest {...props} />));
+      const input = container.querySelector('input');
+
+      input.focus();
+
+      act(() => {
+        fireEvent.change(input, { target: { value: 'Boom' } });
+      });
+
+      const suggestList = await findByTestId('suggestList');
+      const firstElement = suggestList.querySelector('li:nth-of-type(1)');
+
+      act(() => {
+        fireEvent.keyDown(input, { key: 'ArrowDown', code: 40, keyCode: 40 });
+      });
+
+      expect(document.activeElement).toEqual(firstElement);
+
+      act(() => {
+        fireEvent.keyDown(input, { key: 'Escape', code: 13, keyCode: 13 });
+      });
+
+      expect(input.value).toEqual('');
+      expect(document.activeElement).toEqual(input);
+      expect(queryByTestId('suggestList')).not.toBeInTheDocument();
+
+      act(() => {
+        fireEvent.change(input, { target: { value: 'Boomsloot' } });
+      });
+
+      await findByTestId('suggestList');
+
+      act(() => {
+        fireEvent.keyDown(input, { key: 'Esc', code: 13, keyCode: 13 });
+      });
+
+      expect(input.value).toEqual('');
+      expect(document.activeElement).toEqual(input);
+      expect(queryByTestId('suggestList')).not.toBeInTheDocument();
+    });
+
     test('Home', async () => {
       const { container, findByTestId, getByTestId } = render(withAppContext(<AutoSuggest {...props} />));
       const input = container.querySelector('input');
@@ -523,5 +565,32 @@ describe('src/components/AutoSuggest', () => {
     });
 
     expect(onClear).toHaveBeenCalled();
+  });
+
+  it('should work without onClear defined', async () => {
+    const { container, findByTestId } = render(withAppContext(<AutoSuggest {...props} />));
+    const input = container.querySelector('input');
+
+    act(() => {
+      fireEvent.change(input, { target: { value: 'Rembrandt' } });
+    });
+
+    await findByTestId('autoSuggest');
+
+    act(() => {
+      jest.advanceTimersByTime(INPUT_DELAY);
+    });
+
+    act(() => {
+      fireEvent.change(input, { target: { value: '' } });
+    });
+
+    await findByTestId('autoSuggest');
+
+    act(() => {
+      jest.advanceTimersByTime(INPUT_DELAY);
+    });
+
+    await findByTestId('autoSuggest');
   });
 });

--- a/src/components/AutoSuggest/index.js
+++ b/src/components/AutoSuggest/index.js
@@ -11,7 +11,6 @@ export const INPUT_DELAY = 350;
 
 const Wrapper = styled.div`
   position: relative;
-  z-index: 1;
 `;
 
 const StyledInput = styled(Input)`
@@ -26,6 +25,7 @@ const AbsoluteList = styled(SuggestList)`
   position: absolute;
   width: 100%;
   background-color: white;
+  z-index: 1;
 `;
 
 /**

--- a/src/components/AutoSuggest/index.js
+++ b/src/components/AutoSuggest/index.js
@@ -111,7 +111,7 @@ const AutoSuggest = ({
           inputRef.current.value = '';
           setActiveIndex(-1);
           setShowList(false);
-          onClear();
+          if (onClear) onClear();
           break;
 
         case 'Home':
@@ -196,7 +196,7 @@ const AutoSuggest = ({
       } else {
         setShowList(false);
 
-        if (inputValue.length === 0) {
+        if (inputValue.length === 0 && onClear) {
           onClear();
         }
       }


### PR DESCRIPTION
closes Signalen/frontend#100

Fixes two bugs:

- Puts `z-index` on the dropdown list of `AutoSuggest` instead of the whole component. This prevents the bug we had where the calendar pop out of a control above would render below the input element of the `AutoSuggest` (see images below).
- The `onClear` function of the AutoSuggest was not required. It was called, however, without checking if it was defined. Found this bug when pressing escape with focus on the AutoSuggest of the map view in the back office.

Normal:
<img width="717" alt="Screenshot 2021-02-01 at 18 16 17" src="https://user-images.githubusercontent.com/2932084/106495873-83098300-64bc-11eb-8996-87013e664056.png">

Before:
<img width="697" alt="Screenshot 2021-02-01 at 18 17 28" src="https://user-images.githubusercontent.com/2932084/106495837-771dc100-64bc-11eb-9106-c663b19c03c3.png">

After:
<img width="679" alt="Screenshot 2021-02-01 at 18 17 03" src="https://user-images.githubusercontent.com/2932084/106495852-7be27500-64bc-11eb-8ab3-7ea587956d0a.png">

<img width="701" alt="Screenshot 2021-02-01 at 18 16 40" src="https://user-images.githubusercontent.com/2932084/106495893-869d0a00-64bc-11eb-864a-410870a9661c.png">
