### PR TITLE
[SIG-3672] Prevent double trigger on Toggle

### DIFF
--- a/src/signals/incident-management/components/CheckboxList/CheckboxList.js
+++ b/src/signals/incident-management/components/CheckboxList/CheckboxList.js
@@ -258,7 +258,7 @@ const CheckboxList = ({
         <Toggle
           indent={Boolean(title)}
           tabIndex={0}
-          onClick={handleToggle}
+          onClick={groupName ? null : handleToggle}
           onKeyDown={handleKeyDown}
         >
           {toggled ? toggleNothingLabel : toggleAllLabel}


### PR DESCRIPTION
Restore removed guard that prevents double triggering the `onClick` handler