### PR TITLE
Feature/158 thor button feature flag

### DIFF
--- a/app.amsterdam.json
+++ b/app.amsterdam.json
@@ -10,6 +10,7 @@
     "fetchDistrictsFromBackend": false,
     "fetchQuestionsFromBackend": false,
     "mapFilter24Hours": true,
+    "showThorButton": true,
     "showVulaanControls": true,
     "useProjectenSignalType": false,
     "useMapSelectGeneric": false,
@@ -55,10 +56,19 @@
   "map": {
     "municipality": "amsterdam",
     "options": {
-      "center": [52.3731081, 4.8932945],
+      "center": [
+        52.3731081,
+        4.8932945
+      ],
       "maxBounds": [
-        [52.25168, 4.64034],
-        [52.50536, 5.10737]
+        [
+          52.25168,
+          4.64034
+        ],
+        [
+          52.50536,
+          5.10737
+        ]
       ],
       "maxZoom": 14,
       "minZoom": 8,
@@ -70,10 +80,17 @@
       "zoom": 7
     },
     "tiles": {
-      "args": ["https://{s}.data.amsterdam.nl/topo_rd/{z}/{x}/{y}.png"],
+      "args": [
+        "https://{s}.data.amsterdam.nl/topo_rd/{z}/{x}/{y}.png"
+      ],
       "options": {
         "attribution": "<span aria-hidden='true'>Kaartgegevens CC-BY-4.0 Gemeente Amsterdam</span>",
-        "subdomains": ["t1", "t2", "t3", "t4"],
+        "subdomains": [
+          "t1",
+          "t2",
+          "t3",
+          "t4"
+        ],
         "tms": true
       }
     },

--- a/app.base.json
+++ b/app.base.json
@@ -2,19 +2,20 @@
   "apiBaseUrl": "http://localhost:8000",
   "areaTypeCodeForDistrict": "district",
   "featureFlags": {
+    "appMode": false,
     "assignSignalToDepartment": false,
     "assignSignalToEmployee": false,
+    "enableNearIncidents": false,
     "enablePublicSignalMap": false,
     "enableReporter": false,
-    "enableNearIncidents": false,
     "fetchDistrictsFromBackend": false,
     "fetchQuestionsFromBackend": false,
     "mapFilter24Hours": false,
     "showVulaanControls": false,
-    "useProjectenSignalType": false,
+    "showThorButton": false,
     "useMapSelectGeneric": false,
-    "useStaticMapServer": false,
-    "appMode": false
+    "useProjectenSignalType": false,
+    "useStaticMapServer": false
   },
   "head": {
     "androidIcon": "/icon_192x192.png",

--- a/internals/schemas/app.schema.json
+++ b/internals/schemas/app.schema.json
@@ -93,6 +93,10 @@
           "description": "When true, will show no more and no less than the incidents of the last 24 hours on the map (in the back office), regardless of the start and end date filters.",
           "type": "boolean"
         },
+        "showThorButton": {
+          "description": "When true, will show THOR button to the top right on the detail page of a signal",
+          "type": "boolean"
+        },
         "showVulaanControls": {
           "description": "When true, will show extra questions after the first page of questions in the incident submission form",
           "type": "boolean"
@@ -123,6 +127,7 @@
         "fetchDistrictsFromBackend",
         "fetchQuestionsFromBackend",
         "mapFilter24Hours",
+        "showThorButton",
         "showVulaanControls",
         "useProjectenSignalType",
         "useMapSelectGeneric",
@@ -275,7 +280,11 @@
           "format": "uri"
         }
       },
-      "required": ["help", "home", "privacy"],
+      "required": [
+        "help",
+        "home",
+        "privacy"
+      ],
       "title": "Links"
     },
     "Logo": {
@@ -285,26 +294,47 @@
       "properties": {
         "url": {
           "description": "Any URL that will hold the image for the application's logo. Can be a URI or an absolute URL that points to the webroot",
-          "type": ["string", "null"]
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "width": {
           "description": "Length value that sets the logo image's width. See https://developer.mozilla.org/en-US/docs/Web/CSS/width for reference",
-          "type": ["string", "integer"]
+          "type": [
+            "string",
+            "integer"
+          ]
         },
         "height": {
           "description": "Length value that sets the logo image's height. In pixels, the height should be 74 or less.",
-          "type": ["string", "integer"]
+          "type": [
+            "string",
+            "integer"
+          ]
         },
         "smallWidth": {
           "description": "Length value that sets the logo image's width in case the logo is rendered in a site header with limited height",
-          "type": ["string", "integer"]
+          "type": [
+            "string",
+            "integer"
+          ]
         },
         "smallHeight": {
           "description": "Length value that sets the logo image's height in case the logo is rendered in a site header with limited height. In pixels, the smallHeight should be 34 or less.",
-          "type": ["string", "integer"]
+          "type": [
+            "string",
+            "integer"
+          ]
         }
       },
-      "required": ["height", "smallHeight", "smallWidth", "url", "width"],
+      "required": [
+        "height",
+        "smallHeight",
+        "smallWidth",
+        "url",
+        "width"
+      ],
       "title": "Logo"
     },
     "Map": {
@@ -312,7 +342,10 @@
       "additionalProperties": false,
       "properties": {
         "municipality": {
-          "type": ["string", "array"]
+          "type": [
+            "string",
+            "array"
+          ]
         },
         "options": {
           "$ref": "#/definitions/MapOptions"
@@ -345,7 +378,11 @@
           }
         }
       },
-      "required": ["municipality", "options", "tiles"],
+      "required": [
+        "municipality",
+        "options",
+        "tiles"
+      ],
       "title": "Map"
     },
     "MapOptions": {
@@ -377,7 +414,13 @@
           "type": "integer"
         }
       },
-      "required": ["center", "maxBounds", "maxZoom", "minZoom", "zoom"],
+      "required": [
+        "center",
+        "maxBounds",
+        "maxZoom",
+        "minZoom",
+        "zoom"
+      ],
       "title": "MapOptions"
     },
     "Oidc": {
@@ -399,14 +442,23 @@
         },
         "responseType": {
           "description": "oAuth2 `response_type` service parameter value",
-          "enum": ["token", "id_token", "code"]
+          "enum": [
+            "token",
+            "id_token",
+            "code"
+          ]
         },
         "scope": {
           "description": "oAuth2 `scope` service parameter value",
           "type": "string"
         }
       },
-      "required": ["authEndpoint", "clientId", "scope", "responseType"]
+      "required": [
+        "authEndpoint",
+        "clientId",
+        "scope",
+        "responseType"
+      ]
     },
     "OptionsBackOffice": {
       "type": "object",
@@ -447,7 +499,10 @@
           "$ref": "#/definitions/TilesOptions"
         }
       },
-      "required": ["args", "options"],
+      "required": [
+        "args",
+        "options"
+      ],
       "title": "Tiles"
     },
     "TilesOptions": {
@@ -467,7 +522,10 @@
           "type": "boolean"
         }
       },
-      "required": ["attribution", "tms"],
+      "required": [
+        "attribution",
+        "tms"
+      ],
       "title": "TilesOptions"
     },
     "Matomo": {
@@ -484,7 +542,10 @@
           "type": "integer"
         }
       },
-      "required": ["siteId", "urlBase"],
+      "required": [
+        "siteId",
+        "urlBase"
+      ],
       "title": "Matomo"
     },
     "Sentry": {
@@ -497,7 +558,9 @@
           "description": "Sentry data source name value. When omitted, Sentry will not be initialised in the application"
         }
       },
-      "required": ["dsn"],
+      "required": [
+        "dsn"
+      ],
       "title": "Sentry"
     },
     "Theme": {

--- a/src/signals/incident-management/containers/IncidentDetail/components/DetailHeader/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/DetailHeader/index.js
@@ -152,7 +152,7 @@ const DetailHeader = () => {
           </Button>
         )}
 
-        {canThor && (
+        {canThor && configuration.featureFlags.showThorButton && (
           <Button
             type="button"
             variant="application"

--- a/src/signals/incident-management/containers/IncidentDetail/components/DetailHeader/index.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/DetailHeader/index.test.js
@@ -6,10 +6,13 @@ import * as reactRouterDom from 'react-router-dom'
 import { withAppContext } from 'test/utils'
 import { MAP_URL, INCIDENTS_URL } from 'signals/incident-management/routes'
 import incidentFixture from 'utils/__tests__/fixtures/incident.json'
+import configuration from 'shared/services/configuration/configuration'
 import { PATCH_TYPE_THOR } from '../../constants'
 
 import IncidentDetailContext from '../../context'
 import DetailHeader from '.'
+
+jest.mock('shared/services/configuration/configuration')
 
 jest.mock('./components/DownloadButton', () => (props) => (
   <div data-testid="detail-header-button-download" {...props} />
@@ -34,7 +37,12 @@ const renderWithContext = (incident = incidentFixture) =>
 
 describe('signals/incident-management/containers/IncidentDetail/components/DetailHeader', () => {
   beforeEach(() => {
+    configuration.featureFlags.showThorButton = true
     update.mockReset()
+  })
+
+  afterEach(() => {
+    configuration.__reset()
   })
 
   it('should render all buttons when state is gemeld and no parent or children are present', () => {
@@ -60,6 +68,24 @@ describe('signals/incident-management/containers/IncidentDetail/components/Detai
     expect(
       screen.queryAllByTestId('detail-header-button-download')
     ).toHaveLength(1)
+  })
+
+  it('should not render THOR button when feature flag disable', () => {
+    configuration.featureFlags.showThorButton = false
+
+    render(
+      renderWithContext({
+        ...incidentFixture,
+        _links: {
+          ...incidentFixture._links,
+          'sia:children': undefined,
+        },
+      })
+    )
+
+    expect(
+      screen.queryByTestId('detail-header-button-thor')
+    ).not.toBeInTheDocument()
   })
 
   it('should render correct title when parent is present', () => {


### PR DESCRIPTION
closes Signalen/frontend#158

Puts the THOR button, on the top right of a signal detail page, behind a feature flag.

Adds `showThorButton` to `featureFlags` in the configuration. Default value is `false`, thus must be configured in case the THOR button is desired.