### PR TITLE
(Chore) Adds opened/edited PR to e2e test triggers

### DIFF
--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -5,6 +5,8 @@ on:
       - develop
       - master
       - release/*
+  pull_request:
+    types: [opened, edited]
 
 env:
   TZ: "Europe/Amsterdam"

--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -6,7 +6,7 @@ on:
       - master
       - release/*
   pull_request:
-    types: [opened, edited]
+    types: [opened, synchronize]
 
 env:
   TZ: "Europe/Amsterdam"


### PR DESCRIPTION
### Changes

- Trigger e2e test run every time a PR is opened or edited

This will increase visibility of the e2e tests and make sure that regressions are noticed early on. The results of the (currently failing) e2e tests can be viewed [`here`](https://dashboard.cypress.io/projects/xdzm5k/runs?branches=%5B%5D&committers=%5B%5D&flaky=%5B%5D&page=1&status=%5B%5D&tags=%5B%5D&timeRange=%7B%22startDate%22%3A%221970-01-01%22%2C%22endDate%22%3A%222038-01-19%22%7D)

- [ ] Merge only when e2e tests are successful
- [ ] When e2e tests fail, this result should be reflected in the PR