### PR TITLE
[SIG-3535] Add box shadow to the mobile version of the drawer

### DIFF
--- a/src/signals/incident/components/form/ContainerSelect/Selector/Selector.tsx
+++ b/src/signals/incident/components/form/ContainerSelect/Selector/Selector.tsx
@@ -78,6 +78,12 @@ const StyledMap = styled(Map)`
   }
 `;
 
+const StyledMapPanelDrawer = styled(MapPanelDrawer)`
+  & > :first-child {
+    box-shadow: 0 0 0 3px rgb(0 0 0 / 10%);
+  }
+`;
+
 const ButtonBarStyle = styled.div<{ layerVisible: boolean }>`
   @media screen and ${breakpoint('max-width', 'tabletM')} {
     margin-top: ${({ layerVisible }) => !layerVisible && themeSpacing(11)};
@@ -108,7 +114,7 @@ const Selector = () => {
     () =>
       showDesktopVariant
         ? { Panel: MapPanel, panelVariant: 'panel' }
-        : { Panel: MapPanelDrawer, panelVariant: 'drawer' },
+        : { Panel: StyledMapPanelDrawer, panelVariant: 'drawer' },
     [showDesktopVariant]
   );
 

--- a/src/signals/incident/components/form/ContainerSelect/Selector/Selector.tsx
+++ b/src/signals/incident/components/form/ContainerSelect/Selector/Selector.tsx
@@ -78,6 +78,7 @@ const StyledMap = styled(Map)`
   }
 `;
 
+// Added also to `arm` in #1108. Will be removed here when the next version of `arm` is released
 const StyledMapPanelDrawer = styled(MapPanelDrawer)`
   & > :first-child {
     box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.1);

--- a/src/signals/incident/components/form/ContainerSelect/Selector/Selector.tsx
+++ b/src/signals/incident/components/form/ContainerSelect/Selector/Selector.tsx
@@ -80,7 +80,7 @@ const StyledMap = styled(Map)`
 
 const StyledMapPanelDrawer = styled(MapPanelDrawer)`
   & > :first-child {
-    box-shadow: 0 0 0 3px rgb(0 0 0 / 10%);
+    box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.1);
   }
 `;
 


### PR DESCRIPTION
This PR adds a box shadow to the container map drawer for better UX.