### PR TITLE
[SIG-3733] Remove external status change notification

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/__tests__/StatusForm.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/__tests__/StatusForm.test.js
@@ -382,21 +382,6 @@ describe('signals/incident-management/containers/IncidentDetail/components/Statu
     expect(screen.getByTestId('no-email-warning')).toBeInTheDocument()
   })
 
-  it('shows a warning when current status is Extern: verzonden and the new status is Reactie gevraagd', () => {
-    render(
-      renderWithContext({
-        ...incidentFixture,
-        status: {
-          ...incidentFixture.status,
-          state: StatusCode.Verzonden,
-        },
-      })
-    )
-
-    userEvent.click(screen.getByRole('radio', { name: REACTIE_GEVRAAGD.value }))
-    expect(screen.getByTestId('external-reply-warning')).toBeInTheDocument()
-  })
-
   it('shows a warning when switching to reply status user has no email', () => {
     render(
       renderWithContext({

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/constants.ts
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/constants.ts
@@ -27,4 +27,3 @@ export const REPLY_CHANGE_STATUS_HEADING = `Let op, er staat een vraag uit bij d
 export const REPLY_CHANGE_STATUS_CONTENT = `Als je de status nu wijzigt, kan de melder niet meer reageren.`
 export const REPLY_DEELMELDING_EXPLANATION =
   'Deze vraag is voor de collega die de hoofdmelding afhandelt. De melder ontvangt deze toelichting niet.'
-export const REPLY_EXTERNAL_CONTENT = `Het is niet mogelijk een vraag aan de melder te stellen.`

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/utils.ts
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/utils.ts
@@ -108,17 +108,6 @@ export const determineWarnings = ({
     })
   }
 
-  if (
-    originalStatus === StatusCode.Verzonden &&
-    toStatus === StatusCode.ReactieGevraagd
-  ) {
-    warnings.push({
-      key: 'external-reply-warning',
-      content: constants.REPLY_EXTERNAL_CONTENT,
-      level: 'error',
-    })
-  }
-
   return warnings
 }
 


### PR DESCRIPTION
Design review concluded that this notification is better left out. 