### PR TITLE
(Chore) Fix flaky

### DIFF
--- a/e2e-tests/cypress/support/commandsFiltering.ts
+++ b/e2e-tests/cypress/support/commandsFiltering.ts
@@ -30,7 +30,11 @@ export const filterByCategorySlug = (category_slug: string, category: string) =>
   cy.get(`[data-testid*="sub_categories/${category_slug}"]`).check();
 
   cy.get(FILTER.buttonSubmitFilter).should('be.visible').click();
+  
   cy.wait('@getSortedTimeDESC');
+
+  // making sure the table view has been updated
+  cy.wait(500);
 
   if (category_slug === 'vermoeden') {
     cy.get(MANAGE_SIGNALS.filterTagList).should('have.text', 'Ondermijning: Alles').and('be.visible');


### PR DESCRIPTION
Changes fix tests that will break on slower network connections; filtering the incident overview page hasn't updated the table view when the e2e assertions are run. A delay of 500ms fixes that issue, albeit not for all cases. On really slow (or congested) networks, the tests might still fail.