### PR TITLE
[SIG-4299] Always show location map

### DIFF
--- a/src/signals/incident/definitions/__tests__/wizard-step-2-vulaan.test.js
+++ b/src/signals/incident/definitions/__tests__/wizard-step-2-vulaan.test.js
@@ -35,13 +35,18 @@ describe('Wizard step 2 vulaan, formFactory', () => {
   })
 
   describe('Hard coded questions', () => {
-    it('should return no questions with non existing category', () => {
+    it('should only return location when category does not match', () => {
       configuration.featureFlags.showVulaanControls = true
       const actual = formFactory({
         category: 'category',
         subcategory: 'subcategory',
       })
-      const expected = { controls: {} }
+      const expected = {
+        controls: {
+          ...defaultControls,
+          locatie: expect.any(Object),
+        },
+      }
 
       expect(actual).toEqual(expected)
     })

--- a/src/signals/incident/definitions/wizard-step-2-vulaan.js
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan.js
@@ -19,6 +19,7 @@ import overlastPersonenEnGroepen from './wizard-step-2-vulaan/overlast-van-en-do
 import wegenVerkeerStraatmeubilair from './wizard-step-2-vulaan/wegen-verkeer-straatmeubilair'
 import straatverlichtingKlokken from './wizard-step-2-vulaan/straatverlichting-klokken'
 import wonen from './wizard-step-2-vulaan/wonen'
+import locatie from './wizard-step-2-vulaan/locatie'
 
 const mapFieldNameToComponent = (key) => FormComponents[key]
 
@@ -90,8 +91,7 @@ export default {
   previousButtonClass: 'action startagain',
   formAction: 'UPDATE_INCIDENT',
   formFactory: ({ category, subcategory, questions }) => {
-    const noExtraProps = { controls: {} }
-    if (!configuration?.featureFlags.showVulaanControls) return noExtraProps
+    if (!configuration?.featureFlags.showVulaanControls) return { controls: {} }
 
     if (configuration.featureFlags.fetchQuestionsFromBackend) {
       return expandQuestions(questions || {}, category, subcategory)
@@ -145,7 +145,7 @@ export default {
         return expandQuestions(wonen, category, subcategory)
 
       default:
-        return noExtraProps
+        return expandQuestions({ locatie })
     }
   },
 }

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/locatie.test.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/locatie.test.ts
@@ -1,31 +1,7 @@
-import locatie, { locatieFn } from './locatie'
+import locatie from './locatie'
 
 describe('locatie', () => {
   it('return a config object', () => {
     expect(locatie).toMatchSnapshot()
-  })
-
-  describe('locatieFn', () => {
-    it('returns a config object', () => {
-      expect(locatieFn()).toStrictEqual(locatie)
-    })
-
-    it('returns a config object with display conditions', () => {
-      const displayConds = {
-        ifOneOf: {
-          category: 'Zork',
-        },
-      }
-
-      const locatieConfig = locatieFn(displayConds)
-
-      expect(locatieConfig).toEqual(
-        expect.objectContaining({
-          meta: expect.objectContaining({
-            ...displayConds,
-          }),
-        })
-      )
-    })
   })
 })

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/locatie.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/locatie.ts
@@ -1,17 +1,5 @@
 import { FIELD_TYPE_MAP } from 'signals/incident/containers/IncidentContainer/constants'
 
-type Condition = {
-  category?: string | Array<string>
-  subcategory?: string | Array<string>
-  datetime?: string
-}
-
-interface DisplayConditions {
-  ifAllOf?: Condition
-  ifOneOf?: Condition
-  ifNotOf?: Condition
-}
-
 const locatie = {
   meta: {
     featureTypes: [],
@@ -30,13 +18,5 @@ const locatie = {
     validators: ['required'],
   },
 }
-
-export const locatieFn = (displayConditions: DisplayConditions = {}) => ({
-  ...locatie,
-  meta: {
-    ...locatie.meta,
-    ...displayConditions,
-  },
-})
 
 export default locatie


### PR DESCRIPTION
Contains a change that will always show the `AssetSelect` intro in step 2 when a category prediction doesn't have a corresponding set of questions. In addition, the `locatieFn` named export has been removed, since it wasn't used.