### PR TITLE
[SIG-3692] Fix modal styling affected by ASC change

### DIFF
--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -7,11 +7,9 @@ import { Button, Row, Column, Modal as ASCModal, Heading, themeColor } from '@am
 import { Close as CloseIcon } from '@amsterdam/asc-assets';
 
 const StyledModal = styled(ASCModal)`
-  & [role='dialog'] {
-    max-height: 100vh;
-    height: 100vh;
-    max-width: 1430px;
-  }
+  max-height: 100vh;
+  height: 100vh;
+  max-width: 1430px;
 `;
 
 const ModalInner = styled.div`


### PR DESCRIPTION
### Changes

- Fixes modal styling bug

With the recent Amsterdam Styled Components update, the Modal component passes the className prop to a different element.  