### PR TITLE
[SIG-4134] Fix no features error

### DIFF
--- a/src/components/OverviewMap/OverviewMap.tsx
+++ b/src/components/OverviewMap/OverviewMap.tsx
@@ -194,7 +194,7 @@ const OverviewMap = ({ isPublic = false, ...rest }) => {
   }, [get])
 
   useEffect(() => {
-    if (!data || !layerInstance) return () => {}
+    if (!data?.features || !layerInstance) return
 
     data.features.forEach((feature) => {
       const latlng = featureTolocation(feature.geometry)
@@ -256,6 +256,7 @@ const OverviewMap = ({ isPublic = false, ...rest }) => {
           topRight={
             showPanel &&
             incident && (
+              /* istanbul ignore next */
               <DetailPanel incident={incident} onClose={onClosePanel} />
             )
           }


### PR DESCRIPTION
This PR fixes an issue where, when the `geography` endpoint doesn't return a result set (no incidents registered in the past 24 hours), the map wouldn't be rendered because of an exception.
The likelihood of this situation occurring in production is next to nill, but could still occur.