### PR TITLE
(Fix) Asset selector position

### DIFF
--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/Selector.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/Selector.tsx
@@ -54,9 +54,11 @@ const MAP_CONTAINER_ZOOM_LEVEL: ZoomLevel = {
 }
 
 const Wrapper = styled.div`
-  position: absolute;
+  position: fixed;
   top: 0;
   left: 0;
+  right: 0;
+  bottom: 0;
   height: 100%;
   width: 100%;
   box-sizing: border-box; // Override box-sizing: content-box set by Leaflet
@@ -236,6 +238,7 @@ const Selector = () => {
       </StyledMap>
     </Wrapper>
   )
+
   return ReactDOM.createPortal(mapWrapper, appHtmlElement)
 }
 


### PR DESCRIPTION
This PR contains a fix for the `AssetSelector` position on the screen after the page has been scrolled down. This would render the portal an amount of pixels up instead of filling the screen top to bottom and left to right.