### PR TITLE
(Fix) Yarn no global install of dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,7 +57,7 @@ FROM nginx:stable-alpine
 
 RUN apk add --no-cache jq nodejs yarn
 
-RUN yarn global add @exodus/schemasafe lodash
+RUN yarn add @exodus/schemasafe lodash
 
 COPY --from=base /app/build/. /usr/share/nginx/html/
 


### PR DESCRIPTION
Switching to Yarn to install run-time dependencies worked, but installing them globally. This PR fixes that.