### PR TITLE
[SIG-4019] Safari toolbar color fix

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -7,7 +7,6 @@
   <meta name="apple-mobile-web-app-title" content="$SIGNALS_PWA_TITLE" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="apple-mobile-web-app-status-bar-style" content="$SIGNALS_STATUS_BAR_STYLE" />
-  <meta name="theme-color" content="$SIGNALS_THEME_COLOR" />
   <link rel="icon" href="$SIGNALS_FAVICON" />
   <link rel="apple-touch-icon" sizes="180x180" href="$SIGNALS_IOS_ICON" />
   <!-- html-loader should ignore manifest.json so that its filename stays the same -->


### PR DESCRIPTION
Since version 15, [Safari supports the theme-color meta](https://css-tricks.com/meta-theme-color-and-trickery/) tag. Apparently not something we'd want. This PR fixes that.