### PR TITLE
(Chore) Add development configuration to docker-compose

### DIFF
--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -39,7 +39,7 @@ jobs:
         id: cypress
         continue-on-error: true
         with:
-          start: docker-compose up
+          start: docker-compose up frontend
           wait-on: 'http://localhost:8000/signals/'
           wait-on-timeout: 180
           working-directory: e2e-tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ COPY .gitignore \
 RUN npm install
 
 COPY assets /app/assets
+COPY server /app/server
 COPY internals /app/internals
 COPY src /app/src
 

--- a/Makefile
+++ b/Makefile
@@ -15,11 +15,11 @@ build: pull                         ## Build docker image
 	BUILD_ENV=$(BUILD_ENV) $(dc) build
 
 start:                              ## Run frontend
-	$(dc) run --service-ports frontend
+	$(dc) run --service-ports frontend-dev
 
 stop:                               ## Clean docker stuff
 	$(dc) down -v --remove-orphans
 
 start-e2e: build                    ## Starts the application and opens cypress
-	$(dc) up -d
+	$(dc) up -d frontend-dev
 	npm run open --prefix e2e-tests

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,22 @@
 version: '3.8'
 
 services:
+  frontend-dev:
+    build:
+      context: .
+      target: base
+      args:
+        - ENABLE_SERVICEWORKER=0
+    volumes:
+      - ./e2e-tests/app.json:/app/app.json
+      - ./app.amsterdam.json:/app/app.base.json
+      - ./src:/app/src
+    ports:
+      - 3001:3001
+    command: npm start
+    depends_on:
+      - backend
+
   frontend:
     build:
       context: .
@@ -11,6 +27,8 @@ services:
       - ./app.amsterdam.json:/app.base.json
     ports:
       - 3001:80
+    depends_on:
+      - backend
 
   backend:
     image: signalen/backend:latest
@@ -36,6 +54,7 @@ services:
       - 8000:8000
     depends_on:
       - database
+      - dex
 
   database:
     image: amsterdam/postgres11:latest


### PR DESCRIPTION
This PR adds an `frontend-dev` development configuration service to the docker-compose. This enables changes in the sources when running the application in development mode. 
- Use `make start` to run the application in dev mode
- Use `docker-compose up frontend` to start the application as a container. This command will be used in the `gh-actions` as well for the `e2e-tests`.