### PR TITLE
(Chore) Adds lodash install to nginx layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ FROM nginx:stable-alpine
 
 RUN apk add --no-cache jq nodejs npm
 
-RUN npm install @exodus/schemasafe lodash.merge
+RUN npm install @exodus/schemasafe lodash
 
 COPY --from=base /app/build/. /usr/share/nginx/html/
 


### PR DESCRIPTION
`lodash/merge` is used for validating application config in the NGINX layer. Usage of this dependency was changed in #1798 - preventing the container from running correctly.