### PR TITLE
[SIG-3711] Prevent wrapping of radio button legend text

### DIFF
--- a/src/signals/incident/components/form/FormField/FormField.tsx
+++ b/src/signals/incident/components/form/FormField/FormField.tsx
@@ -22,6 +22,7 @@ const StyledErrorWrapper = styled(ErrorWrapper)<{ invalid: boolean }>`
 `
 
 const StyledLabel = styled(Label)`
+  width: 100%;
   margin-bottom: 0;
   line-height: ${themeSpacing(6)};
 `


### PR DESCRIPTION
### Changes

- Prevents wrapping of legend text for radio button form input (Only in Safari)
<img width="326" alt="Screenshot 2021-04-22 at 09 44 09" src="https://user-images.githubusercontent.com/10672773/115677923-40d03f00-a351-11eb-9f90-e704be4877cf.png">

