### PR TITLE
Bug/113 patch filter with areas

### DIFF
--- a/src/signals/incident-management/__tests__/saga.test.js
+++ b/src/signals/incident-management/__tests__/saga.test.js
@@ -454,7 +454,9 @@ describe('signals/incident-management/saga', () => {
     const { name, id, refresh, options } = updatePayload;
     const payload = {
       name: 'New name of my filter',
-      maincategory_slug: ['i', 'a'],
+      options: {
+        maincategory_slug: ['i', 'a'],
+      },
     };
     const action = {
       type: UPDATE_FILTER,
@@ -549,7 +551,9 @@ describe('signals/incident-management/saga', () => {
       const payload = {
         id: 1234,
         name: 'New name of my filter',
-        maincategory_slug: ['i', 'a'],
+        options: {
+          maincategory_slug: ['i', 'a'],
+        },
       };
       const action = {
         type: UPDATE_FILTER,

--- a/src/signals/incident-management/saga.js
+++ b/src/signals/incident-management/saga.js
@@ -195,8 +195,9 @@ export function* doSaveFilter({ payload }) {
   }
 }
 
-export function* doUpdateFilter(action) {
-  const { name, refresh, id, options } = action.payload;
+export function* doUpdateFilter({ payload }) {
+  const { name, refresh, id } = payload;
+  const options = mapFilterParams(payload.options);
 
   try {
     const result = yield call(authPatchCall, `${CONFIGURATION.FILTERS_ENDPOINT}${id}`, {
@@ -205,7 +206,12 @@ export function* doUpdateFilter(action) {
       options,
     });
 
-    yield put(filterUpdatedSuccess(result));
+    yield put(
+      filterUpdatedSuccess({
+        ...result,
+        options: unmapFilterParams(result.options),
+      })
+    );
     yield put(getFilters());
   } catch (error) {
     if (error.response && error.response.status >= 400 && error.response.status < 500) {

--- a/src/signals/shared/filter/__tests__/parse.test.js
+++ b/src/signals/shared/filter/__tests__/parse.test.js
@@ -125,6 +125,7 @@ describe('signals/shared/filter/parse', () => {
       name: 'Afval in Westpoort',
       options: {
         stadsdeel: ['B'],
+        status: 'status',
         address_text: '',
         maincategory_slug: ['afval'],
         category_slug: subSlugs,
@@ -144,6 +145,7 @@ describe('signals/shared/filter/parse', () => {
             value: 'Westpoort',
           },
         ],
+        status: 'status',
         address_text: '',
         maincategory_slug,
         category_slug,
@@ -152,15 +154,9 @@ describe('signals/shared/filter/parse', () => {
 
     it('should parse input FormData', () => {
       expect(parseInputFormData(input)).toEqual({
-        name: 'Afval in Westpoort',
+        ...output,
         options: {
-          stadsdeel: [
-            {
-              key: 'B',
-              value: 'Westpoort',
-            },
-          ],
-          address_text: '',
+          ...output.options,
           maincategory_slug: [],
           category_slug: [],
         },

--- a/src/signals/shared/filter/parse.js
+++ b/src/signals/shared/filter/parse.js
@@ -93,7 +93,7 @@ export const parseInputFormData = (filterData, fixtureData = {}) => {
   if (Object.keys(options).length) {
     // replace string entries in filter data with objects from dataLists
     Object.keys(options)
-      .filter(fieldName => arrayFields.includes(fieldName))
+      .filter(fieldName => arrayFields.includes(fieldName) && Array.isArray(options[fieldName]))
       .forEach(fieldName => {
         options[fieldName] = options[fieldName]
           .map(value => fields[fieldName] && fields[fieldName].find(({ key, slug }) => key === value || slug === value))
@@ -111,7 +111,7 @@ export const parseToAPIData = filterData => {
   const options = clonedeep(filterData.options || {});
 
   Object.keys(options)
-    .filter(fieldName => arrayFields.includes(fieldName))
+    .filter(fieldName => arrayFields.includes(fieldName) && Array.isArray(options[fieldName]))
     .forEach(fieldName => {
       options[fieldName] = options[fieldName].map(({ slug, key }) => slug || key);
     });


### PR DESCRIPTION
closes Signalen/frontend#113

While saving a new filter with areas is already using `area_code` in `options` in the request body (instead of `area`), this is not yet the case for updating an existing filter.