### PR TITLE
[SIG-4139] Fixes column widths

### DIFF
--- a/src/signals/incident-management/containers/IncidentOverviewPage/components/List/index.tsx
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/components/List/index.tsx
@@ -27,6 +27,8 @@ import IncidentManagementContext from '../../../../context'
 import {
   ContentSpan,
   Th,
+  ThId,
+  ThDay,
   TdStyle,
   ThArea,
   ThDate,
@@ -109,8 +111,8 @@ const List: FunctionComponent<ListProps> = ({
           <tr>
             <ThParent />
             <ThPriority />
-            <Th>Id</Th>
-            <Th>Dag</Th>
+            <ThId>Id</ThId>
+            <ThDay>Dag</ThDay>
             <ThDate>Datum en tijd</ThDate>
             <ThSubcategory>Subcategorie</ThSubcategory>
             <ThStatus>Status</ThStatus>

--- a/src/signals/incident-management/containers/IncidentOverviewPage/components/List/styles.ts
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/components/List/styles.ts
@@ -57,6 +57,14 @@ export const ThStatus = styled(Th)`
   width: 160px;
 `
 
+export const ThId = styled(Th)`
+  width: 95px;
+`
+
+export const ThDay = styled(Th)`
+  width: 55px;
+`
+
 export const ContentSpan = styled.span``
 
 export const TdStyle = styled.td`


### PR DESCRIPTION
This PR sets the widths of the `id` and the `day` column to fixed values so that, when the table is sorted, the columns don't 'jump'.