### PR TITLE
[SIG-3693] Remove guard for updating saved filter with empty name

### DIFF
--- a/src/signals/incident-management/components/FilterForm/__tests__/FilterForm.test.js
+++ b/src/signals/incident-management/components/FilterForm/__tests__/FilterForm.test.js
@@ -1118,13 +1118,12 @@ describe('signals/incident-management/components/FilterForm', () => {
     })
 
     it('should handle submit for existing filter', () => {
-      jest.spyOn(window, 'alert').mockImplementation(() => {})
       const handlers = {
         onUpdateFilter: jest.fn(),
         onSubmit: jest.fn(),
       }
 
-      const { container } = render(
+      render(
         withContext(
           <FilterForm
             {...{ ...formProps, ...handlers }}
@@ -1139,39 +1138,37 @@ describe('signals/incident-management/components/FilterForm', () => {
       )
 
       act(() => {
-        fireEvent.click(container.querySelector('button[type="submit"]'))
+        userEvent.click(screen.getByRole('button', { name: 'Filteren' }))
       })
 
       // values haven't changed, update should not be called
       expect(handlers.onUpdateFilter).not.toHaveBeenCalled()
 
-      const nameField = container.querySelector(
-        'input[type="text"][name="name"]'
-      )
+      const nameField = screen.getByLabelText('Filternaam')
 
       act(() => {
-        fireEvent.blur(nameField, { target: { value: ' ' } })
+        userEvent.type(nameField, ' ')
       })
 
       act(() => {
-        fireEvent.click(container.querySelector('button[type="submit"]'))
+        userEvent.click(screen.getByRole('button', { name: 'Filteren' }))
       })
 
       // trimmed field value is empty, update should not be called
       expect(handlers.onUpdateFilter).not.toHaveBeenCalled()
-      expect(window.alert).toHaveBeenCalled()
 
       act(() => {
-        fireEvent.blur(nameField, { target: { value: 'My changed filter' } })
+        userEvent.type(nameField, 'My changed filter')
       })
 
       act(() => {
-        fireEvent.click(container.querySelector('button[type="submit"]'))
+        userEvent.click(
+          screen.getByRole('button', { name: 'Opslaan en filteren' })
+        )
       })
 
       expect(handlers.onUpdateFilter).toHaveBeenCalled()
-
-      window.alert.mockRestore()
+      expect(handlers.onSubmit).toHaveBeenCalledTimes(3)
     })
   })
 })

--- a/src/signals/incident-management/components/FilterForm/index.js
+++ b/src/signals/incident-management/components/FilterForm/index.js
@@ -133,8 +133,8 @@ const FilterForm = ({
 
   const valuesHaveChanged = useMemo(
     () =>
-      (!isNewFilter && !isEqual(currentState, initialState)) ||
-      (isNewFilter && state.filter.name),
+      ((!isNewFilter && !isEqual(currentState, initialState)) || isNewFilter) &&
+      state.filter.name.trim(),
     [currentState, initialState, state.filter.name, isNewFilter]
   )
 
@@ -167,12 +167,6 @@ const FilterForm = ({
       }
 
       if (!isNewFilter && valuesHaveChanged) {
-        if (formData.name.trim() === '') {
-          event.preventDefault()
-          global.window.alert('Filter naam mag niet leeg zijn')
-          return
-        }
-
         onUpdateFilter(formData)
       }
 


### PR DESCRIPTION
## Changes

- Removes guard for updating saved filter with empty name

Instead the list is filtered with the new values (but the saved filter is not updated).