### PR TITLE
[SIG 4127] Only refresh overview map when refresh is set to true in active filter

### DIFF
--- a/src/components/OverviewMap/OverviewMap.test.tsx
+++ b/src/components/OverviewMap/OverviewMap.test.tsx
@@ -146,10 +146,30 @@ describe('OverviewMap', () => {
       expect(fetchMock.mock.calls).toHaveLength(2)
     })
 
-    it('should poll the endpoint', async () => {
+    it('should not poll the endpoint by default', async () => {
       jest.useFakeTimers()
 
       render(withMapContext(<OverviewMap />))
+
+      await screen.findByTestId('overviewMap')
+
+      expect(fetchMock.mock.calls).toHaveLength(1)
+
+      act(() => {
+        jest.advanceTimersByTime(POLLING_INTERVAL)
+      })
+
+      await screen.findByTestId('overviewMap')
+
+      expect(fetchMock.mock.calls).toHaveLength(1)
+
+      jest.useRealTimers()
+    })
+
+    it('should poll the endpoint when refresh is true', async () => {
+      jest.useFakeTimers()
+
+      render(withMapContext(<OverviewMap refresh={true} />))
 
       await screen.findByTestId('overviewMap')
 

--- a/src/components/OverviewMap/OverviewMap.test.tsx
+++ b/src/components/OverviewMap/OverviewMap.test.tsx
@@ -169,7 +169,7 @@ describe('OverviewMap', () => {
     it('should poll the endpoint when refresh is true', async () => {
       jest.useFakeTimers()
 
-      render(withMapContext(<OverviewMap refresh={true} />))
+      render(withMapContext(<OverviewMap refresh />))
 
       await screen.findByTestId('overviewMap')
 

--- a/src/components/OverviewMap/OverviewMap.tsx
+++ b/src/components/OverviewMap/OverviewMap.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2020 - 2021 Gemeente Amsterdam
-import type { Dispatch, SetStateAction } from 'react'
+import type { Dispatch, FC, SetStateAction } from 'react'
 import {
   memo,
   useContext,
@@ -9,7 +9,6 @@ import {
   useEffect,
   useMemo,
 } from 'react'
-import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { useSelector } from 'react-redux'
 import format from 'date-fns/format'
@@ -95,8 +94,16 @@ const clusterLayerOptions = {
   zoomToBoundsOnClick: true,
   chunkedLoading: true,
 }
+interface OverviewMapProps {
+  isPublic?: boolean
+  refresh?: boolean
+}
 
-const OverviewMap = ({ isPublic = false, ...rest }) => {
+const OverviewMap: FC<OverviewMapProps> = ({
+  isPublic = false,
+  refresh,
+  ...rest
+}) => {
   const endpoint = isPublic
     ? configuration.MAP_SIGNALS_ENDPOINT
     : configuration.GEOGRAPHY_ENDPOINT
@@ -163,6 +170,9 @@ const OverviewMap = ({ isPublic = false, ...rest }) => {
   }, [resetMarkerIcons])
 
   useEffect(() => {
+    if (!refresh) {
+      return
+    }
     let active = true
     const pollingFn = () => {
       /* istanbul ignore else */
@@ -173,7 +183,7 @@ const OverviewMap = ({ isPublic = false, ...rest }) => {
       active = false
       clearInterval(intervalId)
     }
-  }, [pollingCount, setPollingCount])
+  }, [refresh, pollingCount, setPollingCount])
 
   useEffect(() => {
     if (isLoading || !initialMount) return
@@ -261,10 +271,6 @@ const OverviewMap = ({ isPublic = false, ...rest }) => {
       </StyledMap>
     </Wrapper>
   )
-}
-
-OverviewMap.propTypes = {
-  isPublic: PropTypes.bool,
 }
 
 export default memo(OverviewMap)

--- a/src/signals/incident-management/containers/IncidentOverviewPage/index.js
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/index.js
@@ -239,7 +239,10 @@ export const IncidentOverviewPageContainerComponent = ({
         <Row>
           <MapWrapper>
             <MapContext>
-              <OverviewMap data-testid="24HourMap" />
+              <OverviewMap
+                data-testid="24HourMap"
+                refresh={activeFilter.refresh}
+              />
             </MapContext>
           </MapWrapper>
         </Row>


### PR DESCRIPTION
- Added refresh as prop to OverviewMap component. When refresh is true, polling is enabled.
- Added a test to show that no polling occurs when refresh is unset en polling does occur when refresh is set.