### PR TITLE
(Chore) Questions field types

### DIFF
--- a/src/types/api/qa/question.ts
+++ b/src/types/api/qa/question.ts
@@ -1,6 +1,13 @@
 export enum FieldType {
   PlainText = 'plain_text',
   FileInput = 'file_input',
+  TextInput = 'text_input',
+  MultiTextInput = 'multi_text_input',
+  CheckboxInput = 'checkbox_input',
+  RadioInput = 'radio_input',
+  SelectInput = 'select_input',
+  TextareaInput = 'text_area_input',
+  MapSelect = 'map_select',
 }
 
 export interface Question {


### PR DESCRIPTION
Based on the [API definition](https://github.com/Amsterdam/signals/blob/d4be5732839ebd487bf6c7ec12f61cb4a14542a6/api/app/signals/apps/signals/models/question.py#L16-L24), the questions endpoint field types aren't complete. This PR corrects that.