### PR TITLE
[SIG-3556] Fix incident form retaining data from previous submissions

### DIFF
--- a/src/signals/incident/services/map-controls-to-params/index.js
+++ b/src/signals/incident/services/map-controls-to-params/index.js
@@ -4,10 +4,6 @@ import parse from 'date-fns/parse';
 import mapValues from '../map-values';
 import mapPaths from '../map-paths';
 
-export const defaultParams = {
-  reporter: {},
-};
-
 const mapControlsToParams = (incident, wizard) => {
   let datetime;
   if (incident.datetime && incident.datetime.id === 'Nu') {
@@ -24,7 +20,9 @@ const mapControlsToParams = (incident, wizard) => {
     datetime = parse(datetimeString, 'yyyy-MM-dd HH:mm', new Date());
   }
 
-  let params = defaultParams;
+  let params = {
+    reporter: {},
+  };
 
   if (datetime) {
     params.incident_date_start = formatISO(datetime);

--- a/src/signals/incident/services/map-controls-to-params/index.test.js
+++ b/src/signals/incident/services/map-controls-to-params/index.test.js
@@ -1,7 +1,7 @@
 import mapValues from '../map-values';
 import mapPaths from '../map-paths';
 
-import mapControlsToParams, { defaultParams } from '.';
+import mapControlsToParams from '.';
 
 jest.mock('../map-values');
 jest.mock('../map-paths');
@@ -13,7 +13,7 @@ describe('The map controls to params service', () => {
   });
 
   it('should map status by default', () => {
-    expect(mapControlsToParams({}, {})).toEqual(defaultParams);
+    expect(mapControlsToParams({}, {})).toEqual({ reporter: {} });
   });
 
   it('should map date: Nu', () => {
@@ -34,7 +34,7 @@ describe('The map controls to params service', () => {
         {}
       )
     ).toEqual({
-      ...defaultParams,
+      reporter: {},
       incident_date_start: isodate,
     });
 
@@ -57,7 +57,7 @@ describe('The map controls to params service', () => {
         {}
       )
     ).toEqual({
-      ...defaultParams,
+      reporter: {},
       incident_date_start: isodate,
     });
     spy.mockRestore();
@@ -80,7 +80,7 @@ describe('The map controls to params service', () => {
         {}
       )
     ).toEqual({
-      ...defaultParams,
+      reporter: {},
       incident_date_start: testDate,
     });
     spy.mockRestore();
@@ -91,7 +91,7 @@ describe('The map controls to params service', () => {
     mapPaths.mockImplementation(params => ({ ...params, varFromMapPaths: 'bar' }));
 
     expect(mapControlsToParams({}, {})).toEqual({
-      ...defaultParams,
+      reporter: {},
       varFromMapValues: 'foo',
       varFromMapPaths: 'bar',
     });


### PR DESCRIPTION
### Changes

- Fix incident form retaining data when using 'back' button