### PR TITLE
(Chore) Change GitHub actions config to break pipeline on broken build

### DIFF
--- a/.github/workflows/end-to-end.yml
+++ b/.github/workflows/end-to-end.yml
@@ -36,7 +36,6 @@ jobs:
       - name: Cypress run
         uses: cypress-io/github-action@v2
         id: cypress
-        continue-on-error: true
         with:
           start: docker-compose up frontend
           wait-on: 'http://localhost:8000/signals/'
@@ -48,8 +47,3 @@ jobs:
         env:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Print Dashboard URL
-        run: |
-          echo Cypress finished with: ${{ steps.cypress.outcome }}
-          echo See results at ${{ steps.cypress.outputs.dashboardUrl }}


### PR DESCRIPTION
E2E job should
- [Fail](https://github.com/Amsterdam/signals-frontend/actions/runs/1304048385) step when build fails
- [Fail](https://github.com/Amsterdam/signals-frontend/actions/runs/1303502021) step when a job fails 
- [Succeed](https://github.com/Amsterdam/signals-frontend/actions/runs/1303504515) when build+tests succeed

Removed step to print dashboard URL because this URL is already printed in every E2E step