### PR TITLE
[SIG-3697] Cypress tests KTO fix mail

### DIFF
--- a/e2e-tests/cypress/integration/_localRun/ktoNotSatisfied.spec.ts
+++ b/e2e-tests/cypress/integration/_localRun/ktoNotSatisfied.spec.ts
@@ -3,6 +3,7 @@
 import { CHANGE_STATUS } from '../../support/selectorsSignalDetails';
 import { KTO_FORM, MAIL } from '../../support/selectorsKTO';
 import { ERROR_MESSAGES, KTO } from '../../support/texts';
+import {DJANGO} from '../../support/selectorsDjangoAdmin';
 import * as requests from '../../support/commandsRequests';
 import { generateToken } from '../../support/jwt';
 import * as routes from '../../support/commandsRouting';
@@ -10,6 +11,33 @@ import * as createSignal from '../../support/commandsCreateSignal';
 import * as general from '../../support/commandsGeneral';
 
 describe('KTO form', () => {
+  describe('Set up mail template in Django Admin', () => {
+    before(() => {
+      cy.visit(`${Cypress.env('backendUrl')}/signals/admin`);
+    });
+    it('Add mail template', () => {
+      cy.get(DJANGO.inputUsername).type('signals.admin@example.com');
+      cy.get(DJANGO.inputPassword).type('password');
+      cy.contains('Aanmelden').click();
+      cy.get(DJANGO.linkEmailTemplate).eq(1).click();
+
+      cy.get(DJANGO.templateList).then(list => {
+        if (list.find(DJANGO.checkboxTemplate).length > 0) {
+          cy.log('Template already exists');
+        }
+        else {
+          cy.log('No template');
+          cy.get(DJANGO.linkEmailTemplateAdd).eq(1).click();
+          cy.get(DJANGO.selectEmailKey).select('Send mail signal handled');
+          cy.get(DJANGO.inputEmailTitle).type('Uw melding {{ formatted_signal_id }}', { parseSpecialCharSequences: false });
+          cy.get(DJANGO.inputEmailBody).type(KTO.body, { parseSpecialCharSequences: false });
+          cy.get(DJANGO.buttonSave).click();
+        }
+      });
+
+      cy.get(DJANGO.linkLogout).click();
+    });
+  });
   describe('Set up testdata', () => {
     before(() => {
       requests.createSignalKTO();
@@ -29,7 +57,7 @@ describe('KTO form', () => {
       cy.visit(`${Cypress.env('mailUrl')}`);
       cy.get(MAIL.lastMail).click();
       cy.wait('@getMail');
-      general.getIframeBody().find('a').eq(1).should('have.text', 'Nee, ik ben niet tevreden.').then(link => {
+      general.getIframeBody().find('a').eq(1).should('have.text', 'Nee, ik ben niet tevreden').then(link => {
         const linkText = link.prop('href') as string;
         const ktoLink = linkText.slice(22);
         cy.writeFile('./cypress/fixtures/tempKTO.json', { ktoLink: `${ktoLink}` }, { flag: 'w' });

--- a/e2e-tests/cypress/integration/handleSignals/deelmeldingen.spec.ts
+++ b/e2e-tests/cypress/integration/handleSignals/deelmeldingen.spec.ts
@@ -4,6 +4,7 @@
 import { CREATE_SIGNAL, BOTEN } from '../../support/selectorsCreateSignal';
 import { CHANGE_STATUS, CHANGE_URGENCY, DEELMELDING, SIGNAL_DETAILS } from '../../support/selectorsSignalDetails';
 import { FILTER, MANAGE_SIGNALS } from '../../support/selectorsManageIncidents';
+import {DJANGO} from '../../support/selectorsDjangoAdmin';
 import { ERROR_MESSAGES, NOTIFICATONS } from '../../support/texts';
 import { generateToken } from '../../support/jwt';
 import signal01 from '../../fixtures/signals/deelmelding01.json';
@@ -19,14 +20,14 @@ describe('Deelmeldingen', () => {
       cy.visit(`${Cypress.env('backendUrl')}/signals/admin`);
     });
     it('Should set can manage', () => {
-      cy.get('#id_username').type('signals.admin@example.com');
-      cy.get('#id_password').type('password');
+      cy.get(DJANGO.inputUsername).type('signals.admin@example.com');
+      cy.get(DJANGO.inputPassword).type('password');
       cy.contains('Aanmelden').click();
-      cy.get('a[href="/signals/admin/signals/department/"]').eq(1).click();
+      cy.get(DJANGO.linkDepartment).eq(1).click();
       cy.contains('ASC').click();
-      cy.get('#id_can_direct').check().should('be.checked');
-      cy.get('[name="_save"]').click();
-      cy.get('a[href="/signals/admin/logout/"]').click();
+      cy.get(DJANGO.checkboxCanDirect).check().should('be.checked');
+      cy.get(DJANGO.buttonSave).click();
+      cy.get(DJANGO.linkLogout).click();
     });
   });
   describe('Create Deelmeldingen', () => {

--- a/e2e-tests/cypress/support/selectorsDjangoAdmin.ts
+++ b/e2e-tests/cypress/support/selectorsDjangoAdmin.ts
@@ -1,0 +1,15 @@
+export const DJANGO = {
+  buttonSave: '[name="_save"]',
+  checkboxCanDirect: '#id_can_direct',
+  checkboxTemplate: '.action-select',
+  inputEmailBody: '#id_body',
+  inputEmailTitle: '#id_title',
+  inputPassword: '#id_password',
+  inputUsername: '#id_username',
+  linkDepartment: 'a[href="/signals/admin/signals/department/"]',
+  linkEmailTemplate: 'a[href="/signals/admin/email_integrations/emailtemplate/"]',
+  linkEmailTemplateAdd: 'a[href="/signals/admin/email_integrations/emailtemplate/add/"]',
+  linkLogout: 'a[href="/signals/admin/logout/"]',
+  templateList: '#changelist',
+  selectEmailKey: '#id_key',
+};

--- a/e2e-tests/cypress/support/texts.ts
+++ b/e2e-tests/cypress/support/texts.ts
@@ -8,12 +8,13 @@ export const ERROR_MESSAGES = {
 };
 
 export const KTO = {
+  body: '[Ja, ik ben tevreden]({{ positive_feedback_url }}) \n  [Nee, ik ben niet tevreden]({{ negative_feedback_url }})',
   formTitelIsAlFeedback: 'Er is al feedback gegeven voor deze melding',
   formTitleBedankt: 'Bedankt voor uw feedback!',
   formTitleOnTevreden: 'Nee, ik ben niet tevreden met de behandeling van mijn melding',
   formTitleTevreden: 'Ja, ik ben tevreden met de behandeling van mijn melding',
-  questionContact: 'Mogen wij contact met u opnemen naar aanleiding van uw feedback? (optioneel)',
-  questionVermelden: 'Wilt u verder nog iets vermelden of toelichten? (optioneel)',
+  questionContact: 'Mogen wij contact met u opnemen naar aanleiding van uw feedback? (niet verplicht)',
+  questionVermelden: 'Wilt u verder nog iets vermelden of toelichten? (niet verplicht)',
   questionWaaromOntevreden: 'Waarom bent u ontevreden?',
   questionWaaromTevreden: 'Waarom bent u tevreden?',
   subtitleQuestionTevreden: 'Een antwoord mogelijk, kies de belangrijkste reden',


### PR DESCRIPTION
Due to a change in the backend, there are no default mail templates available. This fix adds a mail template.