### PR TITLE
(Fix) Add the app.amsterdam.json to the docker base layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ COPY .gitignore \
   package.json \
   package-lock.json \
   app.base.json \
+  app.amsterdam.json \
   /app/
 
 RUN npm install


### PR DESCRIPTION
This PR fixes the jenkins build by adding the app.amsterdam.json to the base docker layer. The types defined in this file are now used as typescript types so the reference of this file is needed for the build
