### PR TITLE
(Chore) Corrects layers endpoints

### DIFF
--- a/src/signals/incident/definitions/wizard-step-2-vulaan/straatverlichting-klokken.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/straatverlichting-klokken.ts
@@ -68,7 +68,7 @@ export const straatverlichtingKlokken = {
       },
       wfsFilter:
         '<BBOX><gml:Envelope srsName="{srsName}"><lowerCorner>{west} {south}</lowerCorner><upperCorner>{east} {north}</upperCorner></gml:Envelope></BBOX>',
-      endpoint: configuration.map.layers?.klokken,
+      endpoint: configuration.map.layers?.verlichting,
       featureTypes: [
         {
           label: 'Grachtmast',
@@ -274,7 +274,7 @@ export const straatverlichtingKlokken = {
       },
       wfsFilter:
         '<BBOX><gml:Envelope srsName="{srsName}"><lowerCorner>{west} {south}</lowerCorner><upperCorner>{east} {north}</upperCorner></gml:Envelope></BBOX>',
-      endpoint: configuration.map.layers?.verlichting,
+      endpoint: configuration.map.layers?.klokken,
       zoomMin: 14,
       featureTypes: [
         {


### PR DESCRIPTION
This changes the URL references in the straatlichting and klokken configuration so that the correct global config props are referenced.
