### PR TITLE
[SIG-3624] Adds a11y to the MapSelect component

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -18,7 +18,7 @@ module.exports = {
   coverageThreshold: {
     global: {
       statements: 99.6,
-      branches: 96.32,
+      branches: 96.29,
       functions: 98.76,
       lines: 99.66,
     },

--- a/src/components/MapSelect/index.js
+++ b/src/components/MapSelect/index.js
@@ -40,6 +40,7 @@ const MapSelect = ({
   onSelectionChange,
   selectionOnly,
   value,
+  ...rest
 }) => {
   const zoomMin = 13;
   const featuresLayer = useRef();
@@ -216,7 +217,7 @@ const MapSelect = ({
   );
 
   return (
-    <Wrapper>
+    <Wrapper {...rest}>
       <StyledMap
         className={classNames('map-component', { write: onSelectionChange })}
         data-testid="mapSelect"

--- a/src/signals/incident/components/form/MapSelect/index.js
+++ b/src/signals/incident/components/form/MapSelect/index.js
@@ -56,6 +56,8 @@ const MapSelect = ({ handler, touched, hasError, meta, parent, getError, validat
         getError={getError}
       >
         <MapSelectComponent
+          id={meta.name}
+          aria-describedby={meta.subtitle && `subtitle-${meta.name}`}
           geojsonUrl={url}
           getIcon={getOVLIcon}
           hasGPSControl
@@ -89,6 +91,7 @@ MapSelect.propTypes = {
     isVisible: PropTypes.bool,
     legend_items: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
     name: PropTypes.string,
+    subtitle: PropTypes.string,
     zoomMin: PropTypes.number,
   }),
   parent: PropTypes.object,

--- a/src/signals/incident/components/form/MapSelectGeneric/index.js
+++ b/src/signals/incident/components/form/MapSelectGeneric/index.js
@@ -51,6 +51,8 @@ const MapSelectGeneric = ({ handler, touched, hasError = () => {}, meta, parent,
         getError={getError}
       >
         <MapSelectComponent
+          id={meta.name}
+          aria-describedby={meta.subtitle && `subtitle-${meta.name}`}
           geojsonUrl={url}
           hasGPSControl
           idField={meta.idField}
@@ -81,6 +83,7 @@ MapSelectGeneric.propTypes = {
     name: PropTypes.string,
     selectionLabel: PropTypes.string,
     zoomMin: PropTypes.number,
+    subtitle: PropTypes.string,
   }),
   parent: PropTypes.object,
   getError: PropTypes.func,


### PR DESCRIPTION
This PR adds the id and aria-describedby attributes on the MapSelect and MapSelectGeneric components for accessibility