### PR TITLE
(Chore) Prevent keycloak redirect to overview page on login

### DIFF
--- a/src/shared/services/auth/services/keycloak.test.ts
+++ b/src/shared/services/auth/services/keycloak.test.ts
@@ -26,6 +26,7 @@ describe('Keycloak authorization', () => {
       authEndpoint: 'https://example.nl/auth',
       clientId: 'frontend',
       realm: 'auth-realm',
+      scope: 'openid',
     } as any
   })
 
@@ -53,7 +54,15 @@ describe('Keycloak authorization', () => {
     it('calls keycloak-js init function', async () => {
       new Keycloak().init()
 
-      expect(keycloakJSMock.init).toHaveBeenCalled()
+      expect(keycloakJSMock.init).toHaveBeenCalledWith({
+        checkLoginIframe: false,
+        flow: 'standard',
+        pkceMethod: 'S256',
+        silentCheckSsoFallback: true,
+        silentCheckSsoRedirectUri:
+          'http://localhost/assets/html/silent-check-sso.html',
+        useNonce: true,
+      })
     })
 
     it('calls keycloak-js init with check-sso when localstorage domain value is set', () => {
@@ -81,7 +90,9 @@ describe('Keycloak authorization', () => {
     it('calls keycloak-js login function', async () => {
       new Keycloak().login()
 
-      expect(keycloakJSMock.login).toHaveBeenCalled()
+      expect(keycloakJSMock.login).toHaveBeenCalledWith({
+        scope: 'openid',
+      })
     })
   })
 

--- a/src/shared/services/auth/services/keycloak.ts
+++ b/src/shared/services/auth/services/keycloak.ts
@@ -3,7 +3,6 @@
 import keycloakJS, { KeycloakInitOptions, KeycloakInstance } from 'keycloak-js'
 import configuration from 'shared/services/configuration/configuration'
 
-const AUTH_REDIRECT_URI = `${window.location.origin}/manage/incidents`
 const SILENT_CHECK_SSO_REDIRECT_URI = `${window.location.origin}/assets/html/silent-check-sso.html`
 const OAUTH_DOMAIN_KEY = 'oauthDomain' // Domain that is used for login
 
@@ -35,7 +34,6 @@ class Keycloak {
       useNonce: true,
       silentCheckSsoRedirectUri: SILENT_CHECK_SSO_REDIRECT_URI,
       silentCheckSsoFallback: true,
-      redirectUri: AUTH_REDIRECT_URI,
     }
 
     /**


### PR DESCRIPTION
On login, the application should return to the same page as where the login flow was started. 

This also fixes an issue where when running the application on `localhost`, the user was not able to reach the incident form page. 