### PR TITLE
[SIG-3689] Add process time to MetaList

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/components/MetaList/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/MetaList/index.js
@@ -144,6 +144,20 @@ const MetaList = () => {
     [handlingTimesBySlug, incident]
   );
 
+  const [processTimeCopy, processTimeClass] = useMemo(() => {
+    const now = new Date();
+
+    if (now > new Date(incident.category?.deadline_factor_3)) {
+      return ['3x buiten de afhandeltermijn', 'alert'];
+    }
+
+    if (now > new Date(incident.category?.deadline)) {
+      return ['Buiten de afhandeltermijn', 'alert'];
+    }
+
+    return ['Binnen de afhandeltermijn', ''];
+  }, [incident]);
+
   const getDepartmentId = useCallback(
     () => (routingDepartments ? `${routingDepartments[0].id}` : departmentOptions && departmentOptions[0].key),
     [departmentOptions, routingDepartments]
@@ -191,6 +205,11 @@ const MetaList = () => {
           <dd data-testid="meta-list-handling-time-value">{handlingTime}</dd>
         </Fragment>
       )}
+
+      <dt data-testid="meta-list-process-time-definition">Doorlooptijd</dt>
+      <dd className={processTimeClass} data-testid="meta-list-process-time-value">
+        {processTimeCopy}
+      </dd>
 
       <Highlight type="status">
         <dt data-testid="meta-list-status-definition">

--- a/src/signals/incident-management/containers/IncidentDetail/components/MetaList/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/MetaList/index.js
@@ -144,7 +144,7 @@ const MetaList = () => {
     [handlingTimesBySlug, incident]
   );
 
-  const [processTimeCopy, processTimeClass] = useMemo(() => {
+  const [processTimeText, processTimeClass] = useMemo(() => {
     const now = new Date();
 
     if (now > new Date(incident.category?.deadline_factor_3)) {
@@ -155,7 +155,7 @@ const MetaList = () => {
       return ['Buiten de afhandeltermijn', 'alert'];
     }
 
-    return ['Binnen de afhandeltermijn', ''];
+    return ['Binnen de afhandeltermijn'];
   }, [incident]);
 
   const getDepartmentId = useCallback(
@@ -208,7 +208,7 @@ const MetaList = () => {
 
       <dt data-testid="meta-list-process-time-definition">Doorlooptijd</dt>
       <dd className={processTimeClass} data-testid="meta-list-process-time-value">
-        {processTimeCopy}
+        {processTimeText}
       </dd>
 
       <Highlight type="status">

--- a/src/signals/incident-management/containers/IncidentDetail/components/MetaList/index.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/MetaList/index.test.js
@@ -96,6 +96,9 @@ describe('MetaList', () => {
       expect(screen.queryByTestId('meta-list-handling-time-definition')).toHaveTextContent(/^Afhandeltermijn$/);
       expect(screen.queryByTestId('meta-list-handling-time-value')).toHaveTextContent(/^4 werkdagen$/);
 
+      expect(screen.queryByTestId('meta-list-process-time-definition')).toHaveTextContent(/^Doorlooptijd$/);
+      expect(screen.queryByTestId('meta-list-process-time-value')).toHaveTextContent(/^Binnen de afhandeltermijn$/);
+
       expect(screen.queryByTestId('meta-list-status-definition')).toHaveTextContent(/^Status$/);
       expect(screen.queryByTestId('meta-list-status-value')).toHaveTextContent(/^Gemeld$/);
 
@@ -197,6 +200,29 @@ describe('MetaList', () => {
     rerender(renderWithContext({ ...plainIncident, category: { sub_slug: 'autom-verzinkbare-palen' } }));
     expect(screen.queryByTestId('meta-list-handling-time-definition')).toHaveTextContent(/^Afhandeltermijn$/);
     expect(screen.queryByTestId('meta-list-handling-time-value')).toHaveTextContent(/^21 dagen$/);
+  });
+
+  it('should render process time copy based on the deadline and current time', () => {
+    const now = new Date();
+    const before = new Date(now.getTime() - 100);
+    const after = new Date(now.getTime() + 100);
+
+    const { rerender, container } = render(
+      renderWithContext({ ...plainIncident, category: { deadline: before.toISOString() } })
+    );
+    expect(screen.queryByTestId('meta-list-process-time-definition')).toHaveTextContent(/^Doorlooptijd$/);
+    expect(screen.queryByTestId('meta-list-process-time-value')).toHaveTextContent(/^Buiten de afhandeltermijn$/);
+    expect(screen.queryByTestId('meta-list-process-time-value').className).toBe('alert');
+
+    rerender(renderWithContext({ ...plainIncident, category: { deadline: after.toISOString() } }));
+    expect(screen.queryByTestId('meta-list-process-time-definition')).toHaveTextContent(/^Doorlooptijd$/);
+    expect(screen.queryByTestId('meta-list-process-time-value')).toHaveTextContent(/^Binnen de afhandeltermijn$/);
+    expect(screen.queryByTestId('meta-list-process-time-value').className).toBe('');
+
+    rerender(renderWithContext({ ...plainIncident, category: { deadline_factor_3: before.toISOString() } }));
+    expect(screen.queryByTestId('meta-list-process-time-definition')).toHaveTextContent(/^Doorlooptijd$/);
+    expect(screen.queryByTestId('meta-list-process-time-value')).toHaveTextContent(/^3x buiten de afhandeltermijn$/);
+    expect(screen.queryByTestId('meta-list-process-time-value').className).toBe('alert');
   });
 
   it('should call edit', () => {

--- a/src/signals/incident-management/containers/IncidentDetail/components/MetaList/index.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/MetaList/index.test.js
@@ -97,7 +97,7 @@ describe('MetaList', () => {
       expect(screen.queryByTestId('meta-list-handling-time-value')).toHaveTextContent(/^4 werkdagen$/);
 
       expect(screen.queryByTestId('meta-list-process-time-definition')).toHaveTextContent(/^Doorlooptijd$/);
-      expect(screen.queryByTestId('meta-list-process-time-value')).toHaveTextContent(/^Binnen de afhandeltermijn$/);
+      expect(screen.queryByTestId('meta-list-process-time-value')).toHaveTextContent(/^3x buiten de afhandeltermijn$/);
 
       expect(screen.queryByTestId('meta-list-status-definition')).toHaveTextContent(/^Status$/);
       expect(screen.queryByTestId('meta-list-status-value')).toHaveTextContent(/^Gemeld$/);
@@ -175,12 +175,14 @@ describe('MetaList', () => {
     const { container, rerender } = render(renderWithContext());
 
     expect(screen.queryByText('Hoog')).not.toBeInTheDocument();
-    expect(container.firstChild.querySelectorAll('.alert')).toHaveLength(1);
+    expect(screen.queryByTestId('meta-list-status-value').className).toBe('alert');
+    expect(screen.queryByTestId('meta-list-priority-value').className).toBe('');
 
     rerender(renderWithContext({ ...incidentFixture, priority: { ...incidentFixture.priority, priority: 'high' } }));
 
     expect(screen.queryByText('Hoog')).toBeInTheDocument();
-    expect(container.firstChild.querySelectorAll('.alert')).toHaveLength(2);
+    expect(screen.queryByTestId('meta-list-status-value').className).toBe('alert');
+    expect(screen.queryByTestId('meta-list-priority-value').className).toBe('alert');
   });
 
   it('should render days and workdays in single and plural form', () => {

--- a/src/utils/__tests__/fixtures/incident.json
+++ b/src/utils/__tests__/fixtures/incident.json
@@ -82,7 +82,9 @@
     "sub_slug": "asbest-accu",
     "main": "Afval",
     "main_slug": "afval",
-    "departments": "AEG, CCA"
+    "departments": "AEG, CCA",
+    "deadline": "1970-01-01T00:00:00.000Z",
+    "deadline_factor_3": "1970-01-01T00:00:00.000Z"
   },
   "reporter": {
     "email": "me@email.com",


### PR DESCRIPTION
Adds process time to the `MetaList` component on the incident detail page

![image](https://user-images.githubusercontent.com/2111164/114533812-98cebd80-9c4e-11eb-9e36-561cb9c374e3.png)
