### PR TITLE
[SIG-3918] Only show Sort when rendering list

### DIFF
--- a/src/signals/incident-management/containers/IncidentOverviewPage/index.js
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/index.js
@@ -222,11 +222,15 @@ export const IncidentOverviewPageContainerComponent = ({
         </Column>
 
         <NavWrapper>
-          {pagination}
-          <Sort
-            activeOrdering={ordering}
-            onChangeOrdering={orderingChangedAction}
-          />
+          {!showsMap && (
+            <>
+              {pagination}
+              <Sort
+                activeOrdering={ordering}
+                onChangeOrdering={orderingChangedAction}
+              />
+            </>
+          )}
           <SubNav showsMap={showsMap} />
         </NavWrapper>
       </Row>


### PR DESCRIPTION
This PR makes sure that the Sort dropdown isn't shown when viewing the map instead of the list on the incident overview page