### PR TITLE
[SIG-3952] Hide header in app mode

### DIFF
--- a/app.base.json
+++ b/app.base.json
@@ -13,7 +13,8 @@
     "showVulaanControls": false,
     "useProjectenSignalType": false,
     "useMapSelectGeneric": false,
-    "useStaticMapServer": false
+    "useStaticMapServer": false,
+    "appMode": false
   },
   "head": {
     "androidIcon": "/icon_192x192.png",

--- a/internals/schemas/app.schema.json
+++ b/internals/schemas/app.schema.json
@@ -111,6 +111,10 @@
         "useStaticMapServer": {
           "description": "When true, will use the static map server defined by map.staticUrl to get a png image for a small map preview, otherwise leaflet without controls will be used.",
           "type": "boolean"
+        },
+        "appMode": {
+          "description": "When true, will render the application in app mode, hiding specific UI elements",
+          "type": "boolean"
         }
       },
       "required": [

--- a/src/containers/App/index.test.tsx
+++ b/src/containers/App/index.test.tsx
@@ -120,6 +120,14 @@ describe('<App />', () => {
     expect(queryByTestId('siteFooter')).not.toBeInTheDocument()
   })
 
+  it('will not render the header when in app mode', () => {
+    configuration.featureFlags.appMode = true
+
+    render(withAppContext(<App />))
+
+    expect(screen.queryByTestId('siteHeader')).not.toBeInTheDocument()
+  })
+
   describe('routing', () => {
     it('should redirect from "/" to "/incident/beschrijf"', () => {
       render(withAppContext(<App />))

--- a/src/containers/App/index.tsx
+++ b/src/containers/App/index.tsx
@@ -100,7 +100,7 @@ export const AppContainer = () => {
     <ThemeProvider>
       <AppContext.Provider value={contextValue}>
         <Fragment>
-          <SiteHeaderContainer />
+          {!configuration.featureFlags.appMode && <SiteHeaderContainer />}
 
           <ContentContainer headerIsTall={headerIsTall}>
             <Suspense fallback={<LoadingIndicator />}>


### PR DESCRIPTION
Adds `appMode` feature flag and prevents rendering of the site header when flag is set.