### PR TITLE
[SIG-4091] Visual changes summary page

### DIFF
--- a/src/signals/incident/components/IncidentPreview/index.js
+++ b/src/signals/incident/components/IncidentPreview/index.js
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2018 - 2021 Gemeente Amsterdam
 import PropTypes from 'prop-types'
+import { Fragment } from 'react'
 import styled from 'styled-components'
 import { Link } from 'react-router-dom'
 import {
@@ -30,14 +31,10 @@ const Header = styled.header`
   column-gap: ${themeSpacing(5)};
   grid-template-columns: 12fr;
   margin-bottom: ${themeSpacing(4)};
-
-  h2 {
-    font-weight: 500;
-  }
 `
 
 const LinkContainer = styled.div`
-  padding-top: ${themeSpacing(5)};
+  padding: ${themeSpacing(6)} 0;
 
   @media screen and ${breakpoint('min-width', 'laptopM')} {
     padding-top: 0;
@@ -53,17 +50,13 @@ const LinkContainer = styled.div`
 const Dl = styled.dl`
   margin: 0;
   padding: 0;
-`
-
-const DefinitionsWrapper = styled.div`
   line-height: 24px;
-
-  dd {
+  dd:not(:last-of-type) {
     margin-bottom: ${themeSpacing(6)};
   }
 
   dt {
-    font-weight: 500;
+    font-weight: 700;
     margin-bottom: ${themeSpacing(1)};
   }
 `
@@ -119,7 +112,7 @@ const IncidentPreview = ({ incident, preview, sectionLabels }) => (
 
             <Dl>
               {visibleEntries.map(([itemKey, itemValue]) => (
-                <DefinitionsWrapper key={itemKey}>
+                <Fragment key={itemKey}>
                   <dt>{itemValue.label}</dt>
                   <dd>
                     {itemValue.render({
@@ -128,7 +121,7 @@ const IncidentPreview = ({ incident, preview, sectionLabels }) => (
                       incident,
                     })}
                   </dd>
-                </DefinitionsWrapper>
+                </Fragment>
               ))}
             </Dl>
 

--- a/src/signals/incident/components/IncidentWizard/index.js
+++ b/src/signals/incident/components/IncidentWizard/index.js
@@ -4,7 +4,12 @@ import { useContext, useMemo } from 'react'
 import PropTypes from 'prop-types'
 import { Route } from 'react-router-dom'
 import { Wizard, Steps, Step } from 'react-albus'
-import { Heading, themeSpacing, StepByStepNav } from '@amsterdam/asc-ui'
+import {
+  Heading,
+  themeSpacing,
+  StepByStepNav,
+  Paragraph,
+} from '@amsterdam/asc-ui'
 import styled, { css } from 'styled-components'
 
 import LoadingIndicator from 'components/LoadingIndicator'
@@ -111,6 +116,7 @@ const IncidentWizard = ({
                         form,
                         formFactory,
                         label,
+                        subHeader,
                         postponeSubmitWhenLoading,
                         previewFactory,
                         sectionLabels,
@@ -125,6 +131,7 @@ const IncidentWizard = ({
                               {countAsStep && `${index + 1}. `}
                               {label || key}
                             </StyledH1>
+                            {subHeader && <Paragraph>{subHeader}</Paragraph>}
                           </Header>
 
                           <Progress>

--- a/src/signals/incident/definitions/wizard-step-4-summary.js
+++ b/src/signals/incident/definitions/wizard-step-4-summary.js
@@ -135,7 +135,7 @@ const getExtraQuestions = (category, subcategory, questions) => {
 
 export default {
   label: 'Versturen',
-  subheader: 'Maak een aanpassing als dat nodig is.',
+  subHeader: 'Controleer uw gegevens en verstuur uw melding.',
   nextButtonLabel: 'Verstuur',
   nextButtonClass: 'action primary',
   previousButtonLabel: 'Vorige',
@@ -148,7 +148,7 @@ export default {
     },
     edit: {
       beschrijf: 'Wijzig uw melding',
-      vulaan: 'Wijzig aanvullende informatie',
+      vulaan: 'Wijzig locatie en vragen',
       contact: 'Wijzig contactgegevens',
     },
   },
@@ -179,7 +179,7 @@ export default {
         render: PreviewComponents.MapPreview,
       },
       description: {
-        label: 'Uw melding gaat over:',
+        label: 'Waar gaat het over?',
         render: ({ value }) => value,
       },
       classification: {


### PR DESCRIPTION
Contains the following:
- Shows subheader on summary page
- Makes all headings and strong elements bolder (700 instead of 500)
- Changes section heading contents
- Changes edit link text for Locatie en vragen
- Adjusts padding for edit links on smaller screens