### PR TITLE
[SIG-4262] Contact page help text placement

### DIFF
--- a/src/signals/incident/definitions/wizard-step-3-contact.js
+++ b/src/signals/incident/definitions/wizard-step-3-contact.js
@@ -69,6 +69,10 @@ export default {
         },
         render: FormComponents.EmphasisCheckboxInput,
       },
+      $field_0: {
+        isStatic: false,
+        render: IncidentNavigation,
+      },
       help_text: {
         meta: {
           label: configuration.language.helpTextHeader,
@@ -76,10 +80,6 @@ export default {
           ignoreVisibility: true,
         },
         render: FormComponents.PlainText,
-      },
-      $field_0: {
-        isStatic: false,
-        render: IncidentNavigation,
       },
     },
   },


### PR DESCRIPTION
Move help text below the navigation buttons