### PR TITLE
[SIG-3315] Changes summary labels to match question labels

### DIFF
--- a/src/signals/incident/definitions/__tests__/wizard-step-5-samenvatting.test.js
+++ b/src/signals/incident/definitions/__tests__/wizard-step-5-samenvatting.test.js
@@ -39,7 +39,6 @@ describe('signals/incident/definitions/wizard-step-5-samenvatting', () => {
       extra_bedrijven_horeca_wat: {
         meta: {
           label: 'Uw melding gaat over:',
-          shortLabel: 'Soort bedrijf',
         },
         options: { validators: [Validators.required] },
         render: FormComponents.RadioInputGroup,
@@ -47,7 +46,6 @@ describe('signals/incident/definitions/wizard-step-5-samenvatting', () => {
       extra_bedrijven_horeca_naam: {
         meta: {
           label: 'Wie of wat zorgt voor deze overlast, denkt u?',
-          shortLabel: 'Mogelijke veroorzaker',
         },
         render: FormComponents.TextInput,
       },
@@ -56,12 +54,12 @@ describe('signals/incident/definitions/wizard-step-5-samenvatting', () => {
     it('should return mapped values', () => {
       expect(summary(controls)).toEqual({
         extra_bedrijven_horeca_wat: {
-          label: 'Soort bedrijf',
+          label: 'Uw melding gaat over:',
           optional: true,
           render: ObjectLabel,
         },
         extra_bedrijven_horeca_naam: {
-          label: 'Mogelijke veroorzaker',
+          label: 'Wie of wat zorgt voor deze overlast, denkt u?',
           optional: true,
           render: Label,
         },
@@ -80,12 +78,12 @@ describe('signals/incident/definitions/wizard-step-5-samenvatting', () => {
       const expected = expect.objectContaining({
         vulaan: {
           extra_afval: {
-            label: 'Waar vandaan',
+            label: 'Heeft u een vermoeden waar het afval vandaan komt?',
             optional: true,
             render: Label,
           },
           extra_container: {
-            label: 'Container(s)',
+            label: 'Kies de container waar het om gaat',
             optional: true,
             render: expect.any(Function),
           },
@@ -137,7 +135,7 @@ describe('signals/incident/definitions/wizard-step-5-samenvatting', () => {
         subcategory: 'subcategory',
         questions: {
           key1: {
-            meta: { shortLabel: 'Label' },
+            meta: { label: 'Label' },
             render: 'TextInput',
           },
         },
@@ -155,13 +153,13 @@ describe('signals/incident/definitions/wizard-step-5-samenvatting', () => {
       expect(actual).toEqual(expected);
     });
 
-    it('should fall back to long label', () => {
+    it('should fall back to short label', () => {
       const actual = previewFactory({
         category: 'category',
         subcategory: 'subcategory',
         questions: {
           key1: {
-            meta: { label: 'Label' },
+            meta: { shortLabel: 'Label' },
             render: 'TextInput',
             required: true,
           },

--- a/src/signals/incident/definitions/wizard-step-5-samenvatting.js
+++ b/src/signals/incident/definitions/wizard-step-5-samenvatting.js
@@ -56,7 +56,7 @@ export const summary = controls =>
     (acc, [key, val]) => ({
       ...acc,
       [key]: {
-        label: val.meta.shortLabel,
+        label: val.meta.label,
         optional: true,
         render: renderPreview(val),
       },
@@ -70,7 +70,7 @@ const expandQuestions = memoize(
       (acc, [key, question]) => ({
         ...acc,
         [key]: {
-          label: question.meta.shortLabel || question.meta.label,
+          label: question.meta.label || question.meta.shortLabel,
           optional: !question.required,
           render: renderPreview({ render: mapFieldNameToComponent(question.render), meta: question.meta }),
         },
@@ -144,7 +144,7 @@ export default {
       },
       sharing_allowed: {
         meta: {
-          shortLabel: 'Toestemming contactgegevens delen',
+          label: 'Toestemming contactgegevens delen',
           value: configuration.language?.consentToContactSharing,
           path: 'reporter.sharing_allowed',
         },
@@ -169,11 +169,11 @@ export default {
         authenticated: true,
       },
       location: {
-        label: 'Locatie',
+        label: 'Waar is het?',
         render: PreviewComponents.Map,
       },
       description: {
-        label: 'Beschrijving',
+        label: 'Waar gaat het om?',
         render: ({ value }) => value,
       },
       classification: {
@@ -182,11 +182,11 @@ export default {
         authenticated: true,
       },
       datetime: {
-        label: 'Tijdstip',
+        label: 'Geef het tijdstip aan',
         render: PreviewComponents.DateTime,
       },
       images_previews: {
-        label: 'Foto',
+        label: 'Foto\'s toevoegen',
         render: PreviewComponents.Image,
         optional: true,
       },
@@ -196,7 +196,7 @@ export default {
 
     telefoon: {
       phone: {
-        label: 'Uw telefoonnummer',
+        label: 'Wat is uw telefoonnummer?',
         optional: true,
         render: ({ value }) => value,
       },
@@ -204,7 +204,7 @@ export default {
 
     email: {
       email: {
-        label: 'Uw e-mailadres',
+        label: 'Wat is uw e-mailadres?',
         optional: true,
         render: ({ value }) => value,
       },


### PR DESCRIPTION
## Changes

- Change summary labels to match question labels

Based on A11Y feedback, labels in the summary page now match the question labels. This prevents confusion for the users when identifying questions.