### PR TITLE
(Chore) Empty ref fix

### DIFF
--- a/src/components/AutoSuggest/index.js
+++ b/src/components/AutoSuggest/index.js
@@ -186,7 +186,8 @@ const AutoSuggest = ({
   }, [data, numOptionsDeterminer])
 
   const handleFocusOut = useCallback((event) => {
-    if (wrapperRef.current.contains(event.relatedTarget)) return
+    if (wrapperRef.current && wrapperRef.current.contains(event.relatedTarget))
+      return
 
     setActiveIndex(-1)
     setShowList(false)


### PR DESCRIPTION
Fix for https://sentry.data.amsterdam.nl/sentry/signals-frontend/issues/2710625/?environment=production.
Apparently, the ref can be `null` when the `focusout` event occurs. Not sure how, but at least this PR fixes it.