### PR TITLE
[SIG 4198] Separate reported layer for caterpillar layer

### DIFF
--- a/src/signals/incident/components/IncidentPreview/components/AssetListPreview/AssetListPreview.test.tsx
+++ b/src/signals/incident/components/IncidentPreview/components/AssetListPreview/AssetListPreview.test.tsx
@@ -2,7 +2,7 @@
 // Copyright (C) 2021 Gemeente Amsterdam
 import { render } from '@testing-library/react'
 import AssetList from 'signals/incident/components/form/MapSelectors/Asset/AssetList'
-import type { FeatureType } from 'signals/incident/components/form/MapSelectors/Asset/types'
+import type { FeatureType } from 'signals/incident/components/form/MapSelectors/types'
 
 import AssetListPreview from './AssetListPreview'
 import type { AssetListPreviewProps } from './AssetListPreview'

--- a/src/signals/incident/components/IncidentPreview/components/AssetListPreview/AssetListPreview.tsx
+++ b/src/signals/incident/components/IncidentPreview/components/AssetListPreview/AssetListPreview.tsx
@@ -3,7 +3,7 @@
 import type {
   FeatureType,
   Item,
-} from 'signals/incident/components/form/MapSelectors/Asset/types'
+} from 'signals/incident/components/form/MapSelectors/types'
 import AssetList from 'signals/incident/components/form/MapSelectors/Asset/AssetList'
 import type { FunctionComponent } from 'react'
 import styled from 'styled-components'

--- a/src/signals/incident/components/form/MapSelectors/Asset/AssetList/AssetList.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/AssetList/AssetList.test.tsx
@@ -5,7 +5,7 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { selection } from 'utils/__tests__/fixtures/caterpillarsSelection'
 
-import type { Item, FeatureType } from '../types'
+import type { FeatureType, Item } from '../../types'
 import type { AssetListProps } from './AssetList'
 
 import AssetList from './AssetList'

--- a/src/signals/incident/components/form/MapSelectors/Asset/AssetList/AssetList.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/AssetList/AssetList.tsx
@@ -57,14 +57,6 @@ const AssetList: FunctionComponent<AssetListProps> = ({
       label,
     }
 
-    if (isReported && icon?.reportedIconSvg) {
-      return {
-        ...baseItem,
-        iconUrl: icon ? icon.reportedIconSvg : '',
-        isReported: true,
-      }
-    }
-
     return {
       ...baseItem,
       iconUrl: icon ? icon.iconUrl : '',

--- a/src/signals/incident/components/form/MapSelectors/Asset/AssetList/AssetList.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/AssetList/AssetList.tsx
@@ -9,7 +9,7 @@ import type { FunctionComponent } from 'react'
 import IconList, { IconListItem } from 'components/IconList/IconList'
 import Button from 'components/Button'
 
-import type { FeatureType, Item } from '../types'
+import type { FeatureType, Item } from '../../types'
 
 const StyledButton = styled(Button).attrs(() => ({
   type: 'button',

--- a/src/signals/incident/components/form/MapSelectors/Asset/AssetSelect.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/AssetSelect.test.tsx
@@ -13,8 +13,8 @@ import { mocked } from 'ts-jest/utils'
 
 import type { Location } from 'types/incident'
 import { UNREGISTERED_TYPE as mockUNREGISTERED_TYPE } from '../constants'
+import type { Item } from '../types'
 import type { AssetSelectProps } from './AssetSelect'
-import type { Item } from './types'
 
 import { initialValue } from './context'
 import withAssetSelectContext, {

--- a/src/signals/incident/components/form/MapSelectors/Asset/AssetSelect.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/AssetSelect.tsx
@@ -15,15 +15,12 @@ import type { Incident, Location } from 'types/incident'
 import type { LatLngLiteral } from 'leaflet'
 import defaultFeatureMarkerUrl from 'shared/images/featureDefaultMarker.svg?url'
 import unknownFeatureMarkerUrl from 'shared/images/featureUnknownMarker.svg?url'
-import type { EventHandler } from '../types'
-
+import type { EventHandler, FeatureType, Item, Meta } from '../types'
 import { UNREGISTERED_TYPE } from '../constants'
 import { AssetSelectProvider } from './context'
 import Intro from './Intro'
 import Selector from './Selector'
 import Summary from './Summary'
-
-import type { FeatureType, Item, Meta } from './types'
 
 const defaultIconConfig: FeatureType['icon'] = {
   options: {

--- a/src/signals/incident/components/form/MapSelectors/Asset/Intro/Intro.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Intro/Intro.test.tsx
@@ -4,7 +4,8 @@ import { fireEvent, render, screen } from '@testing-library/react'
 import { withAppContext } from 'test/utils'
 import { AssetSelectProvider } from 'signals/incident/components/form/MapSelectors/Asset/context'
 
-import type { AssetSelectValue, Meta } from '../types'
+import type { AssetSelectValue } from '../types'
+import type { Meta } from '../../types'
 
 import Intro from '../Intro'
 

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/SelectionPanel/SelectionPanel.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/SelectionPanel/SelectionPanel.tsx
@@ -17,10 +17,9 @@ import {
   themeColor,
 } from '@amsterdam/asc-ui'
 
+import type { FeatureType } from 'signals/incident/components/form/MapSelectors/types'
+import { UNREGISTERED_TYPE } from 'signals/incident/components/form/MapSelectors/constants'
 import AssetList from '../../AssetList'
-
-import type { FeatureType } from '../../types'
-import { UNREGISTERED_TYPE } from '../../../constants'
 import AssetSelectContext from '../../../Asset/context'
 
 const StyledAssetList = styled(AssetList)`

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/AssetLayer/AssetLayer.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/AssetLayer/AssetLayer.test.tsx
@@ -10,9 +10,9 @@ import type { MapOptions } from 'leaflet'
 import assetsJson from 'utils/__tests__/fixtures/assets.json'
 import MAP_OPTIONS from 'shared/services/configuration/map-options'
 
+import type { FeatureType } from 'signals/incident/components/form/MapSelectors/types'
 import { WfsDataProvider } from '../context'
 
-import type { FeatureType } from '../../../types'
 import type { ClusterMarker } from './AssetLayer'
 
 import { shouldSpiderfy, getMarkerByZoomLevel } from './AssetLayer'

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/AssetLayer/AssetLayer.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/AssetLayer/AssetLayer.tsx
@@ -23,7 +23,6 @@ import type {
   FeatureCollection,
 } from 'geojson'
 import type { FunctionComponent } from 'react'
-import type { Item } from 'signals/incident/components/form/MapSelectors/Asset/types'
 import type { Geometrie } from 'types/incident'
 
 import reverseGeocoderService from 'shared/services/reverse-geocoder'
@@ -33,8 +32,12 @@ import MarkerCluster from 'components/MarkerCluster'
 
 import configuration from 'shared/services/configuration/configuration'
 import featureSelectedMarkerUrl from 'shared/images/featureSelectedMarker.svg?url'
+import type {
+  DataLayerProps,
+  Item,
+  Feature,
+} from 'signals/incident/components/form/MapSelectors/types'
 import WfsDataContext from '../context'
-import type { DataLayerProps, Feature } from '../../../types'
 
 const SELECTED_CLASS_MODIFIER = '--selected'
 

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/ReportedLayer/ReportedLayer.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/ReportedLayer/ReportedLayer.test.tsx
@@ -6,10 +6,10 @@ import { render, screen } from '@testing-library/react'
 import { Map } from '@amsterdam/react-maps'
 
 import type {
-  AssetSelectValue,
   Feature,
   FeatureType,
-} from 'signals/incident/components/form/MapSelectors/Asset/types'
+} from 'signals/incident/components/form/MapSelectors/types'
+import type { AssetSelectValue } from 'signals/incident/components/form/MapSelectors/Asset/types'
 
 import streetlightsJson from 'utils/__tests__/fixtures/streetlights.json'
 import MAP_OPTIONS from 'shared/services/configuration/map-options'
@@ -19,7 +19,7 @@ import withAssetSelectContext, {
   contextValue,
 } from 'signals/incident/components/form/MapSelectors/Asset/__tests__/withAssetSelectContext'
 import reportedIconUrl from 'shared/images/icon-reported-marker.svg?url'
-import ReportedLayer from '../ReportedLayer'
+import ReportedLayer from './ReportedLayer'
 
 const { meta } = straatverlichtingKlokken.extra_straatverlichting_nummer
 const assetSelectProviderValue: AssetSelectValue = {

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/ReportedLayer/ReportedLayer.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/ReportedLayer/ReportedLayer.tsx
@@ -7,7 +7,7 @@ import type { FC } from 'react'
 import type {
   Feature,
   FeatureType,
-} from 'signals/incident/components/form/MapSelectors/Asset/types'
+} from 'signals/incident/components/form/MapSelectors/types'
 import { Marker } from '@amsterdam/arm-core'
 import { featureToCoordinates } from 'shared/services/map-location'
 import type { Geometrie } from 'types/incident'

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/WfsLayer.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/WfsLayer.tsx
@@ -9,8 +9,8 @@ import type { FeatureCollection } from 'geojson'
 import type { Map as MapType } from 'leaflet'
 
 import AssetSelectContext from 'signals/incident/components/form/MapSelectors/Asset/context'
+import type { DataLayerProps } from 'signals/incident/components/form/MapSelectors/types'
 import useLayerVisible from '../../../hooks/useLayerVisible'
-import type { DataLayerProps } from '../../types'
 import { NO_DATA, WfsDataProvider } from './context'
 
 const SRS_NAME = 'urn:ogc:def:crs:EPSG::4326'

--- a/src/signals/incident/components/form/MapSelectors/Asset/__tests__/withAssetSelectContext.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/__tests__/withAssetSelectContext.tsx
@@ -4,7 +4,8 @@ import type { ReactNode, ReactPortal } from 'react'
 import { withAppContext } from 'test/utils'
 import { controls } from 'signals/incident/definitions/wizard-step-2-vulaan/afval-container'
 
-import type { AssetSelectValue, FeatureType } from '../types'
+import type { AssetSelectValue } from '../types'
+import type { FeatureType } from '../../types'
 import { AssetSelectProvider } from '../context'
 
 ReactDOM.createPortal = (node) => node as ReactPortal

--- a/src/signals/incident/components/form/MapSelectors/Asset/types.ts
+++ b/src/signals/incident/components/form/MapSelectors/Asset/types.ts
@@ -1,59 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2021 Gemeente Amsterdam
 import type { FC } from 'react'
-import type { Feature as GeoJSONFeature, Point } from 'geojson'
-import type { IconOptions, LatLngLiteral } from 'leaflet'
+import type { LatLngLiteral } from 'leaflet'
 import type { Location } from 'types/incident'
 import type { Address } from 'types/address'
 import type { FormOptions } from 'types/reactive-form'
-import type { EventHandler } from '../types'
-import type { UNREGISTERED_TYPE } from '../constants'
+import type { EventHandler, Meta, Item } from '../types'
 import type { FormFieldProps } from '../../FormField/FormField'
-
-export interface Item extends Record<string, unknown> {
-  location: {
-    address?: Address
-    coordinates?: LatLngLiteral
-  }
-  description?: string
-  id: string | number
-  isReported?: boolean
-  type?: typeof UNREGISTERED_TYPE | string
-}
-
-export interface FeatureType {
-  label: string
-  description: string
-  icon: FeatureIcon
-  idField: string
-  isReportedField?: string
-  isReportedValue?: number
-  typeField: string
-  typeValue: string
-}
-
-export interface FeatureIcon {
-  options?: Partial<IconOptions>
-  iconUrl: string
-}
-
-export interface Options {
-  className: string
-  iconSize: number[]
-}
-
-export interface Meta extends Record<string, unknown> {
-  name?: string
-  endpoint: string
-  featureTypes: FeatureType[]
-  language?: Record<string, string>
-  wfsFilter?: string
-  extraProperties?: string[]
-  ifAllOf?: { subcategory: string }
-  label?: string
-  shortLabel?: string
-  pathMerge?: string
-}
 
 export interface AssetSelectValue {
   address?: Address
@@ -71,18 +24,9 @@ export interface AssetSelectValue {
   setMessage: (message?: string) => void
 }
 
-export interface DataLayerProps {
-  featureTypes: FeatureType[]
-  desktopView?: boolean
-  allowClusters?: boolean
-}
-
 export interface AssetSelectRendererProps extends FormFieldProps {
   meta: Meta
   handler: any
   parent: any
   validatorsOrOpts: FormOptions
 }
-
-export type FeatureProps = Record<string, string | number | undefined>
-export type Feature = GeoJSONFeature<Point, FeatureProps>

--- a/src/signals/incident/components/form/MapSelectors/Asset/types.ts
+++ b/src/signals/incident/components/form/MapSelectors/Asset/types.ts
@@ -10,11 +10,6 @@ import type { EventHandler } from '../types'
 import type { UNREGISTERED_TYPE } from '../constants'
 import type { FormFieldProps } from '../../FormField/FormField'
 
-type Icon = {
-  id: string
-  iconUrl: string
-}
-
 export interface Item extends Record<string, unknown> {
   location: {
     address?: Address
@@ -30,8 +25,6 @@ export interface FeatureType {
   label: string
   description: string
   icon: FeatureIcon
-  iconId?: string
-  iconIsReportedId?: string
   idField: string
   isReportedField?: string
   isReportedValue?: number
@@ -42,7 +35,6 @@ export interface FeatureType {
 export interface FeatureIcon {
   options?: Partial<IconOptions>
   iconUrl: string
-  reportedIconSvg?: string
 }
 
 export interface Options {
@@ -56,7 +48,6 @@ export interface Meta extends Record<string, unknown> {
   featureTypes: FeatureType[]
   language?: Record<string, string>
   wfsFilter?: string
-  icons?: Icon[]
   extraProperties?: string[]
   ifAllOf?: { subcategory: string }
   label?: string

--- a/src/signals/incident/components/form/MapSelectors/Caterpillar/CaterpillarLayer/CaterpillarLayer.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Caterpillar/CaterpillarLayer/CaterpillarLayer.tsx
@@ -6,14 +6,19 @@ import { Marker } from '@amsterdam/arm-core'
 
 import type { FeatureCollection } from 'geojson'
 import type { FC } from 'react'
-import type { Item } from 'signals/incident/components/form/MapSelectors/Asset/types'
-import type { Feature } from 'signals/incident/components/form/MapSelectors/types'
+import type {
+  Item,
+  FeatureType,
+  Feature,
+} from 'signals/incident/components/form/MapSelectors/Asset/types'
 import type { Geometrie } from 'types/incident'
 
 import WfsDataContext from 'signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/context'
 import SelectContext from 'signals/incident/components/form/MapSelectors/Asset/context'
-import defaultFeatureMarkerUrl from 'shared/images/featureDefaultMarker.svg?url'
+import featureSelectedMarkerUrl from 'shared/images/featureSelectedMarker.svg?url'
+
 import { featureToCoordinates } from 'shared/services/map-location'
+import ReportedLayer from '../../Asset/Selector/WfsLayer/ReportedLayer'
 
 export const CaterpillarLayer: FC = () => {
   const { features } = useContext<FeatureCollection>(WfsDataContext)
@@ -25,8 +30,8 @@ export const CaterpillarLayer: FC = () => {
       const coordinates = featureToCoordinates(feature.geometry as Geometrie)
       // Caterpillar layer renders only a single feature type (oak tree)
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      const featureType = meta.featureTypes.find(
-        ({ label }) => label === 'Eikenboom'
+      const featureType = meta.featureTypes!.find(
+        ({ typeValue }) => typeValue === 'Eikenboom'
       )!
       const featureId = feature.properties[featureType.idField] as string
 
@@ -38,22 +43,18 @@ export const CaterpillarLayer: FC = () => {
             featureType.isReportedValue
       )
 
-      let iconId = isReported
-        ? featureType.iconIsReportedId
-        : featureType.iconId
-
-      if (isSelected) {
-        iconId = isReported ? 'isSelectedAndReported' : 'isSelected'
-      }
-
-      const iconUrl = meta.icons?.find(({ id }) => id === iconId)?.iconUrl
+      const altText = `${featureType.description}${
+        isReported ? ', is gemeld' : ''
+      }${isSelected ? ', is geselecteerd' : ''} (${featureId})`
 
       const icon = L.icon({
-        iconSize: isReported ? [44, 44] : [40, 40],
-        iconUrl: iconUrl || defaultFeatureMarkerUrl,
+        iconSize: [40, 40],
+        iconUrl: isSelected
+          ? featureSelectedMarkerUrl
+          : featureType.icon.iconUrl,
       })
 
-      const onClick = () => {
+      const onClick = async () => {
         if (isSelected) {
           removeItem()
           return
@@ -83,9 +84,7 @@ export const CaterpillarLayer: FC = () => {
           key={`${featureId}-${isSelected}`}
           options={{
             icon,
-            alt: `${featureType.description}${isReported ? ', is gemeld' : ''}${
-              isSelected ? ', is geselecteerd' : ''
-            } (${featureId})`,
+            alt: altText,
           }}
           latLng={coordinates}
           events={{
@@ -94,17 +93,33 @@ export const CaterpillarLayer: FC = () => {
         />
       )
     },
-    [
-      meta.extraProperties,
-      meta.featureTypes,
-      meta.icons,
-      removeItem,
-      selection,
-      setItem,
-    ]
+    [meta.extraProperties, meta.featureTypes, removeItem, selection, setItem]
   )
 
-  return <>{features.map(getMarker)}</>
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const reportedFeatureType = meta.featureTypes.find(
+    ({ typeValue }) => typeValue === 'reported'
+  )!
+  const reportedFeatures = features.filter((feature) =>
+    Boolean(
+      reportedFeatureType?.isReportedField &&
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        feature.properties![reportedFeatureType.isReportedField] ===
+          reportedFeatureType.isReportedValue
+    )
+  )
+
+  return (
+    <>
+      {features.map(getMarker)}
+      {reportedFeatures.length > 0 && reportedFeatureType && (
+        <ReportedLayer
+          reportedFeatures={reportedFeatures as Feature[]}
+          reportedFeatureType={reportedFeatureType as FeatureType}
+        />
+      )}
+    </>
+  )
 }
 
 export default CaterpillarLayer

--- a/src/signals/incident/components/form/MapSelectors/Caterpillar/CaterpillarLayer/CaterpillarLayer.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Caterpillar/CaterpillarLayer/CaterpillarLayer.tsx
@@ -29,10 +29,9 @@ export const CaterpillarLayer: FC = () => {
       const feature = feat as Feature
       const coordinates = featureToCoordinates(feature.geometry as Geometrie)
       // Caterpillar layer renders only a single feature type (oak tree)
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      const featureType = meta.featureTypes!.find(
+      const featureType = meta.featureTypes.find(
         ({ typeValue }) => typeValue === 'Eikenboom'
-      )!
+      ) as FeatureType
       const featureId = feature.properties[featureType.idField] as string
 
       const isSelected = selection?.id === featureId
@@ -96,10 +95,9 @@ export const CaterpillarLayer: FC = () => {
     [meta.extraProperties, meta.featureTypes, removeItem, selection, setItem]
   )
 
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const reportedFeatureType = meta.featureTypes.find(
     ({ typeValue }) => typeValue === 'reported'
-  )!
+  ) as FeatureType
   const reportedFeatures = features.filter((feature) =>
     Boolean(
       reportedFeatureType?.isReportedField &&

--- a/src/signals/incident/components/form/MapSelectors/Caterpillar/CaterpillarLayer/CaterpillarLayer.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Caterpillar/CaterpillarLayer/CaterpillarLayer.tsx
@@ -7,10 +7,10 @@ import { Marker } from '@amsterdam/arm-core'
 import type { FeatureCollection } from 'geojson'
 import type { FC } from 'react'
 import type {
-  Item,
   FeatureType,
   Feature,
-} from 'signals/incident/components/form/MapSelectors/Asset/types'
+  Item,
+} from 'signals/incident/components/form/MapSelectors/types'
 import type { Geometrie } from 'types/incident'
 
 import WfsDataContext from 'signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/context'
@@ -54,7 +54,7 @@ export const CaterpillarLayer: FC = () => {
           : featureType.icon.iconUrl,
       })
 
-      const onClick = async () => {
+      const onClick = () => {
         if (isSelected) {
           removeItem()
           return

--- a/src/signals/incident/components/form/MapSelectors/Caterpillar/CaterpillarSelectRenderer/CaterpillarSelectRenderer.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Caterpillar/CaterpillarSelectRenderer/CaterpillarSelectRenderer.test.tsx
@@ -4,7 +4,7 @@ import { render, screen } from '@testing-library/react'
 import { withAppContext } from 'test/utils'
 import incidentJson from 'utils/__tests__/fixtures/incident.json'
 import { controls } from 'signals/incident/definitions/wizard-step-2-vulaan/openbaarGroenEnWater'
-import type { Meta } from '../../Asset/types'
+import type { Meta } from '../../types'
 import CaterpillarSelectRenderer from './CaterpillarSelectRenderer'
 
 jest.mock('../../Asset/AssetSelect', () => () => (

--- a/src/signals/incident/components/form/MapSelectors/Clock/ClockLayer/ClockLayer.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Clock/ClockLayer/ClockLayer.tsx
@@ -7,7 +7,7 @@ import AssetLayer from '../../Asset/Selector/WfsLayer/AssetLayer'
 import ReportedLayer from '../../Asset/Selector/WfsLayer/ReportedLayer'
 import AssetSelectContext from '../../Asset/context'
 import WfsDataContext from '../../Asset/Selector/WfsLayer/context'
-import type { Feature, FeatureType } from '../../Asset/types'
+import type { Feature, FeatureType } from '../../types'
 
 const REPORTED = 1
 

--- a/src/signals/incident/components/form/MapSelectors/Clock/ClockSelectRenderer/ClockSelectRenderer.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Clock/ClockSelectRenderer/ClockSelectRenderer.test.tsx
@@ -6,7 +6,7 @@ import { withAppContext } from 'test/utils'
 import incidentJson from 'utils/__tests__/fixtures/incident.json'
 import straatverlichtingKlokken from 'signals/incident/definitions/wizard-step-2-vulaan/straatverlichting-klokken'
 
-import type { Meta } from '../../Asset/types'
+import type { Meta } from '../../types'
 
 import ClockSelectRenderer from './ClockSelectRenderer'
 

--- a/src/signals/incident/components/form/MapSelectors/Streetlight/StreetlightLayer/StreetlightLayer.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Streetlight/StreetlightLayer/StreetlightLayer.tsx
@@ -7,7 +7,7 @@ import AssetLayer from '../../Asset/Selector/WfsLayer/AssetLayer'
 import ReportedLayer from '../../Asset/Selector/WfsLayer/ReportedLayer'
 import AssetSelectContext from '../../Asset/context'
 import WfsDataContext from '../../Asset/Selector/WfsLayer/context'
-import type { Feature, FeatureType } from '../../Asset/types'
+import type { Feature, FeatureType } from '../../types'
 
 const REPORTED = 1
 

--- a/src/signals/incident/components/form/MapSelectors/Streetlight/StreetlightSelectRenderer/StreetlightSelectRenderer.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Streetlight/StreetlightSelectRenderer/StreetlightSelectRenderer.test.tsx
@@ -6,7 +6,7 @@ import { withAppContext } from 'test/utils'
 import incidentJson from 'utils/__tests__/fixtures/incident.json'
 import straatverlichtingKlokken from 'signals/incident/definitions/wizard-step-2-vulaan/straatverlichting-klokken'
 
-import type { Meta } from '../../Asset/types'
+import type { Meta } from '../../types'
 
 import StreetlightSelectRenderer from './StreetlightSelectRenderer'
 

--- a/src/signals/incident/components/form/MapSelectors/types.ts
+++ b/src/signals/incident/components/form/MapSelectors/types.ts
@@ -3,6 +3,9 @@
 import type { MouseEvent, KeyboardEvent } from 'react'
 import type { IconOptions } from 'leaflet'
 import type { Point, Feature as GeoJSONFeature } from 'geojson'
+import type { Address } from 'types/address'
+import type { LatLngLiteral } from 'leaflet'
+import type { UNREGISTERED_TYPE } from './constants'
 
 export type EventHandler = (
   event:
@@ -14,6 +17,17 @@ export interface BaseItem {
   id: string
   type: string
   description?: string
+}
+
+export interface Item extends Record<string, unknown> {
+  location: {
+    address?: Address
+    coordinates?: LatLngLiteral
+  }
+  description?: string
+  id: string | number
+  isReported?: boolean
+  type?: typeof UNREGISTERED_TYPE | string
 }
 
 export interface FeatureType {
@@ -45,6 +59,19 @@ export interface DataLayerProps {
   featureTypes: FeatureType[]
   desktopView?: boolean
   allowClusters?: boolean
+}
+
+export interface Meta extends Record<string, unknown> {
+  name?: string
+  endpoint: string
+  featureTypes: FeatureType[]
+  language?: Record<string, string>
+  wfsFilter?: string
+  extraProperties?: string[]
+  ifAllOf?: { subcategory: string }
+  label?: string
+  shortLabel?: string
+  pathMerge?: string
 }
 
 export type FeatureProps = Record<string, string | number | undefined>

--- a/src/signals/incident/components/form/MapSelectors/types.ts
+++ b/src/signals/incident/components/form/MapSelectors/types.ts
@@ -20,8 +20,6 @@ export interface FeatureType {
   label: string
   description: string
   icon: FeatureIcon
-  iconId?: string
-  iconIsReportedId?: string
   idField: string
   isReportedField?: string
   isReportedValue?: number
@@ -32,7 +30,6 @@ export interface FeatureType {
 export interface FeatureIcon {
   options?: Partial<IconOptions>
   iconUrl: string
-  reportedIconSvg?: string
 }
 
 export interface Options {
@@ -48,7 +45,6 @@ export interface DataLayerProps {
   featureTypes: FeatureType[]
   desktopView?: boolean
   allowClusters?: boolean
-  reportedLayer?: boolean
 }
 
 export type FeatureProps = Record<string, string | number | undefined>

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/openbaarGroenEnWater.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/openbaarGroenEnWater.ts
@@ -3,16 +3,13 @@
 import { FIELD_TYPE_MAP } from 'signals/incident/containers/IncidentContainer/constants'
 import type { IconOptions } from 'leaflet'
 import oakUrl from 'shared/images/groen_water/oak.svg?url'
-import oakReportedUrl from 'shared/images/groen_water/oakReported.svg?url'
-import featureReportedMarkerUrl from 'shared/images/icon-reported-marker.svg?url'
-import featureSelectedMarkerUrl from 'shared/images/featureSelectedMarker.svg?url'
-import oakSelectedReportedUrl from 'shared/images/groen_water/oakSelectedReported.svg?url'
+import reportedFeatureMarkerUrl from 'shared/images/icon-reported-marker.svg?url'
 import unknownFeatureMarkerUrl from 'shared/images/featureUnknownMarker.svg?url'
 import { validateObjectLocation } from '../../services/custom-validators'
 
 export const ICON_SIZE = 40
 
-const options: Partial<IconOptions> = {
+const options: Pick<IconOptions, 'className' | 'iconSize'> = {
   className: 'object-marker',
   iconSize: [ICON_SIZE, ICON_SIZE],
 }
@@ -37,43 +34,14 @@ export const controls = {
       pathMerge: 'extra_properties',
       endpoint:
         'https://services9.arcgis.com/YBT9ZoJBxXxS3cs6/arcgis/rest/services/EPR_2021_SIA_Amsterdam/FeatureServer/0/query?outFields=*&where=1%3D1&f=geojson&geometryType=esriGeometryEnvelope&geometry={{east},{south},{west},{north}}',
-      icons: [
-        {
-          id: 'oak',
-          iconUrl: oakUrl,
-        },
-        {
-          id: 'oakIsReported',
-          iconUrl: oakReportedUrl,
-        },
-        {
-          id: 'isReported',
-          iconUrl: featureReportedMarkerUrl,
-        },
-        {
-          id: 'isSelected',
-          iconUrl: featureSelectedMarkerUrl,
-        },
-        {
-          id: 'isSelectedAndReported',
-          iconUrl: oakSelectedReportedUrl,
-        },
-        {
-          id: 'unknown',
-          iconUrl: unknownFeatureMarkerUrl,
-        },
-      ],
       featureTypes: [
         {
           label: 'Eikenboom',
           description: 'Eikenboom',
-          iconId: 'oak',
           icon: {
             options,
             iconUrl: oakUrl,
-            reportedIconSvg: oakReportedUrl,
           },
-          iconIsReportedId: 'oakIsReported',
           idField: 'OBJECTID',
           typeValue: 'Eikenboom',
           typeField: '',
@@ -83,14 +51,12 @@ export const controls = {
         {
           label: 'Eikenboom is reeds gemeld ',
           description: 'Eikenboom is reeds gemeld',
-          iconId: 'oakIsReported',
           icon: {
             options,
-            iconUrl: oakReportedUrl,
+            iconUrl: reportedFeatureMarkerUrl,
           },
-          iconIsReportedId: 'oakIsReported',
           idField: 'OBJECTID',
-          typeValue: 'oakIsReported',
+          typeValue: 'reported',
           typeField: '',
           isReportedField: 'AMS_Meldingstatus',
           isReportedValue: 1,
@@ -98,7 +64,6 @@ export const controls = {
         {
           label: 'Onbekend',
           description: 'De boom staat niet op de kaart',
-          iconId: 'unknown',
           icon: {
             options,
             iconUrl: unknownFeatureMarkerUrl,

--- a/src/utils/__tests__/fixtures/caterpillarsSelection.tsx
+++ b/src/utils/__tests__/fixtures/caterpillarsSelection.tsx
@@ -1,5 +1,5 @@
 import oakUrl from 'shared/images/groen_water/oak.svg?url'
-import oakReportedUrl from 'shared/images/groen_water/oakReported.svg?url'
+import reportedFeatureMarkerUrl from '*.svg?url'
 
 export const selection = [
   {
@@ -26,12 +26,6 @@ export const selection = [
 ]
 
 export const meta = {
-  icons: [
-    {
-      id: 'cannot_be_matched',
-      iconUrl: '',
-    },
-  ],
   ifAllOf: {
     subcategory: 'eikenprocessierups',
   },
@@ -44,12 +38,10 @@ export const meta = {
     {
       label: 'Eikenboom',
       description: 'Eikenboom',
-      iconId: 'oak',
       icon: {
         options: {},
         iconUrl: oakUrl,
       },
-      iconIsReportedId: 'oakIsReported',
       idField: 'OBJECTID',
       typeValue: 'Eikenboom',
       typeField: '',
@@ -59,14 +51,13 @@ export const meta = {
     {
       label: 'Eikenboom is reeds gemeld ',
       description: 'Eikenboom is reeds gemeld',
-      iconId: 'oakIsReported',
       icon: {
         options: {},
-        iconUrl: oakReportedUrl,
+        iconUrl: reportedFeatureMarkerUrl,
       },
       iconIsReportedId: 'oakIsReported',
       idField: 'OBJECTID',
-      typeValue: 'oakIsReported',
+      typeValue: 'reported',
       typeField: '',
       isReportedField: 'AMS_Meldingstatus',
       isReportedValue: 1,


### PR DESCRIPTION
- Moved reported icons to separate layer (making the caterpillar layer more similar to the others)
- Cleaned up double types. Moved general map selectors types into `mapselectors/types` and kept types specific for asset select in `asset/types`