### PR TITLE
[SIG-3438] Removes native red border on invalid fields

### DIFF
--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -18,6 +18,7 @@ const StyledInput = styled(AscInput)<{ showError: boolean }>`
   font-size: 16px;
   line-height: 22px;
   padding: 10px; /* needed to style the textboxes as according to the design system */
+  box-shadow: initial;
 
   &[disabled] {
     border: 1px solid ${themeColor('tint', 'level4')};


### PR DESCRIPTION
### Changes

- Removes native red border seen on Firefox for invalid fields