### PR TITLE
Release/v1.56.0

### DIFF
--- a/e2e-tests/cypress/fixtures/addresses/eikenprocessierups.json
+++ b/e2e-tests/cypress/fixtures/addresses/eikenprocessierups.json
@@ -1,0 +1,68 @@
+{
+  "response": {
+    "numFound": 1,
+    "start": 0,
+    "maxScore": 38.048794,
+    "docs": [
+      {
+        "woonplaatsnaam": "Amsterdam",
+        "huis_nlt": "31-2",
+        "weergavenaam": "Van Eeghenlaan 31-2, 1071EP Amsterdam",
+        "id": "adr-a0c6606147944758b7d80edf9028f45b",
+        "postcode": "1071EP",
+        "centroide_ll": "POINT(4.87443569 52.35812925)",
+        "straatnaam": "Van Eeghenlaan"
+      }
+    ]
+  },
+  "highlighting": {
+    "adr-a0c6606147944758b7d80edf9028f45b": {
+      "suggest": [
+        "<b>Van</b> <b>Eeghenlaan</b> <b>31</b>-<b>2</b>, <b>1071EP</b> <b>Amsterdam</b>"
+      ]
+    }
+  },
+  "spellcheck": {
+    "suggestions": [
+      "eeghenlaan",
+      {
+        "numFound": 2,
+        "startOffset": 4,
+        "endOffset": 14,
+        "suggestion": ["eeghenlaa", "eendenlaan"]
+      },
+      "1071ep",
+      {
+        "numFound": 5,
+        "startOffset": 21,
+        "endOffset": 27,
+        "suggestion": ["1051ep", "1071bp", "10710", "10711", "10713"]
+      }
+    ],
+    "collations": [
+      "collation",
+      {
+        "collationQuery": "von eeghenlaa 31-2, 1071ep amsterda",
+        "hits": 1,
+        "misspellingsAndCorrections": [
+          "von",
+          "von",
+          "v",
+          "v",
+          "van",
+          "van",
+          "eeghenlaan",
+          "eeghenlaa",
+          "31",
+          "31",
+          "2",
+          "2",
+          "1071ep",
+          "1071ep",
+          "amsterda",
+          "amsterda"
+        ]
+      }
+    ]
+  }
+}

--- a/e2e-tests/cypress/fixtures/eikenprocessierups/treeData01.json
+++ b/e2e-tests/cypress/fixtures/eikenprocessierups/treeData01.json
@@ -1,0 +1,421 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "id": 318686,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87451722943415, 52.3584695419017]
+      },
+      "properties": {
+        "OBJECTID": 318686,
+        "GlobalID": "785d9702-5e43-4695-a27f-4c76206c1f43",
+        "BoomID": "584697",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 313754,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87344905705838, 52.3581464761855]
+      },
+      "properties": {
+        "OBJECTID": 313754,
+        "GlobalID": "079fa6d4-c86a-402a-9669-fae3d06ddf64",
+        "BoomID": "586454",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 313691,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87479642702745, 52.3588263057673]
+      },
+      "properties": {
+        "OBJECTID": 313691,
+        "GlobalID": "09e46f87-437c-472b-b782-eef64c1366f8",
+        "BoomID": "584920",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 329695,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87477981775156, 52.3584341883022]
+      },
+      "properties": {
+        "OBJECTID": 329695,
+        "GlobalID": "4957174c-b12c-45f4-a30d-e4e26d1e7e06",
+        "BoomID": "584701",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 325753,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87278334698784, 52.3579556520622]
+      },
+      "properties": {
+        "OBJECTID": 325753,
+        "GlobalID": "f3756b2c-2996-43fa-bda0-0c752790c257",
+        "BoomID": "586414",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 328750,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87393818430547, 52.358775564817]
+      },
+      "properties": {
+        "OBJECTID": 328750,
+        "GlobalID": "80f9d815-160e-4a56-b7a2-a59584bc9a89",
+        "BoomID": "586421",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 313688,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87451982845225, 52.3584097846239]
+      },
+      "properties": {
+        "OBJECTID": 313688,
+        "GlobalID": "d2502f28-7843-4b97-8adc-cdf76e1df8d1",
+        "BoomID": "584707",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 625742,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87369721519813, 52.3583407029733]
+      },
+      "properties": {
+        "OBJECTID": 625742,
+        "GlobalID": "95c2c5f8-b595-43d6-904b-8265527ff890",
+        "BoomID": "NB_Amsterdam_20210614_1",
+        "Registratie": "Bestreden",
+        "PrioriteitRegistratie": "Urgent",
+        "AMS_Meldingstatus": 1
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 311759,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87330956996205, 52.3583011792204]
+      },
+      "properties": {
+        "OBJECTID": 311759,
+        "GlobalID": "aae5e960-8b33-47e5-9dec-6b214e47e761",
+        "BoomID": "586471",
+        "Registratie": "Registratie",
+        "PrioriteitRegistratie": "Standaard",
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 326747,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87298655384255, 52.3582179883731]
+      },
+      "properties": {
+        "OBJECTID": 326747,
+        "GlobalID": "15d0cfc8-76ba-4204-8f94-e790b8f8ab0f",
+        "BoomID": "586425",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": "Standaard",
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 323736,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87333631366022, 52.3584382685926]
+      },
+      "properties": {
+        "OBJECTID": 323736,
+        "GlobalID": "ff6b8e75-bd46-469d-b28c-d879230ef72c",
+        "BoomID": "585819",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 328691,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87505155327428, 52.3585601139049]
+      },
+      "properties": {
+        "OBJECTID": 328691,
+        "GlobalID": "15d5051f-5f48-4ecc-8ad9-16592ab60f84",
+        "BoomID": "584700",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 330374,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87277643088989, 52.3579064590172]
+      },
+      "properties": {
+        "OBJECTID": 330374,
+        "GlobalID": "d8b21c28-4b01-48b2-8633-82a95110e9d0",
+        "BoomID": "586500",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 316703,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87470273612685, 52.3584226200116]
+      },
+      "properties": {
+        "OBJECTID": 316703,
+        "GlobalID": "2c61f773-7841-468b-b413-8d5d3cfe9390",
+        "BoomID": "584704",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 327703,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87396869076587, 52.3586815234144]
+      },
+      "properties": {
+        "OBJECTID": 327703,
+        "GlobalID": "ee3a70fa-02d7-4866-a639-723b57d3ff2d",
+        "BoomID": "584986",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 328757,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87286315645015, 52.3579217554312]
+      },
+      "properties": {
+        "OBJECTID": 328757,
+        "GlobalID": "ff4076fa-c7b8-4277-b17d-9025443a1a72",
+        "BoomID": "586501",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 313695,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87282198599873, 52.3581807833227]
+      },
+      "properties": {
+        "OBJECTID": 313695,
+        "GlobalID": "cbcfe3ca-69e5-46cd-a4f6-405a01a6ac20",
+        "BoomID": "584992",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 326728,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87526213724463, 52.3573069639036]
+      },
+      "properties": {
+        "OBJECTID": 326728,
+        "GlobalID": "ba21c4f4-78b1-4e09-b58c-ccd46d741a3d",
+        "BoomID": "585448",
+        "Registratie": "Inspecteren",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 326751,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87315780222188, 52.3585274611426]
+      },
+      "properties": {
+        "OBJECTID": 326751,
+        "GlobalID": "73faa88d-3fac-4ed3-a8c2-625e91d87660",
+        "BoomID": "586445",
+        "Registratie": "Registratie",
+        "PrioriteitRegistratie": "Standaard",
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 310755,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87371131827894, 52.3583421985779]
+      },
+      "properties": {
+        "OBJECTID": 310755,
+        "GlobalID": "3c466eea-0194-493c-87d0-f2748e57bb2c",
+        "BoomID": "586422",
+        "Registratie": "Bestreden",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 1
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 316704,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87495801167404, 52.3586518336929]
+      },
+      "properties": {
+        "OBJECTID": 316704,
+        "GlobalID": "86bbac6f-5363-4106-8121-8a7bd38cf97f",
+        "BoomID": "584708",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 329754,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87326900018037, 52.3581537837938]
+      },
+      "properties": {
+        "OBJECTID": 329754,
+        "GlobalID": "13d9093a-ab26-4269-a3d5-9959fc5d0b0e",
+        "BoomID": "586427",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 313687,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.8743704828795, 52.3583635700155]
+      },
+      "properties": {
+        "OBJECTID": 313687,
+        "GlobalID": "21dea3dd-06fb-42da-9b13-bf6af285f296",
+        "BoomID": "584694",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 311692,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.8747415615809, 52.3584927127378]
+      },
+      "properties": {
+        "OBJECTID": 311692,
+        "GlobalID": "e99e0baf-ebad-4ec3-b1bf-6ba6d52ce002",
+        "BoomID": "584706",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 328752,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87340711640938, 52.3585102980785]
+      },
+      "properties": {
+        "OBJECTID": 328752,
+        "GlobalID": "bfa6f4ba-7d94-4ff2-9741-8776fb279480",
+        "BoomID": "586446",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 327693,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87480407976799, 52.3585323496348]
+      },
+      "properties": {
+        "OBJECTID": 327693,
+        "GlobalID": "a202a93b-ebad-4de6-b4ae-a40d5dcd9af4",
+        "BoomID": "584693",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    }
+  ]
+}

--- a/e2e-tests/cypress/fixtures/eikenprocessierups/treeData02.json
+++ b/e2e-tests/cypress/fixtures/eikenprocessierups/treeData02.json
@@ -1,0 +1,1045 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "id": 311756,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.8712810213838, 52.3600398461975]
+      },
+      "properties": {
+        "OBJECTID": 311756,
+        "GlobalID": "380918a8-e3d6-41bd-bac5-e98583610b0d",
+        "BoomID": "586429",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 329755,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87460713306, 52.3594167903842]
+      },
+      "properties": {
+        "OBJECTID": 329755,
+        "GlobalID": "736778b1-500c-443a-acac-2db8e2b54273",
+        "BoomID": "586434",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 318686,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87451722943415, 52.3584695419017]
+      },
+      "properties": {
+        "OBJECTID": 318686,
+        "GlobalID": "785d9702-5e43-4695-a27f-4c76206c1f43",
+        "BoomID": "584697",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 313754,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87344905705838, 52.3581464761855]
+      },
+      "properties": {
+        "OBJECTID": 313754,
+        "GlobalID": "079fa6d4-c86a-402a-9669-fae3d06ddf64",
+        "BoomID": "586454",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 310213,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87232683999798, 52.3593697778112]
+      },
+      "properties": {
+        "OBJECTID": 310213,
+        "GlobalID": "55290fb7-9639-4d86-b2d7-682b4f41873c",
+        "BoomID": "586214",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 314690,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87310662282239, 52.3598908601589]
+      },
+      "properties": {
+        "OBJECTID": 314690,
+        "GlobalID": "b924da34-185b-4d4d-8499-79909fc175f4",
+        "BoomID": "584698",
+        "Registratie": "Bestreden",
+        "PrioriteitRegistratie": "Standaard",
+        "AMS_Meldingstatus": 1
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 313691,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87479642702745, 52.3588263057673]
+      },
+      "properties": {
+        "OBJECTID": 313691,
+        "GlobalID": "09e46f87-437c-472b-b782-eef64c1366f8",
+        "BoomID": "584920",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 323752,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87341877491802, 52.3599244809872]
+      },
+      "properties": {
+        "OBJECTID": 323752,
+        "GlobalID": "b87b18ea-e7a3-455a-b9d7-ad946943eaeb",
+        "BoomID": "586460",
+        "Registratie": "Bestreden",
+        "PrioriteitRegistratie": "Urgent",
+        "AMS_Meldingstatus": 1
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 311707,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87178512798791, 52.3580322009161]
+      },
+      "properties": {
+        "OBJECTID": 311707,
+        "GlobalID": "9967b130-fe7e-4972-9f9f-ab611d83a023",
+        "BoomID": "584999",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 313751,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87184870151189, 52.3581070759628]
+      },
+      "properties": {
+        "OBJECTID": 313751,
+        "GlobalID": "6bfc89bb-e044-4dc2-a208-c1af28ab495b",
+        "BoomID": "586409",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 314747,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87448703871949, 52.3593796903134]
+      },
+      "properties": {
+        "OBJECTID": 314747,
+        "GlobalID": "2b2a2ff7-399f-4f21-a5ed-8ee7e1e350ba",
+        "BoomID": "586413",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 329695,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87477981775156, 52.3584341883022]
+      },
+      "properties": {
+        "OBJECTID": 329695,
+        "GlobalID": "4957174c-b12c-45f4-a30d-e4e26d1e7e06",
+        "BoomID": "584701",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 325753,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87278334698784, 52.3579556520622]
+      },
+      "properties": {
+        "OBJECTID": 325753,
+        "GlobalID": "f3756b2c-2996-43fa-bda0-0c752790c257",
+        "BoomID": "586414",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 322753,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87436398293002, 52.3593067161813]
+      },
+      "properties": {
+        "OBJECTID": 322753,
+        "GlobalID": "2776f52f-8417-42f9-ac37-8f2c7c8b4986",
+        "BoomID": "586456",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 328750,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87393818430547, 52.358775564817]
+      },
+      "properties": {
+        "OBJECTID": 328750,
+        "GlobalID": "80f9d815-160e-4a56-b7a2-a59584bc9a89",
+        "BoomID": "586421",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 321760,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87155132793745, 52.3580914009201]
+      },
+      "properties": {
+        "OBJECTID": 321760,
+        "GlobalID": "226bd114-a821-4c13-a1a7-12c5e3283661",
+        "BoomID": "586463",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 313688,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87451982845225, 52.3584097846239]
+      },
+      "properties": {
+        "OBJECTID": 313688,
+        "GlobalID": "d2502f28-7843-4b97-8adc-cdf76e1df8d1",
+        "BoomID": "584707",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 312692,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87568579210533, 52.3597376438629]
+      },
+      "properties": {
+        "OBJECTID": 312692,
+        "GlobalID": "7f57c936-239c-419c-b299-3b5d9df31dbf",
+        "BoomID": "584702",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 326750,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87395476928381, 52.3594406581682]
+      },
+      "properties": {
+        "OBJECTID": 326750,
+        "GlobalID": "bbc6f191-fe98-4056-865b-fa928e4941cf",
+        "BoomID": "586443",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 317195,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87124565671057, 52.3578930578534]
+      },
+      "properties": {
+        "OBJECTID": 317195,
+        "GlobalID": "bf3ded21-6522-4c22-a677-687ee7aa8830",
+        "BoomID": "586244",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 315755,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87208426778902, 52.3584140440305]
+      },
+      "properties": {
+        "OBJECTID": 315755,
+        "GlobalID": "ba7a0fd5-d746-47cc-b0bb-e8d1fc82fbad",
+        "BoomID": "586453",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 311201,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87172986900594, 52.3582271743281]
+      },
+      "properties": {
+        "OBJECTID": 311201,
+        "GlobalID": "058bfeb8-be60-4176-a712-9952fb036932",
+        "BoomID": "587439",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 329203,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87164638046521, 52.3601057897713]
+      },
+      "properties": {
+        "OBJECTID": 329203,
+        "GlobalID": "473f5bcc-d488-41c2-89d1-09735300edad",
+        "BoomID": "586519",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 625742,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87369721519813, 52.3583407029733]
+      },
+      "properties": {
+        "OBJECTID": 625742,
+        "GlobalID": "95c2c5f8-b595-43d6-904b-8265527ff890",
+        "BoomID": "NB_Amsterdam_20210614_1",
+        "Registratie": "Bestreden",
+        "PrioriteitRegistratie": "Urgent",
+        "AMS_Meldingstatus": 1
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 325734,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87569028912068, 52.3597677722373]
+      },
+      "properties": {
+        "OBJECTID": 325734,
+        "GlobalID": "33348055-c2d0-4289-81d3-cbc9203d8e5c",
+        "BoomID": "585811",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 311759,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87330956996205, 52.3583011792204]
+      },
+      "properties": {
+        "OBJECTID": 311759,
+        "GlobalID": "aae5e960-8b33-47e5-9dec-6b214e47e761",
+        "BoomID": "586471",
+        "Registratie": "Registratie",
+        "PrioriteitRegistratie": "Standaard",
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 326747,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87298655384255, 52.3582179883731]
+      },
+      "properties": {
+        "OBJECTID": 326747,
+        "GlobalID": "15d0cfc8-76ba-4204-8f94-e790b8f8ab0f",
+        "BoomID": "586425",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": "Standaard",
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 323736,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87333631366022, 52.3584382685926]
+      },
+      "properties": {
+        "OBJECTID": 323736,
+        "GlobalID": "ff6b8e75-bd46-469d-b28c-d879230ef72c",
+        "BoomID": "585819",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 328691,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87505155327428, 52.3585601139049]
+      },
+      "properties": {
+        "OBJECTID": 328691,
+        "GlobalID": "15d5051f-5f48-4ecc-8ad9-16592ab60f84",
+        "BoomID": "584700",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 330374,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87277643088989, 52.3579064590172]
+      },
+      "properties": {
+        "OBJECTID": 330374,
+        "GlobalID": "d8b21c28-4b01-48b2-8633-82a95110e9d0",
+        "BoomID": "586500",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 325757,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87340762368672, 52.3598859650448]
+      },
+      "properties": {
+        "OBJECTID": 325757,
+        "GlobalID": "ceda4348-ee6d-46e4-861d-6a3eb3fd248b",
+        "BoomID": "586493",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 324191,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87210377303067, 52.3580869747493]
+      },
+      "properties": {
+        "OBJECTID": 324191,
+        "GlobalID": "39d9e2ea-dd95-4127-9741-1fe6d6c405cf",
+        "BoomID": "586243",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 329200,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87571106607861, 52.3600410894481]
+      },
+      "properties": {
+        "OBJECTID": 329200,
+        "GlobalID": "5451ff02-97e9-4430-9a02-86b44a8be39d",
+        "BoomID": "586015",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 316703,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87470273612685, 52.3584226200116]
+      },
+      "properties": {
+        "OBJECTID": 316703,
+        "GlobalID": "2c61f773-7841-468b-b413-8d5d3cfe9390",
+        "BoomID": "584704",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 329753,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87166389265077, 52.3581822179695]
+      },
+      "properties": {
+        "OBJECTID": 329753,
+        "GlobalID": "a70048ac-2674-4241-96ee-0f1d046c3484",
+        "BoomID": "586419",
+        "Registratie": "Bestreden",
+        "PrioriteitRegistratie": "Standaard",
+        "AMS_Meldingstatus": 1
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 324749,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87156110258569, 52.3587280458891]
+      },
+      "properties": {
+        "OBJECTID": 324749,
+        "GlobalID": "e77e2f7c-98a2-4d20-a9de-b872ef9cd089",
+        "BoomID": "585902",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 327703,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87396869076587, 52.3586815234144]
+      },
+      "properties": {
+        "OBJECTID": 327703,
+        "GlobalID": "ee3a70fa-02d7-4866-a639-723b57d3ff2d",
+        "BoomID": "584986",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 312747,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87458946143342, 52.3593326784467]
+      },
+      "properties": {
+        "OBJECTID": 312747,
+        "GlobalID": "bf8c39c3-a4c5-4a72-b71b-06dce842ded1",
+        "BoomID": "586497",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 328757,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87286315645015, 52.3579217554312]
+      },
+      "properties": {
+        "OBJECTID": 328757,
+        "GlobalID": "ff4076fa-c7b8-4277-b17d-9025443a1a72",
+        "BoomID": "586501",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 323691,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87552411684038, 52.3593344740661]
+      },
+      "properties": {
+        "OBJECTID": 323691,
+        "GlobalID": "0e842ae8-40b7-4899-ad71-4ff6ed0f8e38",
+        "BoomID": "584705",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 328749,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87103363532303, 52.3600166582213]
+      },
+      "properties": {
+        "OBJECTID": 328749,
+        "GlobalID": "df26e185-2546-4ac5-9003-af5c3cbde551",
+        "BoomID": "586415",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 313695,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87282198599873, 52.3581807833227]
+      },
+      "properties": {
+        "OBJECTID": 313695,
+        "GlobalID": "cbcfe3ca-69e5-46cd-a4f6-405a01a6ac20",
+        "BoomID": "584992",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 325185,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87153637277844, 52.3600976711732]
+      },
+      "properties": {
+        "OBJECTID": 325185,
+        "GlobalID": "93cce73f-f7b6-4a4d-a6c4-a6582df7500e",
+        "BoomID": "586406",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 312693,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87572762287947, 52.3597510365436]
+      },
+      "properties": {
+        "OBJECTID": 312693,
+        "GlobalID": "cb774380-3d4a-4daf-b888-b86b7b3d6d7d",
+        "BoomID": "584703",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 309742,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87181439180937, 52.3593796819398]
+      },
+      "properties": {
+        "OBJECTID": 309742,
+        "GlobalID": "f94fa821-3277-4e2f-b164-df2d1307fa3d",
+        "BoomID": "585835",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 318687,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87544599242892, 52.3593240701699]
+      },
+      "properties": {
+        "OBJECTID": 318687,
+        "GlobalID": "587eb259-be66-4482-bcaa-87365039a615",
+        "BoomID": "584709",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 326728,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87526213724463, 52.3573069639036]
+      },
+      "properties": {
+        "OBJECTID": 326728,
+        "GlobalID": "ba21c4f4-78b1-4e09-b58c-ccd46d741a3d",
+        "BoomID": "585448",
+        "Registratie": "Inspecteren",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 326751,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87315780222188, 52.3585274611426]
+      },
+      "properties": {
+        "OBJECTID": 326751,
+        "GlobalID": "73faa88d-3fac-4ed3-a8c2-625e91d87660",
+        "BoomID": "586445",
+        "Registratie": "Registratie",
+        "PrioriteitRegistratie": "Standaard",
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 330372,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87131321357287, 52.358231201798]
+      },
+      "properties": {
+        "OBJECTID": 330372,
+        "GlobalID": "31999e31-ab4b-4e2d-8667-ea411e44b637",
+        "BoomID": "586486",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 310755,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87371131827894, 52.3583421985779]
+      },
+      "properties": {
+        "OBJECTID": 310755,
+        "GlobalID": "3c466eea-0194-493c-87d0-f2748e57bb2c",
+        "BoomID": "586422",
+        "Registratie": "Bestreden",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 1
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 317700,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87591362452894, 52.3597506714206]
+      },
+      "properties": {
+        "OBJECTID": 317700,
+        "GlobalID": "118da30b-f5a2-4a9b-ae01-9ac36a09bd21",
+        "BoomID": "584699",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 330349,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87224223783026, 52.3594887402542]
+      },
+      "properties": {
+        "OBJECTID": 330349,
+        "GlobalID": "bdef5146-a493-4eda-8a39-351dd7bc3eb8",
+        "BoomID": "584984",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 316753,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87180885107794, 52.3581635253474]
+      },
+      "properties": {
+        "OBJECTID": 316753,
+        "GlobalID": "2169f845-065a-4935-9061-73b3a93b1960",
+        "BoomID": "586465",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 328214,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87423048386623, 52.3598448634888]
+      },
+      "properties": {
+        "OBJECTID": 328214,
+        "GlobalID": "88a38295-e319-484c-b893-b0e995f18c2c",
+        "BoomID": "586242",
+        "Registratie": "Registratie",
+        "PrioriteitRegistratie": "Standaard",
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 316704,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87495801167404, 52.3586518336929]
+      },
+      "properties": {
+        "OBJECTID": 316704,
+        "GlobalID": "86bbac6f-5363-4106-8121-8a7bd38cf97f",
+        "BoomID": "584708",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 329754,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87326900018037, 52.3581537837938]
+      },
+      "properties": {
+        "OBJECTID": 329754,
+        "GlobalID": "13d9093a-ab26-4269-a3d5-9959fc5d0b0e",
+        "BoomID": "586427",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 313687,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.8743704828795, 52.3583635700155]
+      },
+      "properties": {
+        "OBJECTID": 313687,
+        "GlobalID": "21dea3dd-06fb-42da-9b13-bf6af285f296",
+        "BoomID": "584694",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 327745,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87175677776895, 52.3580969690736]
+      },
+      "properties": {
+        "OBJECTID": 327745,
+        "GlobalID": "ad9fb283-9f28-4a78-91db-c7fa00150e70",
+        "BoomID": "586466",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 312748,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87153651539447, 52.3600980313042]
+      },
+      "properties": {
+        "OBJECTID": 312748,
+        "GlobalID": "49397f38-365f-427f-9396-930f23ca0404",
+        "BoomID": "586518",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 318748,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87346244171673, 52.3599440839795]
+      },
+      "properties": {
+        "OBJECTID": 318748,
+        "GlobalID": "8ebb53c5-9098-4310-a35b-a4b602e2fae5",
+        "BoomID": "586455",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 318685,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87581800010125, 52.3598065217718]
+      },
+      "properties": {
+        "OBJECTID": 318685,
+        "GlobalID": "fbbff9a6-4129-43be-9908-ce67602db100",
+        "BoomID": "584695",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 311692,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.8747415615809, 52.3584927127378]
+      },
+      "properties": {
+        "OBJECTID": 311692,
+        "GlobalID": "e99e0baf-ebad-4ec3-b1bf-6ba6d52ce002",
+        "BoomID": "584706",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 329737,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87129658562651, 52.3598881109398]
+      },
+      "properties": {
+        "OBJECTID": 329737,
+        "GlobalID": "386ec0d3-e585-44c2-afbe-9966f6077eb8",
+        "BoomID": "585817",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 328752,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87340711640938, 52.3585102980785]
+      },
+      "properties": {
+        "OBJECTID": 328752,
+        "GlobalID": "bfa6f4ba-7d94-4ff2-9741-8776fb279480",
+        "BoomID": "586446",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    },
+    {
+      "type": "Feature",
+      "id": 327693,
+      "geometry": {
+        "type": "Point",
+        "coordinates": [4.87480407976799, 52.3585323496348]
+      },
+      "properties": {
+        "OBJECTID": 327693,
+        "GlobalID": "a202a93b-ebad-4de6-b4ae-a40d5dcd9af4",
+        "BoomID": "584693",
+        "Registratie": "Geen EPR",
+        "PrioriteitRegistratie": null,
+        "AMS_Meldingstatus": 0
+      }
+    }
+  ]
+}

--- a/e2e-tests/cypress/fixtures/predictions/containerNotOnMap.json
+++ b/e2e-tests/cypress/fixtures/predictions/containerNotOnMap.json
@@ -1,13 +1,13 @@
 {
   "hoofdrubriek": [
     [
-      "https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/afval"
+      "http://localhost:8000/signals/v1/public/terms/categories/afval"
     ],
     [0.9777975354252597]
   ],
   "subrubriek": [
     [
-      "https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/container-is-kapot"
+      "http://localhost:8000/signals/v1/public/terms/categories/afval/sub_categories/container-is-kapot"
     ],
     [0.8496621448662094]
   ]

--- a/e2e-tests/cypress/fixtures/predictions/containerOnMap.json
+++ b/e2e-tests/cypress/fixtures/predictions/containerOnMap.json
@@ -1,13 +1,13 @@
 {
   "hoofdrubriek": [
     [
-      "https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/afval"
+      "http://localhost:8000/signals/v1/public/terms/categories/afval"
     ],
     [0.9777975354252597]
   ],
   "subrubriek": [
     [
-      "https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/container-is-kapot"
+      "http://localhost:8000/signals/v1/public/terms/categories/afval/sub_categories/container-is-kapot"
     ],
     [0.8496621448662094]
   ]

--- a/e2e-tests/cypress/fixtures/predictions/eikenprocessierups.json
+++ b/e2e-tests/cypress/fixtures/predictions/eikenprocessierups.json
@@ -1,0 +1,14 @@
+{
+  "hoofdrubriek": [
+    [
+      "https://localhost:8000/signals/v1/public/terms/categories/openbaar-groen-en-water"
+    ],
+    [0.9054226578031427]
+  ],
+  "subrubriek": [
+    [
+      "https://localhost:8000/signals/v1/public/terms/categories/openbaar-groen-en-water/sub_categories/eikenprocessierups"
+    ],
+    [0.4131259720308121]
+  ]
+}

--- a/e2e-tests/cypress/fixtures/questions/questions.json
+++ b/e2e-tests/cypress/fixtures/questions/questions.json
@@ -339,7 +339,7 @@
     },
     "extra_dieren_waar_duiven_meeuwen_ganzen_woning": {
         "value":
-          "De eigenaar, woningcorporatie of VVE van de woning kan u helpen de overlast te verminderen. U vindt van specialisten dierplaagbestrijding de adressen op nvbp.org of kad.nl. U hoeft dit formulier niet meer verder in te vullen."
+          "De eigenaar, woningcorporatie of VVE van de woning kan u helpen de overlast te verminderen. U vindt adressen van specialisten dierplaagbestrijding op nvbp.org of kad.nl. U hoeft dit formulier niet meer verder in te vullen."
       }
     },
   "overlastPersonenEnGroepen": {

--- a/e2e-tests/cypress/fixtures/questions/questions.json
+++ b/e2e-tests/cypress/fixtures/questions/questions.json
@@ -82,14 +82,8 @@
     "extra_bedrijven_horeca_muziek_ramen_dicht_onderneming_lang": {
       "label": "Gaan de ramen of deuren kort of lang open?",
       "shortLabel": "Ramen/deuren gaan",
-      "values": {
-        "kort": "Kort open",
-        "lang": "Lang open"
-      },
-      "answers": {
-        "kort": "Kort open",
-        "lang": "Lang open"
-      }
+      "values": {"kort": "Kort open", "lang": "Lang open"},
+      "answers": {"kort": "Kort open", "lang": "Lang open"}
     },
     "extra_bedrijven_horeca_muziek_evenement": {
       "label": "Heeft iemand van de organisatie u geïnformeerd?",
@@ -326,8 +320,28 @@
         "Voor alle andere gevallen: bezoek onze pagina: ",
         "Melden van zieke, mishandelde en dode dieren, of overlast van dieren."
       ]
-    }
-  },
+    },
+    "extra_dieren_waar_wespen": {
+      "label": "Waar veroorzaken de wespen overlast?",
+      "shortLabel": "Waar",
+      "values": {
+        "woning": "In of bij de woning",
+        "openbaar": "In de openbare ruimte, zoals een park of straat"
+      }
+    },
+    "extra_dieren_waar_duiven": {
+      "label": "Waar veroorzaken de duiven overlast?",
+      "shortLabel": "Waar",
+      "values": {
+        "woning": "In of bij de woning",
+        "openbaar": "In de openbare ruimte, zoals een park of straat"
+      }
+    },
+    "extra_dieren_waar_duiven_meeuwen_ganzen_woning": {
+        "value":
+          "De eigenaar, woningcorporatie of VVE van de woning kan u helpen de overlast te verminderen. U vindt de adressen op nvbp.org of kad.nl. U hoeft dit formulier niet meer verder in te vullen."
+      }
+    },
   "overlastPersonenEnGroepen": {
     "extra_jongeren_text": {
       "answers": "Weet u de naam van de jongere(n)? Gebruik dan het formulier Melding zorg en woonoverlast. Dan komt uw melding direct bij het juiste team terecht."
@@ -351,14 +365,8 @@
     "extra_personen_overig_vaker": {
       "label": "Gebeurt het vaker?",
       "shortLabel": "Vaker",
-      "values": {
-        "nee": "Nee",
-        "ja": "Ja, het gebeurt vaker:"
-      },
-      "answers": {
-        "nee": "Nee",
-        "ja": "Ja, het gebeurt vaker:"
-      }
+      "values": {"nee": "Nee", "ja": "Ja, het gebeurt vaker:"},
+      "answers": {"nee": "Nee", "ja": "Ja, het gebeurt vaker:"}
     },
     "extra_personen_overig_vaker_momenten": {
       "label": "Wanneer gebeurt het?",
@@ -955,14 +963,8 @@
       "subtitle": "Bijvoorbeeld: u ruikt een sterke gaslucht of er dreigt een schoorsteen of balkon in te storten",
       "label": "Denkt u dat er direct gevaar is?",
       "shortLabel": "Direct gevaar",
-      "values": {
-        "ja": "Ja, er is direct gevaar",
-        "nee": "Nee"
-      },
-      "answers": {
-        "ja": "Ja, er is direct gevaar",
-        "nee": "Nee"
-      }
+      "values": {"ja": "Ja, er is direct gevaar", "nee": "Nee"},
+      "answers": {"ja": "Ja, er is direct gevaar", "nee": "Nee"}
     },
     "extra_wonen_woonkwaliteit_direct_gevaar_alert": {
       "answers": "Bel 112 en vul dit formulier niet verder in"
@@ -970,14 +972,8 @@
     "extra_wonen_woonkwaliteit_gemeld_bij_eigenaar": {
       "label": "Hebt u de klacht al bij uw verhuurder, eigenaar of VvE gemeld?",
       "shortLabel": "Gemeld bij eigenaar",
-      "values": {
-        "ja": "Ja",
-        "nee": "Nee"
-      },
-      "answers": {
-        "ja": "Ja",
-        "nee": "Nee"
-      }
+      "values": {"ja": "Ja", "nee": "Nee"},
+      "answers": {"ja": "Ja", "nee": "Nee"}
     },
     "extra_wonen_woonkwaliteit_direct_gevaar_ja": {
       "answers": "Meld uw klacht eerst bij de verhuurder, eigenaar of VvE. Krijgt u geen antwoord of wordt de klacht niet verholpen, vul dan dit formulier in."
@@ -997,14 +993,8 @@
     "extra_wonen_woonkwaliteit_namens_bewoner": {
       "label": "Doet u de melding namens de bewoner van het adres?",
       "shortLabel": "Namens bewoner",
-      "values": {
-        "ja": "Ja, ik doe de melding namens de bewoner",
-        "nee": "Nee"
-      },
-      "answers": {
-        "ja": "Ja, ik doe de melding namens de bewoner",
-        "nee": "Nee"
-      }
+      "values": {"ja": "Ja, ik doe de melding namens de bewoner", "nee": "Nee"},
+      "answers": {"ja": "Ja, ik doe de melding namens de bewoner", "nee": "Nee"}
     },
     "extra_wonen_woonkwaliteit_toestemming_contact": {
       "subtitle": "Om uw klacht goed te kunnen behandelen willen we vaak even komen kijken of met u overleggen",

--- a/e2e-tests/cypress/fixtures/questions/questions.json
+++ b/e2e-tests/cypress/fixtures/questions/questions.json
@@ -339,7 +339,7 @@
     },
     "extra_dieren_waar_duiven_meeuwen_ganzen_woning": {
         "value":
-          "De eigenaar, woningcorporatie of VVE van de woning kan u helpen de overlast te verminderen. U vindt de adressen op nvbp.org of kad.nl. U hoeft dit formulier niet meer verder in te vullen."
+          "De eigenaar, woningcorporatie of VVE van de woning kan u helpen de overlast te verminderen. U vindt van specialisten dierplaagbestrijding de adressen op nvbp.org of kad.nl. U hoeft dit formulier niet meer verder in te vullen."
       }
     },
   "overlastPersonenEnGroepen": {

--- a/e2e-tests/cypress/fixtures/signals/eikenprocessierups.json
+++ b/e2e-tests/cypress/fixtures/signals/eikenprocessierups.json
@@ -1,0 +1,95 @@
+{
+  "category": {
+    "sub": "Eikenprocessierups",
+    "sub_slug": "eikenprocessierups",
+    "main": "Openbaar groen en water",
+    "main_slug": "openbaar-groen-en-water",
+    "category_url": "http://localhost:8000/signals/v1/public/terms/categories/openbaar-groen-en-water/sub_categories/eikenprocessierups",
+    "departments": "STW",
+    "created_by": null,
+    "text": null,
+    "handling_time": "10 werkdagen"
+  },
+  "id": null,
+  "has_attachments": true,
+  "address": {
+    "stadsdeel": "Zuid",
+    "postcode": "1071EP",
+    "huisletter": "",
+    "huisnummer": 31,
+    "woonplaats": "Amsterdam",
+    "openbare_ruimte": "Van Eeghenlaan",
+    "huisnummer_toevoeging": "2",
+    "address_text": "Van Eeghenlaan 31-2 1071EP Amsterdam",
+    "geometrie": {"type": "Point", "coordinates": [4.87443569, 52.35812925]}
+  },
+  "status": {
+    "text": "",
+    "user": "",
+    "state": "m",
+    "state_display": "Gemeld",
+    "send_email": true,
+    "created_at": "2020-10-29T16:27:54.488819+01:00"
+  },
+  "reporter": {"email": "", "phone": "", "sharing_allowed": "Nee"},
+  "priority": "Normaal",
+  "process_time": "Binnen de afhandeltermijn",
+  "notes": [],
+  "type": "Melding",
+  "source": "online",
+  "text": "Eikenprocessierups gesignaleerd",
+  "text_extra": "",
+  "extra_properties": [
+    {
+      "id": "extra_eikenprocessierups",
+      "label": "Kies de boom waarin u de eikenprocessierupsen hebt gezien",
+      "shortLabel": "Boom",
+      "category_url": "/signals/v1/public/terms/categories/openbaar-groen-en-water/sub_categories/eikenprocessierups",
+      "answer": [
+        {
+          "id": 327693,
+          "type": "Eikenboom",
+          "label": "Eikenboom - 327693",
+          "isReported": false,
+          "GlobalID": "21dea3dd-06fb-42da-9b13-bf6af285f296"
+        },
+        {
+          "id": 311692,
+          "type": "Eikenboom",
+          "label": "Eikenboom - 311692",
+          "isReported": false,
+          "GlobalID": "15d5051f-5f48-4ecc-8ad9-16592ab60f84"
+        },
+        {
+          "id": "",
+          "type": "not-on-map",
+          "label": "De boom staat niet op de kaart"
+        }
+      ]
+    },
+    {
+      "id": "extra_nest_grootte",
+      "label": "Wat hebt u op de boom gezien?",
+      "shortLabel": "Op de boom gezien",
+      "category_url": "/signals/v1/public/terms/categories/openbaar-groen-en-water/sub_categories/eikenprocessierups",
+      "answer": {
+        "id": "klein",
+        "label": "Nest is zo groot als een tennisbal",
+        "info": ""
+      }
+    }
+  ],
+  "created_at": "2020-10-29T15:53:05.650429+01:00",
+  "updated_at": "2020-10-29T16:27:54.569883+01:00",
+  "incident_date_start": "2020-10-29T15:53:05+01:00",
+  "incident_date_end": null,
+  "time": "Nu",
+  "directing_departments": [
+    {"id": 4, "code": "STW", "name": "Stadswerken", "is_intern": true}
+  ],
+  "fixtures": {
+    "address": "eikenprocessierups.json",
+    "attachments": null,
+    "prediction": "eikenprocessierups.json"
+  }
+}

--- a/e2e-tests/cypress/fixtures/signals/wespen.json
+++ b/e2e-tests/cypress/fixtures/signals/wespen.json
@@ -31,11 +31,7 @@
     "send_email": false,
     "created_at": "2020-10-29T16:27:54.488819+01:00"
   },
-  "reporter": {
-    "email": "",
-    "phone": "",
-    "sharing_allowed": "Nee"
-  },
+  "reporter": {"email": "", "phone": "", "sharing_allowed": "Nee"},
   "priority": "Normaal",
   "process_time": "Binnen de afhandeltermijn",
   "notes": [],
@@ -43,7 +39,18 @@
   "source": "1",
   "text": "Er is een wespennest bij de hoofdingang van de Oude kerk",
   "text_extra": "",
-  "extra_properties": [],
+  "extra_properties": [
+    {
+      "id": "extra_dieren_waar_wespen",
+      "label": "Waar veroorzaken de wespen overlast?",
+      "shortLabel": "Waar",
+      "answer": {
+        "id": "openbaar",
+        "label": "In de openbare ruimte, zoals een park of straat"
+      },
+      "category_url": ""
+    }
+  ],
   "created_at": "2020-10-29T15:53:05.650429+01:00",
   "updated_at": "2020-10-29T16:27:54.569883+01:00",
   "incident_date_start": "2020-10-29T15:53:05+01:00",
@@ -52,7 +59,7 @@
   "directing_departments": [
     {"id": 8, "code": "GGD", "name": "GGD", "is_intern": true}
   ],
-  "fixtures":  {
+  "fixtures": {
     "address": "wespen.json",
     "attachments": null,
     "prediction": "wespen.json"

--- a/e2e-tests/cypress/integration/_localRun/ktoNotSatisfied.spec.ts
+++ b/e2e-tests/cypress/integration/_localRun/ktoNotSatisfied.spec.ts
@@ -68,7 +68,7 @@ describe('KTO form', () => {
     it('KTO satisfied send form', () => {
       cy.intercept('PUT', '/signals/v1/public/feedback/forms/*').as('putFeedback');
       cy.readFile('./cypress/fixtures/tempKTO.json').then(json => {
-        cy.visit(`${json.ktoLink}`);
+        cy.visit(`kto/${json.ktoLink}`);
       });
       general.checkHeaderText(KTO.formTitleOnTevreden);
       cy.get(KTO_FORM.questionLabel).eq(0).should('have.text', KTO.questionWaaromOntevreden).and('be.visible');
@@ -103,7 +103,7 @@ describe('KTO form', () => {
     });
     it('KTO send form again', () => {
       cy.readFile('./cypress/fixtures/tempKTO.json').then(json => {
-        cy.visit(`${json.ktoLink}`);
+        cy.visit(`kto/${json.ktoLink}`);
       });
       general.checkHeaderText(KTO.formTitelIsAlFeedback);
       cy.contains(KTO.textNogmaalsBedankt).should('be.visible');

--- a/e2e-tests/cypress/integration/_localRun/ktoSatisfied.spec.ts
+++ b/e2e-tests/cypress/integration/_localRun/ktoSatisfied.spec.ts
@@ -68,7 +68,7 @@ describe('KTO form', () => {
     it('KTO satisfied send form', () => {
       cy.intercept('PUT', '/signals/v1/public/feedback/forms/*').as('putFeedback');
       cy.readFile('./cypress/fixtures/tempKTO.json').then(json => {
-        cy.visit(`${json.ktoLink}`);
+        cy.visit(`kto/${json.ktoLink}`);
       });
       general.checkHeaderText(KTO.formTitleTevreden);
       cy.get(KTO_FORM.questionLabel).eq(0).should('have.text', KTO.questionWaaromTevreden).and('be.visible');
@@ -100,7 +100,7 @@ describe('KTO form', () => {
     });
     it('KTO send form again', () => {
       cy.readFile('./cypress/fixtures/tempKTO.json').then(json => {
-        cy.visit(`${json.ktoLink}`);
+        cy.visit(`kto/${json.ktoLink}`);
       });
       general.checkHeaderText(KTO.formTitelIsAlFeedback);
       cy.contains(KTO.textNogmaalsBedankt).should('be.visible');

--- a/e2e-tests/cypress/integration/createSignals/createSignalContainerNotOnMap.spec.ts
+++ b/e2e-tests/cypress/integration/createSignals/createSignalContainerNotOnMap.spec.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2020 - 2021 Gemeente Amsterdam
-import { CONTAINERS } from '../../support/selectorsCreateSignal';
+import { CONTAINERS, GENERAL_MAP } from '../../support/selectorsCreateSignal';
 import { MANAGE_SIGNALS } from '../../support/selectorsManageIncidents';
 import { generateToken } from '../../support/jwt';
 import signal from '../../fixtures/signals/containerNotOnMap.json';
@@ -21,7 +21,7 @@ describe('Create signal "Container" and check signal details, container is not o
       cy.contains('Volgende').click();
 
       createSignal.checkSpecificInformationPage(signal);
-      cy.get(CONTAINERS.buttonKiesOpKaart).click();
+      cy.get(GENERAL_MAP.buttonKiesOpKaart).click();
       cy.get(CONTAINERS.checkBoxContainerNietopKaart).click();
       cy.get(CONTAINERS.inputContainerNummer).type('666');
       cy.get(CONTAINERS.buttonMeldDezeContainer).click();

--- a/e2e-tests/cypress/integration/createSignals/createSignalContainerOnMap.spec.ts
+++ b/e2e-tests/cypress/integration/createSignals/createSignalContainerOnMap.spec.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2021 Gemeente Amsterdam
 /* eslint-disable cypress/no-unnecessary-waiting */
-import { CONTAINERS } from '../../support/selectorsCreateSignal';
+import { CONTAINERS, GENERAL_MAP} from '../../support/selectorsCreateSignal';
 import { MANAGE_SIGNALS } from '../../support/selectorsManageIncidents';
 import { generateToken } from '../../support/jwt';
 import signal from '../../fixtures/signals/containerOnMap.json';
@@ -24,18 +24,18 @@ describe('Create signal "Container" and check signal details, container is on th
 
       createSignal.checkSpecificInformationPage(signal);
       cy.contains('Kies de container waar het om gaat').should('be.visible');
-      cy.get(CONTAINERS.map).should('be.visible');
-      cy.get(CONTAINERS.buttonKiesOpKaart).click();
+      cy.get(GENERAL_MAP.map).should('be.visible');
+      cy.get(GENERAL_MAP.buttonKiesOpKaart).click();
       cy.contains('U kunt meer dan 1 keuze maken').should('be.visible');
       cy.contains('Maak een keuze op de kaart').should('be.visible');
 
-      cy.get(CONTAINERS.panelContainerInfo).invoke('outerWidth').should('be.at.least', 400).and('be.lt', 401);
-      cy.get(CONTAINERS.buttonCollapsePanel).click();
-      cy.get(CONTAINERS.panelContainerInfo).invoke('outerWidth').should('be.at.least', 30).and('be.lt', 31);
-      cy.get(CONTAINERS.buttonCollapsePanel).click();
-      cy.get(CONTAINERS.panelContainerInfo).invoke('outerWidth').should('be.at.least', 400).and('be.lt', 401);
+      cy.get(GENERAL_MAP.panelInfo).invoke('outerWidth').should('be.at.least', 400).and('be.lt', 401);
+      cy.get(GENERAL_MAP.buttonCollapsePanel).click();
+      cy.get(GENERAL_MAP.panelInfo).invoke('outerWidth').should('be.at.least', 30).and('be.lt', 31);
+      cy.get(GENERAL_MAP.buttonCollapsePanel).click();
+      cy.get(GENERAL_MAP.panelInfo).invoke('outerWidth').should('be.at.least', 400).and('be.lt', 401);
 
-      cy.get(CONTAINERS.buttonLegenda).click();
+      cy.get(GENERAL_MAP.buttonLegenda).click();
       cy.get(CONTAINERS.legendaItemRestafval).should('be.visible');
       cy.get(CONTAINERS.legendaItemPapier).should('be.visible');
       cy.get(CONTAINERS.legendaItemGlas).should('be.visible');
@@ -44,23 +44,23 @@ describe('Create signal "Container" and check signal details, container is on th
       cy.get(CONTAINERS.legendaItemGFT).should('be.visible');
       cy.get(CONTAINERS.legendaItemBrood).should('be.visible');
 
-      cy.get(CONTAINERS.buttonCloseLegenda).click();
+      cy.get(GENERAL_MAP.buttonCloseLegenda).click();
 
-      cy.get(CONTAINERS.clusterIcon).should('have.length', 1);
-      cy.get(CONTAINERS.buttonUitzoomen).click();
+      cy.get(GENERAL_MAP.clusterIcon).should('have.length', 1);
+      cy.get(GENERAL_MAP.buttonUitzoomen).click();
       // wait for zoom
       cy.wait(1000);
-      cy.get(CONTAINERS.buttonUitzoomen).click();
+      cy.get(GENERAL_MAP.buttonUitzoomen).click();
       // wait for zoom
       cy.wait(2000);
-      cy.get(CONTAINERS.clusterIcon, { timeout: 10000 } ).its('length').should('be.gt', 1);
-      cy.get(CONTAINERS.buttonInzoomen).click();
+      cy.get(GENERAL_MAP.clusterIcon, { timeout: 10000 } ).its('length').should('be.gt', 1);
+      cy.get(GENERAL_MAP.buttonInzoomen).click();
       // wait for zoom
       cy.wait(1000);
-      cy.get(CONTAINERS.buttonInzoomen).click();
+      cy.get(GENERAL_MAP.buttonInzoomen).click();
       // wait for zoom
       cy.wait(1000);
-      cy.get(CONTAINERS.clusterIcon).should('have.length', 1);
+      cy.get(GENERAL_MAP.clusterIcon).should('have.length', 1);
     });
   });
   describe('Create signal container', () => {
@@ -73,7 +73,7 @@ describe('Create signal "Container" and check signal details, container is on th
     it('Should create the signal', () => {
       createSignal.setDescriptionPage(signal);
       cy.contains('Volgende').click();
-      cy.get(CONTAINERS.buttonKiesOpKaart).click();
+      cy.get(GENERAL_MAP.buttonKiesOpKaart).click();
 
       cy.get(CONTAINERS.checkBoxContainerNietopKaart).click();
       cy.get(CONTAINERS.inputContainerNummer).type('44Af-1');
@@ -83,7 +83,7 @@ describe('Create signal "Container" and check signal details, container is on th
       cy.get(CONTAINERS.containerPlastic).should('not.exist');
       cy.get(CONTAINERS.containerGlas).should('not.exist');
 
-      cy.get(CONTAINERS.clusterIcon).click();
+      cy.get(GENERAL_MAP.clusterIcon).click();
       cy.wait(1000);
       cy.get(CONTAINERS.containerRestafval).should('have.length', 2).and('be.visible');
       cy.get(CONTAINERS.containerPapier).should('have.length', 1).and('be.visible');
@@ -110,7 +110,7 @@ describe('Create signal "Container" and check signal details, container is on th
 
       cy.contains('Wijzigen').click();
 
-      cy.get(CONTAINERS.clusterIcon).click();
+      cy.get(GENERAL_MAP.clusterIcon).click();
       cy.wait(500);
       cy.get(CONTAINERS.containerGlas).click();
       cy.wait(500);

--- a/e2e-tests/cypress/integration/createSignals/createSignalEikenprocessierups.spec.ts
+++ b/e2e-tests/cypress/integration/createSignals/createSignalEikenprocessierups.spec.ts
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (C) 2021 Gemeente Amsterdam
+/* eslint-disable cypress/no-unnecessary-waiting */
+import { EIKENPROCESSIERUPS, GENERAL_MAP } from '../../support/selectorsCreateSignal';
+import { MANAGE_SIGNALS } from '../../support/selectorsManageIncidents';
+import { generateToken } from '../../support/jwt';
+import signal from '../../fixtures/signals/eikenprocessierups.json';
+import * as routes from '../../support/commandsRouting';
+import * as createSignal from '../../support/commandsCreateSignal';
+
+describe('Create signal "Eikenprocessierups" and check signal details', () => {
+  describe('Check legend and zoom functionality', () => {
+    before(() => {
+      routes.postSignalRoutePublic();
+      routes.stubPreviewMap();
+      routes.stubMap();
+      cy.visit('incident/beschrijf');
+    });
+    it('Should check Legend and zoom in/out', () => {
+      cy.intercept('**/arcgis/rest/services/**', { fixture: 'eikenprocessierups/treeData01' } ).as('getTreeData01');
+      
+      createSignal.setDescriptionPage(signal);
+      cy.contains('Volgende').click();
+
+      createSignal.checkSpecificInformationPage(signal);
+      cy.contains('Kies de boom waarin u de eikenprocessierupsen hebt gezien').should('be.visible');
+      cy.get(GENERAL_MAP.map).should('be.visible');
+      cy.get(GENERAL_MAP.buttonKiesOpKaart).click();
+      cy.wait('@getTreeData01');
+      cy.contains('U kunt meer dan 1 keuze maken').should('be.visible');
+      cy.contains('Maak een keuze op de kaart').should('be.visible');
+
+      cy.get(GENERAL_MAP.panelInfo).invoke('outerWidth').should('be.at.least', 400).and('be.lt', 401);
+      cy.get(GENERAL_MAP.buttonCollapsePanel).click();
+      cy.get(GENERAL_MAP.panelInfo).invoke('outerWidth').should('be.at.least', 30).and('be.lt', 31);
+      // Should show 2 already reported trees
+      cy.wait(1000)
+      cy.get('[alt*="is gemeld"]').should('have.length', 2).and('be.visible');
+
+      cy.get(GENERAL_MAP.buttonCollapsePanel).click();
+      cy.get(GENERAL_MAP.panelInfo).invoke('outerWidth').should('be.at.least', 400).and('be.lt', 401);
+
+      cy.get(GENERAL_MAP.buttonLegenda).click();
+      cy.get(EIKENPROCESSIERUPS.legendaItemEik).should('be.visible');
+      cy.get(EIKENPROCESSIERUPS.legendaItemIsGemeld).should('be.visible');
+
+      cy.get(GENERAL_MAP.buttonCloseLegenda).click();
+
+      // Zoom out, zoom in
+      cy.get(GENERAL_MAP.icon).should('have.length', 26);
+      cy.intercept('**/arcgis/rest/services/**', { fixture: 'eikenprocessierups/treeData02' } ).as('getTreeData02');
+      cy.get(GENERAL_MAP.buttonUitzoomen).click();
+      cy.wait('@getTreeData02');
+      cy.get(GENERAL_MAP.icon).should('have.length', 65);
+      cy.intercept('**/arcgis/rest/services/**', { fixture: 'eikenprocessierups/treeData01' } ).as('getTreeData01');
+      cy.get(GENERAL_MAP.buttonInzoomen).click();
+      cy.wait('@getTreeData01');
+      cy.get(GENERAL_MAP.icon).should('have.length', 26);
+
+      cy.get(GENERAL_MAP.buttonCloseMap).click();
+      cy.get(GENERAL_MAP.buttonKiesOpKaart).should('be.visible');
+    });
+  });
+  describe('Create signal eikenprocessierups', () => {
+    before(() => {
+      routes.postSignalRoutePublic();
+      routes.stubPreviewMap();
+      routes.stubMap();
+      cy.visit('incident/beschrijf');
+    });
+    it('Should create the signal', () => {
+      cy.intercept('**/arcgis/rest/services/**', { fixture: 'eikenprocessierups/treeData01' } ).as('getTreeData01');
+      createSignal.setDescriptionPage(signal);
+      cy.contains('Volgende').click();
+      cy.get(GENERAL_MAP.buttonKiesOpKaart).click();
+
+      // Select 1 tree not on map
+      cy.get(EIKENPROCESSIERUPS.checkBoxBoomNietOpKaart).click();
+
+      // Select 2 trees
+      cy.get(GENERAL_MAP.icon).eq(23).click();
+      cy.wait(1000)
+      cy.get(GENERAL_MAP.icon).eq(24).click();
+      cy.wait(1000)
+      cy.get(EIKENPROCESSIERUPS.boomListItem).should('have.length', 2).and('be.visible');
+
+      // Remove first tree from list
+      cy.get(EIKENPROCESSIERUPS.buttonRemoveBoom).eq(0).click();
+      cy.get(EIKENPROCESSIERUPS.boomListItem).should('have.length', 1).and('be.visible');
+
+      cy.get(EIKENPROCESSIERUPS.buttonMeldDezeBoom).click();
+
+      cy.get(EIKENPROCESSIERUPS.boomListItem).should('have.length', 2).and('be.visible');
+
+      // Change selection of trees, add 1 tree again
+      cy.contains('Wijzigen').click();
+      cy.get(GENERAL_MAP.icon).eq(23).click();
+      cy.get(EIKENPROCESSIERUPS.boomListItem).should('have.length', 2).and('be.visible');
+
+      cy.get(EIKENPROCESSIERUPS.buttonMeldDezeBoom).click();
+
+      cy.get(EIKENPROCESSIERUPS.boomListItem).should('have.length', 3).and('be.visible');
+
+      // Check all answers
+      cy.get(EIKENPROCESSIERUPS.radioButtonGeenNest).check( {force: true} ).should('be.checked');
+      cy.get(EIKENPROCESSIERUPS.radioButtonNestDeken).check( {force: true} ).should('be.checked');
+      cy.get(EIKENPROCESSIERUPS.radiobuttonNestVoetbal).check( {force: true} ).should('be.checked');
+      cy.get(EIKENPROCESSIERUPS.radioButtonNestTennisbal).check( {force: true} ).should('be.checked');
+
+      cy.contains('Volgende').click();
+
+      createSignal.setPhonenumber(signal);
+      cy.contains('Volgende').click();
+
+      createSignal.setEmailAddress(signal);
+      cy.contains('Volgende').click();
+
+      createSignal.checkSummaryPage(signal);
+
+      cy.contains('Verstuur').click();
+      cy.wait('@postSignalPublic');
+      cy.get(MANAGE_SIGNALS.spinner).should('not.exist');
+
+      createSignal.checkThanksPage();
+      createSignal.saveSignalId();
+    });
+  });
+  describe('Check data created signal', () => {
+    before(() => {
+      localStorage.setItem('accessToken', generateToken('Admin', 'signals.admin@example.com'));
+      routes.getManageSignalsRoutes();
+      routes.getSignalDetailsRoutesById();
+      cy.visit('/manage/incidents/');
+      routes.waitForManageSignalsRoutes();
+    });
+
+    it('Should show the details of the signal', () => {
+      routes.stubPreviewMap();
+      createSignal.openCreatedSignal();
+      routes.waitForSignalDetailsRoutes();
+
+      createSignal.checkAllDetails(signal, 'standaardmelding');
+    });
+  });
+});

--- a/e2e-tests/cypress/integration/createSignals/createSignalUserLoggedInWespenOverlast.spec.ts
+++ b/e2e-tests/cypress/integration/createSignals/createSignalUserLoggedInWespenOverlast.spec.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2020 - 2021 Gemeente Amsterdam
 import { MANAGE_SIGNALS } from '../../support/selectorsManageIncidents';
+import { OVERLAST_DIEREN } from '../../support/selectorsCreateSignal';
 import { generateToken } from '../../support/jwt';
 import signal from '../../fixtures/signals/wespen.json';
 import questions from '../../fixtures/questions/questions.json';
@@ -39,11 +40,9 @@ describe('Create signal "Wespen" when logged in and check signal details', () =>
       cy.contains('Volgende').click();
       createSignal.checkSpecificInformationPage(signal);
 
-      Object.values(questions.overlastVanDieren.extra_dieren_text.answers).forEach((elementValue: string) => {
-        cy.contains(elementValue).should('be.visible');
-      });
-      cy.contains('Dierenambulance Amsterdam').should('have.attr', 'href').and('include', 'dierenambulance-amsterdam');
-      cy.contains('overlast van dieren').should('have.attr', 'href').and('include', 'veelgevraagd');
+      cy.contains(questions.overlastVanDieren.extra_dieren_waar_wespen.label).should('be.visible');
+      cy.get(OVERLAST_DIEREN.radioButtonWoningWespen).check({ force: true }).should('be.checked');
+      cy.get(OVERLAST_DIEREN.radioButtonOpenbareRuimteWespen).check({ force: true }).should('be.checked');
 
       cy.contains('Volgende').click();
       createSignal.setPhonenumber(signal);

--- a/e2e-tests/cypress/integration/handleSignals/signalsOverviewMap.spec.ts
+++ b/e2e-tests/cypress/integration/handleSignals/signalsOverviewMap.spec.ts
@@ -41,8 +41,8 @@ describe('Signal overview Map', () => {
       cy.get(OVERVIEW_MAP.buttonZoomIn).should('be.visible');
       cy.get(OVERVIEW_MAP.markerCluster).should('be.visible');
     });
-
-    it('Should not show signals if filtered out', () => {
+    // Skipped, because this test is flaky
+    it.skip('Should not show signals if filtered out', () => {
       routes.defineMapRoutes();
 
       cy.get(MANAGE_SIGNALS.buttonFilter).click();
@@ -53,8 +53,8 @@ describe('Signal overview Map', () => {
       cy.wait(1000);
       cy.get(OVERVIEW_MAP.markerCluster).should('not.exist');
     });
-
-    it('Should show signals again', () => {
+    // Skipped, because this test is flaky
+    it.skip('Should show signals again', () => {
       routes.defineMapRoutes();
 
       cy.get(MANAGE_SIGNALS.buttonFilter).click();

--- a/e2e-tests/cypress/integration/manageSettings/manageStandaardTeksten.spec.ts
+++ b/e2e-tests/cypress/integration/manageSettings/manageStandaardTeksten.spec.ts
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2020 - 2021 Gemeente Amsterdam
 import { STANDAARDTEKSTEN } from '../../support/selectorsSettings';
+import { OVERLAST_DIEREN } from '../../support/selectorsCreateSignal';
 import { MANAGE_SIGNALS } from '../../support/selectorsManageIncidents';
 import { CHANGE_STATUS, SIGNAL_DETAILS } from '../../support/selectorsSignalDetails';
 import * as requests from '../../support/commandsRequests';
 import { generateToken } from '../../support/jwt';
 import signal from '../../fixtures/signals/signalForStandaardteksten.json';
+import questions from '../../fixtures/questions/questions.json';
 import * as routes from '../../support/commandsRouting';
 import * as createSignal from '../../support/commandsCreateSignal';
 import * as general from '../../support/commandsGeneral';
@@ -98,6 +100,10 @@ describe('Standaardteksten', () => {
       cy.contains('Volgende').click();
 
       createSignal.checkSpecificInformationPage(signal);
+
+      cy.contains(questions.overlastVanDieren.extra_dieren_waar_duiven.label).should('be.visible');
+      cy.get(OVERLAST_DIEREN.radioButtonWoningDuiven).check({ force: true }).should('be.checked');
+      cy.contains(questions.overlastVanDieren.extra_dieren_waar_duiven_meeuwen_ganzen_woning.value).should('be.visible');
       cy.contains('Volgende').click();
       createSignal.setPhonenumber(signal);
       cy.contains('Volgende').click();

--- a/e2e-tests/cypress/support/selectorsCreateSignal.ts
+++ b/e2e-tests/cypress/support/selectorsCreateSignal.ts
@@ -78,22 +78,14 @@ export const BRUGGEN = {
 };
 
 export const CONTAINERS = {
-  buttonCloseLegenda: '[class*="CloseButton"]',
-  buttonCollapsePanel: '[title="Open legenda"]',
-  buttonInzoomen: '[title=Inzoomen]',
-  buttonKiesOpKaart: '[data-testid=chooseOnMap]',
-  buttonLegenda: 'button:contains("Legenda")',
   buttonMeldDezeContainer: 'button:contains("Meld deze container")',
   buttonRemoveContainer: '[data-testid*="containerListRemove"]',
-  buttonUitzoomen: '[title=Uitzoomen]',
   checkBoxContainerNietopKaart: '#unregisteredContainerCheckbox',
-  clusterIcon: '[data-testid=markerClusterIcon]',
   containerGlas: '[alt*="Glas"]',
   containerPapier: '[alt*="Papier"]',
   containerPlastic: '[alt*="Plastic"]',
   containerRestafval: '[alt*="Restafval"]',
   containerListItem: '[data-testid*="containerListItem"]',
-  icon: '.leaflet-marker-icon',
   inputContainerNummer: '#unregisteredContainerInput',
   legendaItemBrood: '[data-testid=legendPanelListItem-Brood]',
   legendaItemGlas: '[data-testid=legendPanelListItem-Glas]',
@@ -102,15 +94,41 @@ export const CONTAINERS = {
   legendaItemPlastic: '[data-testid=legendPanelListItem-Plastic]',
   legendaItemRestafval: '[data-testid=legendPanelListItem-Rest]',
   legendaItemTextiel: '[data-testid=legendPanelListItem-Textiel]',
-  map: '[data-testid=mapLocation]',
-  panelContainerInfo: '[data-testid=panelDesktop]',
-  panelLegend: '[data-testid=legendPanel]',
+};
+
+export const EIKENPROCESSIERUPS = {
+  buttonMeldDezeBoom: 'button:contains("Meld deze boom")',
+  buttonRemoveBoom: '[data-testid*="selectionListRemove"]',
+  boomListItem: '[data-testid*="selectionListItem"]',
+  checkBoxBoomNietOpKaart: '#unregisteredCaterpillarCheckbox',
+  legendaItemEik: '[data-testid=legendPanelListItem-oak]',
+  legendaItemIsGemeld: '[data-testid=legendPanelListItem-isReported]',
+  radioButtonGeenNest: '#extra_nest_grootte-geen_nest',
+  radioButtonNestDeken: '#extra_nest_grootte-deken',
+  radioButtonNestTennisbal: '#extra_nest_grootte-klein',
+  radiobuttonNestVoetbal: '#extra_nest_grootte-groot',
 };
 
 export const FIETSNIETJE = {
   inputFietsnietje: '[id*=extra_fietsrek_aanvraag]',
   radioButtonNieuwNietjeJa: '#extra_fietsrek_aanvragen-ja',
 };
+
+export const GENERAL_MAP = {
+  buttonCloseLegenda: '[class*="CloseButton"]',
+  buttonCloseMap: '[data-testid=mapCloseButton]',
+  buttonCollapsePanel: '[title="Open legenda"]',
+  buttonInzoomen: '[title=Inzoomen]',
+  buttonLegenda: 'button:contains("Legenda")',
+  buttonKiesOpKaart: '[data-testid=chooseOnMap]',
+  buttonUitzoomen: '[title=Uitzoomen]',
+  clusterIcon: '[data-testid=markerClusterIcon]',
+  icon: '.leaflet-marker-icon',
+  map: '[data-testid=mapLocation]',
+  panelInfo: '[data-testid=panelDesktop]',
+  panelLegend: '[data-testid=legendPanel]',
+};
+
 
 export const JONGEREN = {
   checkBoxVaker: '#extra_personen_overig_vaker-ja',

--- a/e2e-tests/cypress/support/selectorsCreateSignal.ts
+++ b/e2e-tests/cypress/support/selectorsCreateSignal.ts
@@ -161,6 +161,13 @@ export const LANTAARNPAAL = {
   radioButtonNietGevaarlijk: '#extra_straatverlichting-niet_gevaarlijk',
 };
 
+export const OVERLAST_DIEREN = {
+  radioButtonWoningWespen: '#extra_dieren_waar_wespen-woning',
+  radioButtonOpenbareRuimteWespen: '#extra_dieren_waar_wespen-openbaar',
+  radioButtonWoningDuiven: '#extra_dieren_waar_duiven-woning',
+  radioButtonOpenbareRuimteDuiven: '#extra_dieren_waar_duiven-openbaar',
+};
+
 export const STANK_OVERLAST = {
   inputGeur: '#extra_bedrijven_horeca_stank',
   inputOorzaakGeur: '#extra_bedrijven_horeca_stank_oorzaak',

--- a/e2e-tests/package-lock.json
+++ b/e2e-tests/package-lock.json
@@ -404,9 +404,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.17.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.4.tgz",
-      "integrity": "sha512-8kQ3+wKGRNN0ghtEn7EGps/B8CzuBz1nXZEIGGLP2GnwbqYn4dbTs7k+VKLTq1HvZLRCIDtN3Snx1Ege8B7L5A=="
+      "version": "14.17.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.5.tgz",
+      "integrity": "sha512-bjqH2cX/O33jXT/UmReo2pM7DIJREPMnarixbQ57DOOzzFaI6D2+IcwaJQaJpv0M1E9TIhPCYVxrkcityLjlqA=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -415,9 +415,9 @@
       "dev": true
     },
     "@types/sinonjs__fake-timers": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.2.tgz",
-      "integrity": "sha512-dIPoZ3g5gcx9zZEszaxLSVTvMReD3xxyyDnQUjA6IYDG9Ba2AV0otMPs+77sG9ojB4Qr2N2Vk5RnKeuA0X/0bg=="
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-6.0.3.tgz",
+      "integrity": "sha512-E1dU4fzC9wN2QK2Cr1MLCfyHM8BoNnRFvuf45LYMPNDA+WqbNzC45S4UzPxvp1fFJ1rvSGU0bPvdd35VLmXG8g=="
     },
     "@types/sizzle": {
       "version": "2.3.3",
@@ -425,9 +425,9 @@
       "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ=="
     },
     "@types/yauzl": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
-      "integrity": "sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.2.tgz",
+      "integrity": "sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==",
       "optional": true,
       "requires": {
         "@types/node": "*"
@@ -1805,9 +1805,9 @@
       "dev": true
     },
     "cypress": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-7.6.0.tgz",
-      "integrity": "sha512-tTwQExY28CKt6cY85/2V1uLExcMfpBEBWXt/EcE2ht/Onl9k4lxUS7ul1UnUO5MrYwMIHMdGVh13DxdzXj4Z5w==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-7.7.0.tgz",
+      "integrity": "sha512-uYBYXNoI5ym0UxROwhQXWTi8JbUEjpC6l/bzoGZNxoKGsLrC1SDPgIDJMgLX/MeEdPL0UInXLDUWN/rSyZUCjQ==",
       "requires": {
         "@cypress/request": "^2.88.5",
         "@cypress/xvfb": "^1.2.4",
@@ -1936,9 +1936,9 @@
       "dev": true
     },
     "dayjs": {
-      "version": "1.10.5",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.5.tgz",
-      "integrity": "sha512-BUFis41ikLz+65iH6LHQCDm4YPMj5r1YFLdupPIyM4SGcXMmtiLQ7U37i+hGS8urIuqe7I/ou3IS1jVc4nbN4g=="
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.6.tgz",
+      "integrity": "sha512-AztC/IOW4L1Q41A86phW5Thhcrco3xuAA+YX/BLpLWWjRcTj5TOt/QImBLmCKlrF7u7k47arTnOyL6GnbG8Hvw=="
     },
     "debug": {
       "version": "4.3.1",

--- a/e2e-tests/package.json
+++ b/e2e-tests/package.json
@@ -2,7 +2,7 @@
   "name": "@signalen/e2e-tests",
   "private": true,
   "dependencies": {
-    "cypress": "^7.6.0",
+    "cypress": "^7.7.0",
     "jsonwebtoken": "^8.5.1"
   },
   "scripts": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2683,9 +2683,9 @@
       }
     },
     "node_modules/@testing-library/react": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-11.2.6.tgz",
-      "integrity": "sha512-TXMCg0jT8xmuU8BkKMtp8l7Z50Ykew5WNX8UoIKTaLFwKkP2+1YDhOLA2Ga3wY4x29jyntk7EWfum0kjlYiSjQ==",
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-11.2.7.tgz",
+      "integrity": "sha512-tzRNp7pzd5QmbtXNG/mhdcl7Awfu/Iz1RaVHY75zTdOkmHCuzMhRL83gWHSgOAcjS3CCbyfwUHMZgRJb4kAfpA==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
@@ -2693,6 +2693,10 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-dom": "*"
       }
     },
     "node_modules/@testing-library/react-hooks": {
@@ -26762,9 +26766,9 @@
       }
     },
     "@testing-library/react": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-11.2.6.tgz",
-      "integrity": "sha512-TXMCg0jT8xmuU8BkKMtp8l7Z50Ykew5WNX8UoIKTaLFwKkP2+1YDhOLA2Ga3wY4x29jyntk7EWfum0kjlYiSjQ==",
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-11.2.7.tgz",
+      "integrity": "sha512-tzRNp7pzd5QmbtXNG/mhdcl7Awfu/Iz1RaVHY75zTdOkmHCuzMhRL83gWHSgOAcjS3CCbyfwUHMZgRJb4kAfpA==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.12.5",

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/__tests__/StatusForm.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/__tests__/StatusForm.test.js
@@ -311,7 +311,7 @@ describe('signals/incident-management/containers/IncidentDetail/components/Statu
 
     userEvent.type(textarea, 'A'.repeat(DEFAULT_MESSAGE_MAX_LENGTH + 1))
 
-    userEvent.click(screen.getByRole('button', { name: 'Status opslaan' }))
+    userEvent.click(screen.getByRole('button', { name: 'Opslaan' }))
 
     expect(screen.getByRole('alert').textContent).toBe(
       `Je hebt meer dan de maximale ${DEFAULT_MESSAGE_MAX_LENGTH} tekens ingevoerd.`

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/__tests__/StatusForm.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/__tests__/StatusForm.test.js
@@ -453,6 +453,50 @@ describe('signals/incident-management/containers/IncidentDetail/components/Statu
     expect(screen.queryByText(MAIL_EXPLANATION)).toBeInTheDocument()
   })
 
+  it('is not required to provide text when new status is not an end state of a split incident', () => {
+    const deelmelding = {
+      ...incidentFixture,
+      _links: {
+        ...incidentFixture._links,
+        'sia:parent': {
+          href: 'https://acc.api.data.amsterdam.nl/signals/v1/private/categories/106',
+          public:
+            'https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/civiele-constructies',
+        },
+      },
+    }
+
+    // render component with incident that has a parent
+    const { container } = render(renderWithContext(deelmelding))
+
+    fireEvent.click(container.querySelector('input[value="i"]'))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Opslaan' }))
+    expect(screen.queryByText('Dit veld is verplicht')).not.toBeInTheDocument()
+  })
+
+  it('is required to provide text new status is an end state of a split incident', () => {
+    const deelmelding = {
+      ...incidentFixture,
+      _links: {
+        ...incidentFixture._links,
+        'sia:parent': {
+          href: 'https://acc.api.data.amsterdam.nl/signals/v1/private/categories/106',
+          public:
+            'https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/civiele-constructies',
+        },
+      },
+    }
+
+    // render component with incident that has a parent
+    const { container } = render(renderWithContext(deelmelding))
+
+    fireEvent.click(container.querySelector('input[value="o"]'))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Opslaan' }))
+    expect(screen.getByText('Dit veld is verplicht')).toBeInTheDocument()
+  })
+
   it('shows a warning that is specific to a deelmelding', () => {
     const deelmelding = {
       ...incidentFixture,

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/index.js
@@ -223,7 +223,7 @@ const StatusForm = ({ defaultTexts, childIncidents }) => {
                 type="submit"
                 variant="secondary"
               >
-                Status opslaan
+                Opslaan
               </StyledButton>
 
               <StyledButton

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/index.js
@@ -168,12 +168,12 @@ const StatusForm = ({ defaultTexts, childIncidents }) => {
               <Alert data-testid="statusWarning">{state.warning}</Alert>
             )}
 
+            <QuestionLabel>
+              <strong>Versturen</strong>
+            </QuestionLabel>
+
             {!state.isSplitIncident && (
               <div>
-                <QuestionLabel>
-                  <strong>Versturen</strong>
-                </QuestionLabel>
-
                 {hasEmail ? (
                   <Label
                     disabled={state.check.disabled}

--- a/src/signals/incident/components/IncidentForm/index.js
+++ b/src/signals/incident/components/IncidentForm/index.js
@@ -24,7 +24,7 @@ export const Fieldset = styled.fieldset`
   display: grid;
   grid-template-columns: 1fr;
   grid-row-gap: ${themeSpacing(8)};
-  word-break: break-word;
+  word-break: normal;
 
   & > * {
     grid-column-start: 1;

--- a/src/signals/incident/components/IncidentPreview/index.js
+++ b/src/signals/incident/components/IncidentPreview/index.js
@@ -94,7 +94,7 @@ const DefinitionsWrapper = styled.div`
 
 const Wrapper = styled.div`
   margin-bottom: ${themeSpacing(8)};
-  word-break: break-word;
+  word-break: normal;
 `
 
 const IncidentPreview = ({ incident, preview, sectionLabels }) => (

--- a/src/signals/incident/components/form/PlainText/index.js
+++ b/src/signals/incident/components/form/PlainText/index.js
@@ -30,8 +30,12 @@ const getStyle = (type) => {
     case 'info':
       return css`
         background-color: ${themeColor('primary')};
-        color: ${themeColor('tint', 'level1')};
         padding: ${themeSpacing(5)};
+
+        * {
+          // Make sure links contrast with blue background
+          color: ${themeColor('tint', 'level1')};
+        }
       `
     case 'citation':
     case 'disclaimer':

--- a/src/signals/incident/components/form/PlainText/index.test.js
+++ b/src/signals/incident/components/form/PlainText/index.test.js
@@ -156,7 +156,6 @@ describe('Form component <PlainText />', () => {
       const element = screen.getByTestId('plainText')
       expect(element).toHaveStyleRule('padding', '20px')
       expect(element).toHaveStyleRule('background-color', '#004699')
-      expect(element).toHaveStyleRule('color', '#ffffff')
     })
 
     it('should render plain text caution correctly', () => {

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/overlast-van-dieren.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/overlast-van-dieren.ts
@@ -3,19 +3,231 @@
 import { FIELD_TYPE_MAP } from 'signals/incident/containers/IncidentContainer/constants'
 
 const overlastVanDieren = {
-  extra_dieren_text: {
+  extra_dieren_welk_dier: {
     meta: {
       ifAllOf: {
         category: 'overlast-van-dieren',
+        subcategory: 'overig-dieren',
       },
-      type: 'caution',
-      value: `
-Let op: u kunt met dit formulier een melding doen van:
+      label: 'Waarover gaat de melding?',
+      shortLabel: 'Waarover',
+      pathMerge: 'extra_properties',
+      values: {
+        ratten: 'Rattenoverlast',
+        duiven_meeuwen_ganzen: 'Duiven-, meeuwen- of ganzenoverlast',
+        wespen: 'Wespenoverlast',
+        dode_dieren: 'Dode of zieke dieren',
+        anders: 'Andere dieren',
+      },
+    },
+    options: {
+      validators: ['required'],
+    },
+    render: FIELD_TYPE_MAP.radio_input,
+  },
+  extra_dieren_waar_wespen: {
+    meta: {
+      ifOneOf: {
+        extra_dieren_welk_dier: 'wespen',
+        subcategory: 'wespen',
+      },
+      label: 'Waar veroorzaken de wespen overlast?',
+      shortLabel: 'Waar',
+      pathMerge: 'extra_properties',
+      values: {
+        woning: 'In of bij de woning',
+        openbaar: 'In de openbare ruimte, zoals een park of straat',
+      },
+    },
+    options: {
+      validators: ['required'],
+    },
+    render: FIELD_TYPE_MAP.radio_input,
+  },
+  extra_dieren_waar_dode_dieren: {
+    meta: {
+      ifOneOf: {
+        extra_dieren_welk_dier: 'dode_dieren',
+        subcategory: 'dode-dieren',
+      },
+      label: 'Om wat voor dode of zieke dieren gaat het?',
+      shortLabel: 'Waar',
+      pathMerge: 'extra_properties',
+      values: {
+        woning_tuin: 'Dieren in de woning of tuin',
+        water: 'Dieren in het water, zoals vissen of vogels',
+        openbaar_huisdieren_vogels:
+          'Huisdieren en vogels in de openbare ruimte, zoals een park of straat',
+        openbaar_anders:
+          'Andere dieren in de openbare ruimte, zoals een park of straat',
+      },
+    },
+    options: {
+      validators: ['required'],
+    },
+    render: FIELD_TYPE_MAP.radio_input,
+  },
 
-* dierplagen (ratten, ganzen, duiven, meeuwen,wespen, etc)
-* dode dieren op straat, met uitzondering van dode huisdieren en dode vogels
-* Voor dode huisdieren en dode vogels op straat kunt u contact opnemen met [Dierenambulance Amsterdam](https://www.dierenambulance-amsterdam.nl/dieren/).
-* Voor alle andere gevallen: bezoek onze pagina: [Melden van zieke, mishandelde en dode dieren, of overlast van dieren](https://www.amsterdam.nl/veelgevraagd/?caseid=%7BC46A5854-3DB0-4D7C-9244-58912C2E0E6A%7D).`,
+  extra_dieren_waar_dode_dieren_woning: {
+    meta: {
+      ifOneOf: {
+        extra_dieren_waar_dode_dieren: 'woning_tuin',
+      },
+      value:
+        'De eigenaar, woningcorporatie of VVE van de woning moet het dode of zieke dier laten verwijderen of verzorgen. U hoeft dit formulier niet meer verder in te vullen.',
+      type: 'info',
+    },
+    render: FIELD_TYPE_MAP.plain_text,
+  },
+  extra_dieren_waar_dode_dieren_water: {
+    meta: {
+      ifOneOf: {
+        extra_dieren_waar_dode_dieren: 'water',
+      },
+      value:
+        'Dode of zieke dieren in het water kunt u melden bij Waternet, telefoon: [0900 9394](tel:09009394). U hoeft dit formulier niet meer verder in te vullen.',
+      type: 'info',
+    },
+    render: FIELD_TYPE_MAP.plain_text,
+  },
+  extra_dieren_waar_dode_dieren_openbaar_huisdieren_vogels: {
+    meta: {
+      ifOneOf: {
+        extra_dieren_waar_dode_dieren: 'openbaar_huisdieren_vogels',
+      },
+      value:
+        'Dode of zieke dieren en vogels in de openbare ruimte kunt u melden bij de Dierenambulance: [020 626 2121](tel:0206262121) (24 uur per dag, 7 dagen per week bereikbaar). U hoeft dit formulier niet meer verder in te vullen.',
+      type: 'info',
+    },
+    render: FIELD_TYPE_MAP.plain_text,
+  },
+  extra_dieren_waar_duiven: {
+    meta: {
+      ifOneOf: {
+        subcategory: 'duiven',
+      },
+      label: 'Waar veroorzaken de duiven overlast?',
+      shortLabel: 'Waar',
+      pathMerge: 'extra_properties',
+      values: {
+        woning: 'In of bij de woning',
+        openbaar: 'In de openbare ruimte, zoals een park of straat',
+      },
+    },
+    options: {
+      validators: ['required'],
+    },
+    render: FIELD_TYPE_MAP.radio_input,
+  },
+  extra_dieren_waar_meeuwen: {
+    meta: {
+      ifOneOf: {
+        subcategory: 'meeuwen',
+      },
+      label: 'Waar veroorzaken de meeuwen overlast?',
+      shortLabel: 'Waar',
+      pathMerge: 'extra_properties',
+      values: {
+        woning: 'In of bij de woning',
+        openbaar: 'In de openbare ruimte, zoals een park of straat',
+      },
+    },
+    options: {
+      validators: ['required'],
+    },
+    render: FIELD_TYPE_MAP.radio_input,
+  },
+  extra_dieren_waar_ganzen: {
+    meta: {
+      ifOneOf: {
+        subcategory: 'ganzen',
+      },
+      label: 'Waar veroorzaken de ganzen overlast?',
+      shortLabel: 'Waar',
+      pathMerge: 'extra_properties',
+      values: {
+        woning: 'In of bij de woning',
+        openbaar: 'In de openbare ruimte, zoals een park of straat',
+      },
+    },
+    options: {
+      validators: ['required'],
+    },
+    render: FIELD_TYPE_MAP.radio_input,
+  },
+  extra_dieren_waar_duiven_meeuwen_ganzen: {
+    meta: {
+      ifOneOf: {
+        extra_dieren_welk_dier: 'duiven_meeuwen_ganzen',
+      },
+      label: 'Waar veroorzaken de duiven, meeuwen of ganzen overlast?',
+      shortLabel: 'Waar',
+      pathMerge: 'extra_properties',
+      values: {
+        woning: 'In of bij de woning',
+        openbaar: 'In de openbare ruimte, zoals een park of straat',
+      },
+    },
+    options: {
+      validators: ['required'],
+    },
+    render: FIELD_TYPE_MAP.radio_input,
+  },
+  extra_dieren_waar_duiven_meeuwen_ganzen_woning: {
+    meta: {
+      ifOneOf: {
+        extra_dieren_waar_duiven_meeuwen_ganzen: 'woning',
+        extra_dieren_waar_duiven: 'woning',
+        extra_dieren_waar_ganzen: 'woning',
+        extra_dieren_waar_meeuwen: 'woning',
+      },
+      value:
+        'De eigenaar, woningcorporatie of VVE van de woning kan u helpen de overlast te verminderen. U vindt de adressen op [nvbp.org](https://nvbp.org) of [kad.nl](https://kad.nl). U hoeft dit formulier niet meer verder in te vullen.',
+      type: 'info',
+    },
+    render: FIELD_TYPE_MAP.plain_text,
+  },
+  extra_dieren_waar_ratten: {
+    meta: {
+      ifOneOf: {
+        extra_dieren_welk_dier: 'ratten',
+        subcategory: ['ratten-in-en-rond-woning', 'ratten'],
+      },
+      label: 'Waar denkt u dat de ratten zitten?',
+      shortLabel: 'Waar',
+      pathMerge: 'extra_properties',
+      values: {
+        woning: 'In de woning',
+        tuin: 'In de tuin van de woning of direct naast de woning',
+        ander_gebouw:
+          'In of bij een ander gebouw, zoals een bedrijf, kantoor of ziekenhuis',
+        openbaar: 'In de openbare ruimte, zoals een park of straat',
+      },
+    },
+    options: {
+      validators: ['required'],
+    },
+    render: FIELD_TYPE_MAP.radio_input,
+  },
+  extra_dieren_waar_ratten_woning: {
+    meta: {
+      ifOneOf: {
+        extra_dieren_waar_ratten: 'woning',
+      },
+      value:
+        'Wij willen u graag bellen over het vervolg. Vul daarom uw telefoonnummer in bij de volgende vraag.',
+      type: 'info',
+    },
+    render: FIELD_TYPE_MAP.plain_text,
+  },
+  extra_dieren_waar_ratten_ander_gebouw: {
+    meta: {
+      ifOneOf: {
+        extra_dieren_waar_ratten: 'ander_gebouw',
+      },
+      value:
+        'Het bedrijf, kantoor of ziekenhuis moet zelf een specialist dierplaagbestrijding inhuren. U vindt adressen op [nvbp.org](https://nvbp.org) of [kad.nl](https://kad.nl). U hoeft dit formulier niet meer verder in te vullen.',
+      type: 'info',
     },
     render: FIELD_TYPE_MAP.plain_text,
   },

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/overlast-van-dieren.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/overlast-van-dieren.ts
@@ -182,7 +182,7 @@ const overlastVanDieren = {
         extra_dieren_waar_meeuwen: 'woning',
       },
       value:
-        'De eigenaar, woningcorporatie of VVE van de woning kan u helpen de overlast te verminderen. U vindt de adressen op [nvbp.org](https://nvbp.org) of [kad.nl](https://kad.nl). U hoeft dit formulier niet meer verder in te vullen.',
+        'De eigenaar, woningcorporatie of VVE van de woning kan u helpen de overlast te verminderen. U vindt van specialisten dierplaagbestrijding de adressen op [nvbp.org](https://nvbp.org) of [kad.nl](https://kad.nl). U hoeft dit formulier niet meer verder in te vullen.',
       type: 'info',
     },
     render: FIELD_TYPE_MAP.plain_text,
@@ -226,7 +226,7 @@ const overlastVanDieren = {
         extra_dieren_waar_ratten: 'ander_gebouw',
       },
       value:
-        'Het bedrijf, kantoor of ziekenhuis moet zelf een specialist dierplaagbestrijding inhuren. U vindt adressen op [nvbp.org](https://nvbp.org) of [kad.nl](https://kad.nl). U hoeft dit formulier niet meer verder in te vullen.',
+        'Het bedrijf, kantoor of ziekenhuis moet zelf een specialist dierplaagbestrijding inhuren. U vindt van specialisten dierplaagbestrijding adressen op [nvbp.org](https://nvbp.org) of [kad.nl](https://kad.nl). U hoeft dit formulier niet meer verder in te vullen.',
       type: 'info',
     },
     render: FIELD_TYPE_MAP.plain_text,

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/overlast-van-dieren.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/overlast-van-dieren.ts
@@ -182,7 +182,7 @@ const overlastVanDieren = {
         extra_dieren_waar_meeuwen: 'woning',
       },
       value:
-        'De eigenaar, woningcorporatie of VVE van de woning kan u helpen de overlast te verminderen. U vindt van specialisten dierplaagbestrijding de adressen op [nvbp.org](https://nvbp.org) of [kad.nl](https://kad.nl). U hoeft dit formulier niet meer verder in te vullen.',
+        'De eigenaar, woningcorporatie of VVE van de woning kan u helpen de overlast te verminderen. U vindt adressen van specialisten dierplaagbestrijding op [nvbp.org](https://nvbp.org) of [kad.nl](https://kad.nl). U hoeft dit formulier niet meer verder in te vullen.',
       type: 'info',
     },
     render: FIELD_TYPE_MAP.plain_text,
@@ -226,7 +226,7 @@ const overlastVanDieren = {
         extra_dieren_waar_ratten: 'ander_gebouw',
       },
       value:
-        'Het bedrijf, kantoor of ziekenhuis moet zelf een specialist dierplaagbestrijding inhuren. U vindt van specialisten dierplaagbestrijding adressen op [nvbp.org](https://nvbp.org) of [kad.nl](https://kad.nl). U hoeft dit formulier niet meer verder in te vullen.',
+        'Het bedrijf, kantoor of ziekenhuis moet zelf een specialist dierplaagbestrijding inhuren. U vindt adressen van specialisten dierplaagbestrijding op [nvbp.org](https://nvbp.org) of [kad.nl](https://kad.nl). U hoeft dit formulier niet meer verder in te vullen.',
       type: 'info',
     },
     render: FIELD_TYPE_MAP.plain_text,

--- a/src/signals/incident/definitions/wizard-step-5-samenvatting.js
+++ b/src/signals/incident/definitions/wizard-step-5-samenvatting.js
@@ -17,6 +17,7 @@ import afvalControls from './wizard-step-2-vulaan/afval'
 import overlastPersonenEnGroepenControls from './wizard-step-2-vulaan/overlast-van-en-door-personen-of-groepen'
 import civieleConstructies from './wizard-step-2-vulaan/civieleConstructies'
 import openbaarGroenEnWaterControls from './wizard-step-2-vulaan/openbaarGroenEnWater'
+import overlastVanDieren from './wizard-step-2-vulaan/overlast-van-dieren'
 
 export const ObjectLabel = ({ value }) => value?.label
 export const Label = ({ value }) => value
@@ -122,6 +123,9 @@ const getExtraQuestions = (category, subcategory, questions) => {
 
     case 'overlast-van-en-door-personen-of-groepen':
       return summary(overlastPersonenEnGroepenControls)
+
+    case 'overlast-van-dieren':
+      return summary(overlastVanDieren)
 
     case 'wegen-verkeer-straatmeubilair':
       return summary(wegenVerkeerStraatmeubilairControls)


### PR DESCRIPTION
## CHANGES

#1736 [[SIG-3757]] Change description to be required when closing a split incident 
#1734 [[SIG-3898]] Change additional questions and prevent unnecessary words wrapping (Safari)
#1733 Adjust margins headings for StatusForm component
#1732 Change position of alert in StatusForm component 
#1731 Move copy for StatusForm 
#1730 [[SIG-3845]] Updates additional questions text
#1726 Change position of copy in StatusForm component

## E2E TESTS

#1724 [[SIG-3879]] Eikenprocessierups E2E tests

[SIG-3757]: https://datapunt.atlassian.net/browse/SIG-3757
[SIG-3898]: https://datapunt.atlassian.net/browse/SIG-3898
[SIG-3845]: https://datapunt.atlassian.net/browse/SIG-3845
[SIG-3879]: https://datapunt.atlassian.net/browse/SIG-3879