### PR TITLE
(Chore) Prevent resource depletion (in Firefox)

### DIFF
--- a/src/components/Notification/styled.tsx
+++ b/src/components/Notification/styled.tsx
@@ -43,7 +43,6 @@ export const Wrapper = styled.div<{
   transition-timing-function: ease-out;
   transition-duration: ${ONCLOSE_TIMEOUT}ms;
   width: 100vw;
-  will-change: transform, opacity;
   z-index: 1;
   opacity: 1;
 

--- a/src/global.css
+++ b/src/global.css
@@ -22,6 +22,14 @@
   }
 }
 
+.leaflet-fade-anim .leaflet-tile {
+  will-change: unset !important;
+}
+
+.leaflet-zoom-anim .leaflet-zoom-animated {
+  will-change: unset !important;
+}
+
 *,
 :after,
 :before {


### PR DESCRIPTION
This PR removes or overrides the use of the CSS rule `will-change`. Its use is highly discouraged.
Also see https://github.com/Leaflet/Leaflet/pull/7872
The additions to `global.css` can be reverted as soon as the change to the Leaflet repo has been released.