### PR TITLE
[SIG-3414] Fix map select design comments

### DIFF
--- a/src/signals/incident/components/form/ContainerSelect/Selector/SelectionPanel/SelectionPanel.tsx
+++ b/src/signals/incident/components/form/ContainerSelect/Selector/SelectionPanel/SelectionPanel.tsx
@@ -132,7 +132,7 @@ const SelectionPanel: FunctionComponent<SelectionPanelProps> = ({
       )}
 
       {unregisteredFeature && (
-        <Fragment>
+        <div>
           <Checkbox id="unregisteredContainerCheckbox" checked={hasUnregisteredContainer} onChange={toggleUnregisteredContainer} />
           <Label htmlFor="unregisteredContainerCheckbox" label="De container staat niet op de kaart" />
 
@@ -149,7 +149,7 @@ const SelectionPanel: FunctionComponent<SelectionPanelProps> = ({
               <Input id="unregisteredContainerInput" onSubmit={onClose} onKeyDown={handleKeyDown} onChange={updateUnregisteredContainer} value={unregisteredContainer.id} />
             </Fragment>
           )}
-        </Fragment>
+        </div>
       )}
 
       <StyledButton onClick={onClose} variant="primary">

--- a/src/signals/incident/components/form/ContainerSelect/Selector/Selector.tsx
+++ b/src/signals/incident/components/form/ContainerSelect/Selector/Selector.tsx
@@ -25,6 +25,7 @@ import WfsLayer from './WfsLayer';
 import ZoomMessage from './ZoomMessage';
 import useLayerVisible from './useLayerVisible';
 import SelectionPanel from './SelectionPanel';
+import { UNREGISTERED_CONTAINER_TYPE } from '../constants';
 
 const MAP_PANEL_DRAWER_SNAP_POSITIONS = {
   [SnapPoint.Closed]: '90%',
@@ -87,11 +88,9 @@ const ButtonBar: FunctionComponent<{ zoomLevel: ZoomLevel }> = ({ children, zoom
   const layerVisible = useLayerVisible(zoomLevel);
 
   return (
-    (
-      <ButtonBarStyle data-testid="zoomMessage" layerVisible={layerVisible}>
-        {children}
-      </ButtonBarStyle>
-    ) || null
+    <ButtonBarStyle data-testid="buttonBar" layerVisible={layerVisible}>
+      {children}
+    </ButtonBarStyle>
   );
 };
 
@@ -123,7 +122,6 @@ const Selector = () => {
       maxZoom: 15,
       zoom: 14,
     }),
-
     [location]
   );
 
@@ -177,7 +175,7 @@ const Selector = () => {
                 onClose={handleLegendCloseButton}
                 variant={panelVariant}
                 items={meta.featureTypes
-                  .filter(({ label }) => label !== 'Onbekend') // Filter the unknown icon from the legend
+                  .filter(({ typeValue }) => typeValue !== UNREGISTERED_CONTAINER_TYPE) // Filter the unknown icon from the legend
                   .map(featureType => ({
                     label: featureType.label,
                     iconUrl: `data:image/svg+xml;base64,${btoa(featureType.icon.iconSvg)}`,

--- a/src/signals/incident/components/form/ContainerSelect/Selector/Selector.tsx
+++ b/src/signals/incident/components/form/ContainerSelect/Selector/Selector.tsx
@@ -78,8 +78,8 @@ const StyledMap = styled(Map)`
 `;
 
 const ButtonBarStyle = styled.div<{ layerVisible: boolean }>`
-  @media screen and (${breakpoint('max-width', 'tabletM')}) {
-    margin-top: ${({ layerVisible }) => layerVisible && themeSpacing(11)};
+  @media screen and ${breakpoint('max-width', 'tabletM')} {
+    margin-top: ${({ layerVisible }) => !layerVisible && themeSpacing(11)};
   }
 `;
 

--- a/src/signals/incident/components/form/ContainerSelect/Selector/ZoomMessage/ZoomMessage.tsx
+++ b/src/signals/incident/components/form/ContainerSelect/Selector/ZoomMessage/ZoomMessage.tsx
@@ -16,9 +16,10 @@ export const ZoomMessageStyle = styled.div`
   right: 0;
   z-index: 400;
 
-  @media screen and (${breakpoint('max-width', 'tabletM')}) {
+  @media screen and ${breakpoint('max-width', 'tabletM')} {
     left: 0;
     width: 100%;
+    height: 100%;
     margin: 0;
   }
 `;

--- a/src/signals/incident/components/form/ContainerSelect/Selector/ZoomMessage/ZoomMessage.tsx
+++ b/src/signals/incident/components/form/ContainerSelect/Selector/ZoomMessage/ZoomMessage.tsx
@@ -19,7 +19,6 @@ export const ZoomMessageStyle = styled.div`
   @media screen and ${breakpoint('max-width', 'tabletM')} {
     left: 0;
     width: 100%;
-    height: 100%;
     margin: 0;
   }
 `;

--- a/src/signals/incident/components/form/ContainerSelect/Selector/__tests__/Selector.test.tsx
+++ b/src/signals/incident/components/form/ContainerSelect/Selector/__tests__/Selector.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import 'jest-styled-components';
 import { render, screen } from '@testing-library/react';
 import Selector from '..';
 import fetchMock from 'jest-fetch-mock';
@@ -8,6 +9,12 @@ import {
   withContainerSelectContext,
 } from 'signals/incident/components/form/ContainerSelect/__tests__/context.test';
 import userEvent from '@testing-library/user-event';
+import { ascDefaultTheme } from '@amsterdam/asc-ui';
+
+jest.mock('../useLayerVisible', () => ({
+  __esModule: true,
+  default: () => false,
+}));
 
 let showDesktopVariant: boolean;
 jest.mock('@amsterdam/asc-ui/lib/utils/hooks', () => ({
@@ -85,10 +92,19 @@ describe('signals/incident/components/form/ContainerSelect/Selector', () => {
     expect(screen.queryByTestId('panelMobile')).not.toBeInTheDocument();
   });
 
-  it('should show mobile version on desktop', async () => {
+  it('should show mobile version on mobile', async () => {
     render(withContainerSelectContext(<Selector />));
 
     expect(await screen.findByTestId('panelMobile')).toBeInTheDocument();
     expect(screen.queryByTestId('panelDesktop')).not.toBeInTheDocument();
+  });
+
+  it('handles button bar style when zoom level is low', async () => {
+    const media = `screen and ${ascDefaultTheme.breakpoints.tabletM('max-width')}`;
+
+    render(withContainerSelectContext(<Selector />));
+
+    const bar = await screen.findAllByTestId('buttonBar');
+    expect(bar[0]).toHaveStyleRule('margin-top', '44px', { media });
   });
 });


### PR DESCRIPTION
### Changes

- Fix styling based on review comments

Regarding the brackets change `(${breakpoint('max-width', 'tabletM')})`, contrary to what I first thought, they do 'fix' a linting error but break the functionality itself. Looks like there is a bug in the VSCode styled components plugin (there are multiple reports about this on GitHub). 