### PR TITLE
(Chore) Enable Sentry logging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2594,13 +2594,13 @@
       "integrity": "sha512-afmTuJrylUU/0OtqzaRkbyYFFNgCF73Bvel/sw90pvGrWIZ+vyoIJqA6eMSoA6+nb443kTmulmBtC9NerXboNg=="
     },
     "node_modules/@sentry/browser": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.8.0.tgz",
-      "integrity": "sha512-nxa71csHlG5sMHUxI4e4xxuCWtbCv/QbBfMsYw7ncJSfCKG3yNlCVh8NJ7NS0rZW/MJUT6S6+r93zw0HetNDOA==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.13.0.tgz",
+      "integrity": "sha512-Eh0k2qYhqWiEP3N04AwSrpl4VRD0pzt6SRgJxgiGzSvBT43EOjyNQ3xzMylAechfjSCTWmzZMvwcgT5fNM9cuw==",
       "dependencies": {
-        "@sentry/core": "6.8.0",
-        "@sentry/types": "6.8.0",
-        "@sentry/utils": "6.8.0",
+        "@sentry/core": "6.13.0",
+        "@sentry/types": "6.13.0",
+        "@sentry/utils": "6.13.0",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -2608,14 +2608,14 @@
       }
     },
     "node_modules/@sentry/core": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.8.0.tgz",
-      "integrity": "sha512-vJzWt/znEB+JqVwtwfjkRrAYRN+ep+l070Ti8GhJnvwU4IDtVlV3T/jVNrj6rl6UChcczaJQMxVxtG5x0crlAA==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.13.0.tgz",
+      "integrity": "sha512-Aw0ljRJx5tq4w6ZXxvcu2Lr9NwD+MJ1SLL5+oB1hh4OlcOJ7OLwDjtJ3+ZOwp75GCAp7phh4+s/Sql6roX3Lpw==",
       "dependencies": {
-        "@sentry/hub": "6.8.0",
-        "@sentry/minimal": "6.8.0",
-        "@sentry/types": "6.8.0",
-        "@sentry/utils": "6.8.0",
+        "@sentry/hub": "6.13.0",
+        "@sentry/minimal": "6.13.0",
+        "@sentry/types": "6.13.0",
+        "@sentry/utils": "6.13.0",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -2623,12 +2623,12 @@
       }
     },
     "node_modules/@sentry/hub": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.8.0.tgz",
-      "integrity": "sha512-hFrI2Ss1fTov7CH64FJpigqRxH7YvSnGeqxT9Jc1BL7nzW/vgCK+Oh2mOZbosTcrzoDv+lE8ViOnSN3w/fo+rg==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.13.0.tgz",
+      "integrity": "sha512-BmKgrTyotF008KPfFt1ySyFg0AAMf/ha9Bz9Rmi+usSJjnOLsObzBJQNAozp4Cu6i1kGvj1/R+ymPCD61Gqozw==",
       "dependencies": {
-        "@sentry/types": "6.8.0",
-        "@sentry/utils": "6.8.0",
+        "@sentry/types": "6.13.0",
+        "@sentry/utils": "6.13.0",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -2636,12 +2636,12 @@
       }
     },
     "node_modules/@sentry/minimal": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.8.0.tgz",
-      "integrity": "sha512-MRxUKXiiYwKjp8mOQMpTpEuIby1Jh3zRTU0cmGZtfsZ38BC1JOle8xlwC4FdtOH+VvjSYnPBMya5lgNHNPUJDQ==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.13.0.tgz",
+      "integrity": "sha512-eJQs44sGY2wFuVDznHMDeShR+ZbnM/KS+T5753nJ4QtMqCNTiG9WDlNXAxwFJ6Q3DORtaxcWHyFZdOMUusJiZQ==",
       "dependencies": {
-        "@sentry/hub": "6.8.0",
-        "@sentry/types": "6.8.0",
+        "@sentry/hub": "6.13.0",
+        "@sentry/types": "6.13.0",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -2649,19 +2649,19 @@
       }
     },
     "node_modules/@sentry/types": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.8.0.tgz",
-      "integrity": "sha512-PbSxqlh6Fd5thNU5f8EVYBVvX+G7XdPA+ThNb2QvSK8yv3rIf0McHTyF6sIebgJ38OYN7ZFK7vvhC/RgSAfYTA==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.13.0.tgz",
+      "integrity": "sha512-04ZVmz4txuI3w1KS81eByppvvMfOINj7jZYnO5zX/S3cjHiOpAJiZkN/k9tTi1Ua3td8bEkQLB6Cxrq9MSiH3Q==",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@sentry/utils": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.8.0.tgz",
-      "integrity": "sha512-OYlI2JNrcWKMdvYbWNdQwR4QBVv2V0y5wK0U6f53nArv6RsyO5TzwRu5rMVSIZofUUqjoE5hl27jqnR+vpUrsA==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.13.0.tgz",
+      "integrity": "sha512-e82DBwjYqWkNmafIkHnbqirK4t7WCmqCGaoo1Et6vTRCBS4GthWvS6EzaozY7EKs/TzsfIiDdTLGTbYMQOq9Zw==",
       "dependencies": {
-        "@sentry/types": "6.8.0",
+        "@sentry/types": "6.13.0",
         "tslib": "^1.9.3"
       },
       "engines": {
@@ -27536,59 +27536,59 @@
       "integrity": "sha512-afmTuJrylUU/0OtqzaRkbyYFFNgCF73Bvel/sw90pvGrWIZ+vyoIJqA6eMSoA6+nb443kTmulmBtC9NerXboNg=="
     },
     "@sentry/browser": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.8.0.tgz",
-      "integrity": "sha512-nxa71csHlG5sMHUxI4e4xxuCWtbCv/QbBfMsYw7ncJSfCKG3yNlCVh8NJ7NS0rZW/MJUT6S6+r93zw0HetNDOA==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-6.13.0.tgz",
+      "integrity": "sha512-Eh0k2qYhqWiEP3N04AwSrpl4VRD0pzt6SRgJxgiGzSvBT43EOjyNQ3xzMylAechfjSCTWmzZMvwcgT5fNM9cuw==",
       "requires": {
-        "@sentry/core": "6.8.0",
-        "@sentry/types": "6.8.0",
-        "@sentry/utils": "6.8.0",
+        "@sentry/core": "6.13.0",
+        "@sentry/types": "6.13.0",
+        "@sentry/utils": "6.13.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/core": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.8.0.tgz",
-      "integrity": "sha512-vJzWt/znEB+JqVwtwfjkRrAYRN+ep+l070Ti8GhJnvwU4IDtVlV3T/jVNrj6rl6UChcczaJQMxVxtG5x0crlAA==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-6.13.0.tgz",
+      "integrity": "sha512-Aw0ljRJx5tq4w6ZXxvcu2Lr9NwD+MJ1SLL5+oB1hh4OlcOJ7OLwDjtJ3+ZOwp75GCAp7phh4+s/Sql6roX3Lpw==",
       "requires": {
-        "@sentry/hub": "6.8.0",
-        "@sentry/minimal": "6.8.0",
-        "@sentry/types": "6.8.0",
-        "@sentry/utils": "6.8.0",
+        "@sentry/hub": "6.13.0",
+        "@sentry/minimal": "6.13.0",
+        "@sentry/types": "6.13.0",
+        "@sentry/utils": "6.13.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/hub": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.8.0.tgz",
-      "integrity": "sha512-hFrI2Ss1fTov7CH64FJpigqRxH7YvSnGeqxT9Jc1BL7nzW/vgCK+Oh2mOZbosTcrzoDv+lE8ViOnSN3w/fo+rg==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-6.13.0.tgz",
+      "integrity": "sha512-BmKgrTyotF008KPfFt1ySyFg0AAMf/ha9Bz9Rmi+usSJjnOLsObzBJQNAozp4Cu6i1kGvj1/R+ymPCD61Gqozw==",
       "requires": {
-        "@sentry/types": "6.8.0",
-        "@sentry/utils": "6.8.0",
+        "@sentry/types": "6.13.0",
+        "@sentry/utils": "6.13.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/minimal": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.8.0.tgz",
-      "integrity": "sha512-MRxUKXiiYwKjp8mOQMpTpEuIby1Jh3zRTU0cmGZtfsZ38BC1JOle8xlwC4FdtOH+VvjSYnPBMya5lgNHNPUJDQ==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-6.13.0.tgz",
+      "integrity": "sha512-eJQs44sGY2wFuVDznHMDeShR+ZbnM/KS+T5753nJ4QtMqCNTiG9WDlNXAxwFJ6Q3DORtaxcWHyFZdOMUusJiZQ==",
       "requires": {
-        "@sentry/hub": "6.8.0",
-        "@sentry/types": "6.8.0",
+        "@sentry/hub": "6.13.0",
+        "@sentry/types": "6.13.0",
         "tslib": "^1.9.3"
       }
     },
     "@sentry/types": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.8.0.tgz",
-      "integrity": "sha512-PbSxqlh6Fd5thNU5f8EVYBVvX+G7XdPA+ThNb2QvSK8yv3rIf0McHTyF6sIebgJ38OYN7ZFK7vvhC/RgSAfYTA=="
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-6.13.0.tgz",
+      "integrity": "sha512-04ZVmz4txuI3w1KS81eByppvvMfOINj7jZYnO5zX/S3cjHiOpAJiZkN/k9tTi1Ua3td8bEkQLB6Cxrq9MSiH3Q=="
     },
     "@sentry/utils": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.8.0.tgz",
-      "integrity": "sha512-OYlI2JNrcWKMdvYbWNdQwR4QBVv2V0y5wK0U6f53nArv6RsyO5TzwRu5rMVSIZofUUqjoE5hl27jqnR+vpUrsA==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-6.13.0.tgz",
+      "integrity": "sha512-e82DBwjYqWkNmafIkHnbqirK4t7WCmqCGaoo1Et6vTRCBS4GthWvS6EzaozY7EKs/TzsfIiDdTLGTbYMQOq9Zw==",
       "requires": {
-        "@sentry/types": "6.8.0",
+        "@sentry/types": "6.13.0",
         "tslib": "^1.9.3"
       }
     },

--- a/src/app.js
+++ b/src/app.js
@@ -36,6 +36,7 @@ if (dsn) {
     environment,
     dsn,
     release,
+    autoSessionTracking: false,
   })
 }
 


### PR DESCRIPTION
This PR ensures that Sentry will log errors again. Since PR https://github.com/Amsterdam/signals-frontend/pull/1568, logging wasn't possible, because of the Sentry package upgrade. Its [changelog](https://github.com/getsentry/sentry-javascript/blob/master/CHANGELOG.md#600) explicitly mentions no breaking changes if (and only if) a configuration flag is set. If the flag is not set, by default, session data is sent along with the log POSTs. The receiving server responds with a CORS header fault because of that.