### PR TITLE
[SIG-4099] Markdown parse

### DIFF
--- a/src/components/HistoryList/HistoryList.tsx
+++ b/src/components/HistoryList/HistoryList.tsx
@@ -4,6 +4,8 @@ import type { FunctionComponent } from 'react'
 import type { History } from 'types/history'
 import styled from 'styled-components'
 import { breakpoint, themeColor, themeSpacing } from '@amsterdam/asc-ui'
+import ReactMarkdown from 'react-markdown'
+
 import { string2date, string2time } from 'shared/services/string-parser'
 import type { Theme } from 'types/theme'
 
@@ -60,9 +62,19 @@ const HistoryList: FunctionComponent<HistoryListProps> = ({
         </Time>
 
         <Action>
-          {action && <div data-testid="history-list-item-action">{action}</div>}
+          {action && (
+            <div data-testid="history-list-item-action">
+              <ReactMarkdown allowedElements={['a', 'p']}>
+                {action}
+              </ReactMarkdown>
+            </div>
+          )}
           {description && (
-            <div data-testid="history-list-item-description">{description}</div>
+            <div data-testid="history-list-item-description">
+              <ReactMarkdown allowedElements={['a', 'p']}>
+                {description}
+              </ReactMarkdown>
+            </div>
           )}
         </Action>
       </Item>

--- a/src/components/HistoryList/__tests__/HistoryList.test.tsx
+++ b/src/components/HistoryList/__tests__/HistoryList.test.tsx
@@ -26,4 +26,47 @@ describe('<ChildIncidentHistory />', () => {
 
     expect(screen.getByText('mock description')).toBeInTheDocument()
   })
+
+  it('converts Markdown to HTML', () => {
+    const link1 = 'https://www.amsterdam.nl'
+
+    const { rerender } = render(
+      withAppContext(
+        <HistoryList
+          list={[
+            { ...history[0], action: `mock [link text](${link1}) description` },
+          ]}
+        />
+      )
+    )
+
+    expect(screen.getByRole('link')).toHaveAttribute('href', link1)
+
+    const link2 = 'https://www.amsterdam.nl/contact'
+
+    rerender(
+      withAppContext(
+        <HistoryList
+          list={[
+            {
+              ...history[0],
+              description: `mock [link text](${link2}) description`,
+            },
+          ]}
+        />
+      )
+    )
+
+    expect(screen.getByRole('link')).toHaveAttribute('href', link2)
+  })
+
+  it('does not convert unallowed Markdown', () => {
+    render(
+      withAppContext(
+        <HistoryList list={[{ ...history[0], action: '## Here is an h2' }]} />
+      )
+    )
+
+    expect(screen.queryByRole('heading')).not.toBeInTheDocument()
+  })
 })

--- a/src/components/SiteHeader/index.js
+++ b/src/components/SiteHeader/index.js
@@ -83,6 +83,12 @@ const SearchBarMenuItem = styled(MenuItem)`
 
 const StyledSearchBar = styled(SearchBar)`
   margin-top: 5px;
+
+  ${styles.TextFieldStyle} {
+    button {
+      top: 3px;
+    }
+  }
 `
 
 const HeaderWrapper = styled.div`

--- a/src/components/SiteHeader/index.js
+++ b/src/components/SiteHeader/index.js
@@ -83,12 +83,6 @@ const SearchBarMenuItem = styled(MenuItem)`
 
 const StyledSearchBar = styled(SearchBar)`
   margin-top: 5px;
-
-  ${styles.TextFieldStyle} {
-    button {
-      top: 3px;
-    }
-  }
 `
 
 const HeaderWrapper = styled.div`

--- a/src/signals/incident/components/form/HandlingMessage/HandlingMessage.tsx
+++ b/src/signals/incident/components/form/HandlingMessage/HandlingMessage.tsx
@@ -1,15 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2021 Gemeente Amsterdam
-import { Fragment, ReactElement } from 'react'
-import type { FunctionComponent } from 'react'
-import { Heading } from '@amsterdam/asc-ui'
+import { ReactElement } from 'react'
+import ReactMarkdown from 'react-markdown'
+import { Heading, Paragraph } from '@amsterdam/asc-ui'
 import isString from 'lodash/isString'
 import get from 'lodash/get'
-import styled from 'styled-components'
 
-const Paragraph = styled.p`
-  margin: 0;
-`
+import type { FC } from 'react'
 
 const renderText = (
   key: string,
@@ -19,11 +16,16 @@ const renderText = (
   const replacedValue = get(parent, `meta.incidentContainer.${key}`) as string
   if (replacedValue) {
     return (
-      <Fragment>
+      <>
         {replacedValue.split('\n\n').map((item: string, index: number) => (
-          <Paragraph key={`${name}-${index + 1}`}>{item}</Paragraph>
+          <ReactMarkdown
+            key={`${name}-${index + 1}`}
+            allowedElements={['a', 'p']}
+          >
+            {item}
+          </ReactMarkdown>
         ))}
-      </Fragment>
+      </>
     )
   }
 
@@ -40,10 +42,7 @@ interface HandlingMessageProps {
   parent: Record<string, any>
 }
 
-const HandlingMessage: FunctionComponent<HandlingMessageProps> = ({
-  meta,
-  parent,
-}) =>
+const HandlingMessage: FC<HandlingMessageProps> = ({ meta, parent }) =>
   meta.isVisible ? (
     <div>
       <Heading as="h2" styleAs="h3">

--- a/src/signals/incident/components/form/HandlingMessage/__tests__/HandlingMessage.test.tsx
+++ b/src/signals/incident/components/form/HandlingMessage/__tests__/HandlingMessage.test.tsx
@@ -10,65 +10,114 @@ describe('Form component <HandlingMessage />', () => {
     },
   }
 
-  describe('rendering', () => {
-    it('should render handling message correctly', () => {
-      render(
-        <HandlingMessage
-          meta={{
-            name: 'handling_message',
-            title: 'Foo!',
-            key: 'incident.handling_message',
-            isVisible: true,
-          }}
-          parent={{
-            meta: {
-              incidentContainer,
+  it('should render handling message correctly', () => {
+    render(
+      <HandlingMessage
+        meta={{
+          name: 'handling_message',
+          title: 'Foo!',
+          key: 'incident.handling_message',
+          isVisible: true,
+        }}
+        parent={{
+          meta: {
+            incidentContainer,
+          },
+        }}
+      />
+    )
+
+    expect(screen.getByRole('heading', { name: 'Foo!' })).toBeInTheDocument()
+    expect(screen.getByText('Jaaaaa!')).toBeInTheDocument()
+    expect(screen.getByText('Neee!')).toBeInTheDocument()
+  })
+
+  it('should render empty correctly with no handling message', () => {
+    render(
+      <HandlingMessage
+        meta={{
+          name: 'handling_message',
+          title: 'Foo!',
+          key: 'incident.handling_message',
+          isVisible: true,
+        }}
+        parent={{
+          meta: {},
+        }}
+      />
+    )
+
+    expect(
+      screen.getByText('We gaan zo snel mogelijk aan de slag.')
+    ).toBeInTheDocument()
+  })
+
+  it('should render no handling message when not visible', () => {
+    render(
+      <HandlingMessage
+        meta={{
+          name: 'handling_message',
+          title: 'Foo!',
+          key: 'incident.handling_message',
+          isVisible: false,
+        }}
+        parent={{
+          meta: {},
+        }}
+      />
+    )
+
+    expect(screen.queryByText('Foo!')).not.toBeInTheDocument()
+  })
+
+  it('converts Markdown to HTML', () => {
+    const link = 'https://github.com'
+    const handling_message = `This will print as [a link](${link})`
+    render(
+      <HandlingMessage
+        meta={{
+          name: 'handling_message',
+          title: 'Foo!',
+          key: 'incident.handling_message',
+          isVisible: true,
+        }}
+        parent={{
+          meta: {
+            incidentContainer: {
+              incident: {
+                handling_message,
+              },
             },
-          }}
-        />
-      )
+          },
+        }}
+      />
+    )
 
-      expect(screen.getByRole('heading', { name: 'Foo!' })).toBeInTheDocument()
-      expect(screen.getByText('Jaaaaa!')).toBeInTheDocument()
-      expect(screen.getByText('Neee!')).toBeInTheDocument()
-    })
+    expect(screen.queryByRole('link')).toHaveAttribute('href', link)
+  })
 
-    it('should render empty correctly with no handling message', () => {
-      render(
-        <HandlingMessage
-          meta={{
-            name: 'handling_message',
-            title: 'Foo!',
-            key: 'incident.handling_message',
-            isVisible: true,
-          }}
-          parent={{
-            meta: {},
-          }}
-        />
-      )
+  it('does not convert unallowed Markdown', () => {
+    const handling_message = '# Here is an h1'
+    render(
+      <HandlingMessage
+        meta={{
+          name: 'handling_message',
+          title: 'Foo!',
+          key: 'incident.handling_message',
+          isVisible: true,
+        }}
+        parent={{
+          meta: {
+            incidentContainer: {
+              incident: {
+                handling_message,
+              },
+            },
+          },
+        }}
+      />
+    )
 
-      expect(
-        screen.getByText('We gaan zo snel mogelijk aan de slag.')
-      ).toBeInTheDocument()
-    })
-
-    it('should render no handling message when not visible', () => {
-      render(
-        <HandlingMessage
-          meta={{
-            name: 'handling_message',
-            title: 'Foo!',
-            key: 'incident.handling_message',
-            isVisible: false,
-          }}
-          parent={{
-            meta: {},
-          }}
-        />
-      )
-
-      expect(screen.queryByText('Foo!')).not.toBeInTheDocument()
-    })
+    expect(screen.queryByRole('heading', { level: 1 })).not.toBeInTheDocument()
   })
 })

--- a/src/signals/incident/services/map-dynamic-fields/index.js
+++ b/src/signals/incident/services/map-dynamic-fields/index.js
@@ -5,7 +5,7 @@ import get from 'lodash/get'
 function mapDynamicFields(text, fields) {
   return text.replace(/{.+?}/g, (match) => {
     const key = match.replace(/[{}]/g, '')
-    return get(fields, key, `[niet gevonden: ${key}]`)
+    return get(fields, key, 'onbekend')
   })
 }
 

--- a/src/signals/incident/services/map-dynamic-fields/index.test.js
+++ b/src/signals/incident/services/map-dynamic-fields/index.test.js
@@ -23,6 +23,6 @@ describe('The map dynamic fields service', () => {
       mapDynamicFields('foo {incident.id} bar', {
         incident: {},
       })
-    ).toEqual('foo [niet gevonden: incident.id] bar')
+    ).toEqual('foo onbekend bar')
   })
 })


### PR DESCRIPTION
This PR contains changes that allow for Markdown as input format for any form that renders into a `History` component as well as the 'Thank you' page of the incident form.
Note that a change to the `mapDynamicFields` function was necessary to prevent the Markdown parser to trip over the string that was returned by that function whenever an entry could not be returned.