### PR TITLE
[SIG-4273] Request appropriate dataset for openbare straatverlichting

### DIFF
--- a/src/signals/incident/components/form/MapSelectors/Clock/ClockLayer/ClockLayer.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Clock/ClockLayer/ClockLayer.tsx
@@ -9,7 +9,6 @@ import AssetSelectContext from '../../Asset/context'
 import WfsDataContext from '../../Asset/Selector/WfsLayer/context'
 import type { Feature, FeatureType } from '../../Asset/types'
 
-const CLOCK = 1
 const REPORTED = 1
 
 export const ClockLayer = () => {
@@ -23,9 +22,7 @@ export const ClockLayer = () => {
   )
 
   const reportedFeatures = data.features.filter(
-    (feature) =>
-      feature.properties?.meldingstatus === REPORTED &&
-      feature.properties?.objecttype === CLOCK
+    (feature) => feature.properties?.meldingstatus === REPORTED
   )
 
   return (

--- a/src/signals/incident/components/form/MapSelectors/Streetlight/StreetlightLayer/StreetlightLayer.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Streetlight/StreetlightLayer/StreetlightLayer.tsx
@@ -9,7 +9,6 @@ import AssetSelectContext from '../../Asset/context'
 import WfsDataContext from '../../Asset/Selector/WfsLayer/context'
 import type { Feature, FeatureType } from '../../Asset/types'
 
-const CLOCK = 1
 const REPORTED = 1
 
 export const StreetlightLayer = () => {
@@ -23,9 +22,7 @@ export const StreetlightLayer = () => {
   )
 
   const reportedFeatures = data.features.filter(
-    (feature) =>
-      feature.properties?.objecttype !== CLOCK &&
-      feature.properties?.meldingstatus === REPORTED
+    (feature) => feature.properties?.meldingstatus === REPORTED
   )
 
   return (

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/wegen-verkeer-straatmeubilair.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/wegen-verkeer-straatmeubilair.ts
@@ -189,7 +189,7 @@ Is het glad bij een trein-, bus- of metrostation? Neem dan contact op met de NS 
         ],
       },
       wfsFilter:
-        '<BBOX><gml:Envelope srsName="{srsName}"><lowerCorner>{west} {south}</lowerCorner><upperCorner>{east} {north}</upperCorner></gml:Envelope></BBOX>',
+        '<PropertyIsNotEqualTo><ValueReference>objecttype_omschrijving</ValueReference><Literal>Klok</Literal></PropertyIsNotEqualTo><BBOX><gml:Envelope srsName="{srsName}"><lowerCorner>{west} {south}</lowerCorner><upperCorner>{east} {north}</upperCorner></gml:Envelope></BBOX>',
       endpoint: configuration.map.layers?.klokken,
       featureTypes: [
         {
@@ -407,7 +407,7 @@ Is het glad bij een trein-, bus- of metrostation? Neem dan contact op met de NS 
         ],
       },
       wfsFilter:
-        '<BBOX><gml:Envelope srsName="{srsName}"><lowerCorner>{west} {south}</lowerCorner><upperCorner>{east} {north}</upperCorner></gml:Envelope></BBOX>',
+        '<PropertyIsEqualTo><ValueReference>objecttype_omschrijving</ValueReference><Literal>Klok</Literal></PropertyIsEqualTo><BBOX><gml:Envelope srsName="{srsName}"><lowerCorner>{west} {south}</lowerCorner><upperCorner>{east} {north}</upperCorner></gml:Envelope></BBOX>',
       endpoint: configuration.map.layers?.verlichting,
       zoomMin: 14,
       featureTypes: [


### PR DESCRIPTION
This PR adds a property equalizer filter for both clocks and street lights WFS calls. This ensures that only the required data is provided and not the entire dataset for both clocks and street light.