### PR TITLE
[SIG-2564] Show message when touch device users scroll the incident location selection map

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "invariant": "^2.2.4",
         "keycloak-js": "^12.0.4",
         "leaflet": "^1.7.1",
+        "leaflet-gesture-handling": "^1.2.1",
         "leaflet.markercluster": "^1.5.0",
         "lodash.conformsto": "^4.15.0",
         "lodash.foreach": "^4.5.0",
@@ -16129,6 +16130,11 @@
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.7.1.tgz",
       "integrity": "sha512-/xwPEBidtg69Q3HlqPdU3DnrXQOvQU/CCHA1tcDQVzOwm91YMYaILjNp7L4Eaw5Z4sOYdbBz6koWyibppd8Zqw=="
+    },
+    "node_modules/leaflet-gesture-handling": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/leaflet-gesture-handling/-/leaflet-gesture-handling-1.2.1.tgz",
+      "integrity": "sha512-MEod/3BmosTud0n/sw3iUecnOUDBz2U21gzwaOZS62voaNRkMj4Sm3XPjtnmivyMgYYF0tRHCMfVEYwcRsprUg=="
     },
     "node_modules/leaflet.markercluster": {
       "version": "1.5.0",
@@ -39536,6 +39542,11 @@
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.7.1.tgz",
       "integrity": "sha512-/xwPEBidtg69Q3HlqPdU3DnrXQOvQU/CCHA1tcDQVzOwm91YMYaILjNp7L4Eaw5Z4sOYdbBz6koWyibppd8Zqw=="
+    },
+    "leaflet-gesture-handling": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/leaflet-gesture-handling/-/leaflet-gesture-handling-1.2.1.tgz",
+      "integrity": "sha512-MEod/3BmosTud0n/sw3iUecnOUDBz2U21gzwaOZS62voaNRkMj4Sm3XPjtnmivyMgYYF0tRHCMfVEYwcRsprUg=="
     },
     "leaflet.markercluster": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "invariant": "^2.2.4",
     "keycloak-js": "^12.0.4",
     "leaflet": "^1.7.1",
+    "leaflet-gesture-handling": "^1.2.1",
     "leaflet.markercluster": "^1.5.0",
     "lodash.conformsto": "^4.15.0",
     "lodash.foreach": "^4.5.0",

--- a/src/signals/incident/components/form/MapInput/__snapshots__/index.test.js.snap
+++ b/src/signals/incident/components/form/MapInput/__snapshots__/index.test.js.snap
@@ -65,6 +65,14 @@ exports[`Form component <MapInput /> rendering should render map field correctly
               "zoom": [Function],
             },
             "dragging": true,
+            "gestureHandling": true,
+            "gestureHandlingOptions": Object {
+              "text": Object {
+                "scroll": "Gebruik Ctrl + scrollen om in- en uit te zoomen op de kaart",
+                "scrollMac": "Gebruik ⌘ + scrollen om in en uit te zoomen op de kaart",
+                "touch": "Gebruik twee vingers om de kaart te verplaatsen",
+              },
+            },
             "maxBounds": Array [
               Array [
                 52.25168,

--- a/src/signals/incident/components/form/MapInput/index.js
+++ b/src/signals/incident/components/form/MapInput/index.js
@@ -9,6 +9,7 @@ import MAP_OPTIONS from 'shared/services/configuration/map-options'
 import { formatMapLocation } from 'shared/services/map-location'
 
 import FormField from '../FormField'
+import { TOUCH_GESTURE_MESSAGE_OPTION } from './touchGestureMessage'
 
 const MapInput = ({
   handler,
@@ -23,6 +24,7 @@ const MapInput = ({
   const { lat, lng } = value?.location || {}
   const mapOptions = {
     ...MAP_OPTIONS,
+    ...TOUCH_GESTURE_MESSAGE_OPTION,
     center: lat && lng ? [lat, lng] : [...MAP_OPTIONS.center],
   }
 

--- a/src/signals/incident/components/form/MapInput/touchGestureMessage.ts
+++ b/src/signals/incident/components/form/MapInput/touchGestureMessage.ts
@@ -1,0 +1,17 @@
+import L from 'leaflet'
+import { GestureHandling } from 'leaflet-gesture-handling'
+import 'leaflet-gesture-handling/dist/leaflet-gesture-handling.css'
+
+L.Map.addInitHook('addHandler', 'gestureHandling', GestureHandling)
+
+// When mobile users scroll over the map with one finger, the leaflet-gesture-handling plugin renders a gray layer with a message (configured below)
+export const TOUCH_GESTURE_MESSAGE_OPTION = {
+  gestureHandling: true,
+  gestureHandlingOptions: {
+    text: {
+      touch: 'Gebruik twee vingers om de kaart te verplaatsen',
+      scroll: 'Gebruik Ctrl + scrollen om in- en uit te zoomen op de kaart',
+      scrollMac: 'Gebruik \u2318 + scrollen om in en uit te zoomen op de kaart',
+    },
+  },
+}


### PR DESCRIPTION
Adds a message to the incident selection map when mobile users try to pan the map using one finger.

The supplied options text has some required values that are unused (unless programmatically enabled). 