### PR TITLE
Show employee when department has been selected

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/components/MetaList/MetaList.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/MetaList/MetaList.tsx
@@ -172,6 +172,14 @@ const MetaList = () => {
     [usersData, incident]
   )
 
+  const showAssignedUser =
+    configuration.featureFlags.assignSignalToEmployee &&
+    userOptions &&
+    (incident?.assigned_user_email ||
+      (configuration.featureFlags.assignSignalToDepartment &&
+        incident?.routing_departments) ||
+      !configuration.featureFlags.assignSignalToDepartment)
+
   const departmentOptions = useMemo(() => {
     if (!configuration.featureFlags.assignSignalToDepartment) return []
 
@@ -344,7 +352,7 @@ const MetaList = () => {
         </Highlight>
       )}
 
-      {configuration.featureFlags.assignSignalToEmployee && userOptions && (
+      {showAssignedUser && (
         <Highlight type="assigned_user_email">
           <ChangeValue
             component={SelectInput}

--- a/src/signals/incident-management/containers/IncidentDetail/components/MetaList/__tests__/MetaList.test.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/MetaList/__tests__/MetaList.test.tsx
@@ -503,6 +503,47 @@ describe('MetaList', () => {
       expect(screen.getByText('Niet toegewezen')).toBeInTheDocument()
     })
 
+    it('should not show assigned user without a selected department', async () => {
+      configuration.featureFlags.assignSignalToEmployee = true
+      configuration.featureFlags.assignSignalToDepartment = true
+      render(renderWithContext())
+      await screen.findByTestId('meta-list-date-definition')
+
+      expect(
+        screen.queryByTestId('meta-list-assigned_user_email-definition')
+      ).not.toBeInTheDocument()
+      expect(
+        screen.queryByTestId('meta-list-assigned_user_email-value')
+      ).not.toBeInTheDocument()
+    })
+
+    it('should show assigned user with a selected department', async () => {
+      configuration.featureFlags.assignSignalToEmployee = true
+      configuration.featureFlags.assignSignalToDepartment = true
+      render(
+        renderWithContext({
+          ...incidentFixture,
+          routing_departments: {
+            code: departmentAscCode,
+            name: departmentAscName,
+          },
+          category: {
+            ...incidentFixture.category,
+            departments: `${departmentAscCode}, ${departmentAegCode}`,
+          },
+        })
+      )
+      await screen.findByTestId('meta-list-date-definition')
+
+      expect(
+        screen.getByTestId('meta-list-assigned_user_email-definition')
+      ).toBeInTheDocument()
+      expect(
+        screen.getByTestId('meta-list-assigned_user_email-value')
+      ).toBeInTheDocument()
+      expect(screen.getByText('Niet toegewezen')).toBeInTheDocument()
+    })
+
     it('should not show assigned user when users not defined', async () => {
       configuration.featureFlags.assignSignalToEmployee = true
       mockRequestHandler({
@@ -576,6 +617,38 @@ describe('MetaList', () => {
         expect(
           screen.queryByText(autocompleteUsernamesAscName)
         ).not.toBeInTheDocument()
+        expect(
+          screen.queryByText(autocompleteUsernamesAegName)
+        ).not.toBeInTheDocument()
+        expect(
+          screen.queryByText(autocompleteUsernamesThoName)
+        ).not.toBeInTheDocument()
+      })
+
+      it('should be visible even if no department selected', async () => {
+        configuration.featureFlags.assignSignalToEmployee = true
+        configuration.featureFlags.assignSignalToDepartment = true
+
+        render(
+          renderWithContext({
+            ...incidentFixture,
+            assigned_user_email: autocompleteUsernamesAscName,
+            category: {
+              ...incidentFixture.category,
+              departments: `${departmentAscCode}, ${departmentAegCode}`,
+            },
+          })
+        )
+
+        await screen.findByTestId('meta-list-date-definition')
+
+        expect(screen.queryByText('Niet toegewezen')).not.toBeInTheDocument()
+        expect(
+          screen.queryByText(autocompleteUsernamesAscAegName)
+        ).not.toBeInTheDocument()
+        expect(
+          screen.getByText(autocompleteUsernamesAscName)
+        ).toBeInTheDocument()
         expect(
           screen.queryByText(autocompleteUsernamesAegName)
         ).not.toBeInTheDocument()


### PR DESCRIPTION
closes Signalen/frontend#119

When both feature flags`assignSignalToEmployee` and `assignSignalToDepartment` are turned on. The employee should not be visible as long as a department has not been selected yet.