### PR TITLE
[SIG-3989] Double underscores as special characters in default texts validation

### DIFF
--- a/e2e-tests/cypress/support/selectorsSettings.ts
+++ b/e2e-tests/cypress/support/selectorsSettings.ts
@@ -59,7 +59,7 @@ export const STANDAARDTEKSTEN = {
   radioButtonAfgehandeld: '[data-testid=state-o]',
   radioButtonHeropend: '[data-testid=state-reopened]',
   radioButtonIngepland: '[data-testid=state-ingepland]',
-  textAlert: "Er is een gereserveerd teken ('{{' of '}}') in de toelichting gevonden.\nMogelijk staan er nog een of meerdere interne aanwijzingen in deze tekst. Pas de tekst aan.",
+  textAlert: "Er is een gereserveerd teken ('{{' of '__') in de toelichting gevonden.\nMogelijk staan er nog een of meerdere interne aanwijzingen in deze tekst. Pas de tekst aan.",
   textDescriptionAfhandelen01: 'Beschrijving standaardtekst 1 melding duiven AFHANDELEN. De overlastgevende duif is geïdentificeerd als {{naam duif}}',
   textDescriptionAfhandelen02: 'Beschrijving standaardtekst 2 melding duiven AFHANDELEN. De overlastgevende duif is geïdentificeerd als {{naam duif}}',
   textDescriptionHeropenen: 'Beschrijving standaardtekst 1 melding duiven HEROPENEN. De overlastgevende duif is geïdentificeerd als {{naam duif}}',

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/__tests__/StatusForm.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/__tests__/StatusForm.test.js
@@ -292,8 +292,8 @@ describe('signals/incident-management/containers/IncidentDetail/components/Statu
 
     // type in textarea with special characters '{{' and '}}'
     const textarea = screen.getByRole('textbox')
-    const value = 'Foo {{bar}} baz'
-    userEvent.type(textarea, value)
+    const valueWithBrackets = 'Foo {{bar}} baz'
+    userEvent.type(textarea, valueWithBrackets)
 
     // verify that an error message is NOT shown
     expect(screen.queryByRole('alert')).not.toBeInTheDocument()
@@ -312,6 +312,20 @@ describe('signals/incident-management/containers/IncidentDetail/components/Statu
 
     // clear textarea
     const clearText = '{selectall}{backspace}'
+    userEvent.type(textarea, clearText)
+
+    // verify that an error message is NOT shown
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+
+    const valueWithUnderscores = 'Foo __bar__ baz'
+    userEvent.type(textarea, valueWithUnderscores)
+
+    userEvent.click(screen.getByRole('button', { name: 'Opslaan' }))
+
+    // verify that an error message is shown
+    expect(screen.getByRole('alert')).toBeInTheDocument()
+
+    // clear textarea
     userEvent.type(textarea, clearText)
 
     // type in textarea

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/index.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/index.tsx
@@ -90,11 +90,11 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
         return
       }
 
-      if (/{{|}}/gi.test(textValue)) {
+      if (/{{|}}|__/gi.test(textValue)) {
         dispatch({
           type: 'SET_ERRORS',
           payload: {
-            text: "Er is een gereserveerd teken ('{{' of '}}') in de toelichting gevonden.\nMogelijk staan er nog een of meerdere interne aanwijzingen in deze tekst. Pas de tekst aan.",
+            text: "Er is een gereserveerd teken ('{{' of '__') in de toelichting gevonden.\nMogelijk staan er nog een of meerdere interne aanwijzingen in deze tekst. Pas de tekst aan.",
           },
         })
         return


### PR DESCRIPTION
## Changes

- Double underscores are now a special character in default texts, alongside '{{' and '}}'