### PR TITLE
(Fix) Helptext visibilty

### DIFF
--- a/src/signals/incident/components/form/PlainText/index.js
+++ b/src/signals/incident/components/form/PlainText/index.js
@@ -3,7 +3,7 @@
 import PropTypes from 'prop-types'
 import styled, { css } from 'styled-components'
 import get from 'lodash/get'
-import { Paragraph, themeColor, themeSpacing } from '@amsterdam/asc-ui'
+import { themeColor, themeSpacing } from '@amsterdam/asc-ui'
 
 import { getIsAuthenticated } from 'shared/services/auth/auth'
 import mapDynamicFields from 'signals/incident/services/map-dynamic-fields'
@@ -14,7 +14,7 @@ const injectParent = (value, parent) =>
     incident: get(parent, 'meta.incidentContainer.incident'),
   })
 
-const Label = styled(Paragraph)`
+const Label = styled.div`
   font-weight: 700;
   margin: 0;
 `

--- a/src/signals/incident/definitions/__tests__/wizard-step-2-vulaan.test.js
+++ b/src/signals/incident/definitions/__tests__/wizard-step-2-vulaan.test.js
@@ -13,13 +13,14 @@ const { formFactory } = step2
 const defaultControls = {
   error: expect.objectContaining({}),
   custom_text: expect.objectContaining({}),
-  $field_0: expect.objectContaining({}),
   help_text: expect.objectContaining({
     meta: {
+      ignoreVisibility: true,
       label: configuration.language.helpTextHeader,
       value: configuration.language.helpText,
     },
   }),
+  $field_0: expect.objectContaining({}),
 }
 
 jest.mock('shared/services/configuration/configuration')

--- a/src/signals/incident/definitions/wizard-step-1-beschrijf.js
+++ b/src/signals/incident/definitions/wizard-step-1-beschrijf.js
@@ -175,16 +175,17 @@ const getControls = memoize(
         },
         render: FormComponents.FileInputRenderer,
       },
-      $field_0: {
-        isStatic: false,
-        render: IncidentNavigation,
-      },
       help_text: {
         meta: {
           label: configuration.language.helpTextHeader,
           value: configuration.language.helpText,
+          ignoreVisibility: true,
         },
         render: FormComponents.PlainText,
+      },
+      $field_0: {
+        isStatic: false,
+        render: IncidentNavigation,
       },
     },
   }),

--- a/src/signals/incident/definitions/wizard-step-2-vulaan.js
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan.js
@@ -57,16 +57,17 @@ const expandQuestions = memoize(
         }),
         {}
       ),
-      $field_0: {
-        isStatic: false,
-        render: IncidentNavigation,
-      },
       help_text: {
         meta: {
           label: configuration.language.helpTextHeader,
           value: configuration.language.helpText,
+          ignoreVisibility: true,
         },
         render: FormComponents.PlainText,
+      },
+      $field_0: {
+        isStatic: false,
+        render: IncidentNavigation,
       },
     },
   }),

--- a/src/signals/incident/definitions/wizard-step-3-contact.js
+++ b/src/signals/incident/definitions/wizard-step-3-contact.js
@@ -68,16 +68,17 @@ export default {
         },
         render: FormComponents.EmphasisCheckboxInput,
       },
-      $field_0: {
-        isStatic: false,
-        render: IncidentNavigation,
-      },
       help_text: {
         meta: {
           label: configuration.language.helpTextHeader,
           value: configuration.language.helpText,
+          ignoreVisibility: true,
         },
         render: FormComponents.PlainText,
+      },
+      $field_0: {
+        isStatic: false,
+        render: IncidentNavigation,
       },
     },
   },


### PR DESCRIPTION
Adds `ignoreVisibility` prop to `meta` objects to ensure that field controls are ignore where required. Without this prop, the incident form will always jump from step 1 to step 2 instead of skipping step 2 when there are no extra questions for a specific category.