### PR TITLE
(Hotfix) contain:content blocker

### DIFF
--- a/src/containers/App/index.tsx
+++ b/src/containers/App/index.tsx
@@ -34,7 +34,6 @@ const FooterContainer = styled.div`
 `
 
 const ContentContainer = styled.div<{ headerIsTall: boolean }>`
-  contain: content;
   background-color: #ffffff;
   flex: 1 0 auto;
   margin: 0 auto;


### PR DESCRIPTION
This PR fixes an issue where pages could not be scrolled where the height of the content exceeded the height of the viewport.