### PR TITLE
[FE#102] Source in saved filter

### DIFF
--- a/src/signals/incident-management/__tests__/selectors.test.js
+++ b/src/signals/incident-management/__tests__/selectors.test.js
@@ -10,6 +10,7 @@ import districts from 'utils/__tests__/fixtures/districts.json';
 import sources from 'utils/__tests__/fixtures/sources.json';
 import {
   makeSelectDistricts,
+  selectFixtures,
   makeSelectFilterParams,
   makeSelectAllFilters,
   makeSelectActiveFilter,
@@ -134,6 +135,8 @@ const areaFilter = filters[4];
 const sourceFilter = filters[5];
 const directingDepartmentFilter = filters[6];
 const priorityFilter = filters[7];
+const area = districts;
+const source = sources;
 
 const rawDistricts = [
   {
@@ -171,16 +174,27 @@ describe('signals/incident-management/selectors', () => {
     expect(result).toBeNull();
   });
 
-  it('should select all filters', () => {
-    const state = fromJS({ ...initialState.toJS(), filters });
-    const allFilters = makeSelectAllFilters.resultFunc(
-      state,
-      districts,
-      sources,
+  it('should select fixtures', () => {
+    const result = selectFixtures.resultFunc(area, source, maincategory_slug, category_slug, directing_department);
+
+    expect(result).toMatchObject({
+      area,
+      source,
       maincategory_slug,
       category_slug,
-      directing_department
-    );
+      directing_department,
+    });
+  });
+
+  it('should select all filters', () => {
+    const state = fromJS({ ...initialState.toJS(), filters });
+    const allFilters = makeSelectAllFilters.resultFunc(state, {
+      area,
+      source,
+      maincategory_slug,
+      category_slug,
+      directing_department,
+    });
 
     expect(allFilters.length).toEqual(filters.length);
     expect(allFilters[0].options.maincategory_slug[0].slug).toEqual(filters[0].options.maincategory_slug[0]);
@@ -193,14 +207,13 @@ describe('signals/incident-management/selectors', () => {
       activeFilter.options.priority = [];
 
       expect(
-        makeSelectActiveFilter.resultFunc(
-          initialState,
-          districts,
-          sources,
+        makeSelectActiveFilter.resultFunc(initialState, {
+          area,
+          source,
           maincategory_slug,
           category_slug,
-          directing_department
-        )
+          directing_department,
+        })
       ).toEqual(activeFilter);
     });
 
@@ -208,19 +221,18 @@ describe('signals/incident-management/selectors', () => {
       const activeFilter = initialState.toJS().activeFilter;
       activeFilter.options.priority = [];
 
-      expect(makeSelectActiveFilter.resultFunc(initialState, districts, sources)).toEqual({});
+      expect(makeSelectActiveFilter.resultFunc(initialState, { area, source })).toEqual({});
     });
 
     it('should select active category filter', () => {
       const state = fromJS({ ...initialState.toJS(), activeFilter: mainCategoryFilter });
-      const actual = makeSelectActiveFilter.resultFunc(
-        state,
-        districts,
-        sources,
+      const actual = makeSelectActiveFilter.resultFunc(state, {
+        area,
+        source,
         maincategory_slug,
         category_slug,
-        directing_department
-      );
+        directing_department,
+      });
 
       expect(actual.id).toEqual(mainCategoryFilter.id);
       expect(actual.options).toEqual({
@@ -231,14 +243,13 @@ describe('signals/incident-management/selectors', () => {
 
     it('should select active sub category filter', () => {
       const state = fromJS({ ...initialState.toJS(), activeFilter: subCategoryFilter });
-      const actual = makeSelectActiveFilter.resultFunc(
-        state,
-        districts,
-        sources,
+      const actual = makeSelectActiveFilter.resultFunc(state, {
+        area,
+        source,
         maincategory_slug,
         category_slug,
-        directing_department
-      );
+        directing_department,
+      });
 
       expect(actual.id).toEqual(subCategoryFilter.id);
       expect(actual.options).toEqual({
@@ -249,14 +260,13 @@ describe('signals/incident-management/selectors', () => {
 
     it('should select active stadsdeel filter', () => {
       const state = fromJS({ ...initialState.toJS(), activeFilter: stadsdeelFilter });
-      const actual = makeSelectActiveFilter.resultFunc(
-        state,
-        districts,
-        sources,
+      const actual = makeSelectActiveFilter.resultFunc(state, {
+        area,
+        source,
         maincategory_slug,
         category_slug,
-        directing_department
-      );
+        directing_department,
+      });
 
       expect(actual.id).toEqual(stadsdeelFilter.id);
       expect(actual.options).toEqual({
@@ -267,14 +277,13 @@ describe('signals/incident-management/selectors', () => {
 
     it('should select active status filter', () => {
       const state = fromJS({ ...initialState.toJS(), activeFilter: statusFilter });
-      const actual = makeSelectActiveFilter.resultFunc(
-        state,
-        districts,
-        sources,
+      const actual = makeSelectActiveFilter.resultFunc(state, {
+        area,
+        source,
         maincategory_slug,
         category_slug,
-        directing_department
-      );
+        directing_department,
+      });
 
       expect(actual.id).toEqual(statusFilter.id);
       expect(actual.options).toEqual({
@@ -285,14 +294,13 @@ describe('signals/incident-management/selectors', () => {
 
     it('should select active area filter', () => {
       const state = fromJS({ ...initialState.toJS(), activeFilter: areaFilter });
-      const actual = makeSelectActiveFilter.resultFunc(
-        state,
-        districts,
-        sources,
+      const actual = makeSelectActiveFilter.resultFunc(state, {
+        area,
+        source,
         maincategory_slug,
         category_slug,
-        directing_department
-      );
+        directing_department,
+      });
 
       expect(actual.id).toEqual(areaFilter.id);
       expect(actual.options).toEqual({
@@ -303,14 +311,13 @@ describe('signals/incident-management/selectors', () => {
 
     it('should not select active source filter when sources are empty', () => {
       const state = fromJS({ ...initialState.toJS(), activeFilter: sourceFilter });
-      const actual = makeSelectActiveFilter.resultFunc(
-        state,
-        districts,
-        null,
+      const actual = makeSelectActiveFilter.resultFunc(state, {
+        area,
+        source: null,
         maincategory_slug,
         category_slug,
-        directing_department
-      );
+        directing_department,
+      });
 
       expect(actual.id).toEqual(sourceFilter.id);
       expect(actual.options).toEqual({
@@ -321,14 +328,13 @@ describe('signals/incident-management/selectors', () => {
 
     it('should select active source filter', () => {
       const state = fromJS({ ...initialState.toJS(), activeFilter: sourceFilter });
-      const actual = makeSelectActiveFilter.resultFunc(
-        state,
-        districts,
-        sources,
+      const actual = makeSelectActiveFilter.resultFunc(state, {
+        area,
+        source,
         maincategory_slug,
         category_slug,
-        directing_department
-      );
+        directing_department,
+      });
 
       expect(actual.id).toEqual(sourceFilter.id);
       expect(actual.options).toEqual({
@@ -339,14 +345,13 @@ describe('signals/incident-management/selectors', () => {
 
     it('should select active directing department filter', () => {
       const state = fromJS({ ...initialState.toJS(), activeFilter: directingDepartmentFilter });
-      const actual = makeSelectActiveFilter.resultFunc(
-        state,
-        districts,
-        sources,
+      const actual = makeSelectActiveFilter.resultFunc(state, {
+        area,
+        source,
         maincategory_slug,
         category_slug,
-        directing_department
-      );
+        directing_department,
+      });
 
       expect(actual.id).toEqual(directingDepartmentFilter.id);
       expect(actual.options).toEqual({
@@ -357,14 +362,13 @@ describe('signals/incident-management/selectors', () => {
 
     it('should select active priority filter', () => {
       const state = fromJS({ ...initialState.toJS(), activeFilter: priorityFilter });
-      const actual = makeSelectActiveFilter.resultFunc(
-        state,
-        districts,
-        sources,
+      const actual = makeSelectActiveFilter.resultFunc(state, {
+        area,
+        source,
         maincategory_slug,
         category_slug,
-        directing_department
-      );
+        directing_department,
+      });
 
       expect(actual.id).toEqual(priorityFilter.id);
       expect(actual.options.priority[0].key).toEqual(priorityFilter.options.priority[0]);
@@ -376,33 +380,31 @@ describe('signals/incident-management/selectors', () => {
       const editFilter = initialState.toJS().editFilter;
 
       expect(
-        makeSelectEditFilter.resultFunc(
-          initialState,
-          districts,
-          sources,
+        makeSelectEditFilter.resultFunc(initialState, {
+          area,
+          source,
           maincategory_slug,
           category_slug,
-          directing_department
-        )
+          directing_department,
+        })
       ).toEqual(editFilter);
     });
 
     it('should return an empty object when the backend data is not present', () => {
       const editFilter = initialState.toJS().editFilter;
 
-      expect(makeSelectEditFilter.resultFunc(initialState, districts, sources)).toEqual({});
+      expect(makeSelectEditFilter.resultFunc(initialState, { area, source })).toEqual({});
     });
 
     it('should select edit category filter', () => {
       const state = fromJS({ ...initialState.toJS(), editFilter: mainCategoryFilter });
-      const actual = makeSelectEditFilter.resultFunc(
-        state,
-        districts,
-        sources,
+      const actual = makeSelectEditFilter.resultFunc(state, {
+        area,
+        source,
         maincategory_slug,
         category_slug,
-        directing_department
-      );
+        directing_department,
+      });
 
       expect(actual.id).toEqual(mainCategoryFilter.id);
       expect(actual.options).toEqual({
@@ -412,14 +414,13 @@ describe('signals/incident-management/selectors', () => {
 
     it('should select edit sub category filter', () => {
       const state = fromJS({ ...initialState.toJS(), editFilter: subCategoryFilter });
-      const actual = makeSelectEditFilter.resultFunc(
-        state,
-        districts,
-        sources,
+      const actual = makeSelectEditFilter.resultFunc(state, {
+        area,
+        source,
         maincategory_slug,
         category_slug,
-        directing_department
-      );
+        directing_department,
+      });
 
       expect(actual.id).toEqual(subCategoryFilter.id);
       expect(actual.options).toEqual({
@@ -429,14 +430,13 @@ describe('signals/incident-management/selectors', () => {
 
     it('should select edit stadsdeel filter', () => {
       const state = fromJS({ ...initialState.toJS(), editFilter: stadsdeelFilter });
-      const actual = makeSelectEditFilter.resultFunc(
-        state,
-        districts,
-        sources,
+      const actual = makeSelectEditFilter.resultFunc(state, {
+        area,
+        source,
         maincategory_slug,
         category_slug,
-        directing_department
-      );
+        directing_department,
+      });
 
       expect(actual.id).toEqual(stadsdeelFilter.id);
       expect(actual.options).toEqual({
@@ -446,14 +446,13 @@ describe('signals/incident-management/selectors', () => {
 
     it('should select edit status filter', () => {
       const state = fromJS({ ...initialState.toJS(), editFilter: statusFilter });
-      const actual = makeSelectEditFilter.resultFunc(
-        state,
-        districts,
-        sources,
+      const actual = makeSelectEditFilter.resultFunc(state, {
+        area,
+        source,
         maincategory_slug,
         category_slug,
-        directing_department
-      );
+        directing_department,
+      });
 
       expect(actual.id).toEqual(statusFilter.id);
       expect(actual.options).toEqual({
@@ -463,14 +462,13 @@ describe('signals/incident-management/selectors', () => {
 
     it('should select edit area filter', () => {
       const state = fromJS({ ...initialState.toJS(), editFilter: areaFilter });
-      const actual = makeSelectEditFilter.resultFunc(
-        state,
-        districts,
-        sources,
+      const actual = makeSelectEditFilter.resultFunc(state, {
+        area,
+        source,
         maincategory_slug,
         category_slug,
-        directing_department
-      );
+        directing_department,
+      });
 
       expect(actual.id).toEqual(areaFilter.id);
       expect(actual.options).toEqual({
@@ -480,14 +478,13 @@ describe('signals/incident-management/selectors', () => {
 
     it('should select edit source filter', () => {
       const state = fromJS({ ...initialState.toJS(), editFilter: sourceFilter });
-      const actual = makeSelectEditFilter.resultFunc(
-        state,
-        districts,
-        sources,
+      const actual = makeSelectEditFilter.resultFunc(state, {
+        area,
+        source,
         maincategory_slug,
         category_slug,
-        directing_department
-      );
+        directing_department,
+      });
 
       expect(actual.id).toEqual(sourceFilter.id);
       expect(actual.options).toEqual({
@@ -497,14 +494,13 @@ describe('signals/incident-management/selectors', () => {
 
     it('should select directing department filter', () => {
       const state = fromJS({ ...initialState.toJS(), editFilter: directingDepartmentFilter });
-      const actual = makeSelectEditFilter.resultFunc(
-        state,
-        districts,
-        sources,
+      const actual = makeSelectEditFilter.resultFunc(state, {
+        area,
+        source,
         maincategory_slug,
         category_slug,
-        directing_department
-      );
+        directing_department,
+      });
 
       expect(actual.id).toEqual(directingDepartmentFilter.id);
       expect(actual.options).toEqual({
@@ -514,14 +510,13 @@ describe('signals/incident-management/selectors', () => {
 
     it('should not work without sources', () => {
       const state = fromJS({ ...initialState.toJS(), editFilter: sourceFilter });
-      const actual = makeSelectEditFilter.resultFunc(
-        state,
-        districts,
-        null,
+      const actual = makeSelectEditFilter.resultFunc(state, {
+        area,
+        source: null,
         maincategory_slug,
         category_slug,
-        directing_department
-      );
+        directing_department,
+      });
 
       expect(actual.id).toEqual(sourceFilter.id);
       expect(actual.options).toEqual({

--- a/src/signals/incident-management/__tests__/selectors.test.js
+++ b/src/signals/incident-management/__tests__/selectors.test.js
@@ -10,7 +10,7 @@ import districts from 'utils/__tests__/fixtures/districts.json';
 import sources from 'utils/__tests__/fixtures/sources.json';
 import {
   makeSelectDistricts,
-  selectFixtures,
+  makeSelectFixtures,
   makeSelectFilterParams,
   makeSelectAllFilters,
   makeSelectActiveFilter,
@@ -175,7 +175,7 @@ describe('signals/incident-management/selectors', () => {
   });
 
   it('should select fixtures', () => {
-    const result = selectFixtures.resultFunc(area, source, maincategory_slug, category_slug, directing_department);
+    const result = makeSelectFixtures.resultFunc(area, source, maincategory_slug, category_slug, directing_department);
 
     expect(result).toMatchObject({
       area,

--- a/src/signals/incident-management/__tests__/selectors.test.js
+++ b/src/signals/incident-management/__tests__/selectors.test.js
@@ -173,7 +173,14 @@ describe('signals/incident-management/selectors', () => {
 
   it('should select all filters', () => {
     const state = fromJS({ ...initialState.toJS(), filters });
-    const allFilters = makeSelectAllFilters.resultFunc(state, maincategory_slug, category_slug, directing_department);
+    const allFilters = makeSelectAllFilters.resultFunc(
+      state,
+      districts,
+      sources,
+      maincategory_slug,
+      category_slug,
+      directing_department
+    );
 
     expect(allFilters.length).toEqual(filters.length);
     expect(allFilters[0].options.maincategory_slug[0].slug).toEqual(filters[0].options.maincategory_slug[0]);

--- a/src/signals/incident-management/selectors.js
+++ b/src/signals/incident-management/selectors.js
@@ -29,8 +29,15 @@ export const makeSelectDistricts = createSelector([selectIncidentManagementDomai
 );
 
 export const makeSelectAllFilters = createSelector(
-  [selectIncidentManagementDomain, makeSelectMainCategories, makeSelectSubCategories, makeSelectDirectingDepartments],
-  (stateMap, maincategory_slug, category_slug, directing_department) => {
+  [
+    selectIncidentManagementDomain,
+    makeSelectDistricts,
+    makeSelectSources,
+    makeSelectMainCategories,
+    makeSelectSubCategories,
+    makeSelectDirectingDepartments,
+  ],
+  (stateMap, area, source, maincategory_slug, category_slug, directing_department) => {
     const filters = stateMap.get('filters').toJS();
     return filters.map(filter => {
       const { priority } = filter.options;
@@ -46,7 +53,9 @@ export const makeSelectAllFilters = createSelector(
       return parseInputFormData(fltr, {
         maincategory_slug,
         category_slug,
+        area,
         directing_department,
+        source,
       });
     });
   }

--- a/src/signals/incident-management/selectors.js
+++ b/src/signals/incident-management/selectors.js
@@ -28,7 +28,7 @@ export const makeSelectDistricts = createSelector([selectIncidentManagementDomai
     : null
 );
 
-export const selectFixtures = createSelector(
+export const makeSelectFixtures = createSelector(
   [
     makeSelectDistricts,
     makeSelectSources,
@@ -46,7 +46,7 @@ export const selectFixtures = createSelector(
 );
 
 export const makeSelectAllFilters = createSelector(
-  [selectIncidentManagementDomain, selectFixtures],
+  [selectIncidentManagementDomain, makeSelectFixtures],
   (stateMap, fixtures) => {
     const filters = stateMap.get('filters').toJS();
     return filters.map(filter => {
@@ -66,7 +66,7 @@ export const makeSelectAllFilters = createSelector(
 );
 
 export const makeSelectActiveFilter = createSelector(
-  [selectIncidentManagementDomain, selectFixtures],
+  [selectIncidentManagementDomain, makeSelectFixtures],
   (stateMap, fixtures) => {
     if (!(fixtures.maincategory_slug && fixtures.category_slug && fixtures.directing_department)) {
       return {};
@@ -89,7 +89,7 @@ export const makeSelectActiveFilter = createSelector(
 );
 
 export const makeSelectEditFilter = createSelector(
-  [selectIncidentManagementDomain, selectFixtures],
+  [selectIncidentManagementDomain, makeSelectFixtures],
   (stateMap, fixtures) =>
     fixtures.maincategory_slug && fixtures.category_slug && fixtures.directing_department
       ? parseInputFormData(stateMap.toJS().editFilter, fixtures)

--- a/src/signals/incident-management/selectors.js
+++ b/src/signals/incident-management/selectors.js
@@ -28,16 +28,26 @@ export const makeSelectDistricts = createSelector([selectIncidentManagementDomai
     : null
 );
 
-export const makeSelectAllFilters = createSelector(
+export const selectFixtures = createSelector(
   [
-    selectIncidentManagementDomain,
     makeSelectDistricts,
     makeSelectSources,
     makeSelectMainCategories,
     makeSelectSubCategories,
     makeSelectDirectingDepartments,
   ],
-  (stateMap, area, source, maincategory_slug, category_slug, directing_department) => {
+  (area, source, maincategory_slug, category_slug, directing_department) => ({
+    maincategory_slug,
+    category_slug,
+    area,
+    directing_department,
+    source,
+  })
+);
+
+export const makeSelectAllFilters = createSelector(
+  [selectIncidentManagementDomain, selectFixtures],
+  (stateMap, fixtures) => {
     const filters = stateMap.get('filters').toJS();
     return filters.map(filter => {
       const { priority } = filter.options;
@@ -50,28 +60,15 @@ export const makeSelectAllFilters = createSelector(
         },
       };
 
-      return parseInputFormData(fltr, {
-        maincategory_slug,
-        category_slug,
-        area,
-        directing_department,
-        source,
-      });
+      return parseInputFormData(fltr, fixtures);
     });
   }
 );
 
 export const makeSelectActiveFilter = createSelector(
-  [
-    selectIncidentManagementDomain,
-    makeSelectDistricts,
-    makeSelectSources,
-    makeSelectMainCategories,
-    makeSelectSubCategories,
-    makeSelectDirectingDepartments,
-  ],
-  (stateMap, area, source, maincategory_slug, category_slug, directing_department) => {
-    if (!(maincategory_slug && category_slug && directing_department)) {
+  [selectIncidentManagementDomain, selectFixtures],
+  (stateMap, fixtures) => {
+    if (!(fixtures.maincategory_slug && fixtures.category_slug && fixtures.directing_department)) {
       return {};
     }
 
@@ -86,43 +83,17 @@ export const makeSelectActiveFilter = createSelector(
         priority: converted,
       },
     };
-    const fixtures = {
-      maincategory_slug,
-      category_slug,
-      area,
-      directing_department,
-      source,
-    };
 
     return parseInputFormData(filter, fixtures);
   }
 );
 
 export const makeSelectEditFilter = createSelector(
-  [
-    selectIncidentManagementDomain,
-    makeSelectDistricts,
-    makeSelectSources,
-    makeSelectMainCategories,
-    makeSelectSubCategories,
-    makeSelectDirectingDepartments,
-  ],
-  (stateMap, area, source, maincategory_slug, category_slug, directing_department) => {
-    if (!(maincategory_slug && category_slug && directing_department)) {
-      return {};
-    }
-
-    const state = stateMap.toJS();
-    const fixtures = {
-      maincategory_slug,
-      category_slug,
-      area,
-      directing_department,
-      source,
-    };
-
-    return parseInputFormData(state.editFilter, fixtures);
-  }
+  [selectIncidentManagementDomain, selectFixtures],
+  (stateMap, fixtures) =>
+    fixtures.maincategory_slug && fixtures.category_slug && fixtures.directing_department
+      ? parseInputFormData(stateMap.toJS().editFilter, fixtures)
+      : {}
 );
 
 const filterParamsMap = {


### PR DESCRIPTION
closes Signalen/frontend#102

- The selected `source` was not maintained in a saved filter.
- The same goes for `area` in case the feature flag `fetchDistrictsFromBackend` is turned on. This still requires a change in the backend as well, though. (Signalen/backend#111)