### PR TITLE
[SIG-4113] Scroll block in status form

### DIFF
--- a/src/containers/App/index.tsx
+++ b/src/containers/App/index.tsx
@@ -28,7 +28,6 @@ import AppContext from './context'
 import { makeSelectLoading, makeSelectSources } from './selectors'
 
 const ContentContainer = styled.div<{ headerIsTall: boolean }>`
-  contain: content;
   background-color: #ffffff;
   flex: 1 0 auto;
   margin: 0 auto;


### PR DESCRIPTION
Fixes an issue where, when the height of a page's content would exceed the height of the viewport, it could not be scrolled.