### PR TITLE
[SIG-4260] Fix map center

### DIFF
--- a/src/components/AreaMap/AreaMap.tsx
+++ b/src/components/AreaMap/AreaMap.tsx
@@ -21,7 +21,7 @@ import {
   pointerSelectIcon,
   currentIncidentIcon,
 } from 'shared/services/configuration/map-markers'
-import { featureTolocation } from 'shared/services/map-location'
+import { featureToCoordinates } from 'shared/services/map-location'
 import MapCloseButton from 'components/MapCloseButton'
 
 import type { Feature } from './types'
@@ -62,7 +62,7 @@ const AreaMap: FunctionComponent<AreaMapProps> = ({
   const [map, setMap] = useState<L.Map>()
   const selectedFeatureId = useRef<number>()
   const coordinates =
-    location?.geometrie && featureTolocation(location?.geometrie)
+    location?.geometrie && featureToCoordinates(location?.geometrie)
 
   useEffect(() => {
     selectedFeatureId.current = selectedFeature?.properties.id

--- a/src/components/OverviewMap/OverviewMap.tsx
+++ b/src/components/OverviewMap/OverviewMap.tsx
@@ -28,7 +28,7 @@ import MapContext from 'containers/MapContext/context'
 import { setAddressAction } from 'containers/MapContext/actions'
 import MAP_OPTIONS from 'shared/services/configuration/map-options'
 import configuration from 'shared/services/configuration/configuration'
-import { featureTolocation } from 'shared/services/map-location'
+import { featureToCoordinates } from 'shared/services/map-location'
 import { makeSelectFilterParams } from 'signals/incident-management/selectors'
 import useFetch from 'hooks/useFetch'
 import {
@@ -195,7 +195,7 @@ const OverviewMap = ({ isPublic = false, ...rest }) => {
     if (!data?.features || !layerInstance) return
 
     data.features.forEach((feature) => {
-      const latlng = featureTolocation(feature.geometry)
+      const latlng = featureToCoordinates(feature.geometry)
 
       const clusteredMarker = L.marker(latlng, {
         icon: incidentIcon,

--- a/src/shared/services/map-location/index.ts
+++ b/src/shared/services/map-location/index.ts
@@ -1,9 +1,9 @@
 export {
-  featureTolocation,
+  coordinatesToAPIFeature,
+  coordinatesToFeature,
+  featureToCoordinates,
   formatMapLocation,
   formatPDOKResponse,
-  locationToAPIfeature,
-  locationTofeature,
   pdokResponseFieldList,
   pointWithinBounds,
   serviceResultToAddress,

--- a/src/shared/services/map-location/map-location.test.ts
+++ b/src/shared/services/map-location/map-location.test.ts
@@ -3,11 +3,11 @@
 import type { LatLngTuple } from 'leaflet'
 import PDOKResponseJson from 'utils/__tests__/fixtures/PDOKResponseData.json'
 import {
-  featureTolocation,
+  featureToCoordinates,
   formatMapLocation,
   formatPDOKResponse,
-  locationToAPIfeature,
-  locationTofeature,
+  coordinatesToAPIFeature,
+  coordinatesToFeature,
   pointWithinBounds,
   serviceResultToAddress,
   wktPointToLocation,
@@ -36,19 +36,19 @@ const apiCompatibleFeature = {
 
 describe('locationToFeature', () => {
   it('should convert', () => {
-    expect(locationTofeature(coordinates)).toEqual(testFeature)
+    expect(coordinatesToFeature(coordinates)).toEqual(testFeature)
   })
 })
 
-describe('locationToAPIfeature', () => {
+describe('coordinatesToAPIFeature', () => {
   it('should convert', () => {
-    expect(locationToAPIfeature(coordinates)).toEqual(apiCompatibleFeature)
+    expect(coordinatesToAPIFeature(coordinates)).toEqual(apiCompatibleFeature)
   })
 })
 
-describe('featureTolocation', () => {
+describe('featureToCoordinates', () => {
   it('should convert', () => {
-    expect(featureTolocation(testFeature)).toEqual(coordinates)
+    expect(featureToCoordinates(testFeature)).toEqual(coordinates)
   })
 })
 

--- a/src/shared/services/map-location/map-location.test.ts
+++ b/src/shared/services/map-location/map-location.test.ts
@@ -108,23 +108,22 @@ describe('formatMapLocation', () => {
       buurt_code: null,
       extra_properties: null,
       geometrie: testFeature,
-      address: {
-        openbare_ruimte: 'Keizersgracht',
-        huisnummer: 666,
-        huisletter: '',
-        huisnummer_toevoeging: undefined,
-        postcode: '',
-        woonplaats: 'Amsterdam',
-      },
+      address: null,
     }
 
     const result = {
       coordinates: { lat: 52, lng: 4 },
-      addressText: 'Keizersgracht 666, Amsterdam',
-      address: location.address,
+      addressText: '',
+      address: undefined,
     }
 
-    expect(formatMapLocation(location)).toEqual(result)
+    expect(formatMapLocation(location)).toStrictEqual(result)
+  })
+
+  it('returns an empty object when param is falsy', () => {
+    const location = null
+
+    expect(formatMapLocation(location)).toStrictEqual({})
   })
 })
 

--- a/src/shared/services/map-location/map-location.ts
+++ b/src/shared/services/map-location/map-location.ts
@@ -61,12 +61,12 @@ type FormatMapLocation = {
 export const formatMapLocation = (
   location?: Incident['location']
 ): FormatMapLocation => {
-  if (!location?.geometrie?.coordinates || !location.address) return {}
+  if (!location) return {}
 
   return {
     coordinates: featureToCoordinates(location.geometrie),
-    addressText: formatAddress(location.address),
-    address: location.address,
+    addressText: location.address ? formatAddress(location.address) : '',
+    address: location.address ?? undefined,
   }
 }
 

--- a/src/shared/services/map-location/map-location.ts
+++ b/src/shared/services/map-location/map-location.ts
@@ -61,7 +61,7 @@ type FormatMapLocation = {
 export const formatMapLocation = (
   location?: Incident['location']
 ): FormatMapLocation => {
-  if (!location) return {}
+  if (!location?.geometrie) return {}
 
   return {
     coordinates: featureToCoordinates(location.geometrie),

--- a/src/shared/services/map-location/map-location.ts
+++ b/src/shared/services/map-location/map-location.ts
@@ -8,12 +8,15 @@ import type { RevGeo, Doc } from 'types/pdok/revgeo'
 import configuration from 'shared/services/configuration/configuration'
 import { formatAddress } from 'shared/services/format-address'
 
-export const locationTofeature = ({ lat, lng }: LatLngLiteral): Geometrie => ({
+export const coordinatesToFeature = ({
+  lat,
+  lng,
+}: LatLngLiteral): Geometrie => ({
   type: 'Point',
   coordinates: [lat, lng].sort().reverse() as LatLngTuple,
 })
 
-export const locationToAPIfeature = ({
+export const coordinatesToAPIFeature = ({
   lat,
   lng,
 }: LatLngLiteral): Geometrie => ({
@@ -21,7 +24,7 @@ export const locationToAPIfeature = ({
   coordinates: [lng, lat] as LatLngTuple,
 })
 
-export const featureTolocation = ({
+export const featureToCoordinates = ({
   coordinates,
 }: Geometrie): LatLngLiteral => {
   const [lat, lng] = coordinates.sort().reverse()
@@ -61,7 +64,7 @@ export const formatMapLocation = (
   if (!location?.geometrie?.coordinates || !location.address) return {}
 
   return {
-    coordinates: featureTolocation(location.geometrie),
+    coordinates: featureToCoordinates(location.geometrie),
     addressText: formatAddress(location.address),
     address: location.address,
   }

--- a/src/signals/incident-management/containers/IncidentDetail/components/Detail/components/Location/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/Detail/components/Location/index.js
@@ -10,7 +10,7 @@ import { stadsdeelList } from 'signals/incident-management/definitions'
 import MapStatic from 'components/MapStatic'
 import { smallMarkerIcon } from 'shared/services/configuration/map-markers'
 import configuration from 'shared/services/configuration/configuration'
-import { featureTolocation } from 'shared/services/map-location'
+import { featureToCoordinates } from 'shared/services/map-location'
 
 import MapDetail from '../../../MapDetail'
 import HighLight from '../../../Highlight'
@@ -60,7 +60,7 @@ const StyledMap = styled(MapDetail)`
 const Location = ({ location }) => {
   const { districts } = useContext(IncidentManagementContext)
   const { preview, edit } = useContext(IncidentDetailContext)
-  const { lat, lng } = featureTolocation(location.geometrie)
+  const { lat, lng } = featureToCoordinates(location.geometrie)
 
   return (
     <Fragment>

--- a/src/signals/incident-management/containers/IncidentDetail/components/LocationForm/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/LocationForm/index.js
@@ -5,7 +5,7 @@ import styled from 'styled-components'
 import { Row, Column } from '@amsterdam/asc-ui'
 import { FormBuilder, FieldGroup } from 'react-reactive-form'
 
-import { locationTofeature } from 'shared/services/map-location'
+import { coordinatesToFeature } from 'shared/services/map-location'
 
 import MapContext from 'containers/MapContext'
 
@@ -49,7 +49,7 @@ const LocationForm = () => {
       const patch = { location: { ...location, ...formValueLocation } }
 
       if (coordinates) {
-        patch.location.geometrie = locationTofeature(coordinates)
+        patch.location.geometrie = coordinatesToFeature(coordinates)
         // the API expects a specifc order of coordinates: lng,lat
         patch.location.geometrie.coordinates.reverse()
       }

--- a/src/signals/incident-management/containers/IncidentDetail/components/MapDetail/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/MapDetail/index.js
@@ -6,12 +6,12 @@ import { markerIcon } from 'shared/services/configuration/map-markers'
 import { Marker } from '@amsterdam/react-maps'
 
 import MAP_OPTIONS from 'shared/services/configuration/map-options'
-import { featureTolocation } from 'shared/services/map-location'
+import { featureToCoordinates } from 'shared/services/map-location'
 import { locationType } from 'shared/types'
 
 const MapDetail = ({ value, className, zoom, icon, hasZoomControls }) => {
   const { lat, lng } = value?.geometrie
-    ? featureTolocation(value.geometrie)
+    ? featureToCoordinates(value.geometrie)
     : {}
 
   const options = {

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/AssetLayer/AssetLayer.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/AssetLayer/AssetLayer.tsx
@@ -28,7 +28,7 @@ import type { Geometrie } from 'types/incident'
 
 import reverseGeocoderService from 'shared/services/reverse-geocoder'
 import AssetSelectContext from 'signals/incident/components/form/MapSelectors/Asset/context'
-import { featureTolocation } from 'shared/services/map-location'
+import { featureToCoordinates } from 'shared/services/map-location'
 import MarkerCluster from 'components/MarkerCluster'
 
 import configuration from 'shared/services/configuration/configuration'
@@ -192,7 +192,9 @@ export const AssetLayer: FunctionComponent<DataLayerProps> = ({
               return
             }
 
-            const coordinates = featureTolocation(feature.geometry as Geometrie)
+            const coordinates = featureToCoordinates(
+              feature.geometry as Geometrie
+            )
 
             const item: Item = {
               location: {
@@ -228,7 +230,7 @@ export const AssetLayer: FunctionComponent<DataLayerProps> = ({
           ...feature,
           geometry: { ...(feature.geometry as Point) },
         }
-        const latlng = featureTolocation(feature.geometry as Geometrie)
+        const latlng = featureToCoordinates(feature.geometry as Geometrie)
         const marker = options.pointToLayer(pointFeature, latlng)
 
         /* istanbul ignore else */

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/ReportedLayer/ReportedLayer.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/ReportedLayer/ReportedLayer.tsx
@@ -9,7 +9,7 @@ import type {
   FeatureType,
 } from 'signals/incident/components/form/MapSelectors/Asset/types'
 import { Marker } from '@amsterdam/arm-core'
-import { featureTolocation } from 'shared/services/map-location'
+import { featureToCoordinates } from 'shared/services/map-location'
 import type { Geometrie } from 'types/incident'
 import reportedIconUrl from 'shared/images/icon-reported-marker.svg?url'
 
@@ -26,7 +26,7 @@ const ReportedLayer: FC<ReportedLayerProps> = ({
 }) => {
   const getMarker = (feat: any, index: number) => {
     const feature = feat as Feature
-    const latLng = featureTolocation(feature?.geometry as Geometrie)
+    const latLng = featureToCoordinates(feature?.geometry as Geometrie)
 
     if (!feature || !reportedFeatureType) return
 

--- a/src/signals/incident/components/form/MapSelectors/Caterpillar/CaterpillarLayer/CaterpillarLayer.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Caterpillar/CaterpillarLayer/CaterpillarLayer.test.tsx
@@ -13,7 +13,7 @@ import MAP_OPTIONS from 'shared/services/configuration/map-options'
 import userEvent from '@testing-library/user-event'
 
 import { WfsDataProvider } from 'signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/context'
-import { featureTolocation } from 'shared/services/map-location'
+import { featureToCoordinates } from 'shared/services/map-location'
 
 import withAssetSelectContext, {
   contextValue,
@@ -60,7 +60,7 @@ describe('CaterpillarLayer', () => {
   it('should handle selecting a tree', async () => {
     const featureId = 308779
     const feature = caterpillarsJson.features.find(({ id }) => id === featureId)
-    const coordinates = featureTolocation(feature?.geometry as Geometrie)
+    const coordinates = featureToCoordinates(feature?.geometry as Geometrie)
 
     const { rerender } = render(withMapCaterpillar())
 

--- a/src/signals/incident/components/form/MapSelectors/Caterpillar/CaterpillarLayer/CaterpillarLayer.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Caterpillar/CaterpillarLayer/CaterpillarLayer.tsx
@@ -12,8 +12,8 @@ import type { Geometrie } from 'types/incident'
 
 import WfsDataContext from 'signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/context'
 import SelectContext from 'signals/incident/components/form/MapSelectors/Asset/context'
-import { featureTolocation } from 'shared/services/map-location'
 import defaultFeatureMarkerUrl from 'shared/images/featureDefaultMarker.svg?url'
+import { featureToCoordinates } from 'shared/services/map-location'
 
 export const CaterpillarLayer: FC = () => {
   const { features } = useContext<FeatureCollection>(WfsDataContext)
@@ -22,7 +22,7 @@ export const CaterpillarLayer: FC = () => {
   const getMarker = useCallback(
     (feat: any) => {
       const feature = feat as Feature
-      const coordinates = featureTolocation(feature.geometry as Geometrie)
+      const coordinates = featureToCoordinates(feature.geometry as Geometrie)
       // Caterpillar layer renders only a single feature type (oak tree)
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const featureType = meta.featureTypes.find(

--- a/src/signals/incident/containers/IncidentContainer/saga.js
+++ b/src/signals/incident/containers/IncidentContainer/saga.js
@@ -10,7 +10,7 @@ import { uploadFile } from 'containers/App/saga'
 import resolveClassification from 'shared/services/resolveClassification'
 import mapControlsToParams from 'signals/incident/services/map-controls-to-params'
 import { getIsAuthenticated } from 'shared/services/auth/auth'
-import { locationToAPIfeature } from 'shared/services/map-location'
+import { coordinatesToAPIFeature } from 'shared/services/map-location'
 import {
   getClassificationData,
   makeSelectIncidentContainer,
@@ -164,7 +164,7 @@ export function* getPostData(action) {
     },
     location: {
       address: incident.location.address,
-      geometrie: locationToAPIfeature(incident.location.coordinates),
+      geometrie: coordinatesToAPIFeature(incident.location.coordinates),
     },
   }
 

--- a/src/signals/incident/containers/IncidentContainer/saga.test.js
+++ b/src/signals/incident/containers/IncidentContainer/saga.test.js
@@ -13,7 +13,7 @@ import postIncidentJSON from 'utils/__tests__/fixtures/postIncident.json'
 import configuration from 'shared/services/configuration/configuration'
 import * as auth from 'shared/services/auth/auth'
 import { authPostCall, postCall } from 'shared/services/api/api'
-import { locationToAPIfeature } from 'shared/services/map-location'
+import { coordinatesToAPIFeature } from 'shared/services/map-location'
 
 import { uploadFile } from 'containers/App/saga'
 
@@ -440,7 +440,7 @@ describe('IncidentContainer saga', () => {
         },
         location: {
           address: payloadIncident.location.address,
-          geometrie: locationToAPIfeature(coordinates),
+          geometrie: coordinatesToAPIFeature(coordinates),
         },
       }
 
@@ -459,7 +459,7 @@ describe('IncidentContainer saga', () => {
         },
         location: {
           address: payloadIncident.location.address,
-          geometrie: locationToAPIfeature(coordinates),
+          geometrie: coordinatesToAPIFeature(coordinates),
         },
       }
 
@@ -484,7 +484,7 @@ describe('IncidentContainer saga', () => {
         },
         location: {
           address: payloadIncident.location.address,
-          geometrie: locationToAPIfeature(coordinates),
+          geometrie: coordinatesToAPIFeature(coordinates),
         },
       }
 
@@ -524,7 +524,7 @@ describe('IncidentContainer saga', () => {
         },
         location: {
           address: payloadIncident.location.address,
-          geometrie: locationToAPIfeature(coordinates),
+          geometrie: coordinatesToAPIFeature(coordinates),
         },
       }
 


### PR DESCRIPTION
This PR:
- contains a fix for setting the map center for a location that only has coordinates and no address
- renames functions in the `map-location` module so that they correctly reflect their purpose and return value