### PR TITLE
Sig 4147 adjust summary page

### DIFF
--- a/docs/adr/0006-forms.md
+++ b/docs/adr/0006-forms.md
@@ -69,7 +69,7 @@ The definitions for all steps in the wizard can be turned into components, defin
 - [wizard-step-1-beschrijf.js](../../src/signals/incident/definitions/wizard-step-1-beschrijf.js)
 - [wizard-step-3-contact.js](../../src/signals/incident/definitions/wizard-step-3-contact.js)
 - [wizard-step-4-summary.js](../../src/signals/incident/definitions/wizard-step-5-summary.js)
-- [wizard-step-5-bedankt.js](../../src/signals/incident/definitions/wizard-step-6-bedankt.js)
+- [wizard-step-5-bedankt.js](../../src/signals/incident/definitions/wizard-step-5-bedankt.js)
 - [wizard-step-6-fout.js](../../src/signals/incident/definitions/wizard-step-6-fout.js)
 
 The definition for step 2 should be turned into a component and define logic for rendering definitions for additional questions.

--- a/docs/adr/0006-forms.md
+++ b/docs/adr/0006-forms.md
@@ -68,7 +68,7 @@ The definitions for all steps in the wizard can be turned into components, defin
 
 - [wizard-step-1-beschrijf.js](../../src/signals/incident/definitions/wizard-step-1-beschrijf.js)
 - [wizard-step-3-contact.js](../../src/signals/incident/definitions/wizard-step-3-contact.js)
-- [wizard-step-4-summary.js](../../src/signals/incident/definitions/wizard-step-5-summary.js)
+- [wizard-step-4-summary.js](../../src/signals/incident/definitions/wizard-step-4-summary.js)
 - [wizard-step-5-bedankt.js](../../src/signals/incident/definitions/wizard-step-5-bedankt.js)
 - [wizard-step-6-fout.js](../../src/signals/incident/definitions/wizard-step-6-fout.js)
 

--- a/src/signals/incident/components/IncidentPreview/components/Map/index.js
+++ b/src/signals/incident/components/IncidentPreview/components/Map/index.js
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2018 - 2021 Gemeente Amsterdam
-import { Fragment, useMemo } from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { themeSpacing } from '@amsterdam/asc-ui'
@@ -45,18 +44,15 @@ const MapPreview = ({ value }) => {
     center: [latitude, longitude],
   }
 
-  const geometry = useMemo(
-    () => ({
-      latitude,
-      longitude,
-    }),
-    [longitude, latitude]
-  )
+  const geometry = {
+    latitude,
+    longitude,
+  }
 
   return (
     value && (
-      <Fragment>
-        <Address>
+      <>
+        <Address data-testid="mapAddress">
           {value?.address
             ? formatAddress(value.address)
             : 'Locatie gepind op de kaart'}
@@ -73,7 +69,7 @@ const MapPreview = ({ value }) => {
               />
             </StyledMap>
           ))}
-      </Fragment>
+      </>
     )
   )
 }

--- a/src/signals/incident/components/IncidentPreview/components/Map/index.test.js
+++ b/src/signals/incident/components/IncidentPreview/components/Map/index.test.js
@@ -1,12 +1,16 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2018 - 2021 Gemeente Amsterdam
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { withAppContext } from 'test/utils'
 import configuration from 'shared/services/configuration/configuration'
 
 import MapPreview from '.'
 
 jest.mock('shared/services/configuration/configuration')
+
+jest.mock('components/MapStatic', () => (props) => (
+  <span data-testid="mapStatic" {...props} />
+))
 
 describe('signals/incident/components/IncidentPreview/components/Map', () => {
   const geometrie = {
@@ -17,33 +21,20 @@ describe('signals/incident/components/IncidentPreview/components/Map', () => {
     configuration.__reset()
   })
 
-  it('should show address fallback', async () => {
-    const { getByText } = render(
-      withAppContext(<MapPreview value={{ geometrie }} />)
-    )
+  it('should render normal map with useStaticMapServer disabled', () => {
+    render(withAppContext(<MapPreview value={{ geometrie }} />))
 
-    expect(getByText('Locatie gepind op de kaart')).toBeInTheDocument()
+    expect(screen.getByText('Locatie gepind op de kaart')).toBeInTheDocument()
+    expect(screen.queryByTestId('mapStatic')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('map-base')).toBeInTheDocument()
   })
 
-  it('should render static map with useStaticMapServer enabled', async () => {
+  it('should render static map with useStaticMapServer enabled', () => {
     configuration.featureFlags.useStaticMapServer = true
 
-    const { findByTestId, queryByTestId } = render(
-      withAppContext(<MapPreview value={{ geometrie }} />)
-    )
+    render(withAppContext(<MapPreview value={{ geometrie }} />))
 
-    await findByTestId('mapStatic')
-
-    expect(queryByTestId('mapStatic')).toBeInTheDocument()
-    expect(queryByTestId('map-base')).not.toBeInTheDocument()
-  })
-
-  it('should render normal map with useStaticMapServer disabled', () => {
-    const { queryByTestId } = render(
-      withAppContext(<MapPreview value={{ geometrie }} />)
-    )
-
-    expect(queryByTestId('mapStatic')).not.toBeInTheDocument()
-    expect(queryByTestId('map-base')).toBeInTheDocument()
+    expect(screen.queryByTestId('mapStatic')).toBeInTheDocument()
+    expect(screen.queryByTestId('map-base')).not.toBeInTheDocument()
   })
 })

--- a/src/signals/incident/components/IncidentPreview/index.js
+++ b/src/signals/incident/components/IncidentPreview/index.js
@@ -117,6 +117,16 @@ const IncidentPreview = ({ incident, preview, sectionLabels }) => (
             return incident[entryKey].length > 0
           }
 
+          try {
+            if (
+              Object.prototype.hasOwnProperty.call(incident[entryKey], 'value')
+            ) {
+              return incident[entryKey].value
+            }
+          } catch {
+            // no-op
+          }
+
           return Boolean(incident[entryKey])
         }
       )

--- a/src/signals/incident/components/IncidentPreview/index.test.js
+++ b/src/signals/incident/components/IncidentPreview/index.test.js
@@ -229,6 +229,10 @@ describe('<IncidentPreview />', () => {
             coordinates: [4.899258613586427, 52.36784357172409],
           },
         },
+        sharing_allowed: {
+          value: true,
+        },
+        phone: '0000',
       },
       preview: {
         beschrijf: {
@@ -251,6 +255,18 @@ describe('<IncidentPreview />', () => {
           location: {
             label: 'Locatie',
             render: PreviewComponents.Map,
+          },
+        },
+        contact: {
+          sharing_allowed: {
+            optional: true,
+            label: 'foo bar',
+            render: ({ value }) => (value.value ? 'Ja' : 'Nee'),
+          },
+          phone: {
+            optional: true,
+            label: 'phone',
+            render: ({ value }) => value,
           },
         },
       },

--- a/src/signals/incident/components/form/WithHeading/WithHeading.tsx
+++ b/src/signals/incident/components/form/WithHeading/WithHeading.tsx
@@ -9,7 +9,7 @@ type WrapMeta = FormMeta & {
   wrappedComponent?: FC
 }
 
-type WithHeadingProps = FormOptions & { meta: WrapMeta }
+type WithHeadingProps = FormOptions & { meta: WrapMeta; _parent?: any }
 
 const StyledHeading = styled(Heading)`
   margin: ${themeSpacing(2, 0, 5)};
@@ -20,13 +20,15 @@ const WithHeading: FC<WithHeadingProps> = (props) => {
 
   if (!wrappedComponent || !heading) return null
 
-  const InputComponent = wrappedComponent
+  const Component = wrappedComponent
+
+  const propsWithParent = { ...props, parent: props._parent }
 
   return (
-    <>
+    <div>
       <StyledHeading as="h2">{heading}</StyledHeading>
-      <InputComponent {...props} />
-    </>
+      <Component {...propsWithParent} />
+    </div>
   )
 }
 

--- a/src/signals/incident/definitions/__tests__/wizard-step-4-summary.test.js
+++ b/src/signals/incident/definitions/__tests__/wizard-step-4-summary.test.js
@@ -23,7 +23,7 @@ jest.mock('lodash/memoize', () => ({
   default: jest.fn((fn) => fn),
 }))
 
-describe('signals/incident/definitions/wizard-step-4-summary', () => {
+describe('Wizard summary', () => {
   afterEach(() => {
     configuration.__reset()
   })

--- a/src/signals/incident/definitions/wizard-step-4-summary.js
+++ b/src/signals/incident/definitions/wizard-step-4-summary.js
@@ -158,12 +158,12 @@ export default {
     heading: {
       beschrijf: 'Melding',
       vulaan: 'Aanvullende informatie',
+      contact: 'Contactgegevens',
     },
     edit: {
       beschrijf: 'Wijzig melding',
       vulaan: 'Wijzig aanvullende informatie',
-      telefoon: 'Wijzig uw telefoonnummer',
-      email: 'Wijzig uw e-mailadres',
+      contact: 'Wijzig contactgegevens',
     },
   },
   formAction: 'CREATE_INCIDENT',
@@ -214,19 +214,29 @@ export default {
 
     vulaan: getExtraQuestions(category, subcategory, questions),
 
-    telefoon: {
+    contact: {
       phone: {
         label: 'Wat is uw telefoonnummer?',
         optional: true,
         render: ({ value }) => value,
       },
-    },
 
-    email: {
       email: {
         label: 'Wat is uw e-mailadres?',
         optional: true,
         render: ({ value }) => value,
+      },
+
+      sharing_allowed: {
+        label: 'Melding delen',
+        optional: true,
+        render: ({ value }) => {
+          if (!value) return null
+
+          const { label, value: sharingIsAllowed } = value
+
+          return sharingIsAllowed ? label : null
+        },
       },
     },
   }),


### PR DESCRIPTION
This PR:
- Adds a `Contact` section to the incident form summary page
- Renders the `WithHeading` component in a `<div />` wrapper to make sure that the parent fieldset CSS rules don't mess up the alignment
- Makes sure that the `WithHeading` component pass on the correct values to its child component (the `parent` prop is required by `react-reactive-form`, but isn't automatically passed down when creating a wrapper component)
- Fixes an unrelated test (for the `Map` component) that polluted the test output