### PR TITLE
[SIG-4354] Show step 2 when questions are retrieved from the backend

### DIFF
--- a/src/signals/incident/definitions/__tests__/wizard-step-2-vulaan.test.js
+++ b/src/signals/incident/definitions/__tests__/wizard-step-2-vulaan.test.js
@@ -7,10 +7,12 @@ import configuration from 'shared/services/configuration/configuration'
 
 import step2 from '../wizard-step-2-vulaan'
 import FormComponents from '../../components/form'
+import locatie from '../wizard-step-2-vulaan/locatie'
 
 const { formFactory } = step2
 const defaultControls = {
   error: expect.objectContaining({}),
+  $field_0: expect.objectContaining({}),
   help_text: expect.objectContaining({
     meta: {
       ignoreVisibility: true,
@@ -18,7 +20,6 @@ const defaultControls = {
       value: configuration.language.helpText,
     },
   }),
-  $field_0: expect.objectContaining({}),
 }
 
 jest.mock('shared/services/configuration/configuration')
@@ -27,6 +28,14 @@ jest.mock('lodash/memoize', () => ({
   __esModule: true,
   default: jest.fn((fn) => fn),
 }))
+
+const location = {
+  ...locatie,
+  options: {
+    validators: [Validators.required],
+  },
+  render: expect.any(Function),
+}
 
 describe('Wizard step 2 vulaan, formFactory', () => {
   afterEach(() => {
@@ -43,7 +52,7 @@ describe('Wizard step 2 vulaan, formFactory', () => {
       const expected = {
         controls: {
           ...defaultControls,
-          locatie: expect.any(Object),
+          location,
         },
       }
 
@@ -55,7 +64,7 @@ describe('Wizard step 2 vulaan, formFactory', () => {
 
       expect(formFactory({ category: 'afval' }).controls).toEqual({
         ...defaultControls,
-        locatie: expect.any(Object),
+        location,
       })
     })
   })
@@ -72,7 +81,10 @@ describe('Wizard step 2 vulaan, formFactory', () => {
         subcategory: 'subcategory',
       })
       const expected = {
-        controls: defaultControls,
+        controls: {
+          ...defaultControls,
+          location,
+        },
       }
 
       expect(actual).toEqual(expected)

--- a/src/signals/incident/definitions/wizard-step-2-vulaan.js
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan.js
@@ -19,7 +19,7 @@ import overlastPersonenEnGroepen from './wizard-step-2-vulaan/overlast-van-en-do
 import wegenVerkeerStraatmeubilair from './wizard-step-2-vulaan/wegen-verkeer-straatmeubilair'
 import straatverlichtingKlokken from './wizard-step-2-vulaan/straatverlichting-klokken'
 import wonen from './wizard-step-2-vulaan/wonen'
-import locatie from './wizard-step-2-vulaan/locatie'
+import location from './wizard-step-2-vulaan/locatie'
 
 const mapFieldNameToComponent = (key) => FormComponents[key]
 
@@ -74,7 +74,7 @@ const expandQuestions = memoize(
   (questions, category, subcategory) => `${category}${subcategory}`
 )
 
-const fallback = expandQuestions({ locatie })
+const fallback = expandQuestions({ location })
 
 export default {
   label: 'Locatie en vragen',
@@ -89,7 +89,11 @@ export default {
     }
 
     if (configuration.featureFlags.fetchQuestionsFromBackend) {
-      return expandQuestions(questions || {}, category, subcategory)
+      const hasQuestions = Object.keys(questions || {}).length > 0
+
+      return hasQuestions
+        ? expandQuestions(questions, category, subcategory)
+        : fallback
     }
 
     switch (category) {


### PR DESCRIPTION
Missing piece of the puzzle; not only when feature flag `showVulaanControls` is false, also when `fetchQuestionsFromBackend` has been set should the flow show step 2.