### PR TITLE
(Chore) Fix Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ COPY .gitignore \
   babel.config.js \
   package.json \
   package-lock.json \
+  app.base.json \
   /app/
 
 RUN npm install


### PR DESCRIPTION
### Fixes

- Fix Docker build

Since the file handling application configuration was converted to TypeScript, the example file from which the config type is inferred needs to be present during build time. 

This PR fixes the deploy (and e2e tests).  