### PR TITLE
(Chore) AbortController stub

### DIFF
--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -75,3 +75,14 @@ if (!Array.prototype.flatMap) {
     },
   })
 }
+
+if (!window.AbortController) {
+  // simple AbortController stub; not intended to polyfill the missing API, but to merely prevent
+  // errors in browsers that do not support it.
+  window.AbortController = function () {
+    return {
+      abort: function () {},
+      signal: {},
+    }
+  }
+}


### PR DESCRIPTION
Seeing a number of errors like these: https://sentry.data.amsterdam.nl/sentry/signals-frontend/issues/2710627/?environment=production.
This PR fixes that by stubbing the missing API support.