### PR TITLE
[SIG-4010] Fixes alignment of tabs on overview page

### DIFF
--- a/src/signals/incident-management/containers/IncidentOverviewPage/components/SubNav/SubNav.js
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/components/SubNav/SubNav.js
@@ -70,8 +70,11 @@ export const TabWrapper = styled(Column)`
 `
 
 const SubNav = ({ showsMap }) => (
-  <Wrapper data-testid="subNav">
-    <Column span={{ small: 1, medium: 1, big: 3, large: 6, xLarge: 6 }}>
+  <>
+    <Column
+      data-testid="subNav"
+      span={{ small: 1, medium: 1, big: 3, large: 6, xLarge: 6 }}
+    >
       {showsMap && configuration.featureFlags.mapFilter24Hours && (
         <MapHeading data-testid="subNavHeader">Afgelopen 24 uur</MapHeading>
       )}
@@ -100,7 +103,7 @@ const SubNav = ({ showsMap }) => (
         )}
       </TabContainer>
     </TabWrapper>
-  </Wrapper>
+  </>
 )
 
 SubNav.defaultProps = {

--- a/src/signals/incident-management/containers/IncidentOverviewPage/index.js
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/index.js
@@ -47,6 +47,7 @@ import {
   ButtonWrapper,
   PaginationWrapper,
   MapWrapper,
+  NavWrapper,
   NoResults,
   StyledButton,
   StyledPagination,
@@ -221,10 +222,11 @@ export const IncidentOverviewPageContainerComponent = ({
           )}
         </Column>
 
-        {pagination}
+        <NavWrapper>
+          {pagination}
+          <SubNav showsMap={showsMap} />
+        </NavWrapper>
       </Row>
-
-      <SubNav showsMap={showsMap} />
 
       {showsMap && (
         <Row>

--- a/src/signals/incident-management/containers/IncidentOverviewPage/styled.tsx
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/styled.tsx
@@ -69,6 +69,16 @@ export const MapWrapper = styled(Column).attrs({
   flex-direction: column;
 `
 
+export const NavWrapper = styled(Column).attrs({
+  span: 12,
+})`
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  width: 100%;
+  margin-bottom: ${themeSpacing(5)};
+`
+
 export const PageTitle = styled.div`
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
## Changes

- On incident overview page, tabs are now aligned with the pagination component