### PR TITLE
Add small crs value for use with bbox query string

### DIFF
--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/WfsLayer.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/WfsLayer.test.tsx
@@ -20,7 +20,7 @@ import * as useLayerVisible from '../../../hooks/useLayerVisible'
 import { AssetSelectProvider } from '../../context'
 
 import WfsDataContext, { NO_DATA } from './context'
-import { SRS_NAME, SRS_NAME_SMALL } from './WfsLayer'
+import { SRS_NAME } from './WfsLayer'
 
 const fetchMock = fetch as FetchMock
 
@@ -185,8 +185,8 @@ describe('src/signals/incident/components/form/AssetSelect/WfsLayer', () => {
   it('supports replacements in the endpoint', async () => {
     fetchMock.mockResponse(JSON.stringify(assetsJson), { status: 200 })
     const endpoint =
-      'https://endpoint/?version=2&srsName={srsName}&srsNameSmall={srsNameSmall}&bbox={north},{east},{south},{west}'
-    const expectedEndpoint = `https://endpoint/?version=2&srsName=${SRS_NAME}&srsNameSmall=${SRS_NAME_SMALL}&bbox=52.37309163108818,4.879893974954347,52.37309163108818,4.879893974954347`
+      'https://endpoint/?version=2&srsName={srsName}&bbox={north},{east},{south},{west}'
+    const expectedEndpoint = `https://endpoint/?version=2&srsName=${SRS_NAME}&bbox=52.37309163108818,4.879893974954347,52.37309163108818,4.879893974954347`
     const promise = Promise.resolve()
     const assetSelectProviderValue: AssetSelectValue = {
       selection: undefined,
@@ -243,7 +243,7 @@ describe('src/signals/incident/components/form/AssetSelect/WfsLayer', () => {
     }
 
     const urlWithFilter =
-      'https://endpoint/?version=2&filter=%3CFilter%3E%3CAnd%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Egeometrie%3C%2FPropertyName%3E%3Cgml%3AEnvelope+srsName%3D%22urn%3Aogc%3Adef%3Acrs%3AEPSG%3A%3A4326%22%3E%3ClowerCorner%3E4.879893974954347+52.37309163108818%3C%2FlowerCorner%3E%3CupperCorner%3E4.879893974954347+52.37309163108818%3C%2FupperCorner%3E%3C%2Fgml%3AEnvelope%3E%3C%2FAnd%3E%3C%2FFilter%3E'
+      'https://endpoint/?version=2&filter=%3CFilter%3E%3CAnd%3E%3CPropertyIsEqualTo%3E%3CPropertyName%3Egeometrie%3C%2FPropertyName%3E%3Cgml%3AEnvelope+srsName%3D%22EPSG%3A4326%22%3E%3ClowerCorner%3E4.879893974954347+52.37309163108818%3C%2FlowerCorner%3E%3CupperCorner%3E4.879893974954347+52.37309163108818%3C%2FupperCorner%3E%3C%2Fgml%3AEnvelope%3E%3C%2FAnd%3E%3C%2FFilter%3E'
 
     render(
       withMapAsset(

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/WfsLayer.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/WfsLayer.test.tsx
@@ -20,6 +20,7 @@ import * as useLayerVisible from '../../../hooks/useLayerVisible'
 import { AssetSelectProvider } from '../../context'
 
 import WfsDataContext, { NO_DATA } from './context'
+import { SRS_NAME, SRS_NAME_SMALL } from './WfsLayer'
 
 const fetchMock = fetch as FetchMock
 
@@ -176,6 +177,45 @@ describe('src/signals/incident/components/form/AssetSelect/WfsLayer', () => {
 
     expect(fetchMock).toHaveBeenCalledWith(
       endpoint,
+      expect.objectContaining({})
+    )
+    await act(() => promise)
+  })
+
+  it('supports replacements in the endpoint', async () => {
+    fetchMock.mockResponse(JSON.stringify(assetsJson), { status: 200 })
+    const endpoint =
+      'https://endpoint/?version=2&srsName={srsName}&srsNameSmall={srsNameSmall}&bbox={north},{east},{south},{west}'
+    const expectedEndpoint = `https://endpoint/?version=2&srsName=${SRS_NAME}&srsNameSmall=${SRS_NAME_SMALL}&bbox=52.37309163108818,4.879893974954347,52.37309163108818,4.879893974954347`
+    const promise = Promise.resolve()
+    const assetSelectProviderValue: AssetSelectValue = {
+      selection: undefined,
+      coordinates: { lat: 0, lng: 0 },
+      meta: {
+        endpoint,
+        featureTypes: [],
+      },
+      setItem: jest.fn(() => promise),
+      removeItem: jest.fn(),
+      edit: jest.fn(),
+      close: jest.fn(),
+      setMessage: jest.fn(),
+      fetchLocation: jest.fn(),
+      setLocation: jest.fn(),
+    }
+
+    render(
+      withMapAsset(
+        <AssetSelectProvider value={assetSelectProviderValue}>
+          <WfsLayer>
+            <TestLayer featureTypes={[]} desktopView />
+          </WfsLayer>
+        </AssetSelectProvider>
+      )
+    )
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expectedEndpoint,
       expect.objectContaining({})
     )
     await act(() => promise)

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/WfsLayer.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/WfsLayer.tsx
@@ -13,8 +13,8 @@ import useLayerVisible from '../../../hooks/useLayerVisible'
 import type { DataLayerProps } from '../../types'
 import { NO_DATA, WfsDataProvider } from './context'
 
-const SRS_NAME = 'urn:ogc:def:crs:EPSG::4326'
-const SRS_NAME_SMALL = 'EPSG:4326'
+export const SRS_NAME = 'urn:ogc:def:crs:EPSG::4326'
+export const SRS_NAME_SMALL = 'EPSG:4326'
 
 interface Bbox {
   east: string

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/WfsLayer.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/WfsLayer.tsx
@@ -13,8 +13,7 @@ import useLayerVisible from '../../../hooks/useLayerVisible'
 import type { DataLayerProps } from '../../types'
 import { NO_DATA, WfsDataProvider } from './context'
 
-export const SRS_NAME = 'urn:ogc:def:crs:EPSG::4326'
-export const SRS_NAME_SMALL = 'EPSG:4326'
+export const SRS_NAME = 'EPSG:4326'
 
 interface Bbox {
   east: string
@@ -55,7 +54,6 @@ const WfsLayer: FunctionComponent<WfsLayerProps> = ({
     bbox && {
       ...bbox,
       srsName: SRS_NAME,
-      srsNameSmall: SRS_NAME_SMALL,
     }
   const wfsUrl = urlReplacements
     ? Object.entries(urlReplacements).reduce(

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/WfsLayer.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/WfsLayer.tsx
@@ -14,6 +14,7 @@ import type { DataLayerProps } from '../../types'
 import { NO_DATA, WfsDataProvider } from './context'
 
 const SRS_NAME = 'urn:ogc:def:crs:EPSG::4326'
+const SRS_NAME_SMALL = 'EPSG:4326'
 
 interface Bbox {
   east: string
@@ -54,6 +55,7 @@ const WfsLayer: FunctionComponent<WfsLayerProps> = ({
     bbox && {
       ...bbox,
       srsName: SRS_NAME,
+      srsNameSmall: SRS_NAME_SMALL,
     }
   const wfsUrl = urlReplacements
     ? Object.entries(urlReplacements).reduce(


### PR DESCRIPTION
Necessary to make the following wfs service work:

`https://data.haarlem.nl/geoserver/wfs?request=GetFeature&service=wfs&outputFormat=json&typeNames=gemeentehaarlem:bor_afvalinzamel&version=2.0.0&srsName={srsName}&bbox={west},{south},{east},{north},{srsNameSmall}`
