### PR TITLE
(Chore) fix flaky unit test

### DIFF
--- a/src/signals/incident-management/containers/ReporterContainer/__tests__/useFetchReporter.test.ts
+++ b/src/signals/incident-management/containers/ReporterContainer/__tests__/useFetchReporter.test.ts
@@ -52,6 +52,8 @@ const REPORTER_MOCK: Result = {
 }
 
 describe('Fetch Reporter hook', () => {
+  beforeEach(() => server.resetHandlers())
+
   it('correctly implements pagination', async () => {
     mockRequestHandler({
       body: {


### PR DESCRIPTION
Fixes flaky unit test by resetting the handlers after each test run