### PR TITLE
[FE#104] Save filter with area_code

### DIFF
--- a/src/signals/incident-management/__tests__/saga.test.js
+++ b/src/signals/incident-management/__tests__/saga.test.js
@@ -305,13 +305,14 @@ describe('signals/incident-management/saga', () => {
 
   describe('fetch filters', () => {
     it('should dispatch getFiltersSuccess', () => {
-      const filters = { results: [{ a: 1 }] };
+      const response = { results: [{ a: 1, options: { option: 'option', area_code: ['123', '456'] } }] };
+      const filters = [{ a: 1, options: { option: 'option', area: ['123', '456'] } }];
 
       testSaga(fetchFilters)
         .next()
         .call(authCall, CONFIGURATION.FILTERS_ENDPOINT)
-        .next(filters)
-        .put(getFiltersSuccess(filters.results))
+        .next(response)
+        .put(getFiltersSuccess(filters))
         .next()
         .isDone();
     });
@@ -529,8 +530,10 @@ describe('signals/incident-management/saga', () => {
     it('should spawn doSaveFilter', () => {
       const payload = {
         name: 'Name of my filter',
-        maincategory_slug: ['i', 'a', 'o', 'u'],
-        address_text: 'Weesperstraat 113-117',
+        options: {
+          maincategory_slug: ['i', 'a', 'o', 'u'],
+          address_text: 'Weesperstraat 113-117',
+        },
       };
       const action = {
         type: SAVE_FILTER,

--- a/src/signals/incident-management/selectors.js
+++ b/src/signals/incident-management/selectors.js
@@ -1,6 +1,6 @@
 import { fromJS } from 'immutable';
 
-import { parseInputFormData } from 'signals/shared/filter/parse';
+import { mapFilterParams, mapOrdering, parseInputFormData } from 'signals/shared/filter/parse';
 import { makeSelectMainCategories, makeSelectSubCategories } from 'models/categories/selectors';
 import configuration from 'shared/services/configuration/configuration';
 
@@ -96,30 +96,19 @@ export const makeSelectEditFilter = createSelector(
       : {}
 );
 
-const filterParamsMap = {
-  area: 'area_code',
-  areaType: 'area_type_code',
-};
-const mapFilterParam = param => (filterParamsMap[param] ? filterParamsMap[param] : param);
-const orderingMap = {
-  days_open: '-created_at',
-  '-days_open': 'created_at',
-};
-
 export const makeSelectFilterParams = createSelector(selectIncidentManagementDomain, incidentManagementState => {
   const { activeFilter: filter, ordering, page } = incidentManagementState.toJS();
   const pagingOptions = {
     page,
-    ordering: orderingMap[ordering] || ordering,
+    ordering: mapOrdering(ordering),
     page_size: FILTER_PAGE_SIZE,
   };
-  const options = filter.options.area
+  const filterOptions = filter.options.area
     ? { ...filter.options, areaType: configuration.areaTypeCodeForDistrict }
     : filter.options;
-  const optionParams = Object.keys(options).reduce((acc, key) => ({ ...acc, [mapFilterParam(key)]: options[key] }), {});
 
   return {
-    ...optionParams,
+    ...mapFilterParams(filterOptions),
     ...pagingOptions,
   };
 });

--- a/src/signals/shared/filter/__tests__/parse.test.js
+++ b/src/signals/shared/filter/__tests__/parse.test.js
@@ -5,7 +5,15 @@ import { filterForSub, filterForMain } from 'models/categories/selectors';
 import dataLists from 'signals/incident-management/definitions';
 import category from 'utils/__tests__/fixtures/category.json';
 
-import { parseDate, parseOutputFormData, parseInputFormData, parseToAPIData } from '../parse';
+import {
+  parseDate,
+  parseOutputFormData,
+  parseInputFormData,
+  parseToAPIData,
+  mapFilterParams,
+  unmapFilterParams,
+  mapOrdering,
+} from '../parse';
 import { subCategories, mainCategories } from 'utils/__tests__/fixtures';
 
 const filteredSubCategories = categories.results.filter(filterForSub);
@@ -39,6 +47,7 @@ describe('signals/shared/filter/parse', () => {
 
   describe('parseOutputFormData', () => {
     it('should parse output FormData', () => {
+      const area = { key: 'area' };
       const maincategory_slug = [...mainCategories, category];
       const category_slug = subCategories.filter(
         ({ slug }) => slug === 'bedrijfsafval' || slug === 'autom-verzinkbare-palen'
@@ -49,7 +58,7 @@ describe('signals/shared/filter/parse', () => {
         maincategory_slug,
         category_slug,
         stadsdeel,
-        contact_details: [dataLists.contact_details[0]],
+        area: [area],
       };
 
       const expected = {
@@ -57,7 +66,7 @@ describe('signals/shared/filter/parse', () => {
         maincategory_slug: maincategory_slug.map(({ slug }) => slug),
         category_slug: category_slug.map(({ slug }) => slug),
         stadsdeel: stadsdeel.map(({ key }) => key),
-        contact_details: [dataLists.contact_details[0].key],
+        area: [area.key],
       };
 
       const parsedOutput = parseOutputFormData(formState);
@@ -196,6 +205,44 @@ describe('signals/shared/filter/parse', () => {
           name: 'foo',
         });
       });
+    });
+  });
+
+  describe('mapObject', () => {
+    it('should mapFilterParams', () => {
+      const data = {
+        area: ['123', '456'],
+        areaType: 'district',
+        other: 'value',
+      };
+      const expected = {
+        area_code: data.area,
+        area_type_code: data.areaType,
+        other: data.other,
+      };
+
+      expect(mapFilterParams(data)).toEqual(expected);
+    });
+
+    it('should unmapFilterParams', () => {
+      const data = {
+        area_code: ['123', '456'],
+        area_type_code: 'district',
+        other: 'value',
+      };
+      const expected = {
+        area: data.area_code,
+        areaType: data.area_type_code,
+        other: data.other,
+      };
+
+      expect(unmapFilterParams(data)).toEqual(expected);
+    });
+
+    it('should mapOrdering', () => {
+      expect(mapOrdering('days_open')).toBe('-created_at');
+      expect(mapOrdering('-days_open')).toBe('created_at');
+      expect(mapOrdering('other')).toBe('other');
     });
   });
 });

--- a/src/signals/shared/filter/parse.js
+++ b/src/signals/shared/filter/parse.js
@@ -116,3 +116,28 @@ export const parseToAPIData = filterData => {
 
   return { ...filterData, options };
 };
+
+const map = (key, mapping) => mapping[key] || key;
+const mapObject = (original, mapping) =>
+  Object.entries(original).reduce((acc, [key, value]) => ({ ...acc, [map(key, mapping)]: value }), {});
+
+const filterParamsMapping = {
+  area: 'area_code',
+  areaType: 'area_type_code',
+};
+export const mapFilterParams = params => mapObject(params, filterParamsMapping);
+
+const filterParamsUnmapping = Object.entries(filterParamsMapping).reduce(
+  (acc, [key, value]) => ({
+    ...acc,
+    [value]: key,
+  }),
+  {}
+);
+export const unmapFilterParams = params => mapObject(params, filterParamsUnmapping);
+
+const orderingsMapping = {
+  days_open: '-created_at',
+  '-days_open': 'created_at',
+};
+export const mapOrdering = ordering => map(ordering, orderingsMapping);


### PR DESCRIPTION
closes Signalen/frontend#104

Saving a filter on `area` should convert the filter key `area` to `area_code`.
Dependant on a fix in the backend as well: Amsterdam/signals#708.
We can merge independently of the bugfix in the backend since it's not working now anyway.