### PR TITLE
(Chore) Update docker compose usage

### DIFF
--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -22,14 +22,14 @@ jobs:
       # https://github.com/cypress-io/github-action/issues/48
       fail-fast: false
       matrix:
-        # run 3 copies of the current job in parallel
+        # run 12 copies of the current job in parallel
         containers: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
 
     steps:
       - uses: actions/checkout@v2
 
       - name: Build frontend
-        run: docker-compose build
+        run: docker compose build
 
       # Install NPM dependencies, cache them correctly
       # and run all Cypress tests
@@ -38,7 +38,7 @@ jobs:
         id: cypress
         continue-on-error: true
         with:
-          start: docker-compose up frontend
+          start: docker compose up frontend
           wait-on: 'http://localhost:8000/signals/'
           wait-on-timeout: 180
           working-directory: e2e-tests

--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - develop
       - master
-      - release/*
   pull_request:
     types: [opened, synchronize]
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # https://git.datapunt.amsterdam.nl/Datapunt/python-best-practices/blob/master/dependency_management/
 #
 .PHONY = help build stop pull start stop release start-e2e
-dc = docker-compose
+dc = docker compose
 BUILD_ENV ?= development
 GITHUB_TOKEN := $(shell cat .githubtoken)
 JIRA_TOKEN := $(shell cat .jiratoken)

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ npm test
 First start the backend and frontend with Docker compose:
 
 ```bash
-docker-compose build
-docker-compose up -d
+docker compose build
+docker compose up -d
 ```
 
 Then run the end-to-end tests:


### PR DESCRIPTION
- It is unnecessary to install `docker-compose`, since it's possible to use `docker compose` instead 
- Prevent running pipeline on `release` build, which triggered two GitHub action 'checks'. 