### PR TITLE
[SIG-3682] Use Fieldset with Legend for radio group form input

### DIFF
--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -15,6 +15,7 @@ const Label =
     font-family: Avenir Next LT W01${({ inline = false }) => inline ? '-Regular' : ' Demi'}, arial, sans-serif;
     font-size: 16px;
     margin-bottom: ${themeSpacing(1)};
+    padding: 0;
     display: inline-block;
     vertical-align: text-top;
     color: inherit;

--- a/src/signals/incident/components/form/CategorySelectRenderer/CategorySelectRenderer.js
+++ b/src/signals/incident/components/form/CategorySelectRenderer/CategorySelectRenderer.js
@@ -3,14 +3,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { isAuthenticated } from 'shared/services/auth/auth';
-import Header from '../Header';
+import FormField from '../FormField';
 import CategorySelect from '../CategorySelect';
 
 const CategorySelectRenderer = ({ handler, touched, hasError, meta, parent, getError, validatorsOrOpts }) =>
   meta?.isVisible && isAuthenticated() && (
-    <Header meta={meta} options={validatorsOrOpts} touched={touched} hasError={hasError} getError={getError}>
+    <FormField meta={meta} options={validatorsOrOpts} touched={touched} hasError={hasError} getError={getError}>
       <CategorySelect handler={handler} meta={meta} parent={parent} />
-    </Header>
+    </FormField>
   );
 
 CategorySelectRenderer.propTypes = {

--- a/src/signals/incident/components/form/CheckboxInput/CheckboxInput.js
+++ b/src/signals/incident/components/form/CheckboxInput/CheckboxInput.js
@@ -8,7 +8,7 @@ import { Label } from '@amsterdam/asc-ui';
 
 import Checkbox from 'components/Checkbox';
 
-import Header from '../Header';
+import FormField from '../FormField';
 import styled from 'styled-components';
 
 function updateIncidentCheckboxMulti(checked, value, key, oldValue, meta, parent) {
@@ -38,7 +38,7 @@ const CheckboxGroup = styled.div`
 
 const CheckboxInput = ({ handler, touched, hasError, meta, parent, getError, validatorsOrOpts }) =>
   meta.isVisible && (
-    <Header meta={meta} options={validatorsOrOpts} touched={touched} hasError={hasError} getError={getError}>
+    <FormField meta={meta} options={validatorsOrOpts} touched={touched} hasError={hasError} getError={getError}>
       <CheckboxWrapper>
         {isObject(meta.values) ? (
           <CheckboxGroup role="group" id={meta.name}>
@@ -76,7 +76,7 @@ const CheckboxInput = ({ handler, touched, hasError, meta, parent, getError, val
           </Label>
         )}
       </CheckboxWrapper>
-    </Header>
+    </FormField>
   );
 
 CheckboxInput.defaultProps = {

--- a/src/signals/incident/components/form/ContainerSelectRenderer/ContainerSelectRenderer.js
+++ b/src/signals/incident/components/form/ContainerSelectRenderer/ContainerSelectRenderer.js
@@ -2,14 +2,14 @@
 // Copyright (C) 2020 - 2021 Gemeente Amsterdam
 import React from 'react';
 import PropTypes from 'prop-types';
-import Header from '../Header';
+import FormField from '../FormField';
 import ContainerSelect from '../ContainerSelect/ContainerSelect';
 
 const ContainerSelectRenderer = ({ handler, touched, hasError, meta, parent, getError, validatorsOrOpts }) =>
   meta?.isVisible && (
-    <Header meta={meta} options={validatorsOrOpts} touched={touched} hasError={hasError} getError={getError}>
+    <FormField meta={meta} options={validatorsOrOpts} touched={touched} hasError={hasError} getError={getError}>
       <ContainerSelect handler={handler} meta={meta} parent={parent} />
-    </Header>
+    </FormField>
   );
 
 ContainerSelectRenderer.propTypes = {

--- a/src/signals/incident/components/form/DateTimeInput/__snapshots__/index.test.js.snap
+++ b/src/signals/incident/components/form/DateTimeInput/__snapshots__/index.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Form component <DateTimeInput /> rendering should render date time field correctly 1`] = `
-<Header
+<FormField
   hasError={[Function]}
   meta={
     Object {
@@ -293,7 +293,7 @@ exports[`Form component <DateTimeInput /> rendering should render date time fiel
       </styled.div>
     </styled.fieldset>
   </styled.div>
-</Header>
+</FormField>
 `;
 
 exports[`Form component <DateTimeInput /> rendering should render no date time field when not visible 1`] = `""`;

--- a/src/signals/incident/components/form/DateTimeInput/index.js
+++ b/src/signals/incident/components/form/DateTimeInput/index.js
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import nl from 'date-fns/locale/nl';
 import Select from 'components/Select';
 import { capitalize } from 'shared/services/date-utils';
-import Header from '../Header';
+import FormField from '../FormField';
 import styled from 'styled-components';
 import Label from 'components/Label';
 import { themeSpacing } from '@amsterdam/asc-ui';
@@ -82,7 +82,7 @@ const DateTimeInput = ({ touched, hasError, meta, parent, getError, validatorsOr
   });
 
   return (
-    <Header meta={meta} options={validatorsOrOpts} touched={touched} hasError={hasError} getError={getError}>
+    <FormField meta={meta} options={validatorsOrOpts} touched={touched} hasError={hasError} getError={getError}>
       <DateTimeInputStyle>
         <FieldWrapper>
           <StyledLabel htmlFor="day">Dag</StyledLabel>
@@ -134,7 +134,7 @@ const DateTimeInput = ({ touched, hasError, meta, parent, getError, validatorsOr
           </TimeWrapper>
         </TimeFieldset>
       </DateTimeInputStyle>
-    </Header>
+    </FormField>
   );
 };
 

--- a/src/signals/incident/components/form/DescriptionInputRenderer/DescriptionInputRenederer.js
+++ b/src/signals/incident/components/form/DescriptionInputRenderer/DescriptionInputRenederer.js
@@ -2,7 +2,7 @@
 // Copyright (C) 2020 - 2021 Gemeente Amsterdam
 import React from 'react';
 import PropTypes from 'prop-types';
-import Header from '../Header';
+import FormField from '../FormField';
 import DescriptionInput from '../DescriptionInput';
 
 const DescriptionInputRenderer = ({
@@ -18,9 +18,9 @@ const DescriptionInputRenderer = ({
   if (!meta?.isVisible) return null;
 
   return (
-    <Header meta={meta} options={validatorsOrOpts} touched={touched} hasError={hasError} getError={getError}>
+    <FormField meta={meta} options={validatorsOrOpts} touched={touched} hasError={hasError} getError={getError}>
       <DescriptionInput handler={handler} meta={meta} parent={parent} value={value} />
-    </Header>
+    </FormField>
   );
 };
 

--- a/src/signals/incident/components/form/FileInputRenderer/index.js
+++ b/src/signals/incident/components/form/FileInputRenderer/index.js
@@ -3,7 +3,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import Header from '../Header';
+import FormField from '../FormField';
 
 import FileInput from '../FileInput';
 
@@ -11,9 +11,9 @@ const FileInputRenderer = ({ handler, touched, hasError, getError, parent, meta,
   if (!meta?.isVisible) return null;
 
   return (
-    <Header meta={meta} options={validatorsOrOpts} touched={touched} hasError={hasError} getError={getError}>
+    <FormField meta={meta} options={validatorsOrOpts} touched={touched} hasError={hasError} getError={getError}>
       <FileInput handler={handler} parent={parent} meta={meta} />
-    </Header>
+    </FormField>
   );
 };
 

--- a/src/signals/incident/components/form/FormField/FormField.tsx
+++ b/src/signals/incident/components/form/FormField/FormField.tsx
@@ -45,14 +45,14 @@ const SubTitle = styled.p`
 `;
 
 type PickedProps = 'touched' | 'hasError' | 'getError';
-export interface HeaderProps extends Pick<ReactiveFormMeta, PickedProps> {
+export interface FormFieldProps extends Pick<ReactiveFormMeta, PickedProps> {
   className?: string;
   meta: FormMeta;
   options?: FormOptions;
   isFieldSet?: boolean;
 }
 
-const Header: FunctionComponent<HeaderProps> = ({
+const FormField: FunctionComponent<FormFieldProps> = ({
   isFieldSet,
   className,
   meta,
@@ -114,4 +114,4 @@ const Header: FunctionComponent<HeaderProps> = ({
   );
 };
 
-export default Header;
+export default FormField;

--- a/src/signals/incident/components/form/FormField/__tests__/index.test.tsx
+++ b/src/signals/incident/components/form/FormField/__tests__/index.test.tsx
@@ -7,11 +7,11 @@ import { Validators } from 'react-reactive-form';
 import { withAppContext } from 'test/utils';
 import { createRequired } from '../../../../services/custom-validators';
 
-import type { HeaderProps } from '../Header';
-import Header from '..';
+import type { FormFieldProps } from '../FormField';
+import FormField from '..';
 import type { FormMeta } from 'types/reactive-form';
 
-describe('signals/incident/components/form/Header', () => {
+describe('signals/incident/components/form/FormField', () => {
   const label = 'Foo barrrr';
   const props = {
     meta: {
@@ -22,51 +22,51 @@ describe('signals/incident/components/form/Header', () => {
     touched: false,
     hasError: () => false,
     getError: () => '',
-  } as HeaderProps;
+  } as FormFieldProps;
 
   it('should render label', () => {
-    render(withAppContext(<Header {...props} />));
+    render(withAppContext(<FormField {...props} />));
 
     expect(screen.getByText(label)).toBeInTheDocument();
   });
 
   it('should render fieldset with legend', () => {
-    render(withAppContext(<Header {...props} isFieldSet />));
+    render(withAppContext(<FormField {...props} isFieldSet />));
 
     // Role 'group' asserts that a fieldset is rendered with a legend as its first child.
     expect(screen.getByRole('group', { name: /Foo barrrr/ })).toBeInTheDocument();
   });
 
   it('should render optional indicator', () => {
-    const { rerender } = render(withAppContext(<Header {...props} options={{}} />));
+    const { rerender } = render(withAppContext(<FormField {...props} options={{}} />));
 
     expect(screen.queryByText('(niet verplicht)')).toBeInTheDocument();
 
-    rerender(withAppContext(<Header {...props} options={{ validators: undefined }} />));
+    rerender(withAppContext(<FormField {...props} options={{ validators: undefined }} />));
 
     expect(screen.queryByText('(niet verplicht)')).toBeInTheDocument();
 
-    rerender(withAppContext(<Header {...props} options={{ validators: [] }} />));
+    rerender(withAppContext(<FormField {...props} options={{ validators: [] }} />));
 
     expect(screen.queryByText('(niet verplicht)')).toBeInTheDocument();
 
-    rerender(withAppContext(<Header {...props} meta={{ ...props.meta, label: undefined }} options={{}} />));
+    rerender(withAppContext(<FormField {...props} meta={{ ...props.meta, label: undefined }} options={{}} />));
 
     expect(screen.queryByText('(niet verplicht)')).not.toBeInTheDocument();
 
     // eslint-disable-next-line jest/unbound-method
-    rerender(withAppContext(<Header {...props} options={{ validators: [Validators.required] }} />));
+    rerender(withAppContext(<FormField {...props} options={{ validators: [Validators.required] }} />));
 
     expect(screen.queryByText('(niet verplicht)')).not.toBeInTheDocument();
 
-    rerender(withAppContext(<Header {...props} options={{ validators: [createRequired('Verplicht')] }} />));
+    rerender(withAppContext(<FormField {...props} options={{ validators: [createRequired('Verplicht')] }} />));
 
     expect(screen.queryByText('(niet verplicht)')).not.toBeInTheDocument();
   });
 
   it('should render subtitle', () => {
     const subtitle = 'Bar bazzz';
-    render(withAppContext(<Header {...props} meta={{ ...props.meta, subtitle }} />));
+    render(withAppContext(<FormField {...props} meta={{ ...props.meta, subtitle }} />));
 
     expect(screen.getByText(subtitle)).toBeInTheDocument();
   });
@@ -74,9 +74,9 @@ describe('signals/incident/components/form/Header', () => {
   it('should render children', () => {
     const { container } = render(
       withAppContext(
-        <Header {...props}>
+        <FormField {...props}>
           <span className="child" />
-        </Header>
+        </FormField>
       )
     );
 
@@ -88,11 +88,11 @@ describe('signals/incident/components/form/Header', () => {
     const getError = () => true;
     const error = 'Dit is een verplicht veld';
 
-    const { rerender } = render(withAppContext(<Header {...props} touched />));
+    const { rerender } = render(withAppContext(<FormField {...props} touched />));
 
     expect(screen.queryByText(error)).not.toBeInTheDocument();
 
-    rerender(withAppContext(<Header {...props} getError={getError} hasError={hasError} touched />));
+    rerender(withAppContext(<FormField {...props} getError={getError} hasError={hasError} touched />));
 
     expect(screen.queryByText(error)).toBeInTheDocument();
   });
@@ -102,11 +102,11 @@ describe('signals/incident/components/form/Header', () => {
     const hasError = (prop: string) => prop === 'required';
     const getError = () => error;
 
-    const { rerender } = render(withAppContext(<Header {...props} touched />));
+    const { rerender } = render(withAppContext(<FormField {...props} touched />));
 
     expect(screen.queryByText(error)).not.toBeInTheDocument();
 
-    rerender(withAppContext(<Header {...props} getError={getError} hasError={hasError} touched />));
+    rerender(withAppContext(<FormField {...props} getError={getError} hasError={hasError} touched />));
 
     expect(screen.queryByText(error)).toBeInTheDocument();
   });
@@ -115,11 +115,11 @@ describe('signals/incident/components/form/Header', () => {
     const hasError = (prop: string) => prop === 'email';
     const error = 'Vul een geldig e-mailadres in, met een @ en een domeinnaam. Bijvoorbeeld: naam@domein.nl';
 
-    const { rerender } = render(withAppContext(<Header {...props} touched />));
+    const { rerender } = render(withAppContext(<FormField {...props} touched />));
 
     expect(screen.queryByText(error)).not.toBeInTheDocument();
 
-    rerender(withAppContext(<Header {...props} hasError={hasError} touched />));
+    rerender(withAppContext(<FormField {...props} hasError={hasError} touched />));
 
     expect(screen.queryByText(error)).toBeInTheDocument();
   });
@@ -130,11 +130,11 @@ describe('signals/incident/components/form/Header', () => {
     const getError = () => ({ requiredLength });
     const error = `U heeft meer dan de maximale ${requiredLength} tekens ingevoerd`;
 
-    const { rerender } = render(withAppContext(<Header {...props} getError={getError} touched />));
+    const { rerender } = render(withAppContext(<FormField {...props} getError={getError} touched />));
 
     expect(screen.queryByText(error)).not.toBeInTheDocument();
 
-    rerender(withAppContext(<Header {...props} hasError={hasError} getError={getError} touched />));
+    rerender(withAppContext(<FormField {...props} hasError={hasError} getError={getError} touched />));
 
     expect(screen.queryByText(error)).toBeInTheDocument();
   });
@@ -144,11 +144,11 @@ describe('signals/incident/components/form/Header', () => {
     const hasError = (prop: string) => prop === 'custom';
     const getError = () => error;
 
-    const { rerender } = render(withAppContext(<Header {...props} getError={getError} touched />));
+    const { rerender } = render(withAppContext(<FormField {...props} getError={getError} touched />));
 
     expect(screen.queryByText(error)).not.toBeInTheDocument();
 
-    rerender(withAppContext(<Header {...props} hasError={hasError} getError={getError} touched />));
+    rerender(withAppContext(<FormField {...props} hasError={hasError} getError={getError} touched />));
 
     expect(screen.queryByText(error)).toBeInTheDocument();
   });
@@ -159,11 +159,11 @@ describe('signals/incident/components/form/Header', () => {
     const touched = false;
     const error = 'Dit is een verplicht veld';
 
-    const { rerender } = render(withAppContext(<Header {...props} hasError={hasError} touched={touched} />));
+    const { rerender } = render(withAppContext(<FormField {...props} hasError={hasError} touched={touched} />));
 
     expect(screen.queryByText(error)).not.toBeInTheDocument();
 
-    rerender(withAppContext(<Header {...props} getError={getError} hasError={hasError} touched />));
+    rerender(withAppContext(<FormField {...props} getError={getError} hasError={hasError} touched />));
 
     expect(screen.queryByText(error)).toBeInTheDocument();
   });

--- a/src/signals/incident/components/form/FormField/index.ts
+++ b/src/signals/incident/components/form/FormField/index.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2021 Gemeente Amsterdam
-import Header from './Header';
+import FormField from './FormField';
 
-export default Header;
+export default FormField;

--- a/src/signals/incident/components/form/Header/Header.tsx
+++ b/src/signals/incident/components/form/Header/Header.tsx
@@ -22,6 +22,16 @@ const StyledLabel = styled(Label)`
   line-height: ${themeSpacing(6)};
 `;
 
+const FieldSet = styled.fieldset`
+  border: 0;
+  padding: 0;
+  margin-bottom: 0;
+
+  & > :last-child {
+    margin-top: ${themeSpacing(3)};
+  }
+`;
+
 const Optional = styled.span`
   font-family: Avenir Next LT W01-Regular, arial, sans-serif;
   margin-left: ${themeSpacing(2)};
@@ -39,9 +49,11 @@ export interface HeaderProps extends Pick<ReactiveFormMeta, PickedProps> {
   className?: string;
   meta: FormMeta;
   options?: FormOptions;
+  isFieldSet?: boolean;
 }
 
 const Header: FunctionComponent<HeaderProps> = ({
+  isFieldSet,
   className,
   meta,
   options,
@@ -53,48 +65,51 @@ const Header: FunctionComponent<HeaderProps> = ({
   const containsErrors: boolean =
     touched && (hasError('required') || hasError('email') || hasError('maxLength') || hasError('custom'));
   const isOptional = !options?.validators?.some(validator => validator.name === 'required');
+  const FieldSetWrapper = isFieldSet ? FieldSet : Fragment;
 
   return (
     <StyledErrorWrapper className={className} invalid={containsErrors}>
-      {meta?.label && (
-        <StyledLabel htmlFor={meta.name}>
-          {meta.label}
+      <FieldSetWrapper>
+        {meta?.label && (
+          <StyledLabel {...(isFieldSet ? { as: 'legend' } : { htmlFor: meta.name })}>
+            <Fragment>
+              {meta.label}{isOptional && <Optional>(niet verplicht)</Optional>}
+            </Fragment>
+          </StyledLabel>
+        )}
 
-          {isOptional && <Optional>(niet verplicht)</Optional>}
-        </StyledLabel>
-      )}
+        {meta?.subtitle && <SubTitle id={`subtitle-${meta.name}`}>{meta.subtitle}</SubTitle>}
 
-      {meta?.subtitle && <SubTitle id={`subtitle-${meta.name}`}>{meta.subtitle}</SubTitle>}
+        {touched && containsErrors && (
+          <Fragment>
+            {hasError('required') && (
+              <ErrorMessage
+                data-testid={`${meta.name}-required`}
+                message={getError('required') === true ? 'Dit is een verplicht veld' : (getError('required') as string)}
+              />
+            )}
 
-      {touched && containsErrors && (
-        <Fragment>
-          {hasError('required') && (
-            <ErrorMessage
-              data-testid={`${meta.name}-required`}
-              message={getError('required') === true ? 'Dit is een verplicht veld' : (getError('required') as string)}
-            />
-          )}
+            {hasError('email') && (
+              <ErrorMessage
+                data-testid="invalid-mail"
+                message="Vul een geldig e-mailadres in, met een @ en een domeinnaam. Bijvoorbeeld: naam@domein.nl"
+              />
+            )}
 
-          {hasError('email') && (
-            <ErrorMessage
-              data-testid="invalid-mail"
-              message="Vul een geldig e-mailadres in, met een @ en een domeinnaam. Bijvoorbeeld: naam@domein.nl"
-            />
-          )}
+            {hasError('maxLength') && (
+              <ErrorMessage
+                message={`U heeft meer dan de maximale ${String(
+                  (getError('maxLength') as { requiredLength: number }).requiredLength
+                )} tekens ingevoerd`}
+              />
+            )}
 
-          {hasError('maxLength') && (
-            <ErrorMessage
-              message={`U heeft meer dan de maximale ${String(
-                (getError('maxLength') as { requiredLength: number }).requiredLength
-              )} tekens ingevoerd`}
-            />
-          )}
+            {hasError('custom') && <ErrorMessage message={getError('custom') as string} />}
+          </Fragment>
+        )}
 
-          {hasError('custom') && <ErrorMessage message={getError('custom') as string} />}
-        </Fragment>
-      )}
-
-      {children}
+        {children}
+      </FieldSetWrapper>
     </StyledErrorWrapper>
   );
 };

--- a/src/signals/incident/components/form/Header/__tests__/index.test.tsx
+++ b/src/signals/incident/components/form/Header/__tests__/index.test.tsx
@@ -30,6 +30,13 @@ describe('signals/incident/components/form/Header', () => {
     expect(screen.getByText(label)).toBeInTheDocument();
   });
 
+  it('should render fieldset with legend', () => {
+    render(withAppContext(<Header {...props} isFieldSet />));
+
+    // Role 'group' asserts that a fieldset is rendered with a legend as its first child.
+    expect(screen.getByRole('group', { name: /Foo barrrr/ })).toBeInTheDocument();
+  });
+
   it('should render optional indicator', () => {
     const { rerender } = render(withAppContext(<Header {...props} options={{}} />));
 

--- a/src/signals/incident/components/form/MapInput/__snapshots__/index.test.js.snap
+++ b/src/signals/incident/components/form/MapInput/__snapshots__/index.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Form component <MapInput /> rendering should render map field correctly 1`] = `
-<Header
+<FormField
   className="mapInput"
   getError={[MockFunction]}
   hasError={[MockFunction]}
@@ -86,7 +86,7 @@ exports[`Form component <MapInput /> rendering should render map field correctly
       />
     </Memo(MapContext)>
   </div>
-</Header>
+</FormField>
 `;
 
 exports[`Form component <MapInput /> rendering should render no map field when not visible 1`] = `""`;

--- a/src/signals/incident/components/form/MapInput/index.js
+++ b/src/signals/incident/components/form/MapInput/index.js
@@ -9,7 +9,7 @@ import configuration from 'shared/services/configuration/configuration';
 import MAP_OPTIONS from 'shared/services/configuration/map-options';
 import { formatMapLocation } from 'shared/services/map-location';
 
-import Header from '../Header';
+import FormField from '../FormField';
 
 const MapInput = ({ handler, touched, hasError, meta, parent, getError, validatorsOrOpts }) => {
   const value = formatMapLocation(handler().value || {});
@@ -26,7 +26,7 @@ const MapInput = ({ handler, touched, hasError, meta, parent, getError, validato
 
   return (
     meta?.isVisible && (
-      <Header
+      <FormField
         className="mapInput"
         meta={meta}
         options={validatorsOrOpts}
@@ -47,7 +47,7 @@ const MapInput = ({ handler, touched, hasError, meta, parent, getError, validato
             />
           </MapContext>
         </div>
-      </Header>
+      </FormField>
     )
   );
 };

--- a/src/signals/incident/components/form/MapSelect/index.js
+++ b/src/signals/incident/components/form/MapSelect/index.js
@@ -9,7 +9,7 @@ import { themeSpacing } from '@amsterdam/asc-ui';
 import MapSelectComponent from 'components/MapSelect';
 import configuration from 'shared/services/configuration/configuration';
 
-import Header from '../Header';
+import FormField from '../FormField';
 import { getOVLIcon, LEGEND_ITEMS } from './iconMapping';
 import MapSelectGeneric from '../MapSelectGeneric';
 
@@ -48,7 +48,7 @@ const MapSelect = ({ handler, touched, hasError, meta, parent, getError, validat
 
   return (
     meta?.isVisible && (
-      <Header
+      <FormField
         // className value is referenced by form component
         className="mapSelect"
         meta={meta}
@@ -74,7 +74,7 @@ const MapSelect = ({ handler, touched, hasError, meta, parent, getError, validat
         {selection.length > 0 && (
           <Selection>Het gaat om lamp of lantaarnpaal met nummer: {selection.join('; ')}</Selection>
         )}
-      </Header>
+      </FormField>
     )
   );
 };

--- a/src/signals/incident/components/form/MapSelectGeneric/index.js
+++ b/src/signals/incident/components/form/MapSelectGeneric/index.js
@@ -8,7 +8,7 @@ import { themeSpacing } from '@amsterdam/asc-ui';
 import MapSelectComponent from 'components/MapSelectGeneric';
 import configuration from 'shared/services/configuration/configuration';
 
-import Header from '../Header';
+import FormField from '../FormField';
 
 export const getLatlng = meta =>
   meta?.incidentContainer?.incident?.location?.geometrie?.coordinates
@@ -43,7 +43,7 @@ const MapSelectGeneric = ({ handler, touched, hasError = () => {}, meta, parent,
 
   return (
     meta?.isVisible && (
-      <Header
+      <FormField
         // className value is referenced by form component
         className="mapSelectGeneric"
         meta={meta}
@@ -68,7 +68,7 @@ const MapSelectGeneric = ({ handler, touched, hasError = () => {}, meta, parent,
             Het gaat om{meta.selectionLabel ? ` ${meta.selectionLabel}` : ''}: {selection.join('; ')}
           </Selection>
         )}
-      </Header>
+      </FormField>
     )
   );
 };

--- a/src/signals/incident/components/form/MultiTextInput/MultiTextInput.tsx
+++ b/src/signals/incident/components/form/MultiTextInput/MultiTextInput.tsx
@@ -8,7 +8,7 @@ import map from 'lodash.map';
 import Input from 'components/Input';
 import Button from 'components/Button';
 
-import Header from '../Header';
+import FormField from '../FormField';
 import type { FormInputProps, FormMeta, ParentType } from 'types/reactive-form';
 import { themeSpacing } from '@amsterdam/asc-ui';
 
@@ -61,7 +61,7 @@ const MultiTextInput: FunctionComponent<MultiTextInputProps> = ({
   validatorsOrOpts,
 }) =>
   (meta?.isVisible && (
-    <Header meta={meta} options={validatorsOrOpts} touched={touched} hasError={hasError} getError={getError}>
+    <FormField meta={meta} options={validatorsOrOpts} touched={touched} hasError={hasError} getError={getError}>
       <div>
         <input type="hidden" {...handler()} />
 
@@ -98,7 +98,7 @@ const MultiTextInput: FunctionComponent<MultiTextInputProps> = ({
           {meta.newItemText}
         </Button>
       </div>
-    </Header>
+    </FormField>
   )) ||
   null;
 

--- a/src/signals/incident/components/form/RadioInputGroup/RadioInputGroup.js
+++ b/src/signals/incident/components/form/RadioInputGroup/RadioInputGroup.js
@@ -29,11 +29,10 @@ const RadioInputGroup = ({ handler, touched, hasError, meta, parent, getError, v
   if (!meta.isVisible) return null;
 
   return (
-    <Header meta={meta} options={validatorsOrOpts} touched={touched} hasError={hasError} getError={getError}>
+    <Header isFieldSet meta={meta} options={validatorsOrOpts} touched={touched} hasError={hasError} getError={getError}>
       {meta.values && isObject(meta.values) && (
         <div>
           <StyledRadioGroup
-            role="radiogroup"
             id={meta.name}
             name={meta.name}
             aria-describedby={meta.subtitle && `subtitle-${meta.name}`}

--- a/src/signals/incident/components/form/RadioInputGroup/RadioInputGroup.js
+++ b/src/signals/incident/components/form/RadioInputGroup/RadioInputGroup.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import isObject from 'lodash.isobject';
 import { themeColor, themeSpacing, RadioGroup } from '@amsterdam/asc-ui';
 
-import Header from '../Header';
+import FormField from '../FormField';
 import RadioInput from '../RadioInput';
 
 const Info = styled.p`
@@ -29,7 +29,7 @@ const RadioInputGroup = ({ handler, touched, hasError, meta, parent, getError, v
   if (!meta.isVisible) return null;
 
   return (
-    <Header isFieldSet meta={meta} options={validatorsOrOpts} touched={touched} hasError={hasError} getError={getError}>
+    <FormField isFieldSet meta={meta} options={validatorsOrOpts} touched={touched} hasError={hasError} getError={getError}>
       {meta.values && isObject(meta.values) && (
         <div>
           <StyledRadioGroup
@@ -57,7 +57,7 @@ const RadioInputGroup = ({ handler, touched, hasError, meta, parent, getError, v
           )}
         </div>
       )}
-    </Header>
+    </FormField>
   );
 };
 

--- a/src/signals/incident/components/form/RadioInputGroup/__tests__/RadioInputGroup.test.js
+++ b/src/signals/incident/components/form/RadioInputGroup/__tests__/RadioInputGroup.test.js
@@ -48,7 +48,7 @@ describe('Form component <RadioInput />', () => {
     it('renders radio fields correctly', () => {
       render(withAppContext(<RadioInputGroup {...props} />));
 
-      expect(screen.getByRole('radiogroup')).toBeInTheDocument();
+      expect(screen.getByRole('group')).toBeInTheDocument();
       expect(screen.getByRole('radio', { name: 'Foo' })).toBeInTheDocument();
       expect(screen.getByRole('radio', { name: 'Bar' })).toBeInTheDocument();
     });
@@ -56,7 +56,7 @@ describe('Form component <RadioInput />', () => {
     it('renders zero radio fields when values are not supplied', async () => {
       render(withAppContext(<RadioInputGroup {...props} meta={{ ...props.meta, values: undefined }} />));
 
-      expect(screen.queryByRole('radiogroup')).not.toBeInTheDocument();
+      expect(screen.queryByRole('group')).toBeInTheDocument();
       expect(screen.queryByRole('radio', { name: 'Foo' })).not.toBeInTheDocument();
       expect(screen.queryByRole('radio', { name: 'Bar' })).not.toBeInTheDocument();
     });
@@ -64,7 +64,7 @@ describe('Form component <RadioInput />', () => {
     it('renders no radio field when not visible', () => {
       render(withAppContext(<RadioInputGroup {...props} meta={{ ...props.meta, isVisible: false }} />));
 
-      expect(screen.queryByRole('radiogroup')).not.toBeInTheDocument();
+      expect(screen.queryByRole('group')).not.toBeInTheDocument();
       expect(screen.queryByRole('radio', { name: 'Foo' })).not.toBeInTheDocument();
       expect(screen.queryByRole('radio', { name: 'Bar' })).not.toBeInTheDocument();
     });

--- a/src/signals/incident/components/form/SelectInput/__snapshots__/index.test.js.snap
+++ b/src/signals/incident/components/form/SelectInput/__snapshots__/index.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Form component <SelectInput /> rendering should render empty select field when values are not supplied 1`] = `
-<Header
+<FormField
   getError={[MockFunction]}
   hasError={[MockFunction]}
   meta={
@@ -21,13 +21,13 @@ exports[`Form component <SelectInput /> rendering should render empty select fie
     options={Array []}
     value="baz"
   />
-</Header>
+</FormField>
 `;
 
 exports[`Form component <SelectInput /> rendering should render no select field when not visible 1`] = `""`;
 
 exports[`Form component <SelectInput /> rendering should render select field correctly 1`] = `
-<Header
+<FormField
   getError={[MockFunction]}
   hasError={[MockFunction]}
   meta={
@@ -69,5 +69,5 @@ exports[`Form component <SelectInput /> rendering should render select field cor
     }
     value="baz"
   />
-</Header>
+</FormField>
 `;

--- a/src/signals/incident/components/form/SelectInput/index.js
+++ b/src/signals/incident/components/form/SelectInput/index.js
@@ -6,11 +6,11 @@ import isObject from 'lodash.isobject';
 
 import Select from 'components/Select';
 
-import Header from '../Header';
+import FormField from '../FormField';
 
 const SelectInput = ({ handler, touched, hasError, meta, parent, getError, validatorsOrOpts }) =>
   meta?.isVisible && (
-    <Header meta={meta} options={validatorsOrOpts} touched={touched} hasError={hasError} getError={getError}>
+    <FormField meta={meta} options={validatorsOrOpts} touched={touched} hasError={hasError} getError={getError}>
       <Select
         id={meta.name}
         aria-describedby={meta.subtitle && `subtitle-${meta.name}`}
@@ -30,7 +30,7 @@ const SelectInput = ({ handler, touched, hasError, meta, parent, getError, valid
             []
         }
       />
-    </Header>
+    </FormField>
   );
 
 SelectInput.propTypes = {

--- a/src/signals/incident/components/form/TextInput/TextInput.tsx
+++ b/src/signals/incident/components/form/TextInput/TextInput.tsx
@@ -4,7 +4,7 @@ import type { FunctionComponent } from 'react';
 import React from 'react';
 import Input from 'components/Input';
 
-import Header from '../Header';
+import FormField from '../FormField';
 import type { FormInputProps } from 'types/reactive-form';
 
 export type TextInputProps = FormInputProps;
@@ -19,7 +19,7 @@ const TextInput: FunctionComponent<TextInputProps> = ({
   validatorsOrOpts,
 }) =>
   (meta?.isVisible && (
-    <Header meta={meta} options={validatorsOrOpts} touched={touched} hasError={hasError} getError={getError}>
+    <FormField meta={meta} options={validatorsOrOpts} touched={touched} hasError={hasError} getError={getError}>
       <Input
         id={meta.name}
         aria-describedby={meta.subtitle && `subtitle-${meta.name}`}
@@ -34,7 +34,7 @@ const TextInput: FunctionComponent<TextInputProps> = ({
           });
         }}
       />
-    </Header>
+    </FormField>
   )) ||
   null;
 

--- a/src/signals/incident/components/form/TextareaInput/TextareaInput.tsx
+++ b/src/signals/incident/components/form/TextareaInput/TextareaInput.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import TextArea from 'components/TextArea';
 
 import type { FormInputProps } from 'types/reactive-form';
-import Header from '../Header';
+import FormField from '../FormField';
 
 export type TextAreaInputProps = FormInputProps;
 
@@ -20,7 +20,7 @@ const TextareaInput: FunctionComponent<TextAreaInputProps> = ({
   validatorsOrOpts,
 }) =>
   (meta?.isVisible && (
-    <Header meta={meta} options={validatorsOrOpts} touched={touched} hasError={hasError} getError={getError}>
+    <FormField meta={meta} options={validatorsOrOpts} touched={touched} hasError={hasError} getError={getError}>
       <TextArea
         id={meta.name}
         aria-describedby={meta.subtitle && `subtitle-${meta.name}`}
@@ -33,7 +33,7 @@ const TextareaInput: FunctionComponent<TextAreaInputProps> = ({
         }}
         infoText={meta.maxLength && `${value ? value.length : '0'}/${meta.maxLength} tekens`}
       />
-    </Header>
+    </FormField>
   )) ||
   null;
 export default TextareaInput;

--- a/src/signals/incident/containers/KtoContainer/components/KtoForm/index.js
+++ b/src/signals/incident/containers/KtoContainer/components/KtoForm/index.js
@@ -29,6 +29,11 @@ const Form = styled.form`
 
 const GridArea = styled.div``;
 
+const FieldSet = styled.fieldset`
+  border: 0;
+  padding: 0;
+`;
+
 const StyledLabel = styled(Label)`
   margin-bottom: 0;
   line-height: ${themeSpacing(6)};
@@ -168,24 +173,25 @@ const KtoForm = ({ options, isSatisfied, onSubmit }) => {
   return (
     <Form data-testid="ktoForm" onSubmit={handleSubmit}>
       <GridArea>
-        <StyledLabel htmlFor="kto" ref={firstLabelRef}>
-          Waarom bent u {!isSatisfied ? 'on' : ''}tevreden?
-        </StyledLabel>
-        <HelpText id="subtitle-kto">Een antwoord mogelijk, kies de belangrijkste reden</HelpText>
+        <FieldSet>
+          <StyledLabel as="legend" ref={firstLabelRef}>
+            Waarom bent u {!isSatisfied ? 'on' : ''}tevreden?
+          </StyledLabel>
+          <HelpText id="subtitle-kto">Een antwoord mogelijk, kies de belangrijkste reden</HelpText>
 
-        <StyledRadioButtonList
-          id="kto"
-          aria-describedby="subtitle-kto"
-          error={Boolean(state.errors.text)}
-          groupName="kto"
-          hasEmptySelectionButton={false}
-          onChange={onChangeOption}
-          options={options}
-        />
-        {state.areaVisibility && (
-          <StyledTextArea data-testid="ktoText" maxRows={5} name="text" onChange={onChangeText('SET_TEXT')} rows="2" />
-        )}
-        {state.errors.text && <ErrorMessage message={state.errors.text} />}
+          <StyledRadioButtonList
+            aria-describedby="subtitle-kto"
+            error={Boolean(state.errors.text)}
+            groupName="kto"
+            hasEmptySelectionButton={false}
+            onChange={onChangeOption}
+            options={options}
+          />
+          {state.areaVisibility && (
+            <StyledTextArea data-testid="ktoText" maxRows={5} name="text" onChange={onChangeText('SET_TEXT')} rows="2" />
+          )}
+          {state.errors.text && <ErrorMessage message={state.errors.text} />}
+        </FieldSet>
       </GridArea>
 
       <GridArea>


### PR DESCRIPTION
### Changes

- Removes role radiogroup as A11Y review found it an insufficient solution
- Updates header component to optionally render fieldset/legend instead of a label
- Use fieldset/legend for KTO form