### PR TITLE
Revert "[SIG-3692] Fix modal styling affected by ASC change"

### DIFF
--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -7,9 +7,11 @@ import { Button, Row, Column, Modal as ASCModal, Heading, themeColor } from '@am
 import { Close as CloseIcon } from '@amsterdam/asc-assets';
 
 const StyledModal = styled(ASCModal)`
-  max-height: 100vh;
-  height: 100vh;
-  max-width: 1430px;
+  & [role='dialog'] {
+    max-height: 100vh;
+    height: 100vh;
+    max-width: 1430px;
+  }
 `;
 
 const ModalInner = styled.div`


### PR DESCRIPTION
Reverts Amsterdam/signals-frontend#1522