### PR TITLE
(chore) Fix async test warnings

### DIFF
--- a/src/signals/incident-management/containers/IncidentSplitContainer/IncidentSplitContainer.test.js
+++ b/src/signals/incident-management/containers/IncidentSplitContainer/IncidentSplitContainer.test.js
@@ -105,8 +105,20 @@ const renderAwait = async (
 
 const Form =
   (formData = submittedFormData) =>
-  ({ onSubmit, ...props }) => {
-    const handleSubmit = () => {
+  // making sure that the <form> elements doesn't print unsupported attributes
+  ({
+    onSubmit,
+    // eslint-disable-next-line no-unused-vars
+    parentIncident,
+    // eslint-disable-next-line no-unused-vars
+    directingDepartments,
+    // eslint-disable-next-line no-unused-vars
+    isSubmitting,
+    ...props
+  }) => {
+    const handleSubmit = (e) => {
+      // preventing default form submission behaviour to suppress warning in the test console log
+      e.preventDefault()
       onSubmit(formData)
     }
 

--- a/src/signals/incident-management/containers/ReporterContainer/__tests__/useFetchReporter.test.ts
+++ b/src/signals/incident-management/containers/ReporterContainer/__tests__/useFetchReporter.test.ts
@@ -10,7 +10,6 @@ import { store } from 'test/utils'
 import incidentFixture from 'utils/__tests__/fixtures/incident.json'
 import configuration from 'shared/services/configuration/configuration'
 import type { Result } from 'types/api/reporter'
-import { waitFor } from '@testing-library/react'
 import {
   fetchMock,
   mockRequestHandler,
@@ -185,15 +184,13 @@ describe('Fetch Reporter hook', () => {
       result.current.selectIncident(Number(INCIDENT_ID_2))
     })
 
-    await waitFor(
-      () => expect(result.current.incident?.id).toBe(Number(INCIDENT_ID_2)),
-      { timeout: 3000 }
-    )
-    await waitFor(
-      () =>
-        expect(result.current.incident?.data?.id).toBe(Number(INCIDENT_ID_2)),
-      { timeout: 3000 }
-    )
+    await waitForNextUpdate()
+
+    expect(result.current.incident?.id).toBe(Number(INCIDENT_ID_2))
+
+    await waitForNextUpdate()
+
+    expect(result.current.incident?.data?.id).toBe(Number(INCIDENT_ID_2))
   })
 
   it('does not fetch incident for which the user has no permission', async () => {
@@ -206,7 +203,6 @@ describe('Fetch Reporter hook', () => {
     )
 
     await waitForNextUpdate()
-    await waitForNextUpdate()
 
     // User has no permission to view incident data for incident with id={INCIDENT_ID_3}
     expect(
@@ -218,6 +214,8 @@ describe('Fetch Reporter hook', () => {
     act(() => {
       result.current.selectIncident(Number(INCIDENT_ID_3))
     })
+
+    await waitForNextUpdate()
 
     expect(result.current.incident.isLoading).toBe(false)
   })


### PR DESCRIPTION
Fixing a couple of minor issues in tests. In general, every unit test that covers a component that directly or indirectly makes use of the `useFetch` hook or otherwise performs an asynchronous request, should await render results. There are more tests in which these issues occur. Will be tackled gradually in future PRs.