### PR TITLE
[SIG-4011] Make incident overview table lines clickable

### DIFF
--- a/src/signals/incident-management/containers/IncidentOverviewPage/components/List/index.test.tsx
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/components/List/index.test.tsx
@@ -285,4 +285,22 @@ describe('List', () => {
       )
     })
   })
+
+  it('should tab through rows focusing only the "id" column', () => {
+    render(withContext(<List {...props} />))
+
+    expect(document.body).toHaveFocus()
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const [_columnheaders, ...rows] = screen.getAllByRole('row')
+
+    rows.forEach((row, index) => {
+      // Tab to next row
+      userEvent.tab()
+
+      const idCell = within(row).getByText(incidents[index].id)
+
+      expect(idCell.parentNode).toHaveFocus()
+    })
+  })
 })

--- a/src/signals/incident-management/containers/IncidentOverviewPage/components/List/index.tsx
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/components/List/index.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2018 - 2021 Gemeente Amsterdam
 import { FunctionComponent, useCallback, useContext } from 'react'
-import { Link } from 'react-router-dom'
+import { Link, useHistory } from 'react-router-dom'
 import parseISO from 'date-fns/parseISO'
 import differenceInCalendarDays from 'date-fns/differenceInCalendarDays'
 import { ChevronUp, ChevronDown, Play } from '@amsterdam/asc-assets'
@@ -23,6 +23,7 @@ import type {
 } from 'signals/incident-management/definitions/types'
 import { IncidentListItem, IncidentList } from 'types/api/incident-list'
 import { formatAddress } from 'shared/services/format-address'
+import { INCIDENT_URL } from 'signals/incident-management/routes'
 import IncidentManagementContext from '../../../../context'
 import {
   ContentSpan,
@@ -34,6 +35,7 @@ import {
   ThPriority,
   ThStatus,
   ThSubcategory,
+  Tr,
   StyledList,
   Table,
   StyledIcon,
@@ -55,14 +57,13 @@ export const getDaysOpen = (incident: IncidentListItem) => {
   return differenceInCalendarDays(new Date(), createdAtDate)
 }
 
-const Td: FunctionComponent<{ detailLink: string; isFocusable?: boolean }> = ({
+const Td: FunctionComponent<{ detailLink: string }> = ({
   detailLink,
   children,
-  isFocusable = false,
   ...rest
 }) => (
   <TdStyle {...rest}>
-    <Link to={detailLink} tabIndex={isFocusable ? 0 : -1}>
+    <Link to={detailLink} tabIndex={-1}>
       <ContentSpan>{children}</ContentSpan>
     </Link>
   </TdStyle>
@@ -96,6 +97,7 @@ const List: FunctionComponent<ListProps> = ({
   status,
 }) => {
   const { districts } = useContext(IncidentManagementContext)
+  const history = useHistory()
 
   const onSort = useCallback(
     (newSort) => () => {
@@ -119,6 +121,10 @@ const List: FunctionComponent<ListProps> = ({
     },
     [sort]
   )
+
+  const navigateToIncident = (id: number) => {
+    history.push(`${INCIDENT_URL}/${id}`)
+  }
 
   return (
     <StyledList
@@ -187,7 +193,11 @@ const List: FunctionComponent<ListProps> = ({
           {incidents.map((incident) => {
             const detailLink = `/manage/incident/${incident.id}`
             return (
-              <tr key={incident.id}>
+              <Tr
+                key={incident.id}
+                tabIndex={0}
+                onKeyPress={() => navigateToIncident(incident.id)}
+              >
                 <Td detailLink={detailLink} data-testid="incidentParent">
                   {incident.has_children && <ParentIncidentIcon />}
                   {incident.has_parent && <ChildIcon />}
@@ -197,11 +207,7 @@ const List: FunctionComponent<ListProps> = ({
                     {getListIconByKey(priority, incident.priority?.priority)}
                   </StyledIcon>
                 </Td>
-                <Td
-                  isFocusable
-                  detailLink={detailLink}
-                  data-testid="incidentId"
-                >
+                <Td detailLink={detailLink} data-testid="incidentId">
                   {incident.id}
                 </Td>
                 <Td detailLink={detailLink} data-testid="incidentDaysOpen">
@@ -237,7 +243,7 @@ const List: FunctionComponent<ListProps> = ({
                     {incident.assigned_user_email}
                   </Td>
                 )}
-              </tr>
+              </Tr>
             )
           })}
         </tbody>

--- a/src/signals/incident-management/containers/IncidentOverviewPage/components/List/index.tsx
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/components/List/index.tsx
@@ -25,6 +25,7 @@ import { IncidentListItem, IncidentList } from 'types/api/incident-list'
 import { formatAddress } from 'shared/services/format-address'
 import IncidentManagementContext from '../../../../context'
 import {
+  ContentSpan,
   Th,
   TdStyle,
   ThArea,
@@ -54,13 +55,16 @@ export const getDaysOpen = (incident: IncidentListItem) => {
   return differenceInCalendarDays(new Date(), createdAtDate)
 }
 
-const Td: FunctionComponent<{ detailLink: string }> = ({
+const Td: FunctionComponent<{ detailLink: string; isFocusable?: boolean }> = ({
   detailLink,
   children,
+  isFocusable = false,
   ...rest
 }) => (
   <TdStyle {...rest}>
-    <Link to={detailLink}>{children}</Link>
+    <Link to={detailLink} tabIndex={isFocusable ? 0 : -1}>
+      <ContentSpan>{children}</ContentSpan>
+    </Link>
   </TdStyle>
 )
 
@@ -125,8 +129,8 @@ const List: FunctionComponent<ListProps> = ({
       <Table cellSpacing="0">
         <thead>
           <tr>
-            <ThParent data-testid="parent"></ThParent>
-            <ThPriority data-testid="priority"></ThPriority>
+            <ThParent data-testid="parent" />
+            <ThPriority data-testid="priority" />
             <Th data-testid="sortId" onClick={onSort('id')}>
               Id {renderChevron('id')}
             </Th>
@@ -193,7 +197,11 @@ const List: FunctionComponent<ListProps> = ({
                     {getListIconByKey(priority, incident.priority?.priority)}
                   </StyledIcon>
                 </Td>
-                <Td detailLink={detailLink} data-testid="incidentId">
+                <Td
+                  isFocusable
+                  detailLink={detailLink}
+                  data-testid="incidentId"
+                >
                   {incident.id}
                 </Td>
                 <Td detailLink={detailLink} data-testid="incidentDaysOpen">

--- a/src/signals/incident-management/containers/IncidentOverviewPage/components/List/styles.ts
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/components/List/styles.ts
@@ -32,7 +32,8 @@ export const Th = styled.th`
 `
 
 export const ThParent = styled(Th)`
-  width: 40px;
+  width: 45px;
+  min-height: 1px;
 `
 
 export const ThPriority = styled(Th)`
@@ -55,21 +56,31 @@ export const ThStatus = styled(Th)`
   width: 160px;
 `
 
+export const ContentSpan = styled.span``
+
 export const TdStyle = styled.td`
-  padding: 0 ${themeSpacing(2)};
+  padding: 0;
   height: 60px;
 
   a {
+    display: flex;
+    align-items: center;
+    padding: 0 ${themeSpacing(2)};
+    height: 100%;
+
     text-decoration: none;
     color: black;
-    overflow: hidden;
-    text-overflow: ellipsis;
 
-    // Show ellipsis on second line
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
-    line-clamp: 2;
+    ${ContentSpan} {
+      // Show ellipsis on second line
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      line-clamp: 2;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      height: auto;
+    }
   }
 `
 

--- a/src/signals/incident-management/containers/IncidentOverviewPage/components/List/styles.ts
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/components/List/styles.ts
@@ -31,6 +31,12 @@ export const Th = styled.th`
   }
 `
 
+export const Tr = styled.tr`
+  :focus {
+    outline: auto;
+  }
+`
+
 export const ThParent = styled(Th)`
   width: 45px;
   min-height: 1px;


### PR DESCRIPTION
## Changes

- Bugfix: instead of only the 'data' part of a row being clickable, it is now possible to click anywhere in the row to navigate to an incident
- Tabbing through incidents skips to the next row instead of cycling through all data cells in the row