### PR TITLE
[SIA-3574] Prevents the selected cluster from closing

### DIFF
--- a/e2e-tests/cypress/integration/createSignals/createSignalContainerOnMap.spec.ts
+++ b/e2e-tests/cypress/integration/createSignals/createSignalContainerOnMap.spec.ts
@@ -77,6 +77,7 @@ describe('Create signal "Container" and check signal details, container is on th
       cy.get('.Glas').should('not.exist');
 
       cy.get(CONTAINERS.clusterIcon).click();
+      cy.wait(500);
       cy.get('.Restafval').should('have.length', 2).and('be.visible');
       cy.get('.Papier').should('have.length', 1).and('be.visible');
       cy.get('.Plastic').should('have.length', 1).and('be.visible');

--- a/src/signals/incident/components/form/ContainerSelect/Selector/WfsLayer/ContainerLayer/ContainerLayer.tsx
+++ b/src/signals/incident/components/form/ContainerSelect/Selector/WfsLayer/ContainerLayer/ContainerLayer.tsx
@@ -151,6 +151,7 @@ export const ContainerLayer: FunctionComponent<DataLayerProps> = ({ featureTypes
         const { coordinates } = pointFeature.geometry;
         const latlng = featureTolocation({ coordinates });
         const marker = options.pointToLayer(pointFeature, latlng);
+
         /* istanbul ignore else */
         if (marker) {
           layerInstance.addLayer(marker);
@@ -164,8 +165,8 @@ export const ContainerLayer: FunctionComponent<DataLayerProps> = ({ featureTypes
             event.layer.spiderfy();
             const latlng = event.layer.getLatLng();
             const selectedLatLng = selectedCluster.current.getLatLng();
-            if (isEqual(latlng, selectedLatLng)) selectedCluster.current = undefined;
-            else selectedCluster.current = event.layer;
+
+            if (!isEqual(latlng, selectedLatLng)) selectedCluster.current = event.layer;
           } else {
             selectedCluster.current = event.layer;
             selectedCluster.current.spiderfy();
@@ -187,6 +188,7 @@ export const ContainerLayer: FunctionComponent<DataLayerProps> = ({ featureTypes
         });
 
         const parent = getMarkerByZoomLevel(cluster as any, mapInstance.getZoom());
+
         if (parent) {
           selectedCluster.current = parent;
           selectedCluster.current.spiderfy();


### PR DESCRIPTION
This PR solves a bug in the container selection; When the spiderfied version of the cluster was closed by clicking in the map, the selected cluster was lost.