### PR TITLE
[SIG-3633] Prevent interaction with background map in container selection flow

### DIFF
--- a/src/signals/incident/components/form/ContainerSelect/Intro/Intro.tsx
+++ b/src/signals/incident/components/form/ContainerSelect/Intro/Intro.tsx
@@ -40,6 +40,9 @@ const Intro = () => {
       ...MAP_OPTIONS,
       attributionControl: false,
       center: [lat, lng],
+      dragging: false,
+      keyboard: false,
+      doubleClickZoom: false,
     }),
     [lat, lng]
   );


### PR DESCRIPTION
### Changes

- Prevents interaction with background map in container selection flow

Specifically, it was possible to select/drag/zoom the map shown in the background of the `<Intro />` component. 
