### PR TITLE
(Chore) add type annotation for config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,12 +7,9 @@ services:
       target: base
       args:
         - ENABLE_SERVICEWORKER=0
-    environment:
-        - CONFIG=app.amsterdam.json 
     volumes:
       - ./e2e-tests/app.json:/app/app.json
-      - ./app.amsterdam.json:/app/app.amsterdam.json
-      - ./app.base.json:/app/app.base.json
+      - ./app.amsterdam.json:/app/app.base.json
       - ./src:/app/src
       - ./internals:/app/internals
       - ./server:/app/server

--- a/src/components/ThemeProvider/index.tsx
+++ b/src/components/ThemeProvider/index.tsx
@@ -54,7 +54,7 @@ export const getConfig: (theme?: RecursivePartial<Theme>) => Theme = (defaultCon
 };
 
 const ThemeProvider: FunctionComponent = ({ children }) => (
-  <ASCThemeProvider overrides={getConfig(configuration.theme)}>
+  <ASCThemeProvider overrides={getConfig((configuration as Partial<{ theme?: RecursivePartial<Theme> }>).theme)}>
     {children}
   </ASCThemeProvider>
 );


### PR DESCRIPTION
Restores changes to `docker-compose.yml` and adds type information for passed config object