### PR TITLE
[SIG-4115] Sort dropdown

### DIFF
--- a/src/signals/incident-management/containers/IncidentOverviewPage/components/Sort/Sort.test.tsx
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/components/Sort/Sort.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { withAppContext } from 'test/utils'
+
+import Sort, { SortOptions } from '.'
+
+const onChangeOrdering = jest.fn()
+
+describe('Sort', () => {
+  it('renders sort options', () => {
+    render(withAppContext(<Sort onChangeOrdering={onChangeOrdering} />))
+
+    expect(screen.getByTestId('incidentSortSelect')).toBeInTheDocument()
+    expect(screen.getAllByRole('option').length).toBeGreaterThan(0)
+  })
+
+  it('calls onChange callback', () => {
+    render(withAppContext(<Sort onChangeOrdering={onChangeOrdering} />))
+
+    expect(onChangeOrdering).not.toHaveBeenCalled()
+
+    userEvent.selectOptions(screen.getByTestId('incidentSortSelect'), [
+      SortOptions.STATUS_ASC,
+    ])
+
+    expect(onChangeOrdering).toHaveBeenCalledWith(SortOptions.STATUS_ASC)
+
+    userEvent.selectOptions(screen.getByTestId('incidentSortSelect'), [
+      SortOptions.STATUS_ASC,
+    ])
+
+    expect(onChangeOrdering).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/signals/incident-management/containers/IncidentOverviewPage/components/Sort/Sort.tsx
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/components/Sort/Sort.tsx
@@ -1,0 +1,88 @@
+import { useCallback, useEffect, useState } from 'react'
+import { Select, themeSpacing } from '@amsterdam/asc-ui'
+import styled from 'styled-components'
+
+import type { FC } from 'react'
+
+const SelectContainer = styled.div`
+  display: flex;
+  align-items: center;
+  margin: 0 ${themeSpacing(8)} 0 auto;
+
+  label {
+    margin-right: ${themeSpacing(8)};
+  }
+`
+
+type SortProps = {
+  className?: ''
+  onChangeOrdering: (sort: string) => void
+}
+
+export enum SortOptions {
+  ADDRESS_ASC = 'address',
+  ADDRESS_DESC = '-address',
+  ASSIGNED_USER_EMAIL_ASC = 'assigned_user_email',
+  ASSIGNED_USER_EMAIL_DESC = '-assigned_user_email',
+  BUROUGH_ASC = 'stadsdeel',
+  BUROUGH_DESC = '-stadsdeel',
+  CREATED_AT_ASC = 'created_at',
+  CREATED_AT_DESC = '-created_at',
+  PRIORITY_ASC = 'priority',
+  PRIORITY_DESC = '-priority',
+  STATUS_ASC = 'status',
+  STATUS_DESC = '-status',
+  SUBCATEGORY_ASC = 'sub_category',
+  SUBCATEGORY_DESC = '-sub_category',
+}
+
+const Sort: FC<SortProps> = ({ onChangeOrdering }) => {
+  const [sort, setSort] = useState<SortOptions>()
+  const onChange = useCallback(
+    (event) => {
+      const { value } = event.target
+
+      if (sort !== value) setSort(value)
+    },
+    [sort]
+  )
+
+  useEffect(() => {
+    if (!sort) return
+    onChangeOrdering(sort)
+  }, [onChangeOrdering, sort])
+
+  return (
+    <SelectContainer>
+      <Select
+        data-testid="incidentSortSelect"
+        id="sortSelect"
+        label="Sorteren"
+        onChange={onChange}
+      >
+        <option value={SortOptions.CREATED_AT_ASC}>Datum: nieuw - oud</option>
+        <option value={SortOptions.CREATED_AT_DESC}>Datum: oud - nieuw</option>
+        <option value={SortOptions.PRIORITY_ASC}>Urgentie: hoog - laag</option>
+        <option value={SortOptions.PRIORITY_DESC}>Urgentie: laag - hoog</option>
+        <option value={SortOptions.BUROUGH_ASC}>Stadsdeel A-Z</option>
+        <option value={SortOptions.BUROUGH_DESC}>Stadsdeel Z-A</option>
+        <option value={SortOptions.STATUS_ASC}>Status A-Z</option>
+        <option value={SortOptions.STATUS_DESC}>Status Z-A</option>
+        <option value={SortOptions.ADDRESS_ASC}>Adres A-Z</option>
+        <option value={SortOptions.ADDRESS_DESC}>Adres Z-A</option>
+        <option value={SortOptions.CREATED_AT_ASC}>Dag: hoog - laag</option>
+        <option value={SortOptions.CREATED_AT_DESC}>Dag: laag - hoog</option>
+        <option value={SortOptions.ASSIGNED_USER_EMAIL_ASC}>
+          Toegewezen aan: A-Z
+        </option>
+        <option value={SortOptions.ASSIGNED_USER_EMAIL_DESC}>
+          Toegewezen aan: Z-A
+        </option>
+        <option value={SortOptions.SUBCATEGORY_ASC}>Subcategorie: A-Z</option>
+        <option value={SortOptions.SUBCATEGORY_DESC}>Subcategorie: Z-A</option>
+      </Select>
+    </SelectContainer>
+  )
+}
+
+export default Sort

--- a/src/signals/incident-management/containers/IncidentOverviewPage/components/Sort/index.ts
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/components/Sort/index.ts
@@ -1,0 +1,1 @@
+export { default, SortOptions } from './Sort'


### PR DESCRIPTION
This PR adds the `Sort` component. This will replace the incident overview table header in an upcoming PR.