### PR TITLE
(Chore) Removes legacy service workers

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -78,6 +78,17 @@ const registerServiceWorkerProxy = () => {
   }
 }
 
+const unregisterServiceWorkers = () => {
+  // Removes legacy service worker
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.getRegistrations().then(function (registrations) {
+      for (let registration of registrations) {
+        registration.unregister()
+      }
+    })
+  }
+}
+
 if (module.hot) {
   // Hot reloadable React components and translation json files
   // modules.hot.accept does not accept dynamic dependencies,
@@ -94,6 +105,7 @@ authenticate()
   .finally(() => {
     render()
 
+    unregisterServiceWorkers()
     registerServiceWorkerProxy()
   })
   .catch(() => {})


### PR DESCRIPTION
We previously removed the service worker implementation from the application. However, old service workers were not cleaned up (even though they will never be updated).