### PR TITLE
[SIG-4124] No caching for index.html

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -4,12 +4,27 @@ server {
 
     root /usr/share/nginx/html/;
 
+    # disable content-type sniffing on some browsers.
+    add_header X-Content-Type-Options nosniff;
+    # This header enables the Cross-site scripting (XSS) filter
+    add_header X-XSS-Protection "1; mode=block";
+    # This will enforce HTTP browsing into HTTPS and avoid ssl stripping attack
+    add_header Strict-Transport-Security "max-age=31536000; includeSubdomains;";
+
+    error_page   404  /index.html;
+
     location ~ /\.ht {
         deny all;
     }
 
     location / {
         alias /usr/share/nginx/html/;
-        try_files $uri $uri/ /index.html =404;
+        try_files $uri $uri/ @index;
+    }
+
+    location @index {
+        add_header Cache-Control "no-store, no-cache, must-revalidate";
+        expires -1;
+        try_files $uri /index.html =404;
     }
 }


### PR DESCRIPTION
The changes in this PR will force `index.html` to never cache. This will prevent errors with outdated code when a visitor hasn't visited the site for a long time.