### PR TITLE
[SIG-3691] Clear name/address/note fields when clear button is clicked

### DIFF
--- a/src/signals/incident-management/components/FilterForm/index.js
+++ b/src/signals/incident-management/components/FilterForm/index.js
@@ -196,9 +196,9 @@ const FilterForm = ({ filter, onCancel, onClearFilter, onSaveFilter, onSubmit, o
     [dispatch]
   );
 
-setControlledTextInput({ ...controlledTextInput, name: event.target?.value })
-  const onNoteChange = useCallback(event => setControlledTextInput({ note: event.target?.value }), [setControlledTextInput]);
-  const onAddressChange = useCallback(event => setControlledTextInput({ address: event.target?.value }), [setControlledTextInput]);
+  const onNameChange = useCallback(event => setControlledTextInput({ ...controlledTextInput, name: event.target?.value }), [controlledTextInput]);
+  const onNoteChange = useCallback(event => setControlledTextInput({ ...controlledTextInput, note: event.target?.value }), [controlledTextInput]);
+  const onAddressChange = useCallback(event => setControlledTextInput({ ...controlledTextInput, address: event.target?.value }), [controlledTextInput]);
 
   const onRefreshChange = useCallback(
     event => {

--- a/src/signals/incident-management/components/FilterForm/index.js
+++ b/src/signals/incident-management/components/FilterForm/index.js
@@ -196,7 +196,7 @@ const FilterForm = ({ filter, onCancel, onClearFilter, onSaveFilter, onSubmit, o
     [dispatch]
   );
 
-  const onNameChange = useCallback(event => setControlledTextInput({ name: event.target?.value }), [setControlledTextInput]);
+setControlledTextInput({ ...controlledTextInput, name: event.target?.value })
   const onNoteChange = useCallback(event => setControlledTextInput({ note: event.target?.value }), [setControlledTextInput]);
   const onAddressChange = useCallback(event => setControlledTextInput({ address: event.target?.value }), [setControlledTextInput]);
 

--- a/src/signals/incident-management/components/FilterForm/index.js
+++ b/src/signals/incident-management/components/FilterForm/index.js
@@ -73,6 +73,11 @@ const FilterForm = ({ filter, onCancel, onClearFilter, onSaveFilter, onSubmit, o
 
   const [assignedSelectValue, setAssignedSelectValue] = useState('');
   const [routedFilterValue, setRoutedFilterValue] = useState([]);
+  const [controlledTextInput, setControlledTextInput] = useState({
+    name: state.filter.name,
+    address: state.options.address_text,
+    note: state.options.note_keyword,
+  });
 
   const dataListValues = useMemo(
     () => ({
@@ -152,6 +157,11 @@ const FilterForm = ({ filter, onCancel, onClearFilter, onSaveFilter, onSubmit, o
   const onResetForm = useCallback(() => {
     dispatch(reset());
     onClearFilter();
+    setControlledTextInput({
+      name: '',
+      address: '',
+      note: '',
+    });
   }, [dispatch, onClearFilter]);
 
   // callback handler that is called whenever a checkbox is (un)checked in the list of
@@ -186,6 +196,10 @@ const FilterForm = ({ filter, onCancel, onClearFilter, onSaveFilter, onSubmit, o
     [dispatch]
   );
 
+  const onNameChange = useCallback(event => setControlledTextInput({ name: event.target?.value }), [setControlledTextInput]);
+  const onNoteChange = useCallback(event => setControlledTextInput({ note: event.target?.value }), [setControlledTextInput]);
+  const onAddressChange = useCallback(event => setControlledTextInput({ address: event.target?.value }), [setControlledTextInput]);
+
   const onRefreshChange = useCallback(
     event => {
       event.persist();
@@ -212,7 +226,7 @@ const FilterForm = ({ filter, onCancel, onClearFilter, onSaveFilter, onSubmit, o
     [dispatch]
   );
 
-  const onNotesBlur = useCallback(
+  const onNoteBlur = useCallback(
     event => {
       dispatch(setNoteKeyword(event.target.value));
     },
@@ -307,10 +321,11 @@ const FilterForm = ({ filter, onCancel, onClearFilter, onSaveFilter, onSubmit, o
           <div className="invoer">
             <Input
               data-testid="filterName"
-              defaultValue={state.filter.name}
+              value={controlledTextInput.name}
               id="filter_name"
               name="name"
               onBlur={onNameBlur}
+              onChange={onNameChange}
               placeholder="Geef deze filterinstelling een naam om deze op te slaan"
               type="text"
             />
@@ -347,8 +362,9 @@ const FilterForm = ({ filter, onCancel, onClearFilter, onSaveFilter, onSubmit, o
               data-testid="filterNotes"
               name="note_keyword"
               id="filter_notes"
-              onBlur={onNotesBlur}
-              defaultValue={state.options.note_keyword}
+              onBlur={onNoteBlur}
+              onChange={onNoteChange}
+              value={controlledTextInput.note}
               type="text"
             />
           </FilterGroup>
@@ -512,7 +528,8 @@ const FilterForm = ({ filter, onCancel, onClearFilter, onSaveFilter, onSubmit, o
               name="address_text"
               id="filter_address"
               onBlur={onAddressBlur}
-              defaultValue={state.options.address_text}
+              onChange={onAddressChange}
+              value={controlledTextInput.address}
               type="text"
             />
           </FilterGroup>


### PR DESCRIPTION
### Changes

- Fix name, note and address inputs not clearing when clicking "Nieuw filter" button

Didn't go with the `createRef` solution discussed earlier - where the uncontrolled input value would be set to empty outside of react - because React complained about it (console error) and I feel like the current solution is more in line with 'normal' usage of React. 