### PR TITLE
[FE#117] Add scroll to top

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/IncidentDetail.js
+++ b/src/signals/incident-management/containers/IncidentDetail/IncidentDetail.js
@@ -1,4 +1,4 @@
-import React, { useReducer, useEffect, useCallback, useMemo } from 'react';
+import React, { useReducer, useEffect, useCallback, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { Row, Column } from '@amsterdam/asc-ui';
 import styled from 'styled-components';
@@ -74,8 +74,23 @@ const IncidentDetail = () => {
   const { get: getAttachments, data: attachments } = useFetch();
   const { get: getDefaultTexts, data: defaultTexts } = useFetch();
   const { get: getChildren, data: children } = useFetch();
+  const [editingStatus, setEditingStatus] = useState(false);
 
   const subcategories = useSelector(makeSelectSubCategories);
+
+  useEffect(() => {
+    if (state.edit === 'status') {
+      setEditingStatus(true);
+      window.scrollTo(0, 0);
+    }
+  }, [state.edit]);
+
+  useEffect(() => {
+    if (editingStatus && state.edit !== 'status') {
+      setEditingStatus(false);
+      window.scrollTo(0, 0);
+    }
+  }, [editingStatus, state.edit]);
 
   useEffect(() => {
     document.addEventListener('keyup', handleKeyUp);

--- a/src/signals/incident-management/containers/IncidentDetail/__tests__/IncidentDetail.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/__tests__/IncidentDetail.test.js
@@ -16,6 +16,7 @@ import { showGlobalNotification } from 'containers/App/actions';
 import { VARIANT_ERROR, TYPE_LOCAL } from 'containers/Notification/constants';
 import { patchIncidentSuccess } from 'signals/incident-management/actions';
 
+jest.spyOn(window, 'scrollTo');
 jest.spyOn(categoriesSelectors, 'makeSelectSubCategories').mockImplementation(() => subCategories);
 
 // prevent fetch requests that we don't need to verify
@@ -330,12 +331,25 @@ describe('signals/incident-management/containers/IncidentDetail', () => {
     const editStatusButton = await findByTestId('editStatusButton');
 
     expect(queryByTestId('statusForm')).not.toBeInTheDocument();
+    expect(window.scrollTo).not.toHaveBeenCalled();
 
     act(() => {
       fireEvent.click(editStatusButton);
     });
 
     expect(queryByTestId('statusForm')).toBeInTheDocument();
+    expect(window.scrollTo).toHaveBeenCalledTimes(1);
+
+    const cancelButton = await findByTestId('statusFormCancelButton');
+
+    act(() => {
+      fireEvent.click(cancelButton);
+    });
+
+    expect(queryByTestId('statusForm')).not.toBeInTheDocument();
+    expect(window.scrollTo).toHaveBeenCalledTimes(2);
+
+    await findByTestId('editStatusButton');
   });
 
   it('renders attachment viewer', async () => {

--- a/src/signals/incident-management/containers/IncidentDetail/__tests__/IncidentDetail.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/__tests__/IncidentDetail.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { fireEvent, render, act, waitForElementToBeRemoved, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import * as reactRouterDom from 'react-router-dom';
 import * as reactRedux from 'react-redux';
 
@@ -340,11 +341,7 @@ describe('signals/incident-management/containers/IncidentDetail', () => {
     expect(queryByTestId('statusForm')).toBeInTheDocument();
     expect(window.scrollTo).toHaveBeenCalledTimes(1);
 
-    const cancelButton = await findByTestId('statusFormCancelButton');
-
-    act(() => {
-      fireEvent.click(cancelButton);
-    });
+    userEvent.click(await findByTestId('statusFormCancelButton'));
 
     expect(queryByTestId('statusForm')).not.toBeInTheDocument();
     expect(window.scrollTo).toHaveBeenCalledTimes(2);


### PR DESCRIPTION
fixes Signalen/frontend#117

Added scroll to top when you open the edit status form of an incident. And again when closing the form.
See the issue mentioned above for the details of the problem.