### PR TITLE
[SIG-3691] Clear 'name' field when reset filter button is clicked

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -87,6 +87,7 @@
         "@types/lodash": "^4.14.168",
         "@types/lodash.clonedeep": "^4.5.6",
         "@types/lodash.get": "^4.4.6",
+        "@types/lodash.isequal": "^4.5.5",
         "@types/lodash.isstring": "^4.0.6",
         "@types/lodash.map": "^4.6.13",
         "@types/react": "^17.0.3",
@@ -3818,6 +3819,15 @@
       "version": "4.4.6",
       "resolved": "https://registry.npmjs.org/@types/lodash.get/-/lodash.get-4.4.6.tgz",
       "integrity": "sha512-E6zzjR3GtNig8UJG/yodBeJeIOtgPkMgsLjDU3CbgCAPC++vJ0eCMnJhVpRZb/ENqEFlov1+3K9TKtY4UdWKtQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/lodash": "*"
+      }
+    },
+    "node_modules/@types/lodash.isequal": {
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/@types/lodash.isequal/-/lodash.isequal-4.5.5.tgz",
+      "integrity": "sha512-4IKbinG7MGP131wRfceK6W4E/Qt3qssEFLF30LnJbjYiSfHGGRU/Io8YxXrZX109ir+iDETC8hw8QsDijukUVg==",
       "dev": true,
       "dependencies": {
         "@types/lodash": "*"
@@ -35359,6 +35369,15 @@
       "version": "4.4.6",
       "resolved": "https://registry.npmjs.org/@types/lodash.get/-/lodash.get-4.4.6.tgz",
       "integrity": "sha512-E6zzjR3GtNig8UJG/yodBeJeIOtgPkMgsLjDU3CbgCAPC++vJ0eCMnJhVpRZb/ENqEFlov1+3K9TKtY4UdWKtQ==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
+    "@types/lodash.isequal": {
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/@types/lodash.isequal/-/lodash.isequal-4.5.5.tgz",
+      "integrity": "sha512-4IKbinG7MGP131wRfceK6W4E/Qt3qssEFLF30LnJbjYiSfHGGRU/Io8YxXrZX109ir+iDETC8hw8QsDijukUVg==",
       "dev": true,
       "requires": {
         "@types/lodash": "*"

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "@types/lodash": "^4.14.168",
     "@types/lodash.clonedeep": "^4.5.6",
     "@types/lodash.get": "^4.4.6",
+    "@types/lodash.isequal": "^4.5.5",
     "@types/lodash.isstring": "^4.0.6",
     "@types/lodash.map": "^4.6.13",
     "@types/react": "^17.0.3",

--- a/src/signals/incident-management/components/FilterForm/__tests__/FilterForm.test.js
+++ b/src/signals/incident-management/components/FilterForm/__tests__/FilterForm.test.js
@@ -672,7 +672,7 @@ describe('signals/incident-management/components/FilterForm', () => {
     expect(submitButton.textContent).toEqual(DEFAULT_SUBMIT_BUTTON_LABEL);
 
     act(() => {
-      fireEvent.blur(nameField, { target: { value: 'My filter' } });
+      fireEvent.change(nameField, { target: { value: 'My filter' } });
     });
 
     expect(submitButton.textContent).toEqual(SAVE_SUBMIT_BUTTON_LABEL);
@@ -885,7 +885,7 @@ describe('signals/incident-management/components/FilterForm', () => {
       expect(handlers.onSaveFilter).not.toHaveBeenCalled(); // name field is empty
 
       act(() => {
-        fireEvent.blur(nameField, { target: { value: 'New name' } });
+        fireEvent.change(nameField, { target: { value: 'New name' } });
       });
 
       act(() => {
@@ -916,17 +916,10 @@ describe('signals/incident-management/components/FilterForm', () => {
         )
       );
 
-      act(() => {
-        fireEvent.click(container.querySelector('button[type="submit"]'));
-      });
-
-      // values haven't changed, update should not be called
-      expect(handlers.onUpdateFilter).not.toHaveBeenCalled();
-
       const nameField = container.querySelector('input[type="text"][name="name"]');
 
       act(() => {
-        fireEvent.blur(nameField, { target: { value: ' ' } });
+        fireEvent.change(nameField, { target: { value: ' ' } });
       });
 
       act(() => {
@@ -938,7 +931,7 @@ describe('signals/incident-management/components/FilterForm', () => {
       expect(window.alert).toHaveBeenCalled();
 
       act(() => {
-        fireEvent.blur(nameField, { target: { value: 'My changed filter' } });
+        fireEvent.change(nameField, { target: { value: 'My changed filter' } });
       });
 
       act(() => {

--- a/src/signals/incident-management/components/FilterForm/index.js
+++ b/src/signals/incident-management/components/FilterForm/index.js
@@ -302,8 +302,6 @@ const FilterForm = ({ filter, onCancel, onClearFilter, onSaveFilter, onSubmit, o
     [notRoutedOption.key, state.options.routing_department]
   );
 
-  const [nameValue, setNameValue] = useState(state.filter.name);
-
   return (
     <Form action="" novalidate>
       <ControlsWrapper>


### PR DESCRIPTION
### Changes

- Fix bug where name filter was not reset after 'Nieuw filter' button was clicked

Technically, the bug is caused by the 'filter name' input not being a controlled input. However, changing this has implications to how the form behaves: Form state is handled in a react reducer, and updates to it causes the `onSubmitForm` callback to be recomputed, which in turn causes all form elements to rerender. This has a noticeable performance impact. 

The solution implemented here (with help from @samuelleeuwenburg) stores the filter data into a ref to remove the filter dependency from the `onSubmitForm` callback. There are some issues with it though: `valuesHaveChanged` is also dependent on the same data, but it's computed with a `useMemo` (thus not updated if changed to use the ref data). 

An alternative could be to use a debounce, which has some other drawbacks (e.g. the submit button label will update after some time instead of directly). 