### PR TITLE
[SIG-4040] Fix form submit

### DIFF
--- a/src/signals/incident/components/IncidentForm/index.js
+++ b/src/signals/incident/components/IncidentForm/index.js
@@ -211,7 +211,7 @@ class IncidentForm extends Component {
         }
       }
 
-      if (this.form.valid) {
+      if (this.form.valid || this.form.status === 'DISABLED') {
         this.setIncident(formAction)
         next()
       } else {

--- a/src/signals/incident/components/IncidentForm/index.test.js
+++ b/src/signals/incident/components/IncidentForm/index.test.js
@@ -60,6 +60,15 @@ const renderIncidentForm = (props, renderFunction = render) =>
 describe('<IncidentForm />', () => {
   let defaultProps
 
+  beforeAll(() => {
+    // disable annoying deprecation warnings from `react-reactive-form`
+    jest.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterAll(() => {
+    jest.restoreAllMocks()
+  })
+
   beforeEach(() => {
     nextSpy.mockReset()
     defaultProps = {
@@ -306,6 +315,32 @@ describe('<IncidentForm />', () => {
       renderIncidentForm(propsAfterLoading, rerender)
 
       expect(nextSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('submits form with status DISABLED', () => {
+      const emptyControlsSet = {
+        controls: {
+          // no controls to verify; status of the form is set to 'DISABLED' by `react-reactive-form`
+          page_summary: {},
+          $field_0: {
+            isStatic: false,
+            render: IncidentNavigation,
+          },
+        },
+      }
+
+      const props = {
+        ...defaultProps,
+        fieldConfig: emptyControlsSet,
+      }
+
+      renderIncidentForm(props)
+
+      expect(nextSpy).toHaveBeenCalledTimes(1)
+
+      userEvent.click(screen.getByText(mockForm.nextButtonLabel))
+
+      expect(nextSpy).toHaveBeenCalledTimes(2)
     })
   })
 })


### PR DESCRIPTION
This PR fixes an issue where the incident form cannot be submitted when the list of controls doesn't have a field that can or should be validated. Apparently, `react-reactive-form` sets the status of the form to `DISABLED` when there are no controls in a form's configuration.