### PR TITLE
(Chore) Remove step to run GitHub actions for release branches

### DIFF
--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - develop
       - master
-      - release/*
   pull_request:
     types: [opened, synchronize]
 
@@ -23,7 +22,7 @@ jobs:
       # https://github.com/cypress-io/github-action/issues/48
       fail-fast: false
       matrix:
-        # run 3 copies of the current job in parallel
+        # run 12 copies of the current job in parallel
         containers: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
 
     steps:


### PR DESCRIPTION
The GitHub actions will be run when the `release` PR is created