### PR TITLE
[SIG-3315] Hide summary checkbox label

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/index.js
@@ -22,7 +22,6 @@ import {
   StyledColumn,
   StyledErrorMessage,
   StyledH4,
-  StyledLabel,
   TextsArea,
   Wrapper,
 } from './styled';
@@ -160,7 +159,7 @@ const StatusForm = ({ defaultTexts, childIncidents }) => {
             )}
 
             {!isDeelmelding && (
-              <StyledLabel
+              <Label
                 disabled={state.check.disabled}
                 htmlFor="send_email"
                 label={constants.MELDING_CHECKBOX_DESCRIPTION}
@@ -174,7 +173,7 @@ const StatusForm = ({ defaultTexts, childIncidents }) => {
                   name="send_email"
                   onClick={onCheck}
                 />
-              </StyledLabel>
+              </Label>
             )}
 
             <div>

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/styled.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/styled.js
@@ -83,10 +83,6 @@ export const StyledColumn = styled(Column)`
   margin-bottom: ${themeSpacing(3)};
 `;
 
-export const StyledLabel = styled(Label)`
-  align-items: baseline;
-`;
-
 export const StyledButton = styled(Button)`
   margin-right: ${themeSpacing(2)};
 `;

--- a/src/signals/incident/definitions/wizard-step-5-samenvatting.js
+++ b/src/signals/incident/definitions/wizard-step-5-samenvatting.js
@@ -144,7 +144,7 @@ export default {
       },
       sharing_allowed: {
         meta: {
-          label: 'Toestemming contactgegevens delen',
+          shortLabel: 'Toestemming contactgegevens delen',
           value: configuration.language?.consentToContactSharing,
           path: 'reporter.sharing_allowed',
         },


### PR DESCRIPTION
### Changes

- Hides summary checkbox label inadvertently added in https://github.com/Amsterdam/signals-frontend/pull/1428
- Fixes alignment of checkbox label