### PR TITLE
(Chore) Fix favicon loading

### DIFF
--- a/internals/webpack/webpack.base.babel.js
+++ b/internals/webpack/webpack.base.babel.js
@@ -173,7 +173,10 @@ module.exports = ({
     }),
 
     new CopyPlugin({
-      patterns: [{ from: path.resolve(__rootdir, 'assets'), to: 'assets' }],
+      patterns: [
+        { from: path.resolve(__rootdir, 'assets'), to: 'assets' },
+        { from: path.resolve(__rootdir, 'src/images') },
+      ],
     }),
 
     process.env.ANALYZE && new BundleAnalyzerPlugin(),

--- a/src/app.js
+++ b/src/app.js
@@ -14,13 +14,6 @@ import { authenticate } from 'shared/services/auth/auth'
 import configuration from 'shared/services/configuration/configuration'
 import loadModels from 'models'
 
-// Make sure these icons are picked up by webpack
-/* eslint-disable import/no-unresolved,import/extensions */
-import '!file-loader?name=[name][ext]!./images/favicon.png'
-import '!file-loader?name=[name][ext]!./images/icon_180x180.png'
-import '!file-loader?name=[name][ext]!./images/icon_192x192.png'
-/* eslint-enable import/no-unresolved,import/extensions */
-
 // Import CSS and Global Styles
 import './global.scss'
 import './polyfills'


### PR DESCRIPTION
Assets from the `src/images` folder weren't loaded in the client. This PR fixes that.