### PR TITLE
[SIG-4344] Empty section fallback

### DIFF
--- a/src/signals/incident/components/IncidentPreview/IncidentPreview.test.tsx
+++ b/src/signals/incident/components/IncidentPreview/IncidentPreview.test.tsx
@@ -3,9 +3,12 @@
 import { render, screen } from '@testing-library/react'
 import 'jest-styled-components'
 
-import { getIsAuthenticated } from 'shared/services/auth/auth'
+import * as auth from 'shared/services/auth/auth'
 import { withAppContext } from 'test/utils'
 import { formatAddress } from 'shared/services/format-address'
+import { mock } from 'types/incident'
+
+import type { IncidentPreviewProps } from './IncidentPreview'
 
 import PreviewComponents from './components'
 import IncidentPreview from '.'
@@ -13,56 +16,54 @@ import IncidentPreview from '.'
 jest.mock('shared/services/auth/auth')
 
 describe('<IncidentPreview />', () => {
-  let props
+  let props: IncidentPreviewProps
 
   beforeEach(() => {
-    getIsAuthenticated.mockImplementation(() => false)
+    jest.spyOn(auth, 'getIsAuthenticated').mockImplementation(() => false)
 
     props = {
-      incident: {
-        phone: '0666 666 666',
-        email: 'duvel@uiteendoosje.nl',
-        other_prop: 'Lorem ipsum',
-        optional_array_prop: [],
-      },
+      incident: mock,
       preview: {
         beschrijf: {
           phone: {
             label: 'Uw (mobiele) telefoon',
-            render: ({ value }) => value,
+            render: ({ value }: { value: string }) => <span>{value}</span>,
           },
           other_prop: {
             label: 'Foo bar',
             authenticated: true,
-            render: ({ value }) => value,
+            render: ({ value }: { value: string }) => <span>{value}</span>,
           },
           optional_prop: {
             label: 'Bazzzz',
             optional: true,
-            render: ({ value }) => value,
+            render: ({ value }: { value: string }) => <span>{value}</span>,
           },
           optional_array_prop: {
             label: 'Opttt',
             optional: true,
-            render: ({ value }) => value,
+            render: ({ value }: { value: string }) => <span>{value}</span>,
           },
           required_prop: {
             label: 'Qux',
             authenticated: false,
             optional: false,
-            render: ({ value }) => value,
+            render: ({ value }: { value: string }) => <span>{value}</span>,
           },
         },
         vulaan: {
           email: {
             label: 'Uw e-mailadres',
-            render: ({ value }) => value,
+            render: ({ value }: { value: string }) => <span>{value}</span>,
           },
         },
-        some_other_section: {
-          field: {
-            label: 'Bar baz qux',
-            render: ({ value }) => value,
+        contact: {
+          sharing_allowed: {
+            optional: true,
+            label: 'foo bar',
+            render: ({ value }: { value: { value?: string } }) => (
+              <span>{value.value ? 'Ja' : 'Nee'}</span>
+            ),
           },
         },
       },
@@ -70,11 +71,12 @@ describe('<IncidentPreview />', () => {
         heading: {
           vulaan: 'Vulaan heading',
           beschrijf: 'Beschrijf heading',
+          contact: 'Contact',
         },
         edit: {
           vulaan: 'Wijzig vulaan',
           beschrijf: 'Wijzig beschrijf',
-          some_other_section: 'Wijzig bar baz qux',
+          contact: 'Wijzig bar baz qux',
         },
       },
     }
@@ -91,13 +93,12 @@ describe('<IncidentPreview />', () => {
 
     await findByTestId('incidentPreview')
 
-    expect(queryByText(props.incident.phone)).toBeInTheDocument()
+    expect(queryByText(props.incident.phone || '')).toBeInTheDocument()
     expect(queryByText(props.preview.beschrijf.phone.label)).toBeInTheDocument()
 
     expect(queryByText(props.incident.email)).toBeInTheDocument()
     expect(queryByText(props.preview.vulaan.email.label)).toBeInTheDocument()
 
-    expect(queryByText(props.incident.other_prop)).not.toBeInTheDocument()
     expect(
       queryByText(props.preview.beschrijf.other_prop.label)
     ).not.toBeInTheDocument()
@@ -131,9 +132,6 @@ describe('<IncidentPreview />', () => {
     expect(
       screen.getByText(props.sectionLabels.edit.vulaan)
     ).toBeInTheDocument()
-    expect(
-      screen.getByText(props.sectionLabels.edit.some_other_section)
-    ).toBeInTheDocument()
 
     container.querySelectorAll('a').forEach((element) => {
       expect(element.href).toEqual(expect.stringMatching(sectionRe))
@@ -145,62 +143,27 @@ describe('<IncidentPreview />', () => {
       sectionLabels: {
         heading: {
           beschrijf: 'Beschrijf',
+          vulaan: 'Aanvullen',
+          contact: 'Contact',
         },
         edit: {
           beschrijf: 'Wijzig beschrijf',
+          vulaan: 'Wijzig aanvullen',
+          contact: 'Wijzig contact',
         },
       },
-      incident: {
-        plain_text: 'Dit is een melding',
-        objectValue: {
-          id: 'horecabedrijf',
-          label: 'Horecabedrijf, zoals een café, restaurant',
-        },
-        listObjectValue: [
-          {
-            id: 'uitgewaaierd_terras',
-            label: 'Uitgewaaierd terras',
-          },
-          {
-            id: 'doorloop',
-            label: 'Het terras belemmert de doorloop',
-          },
-        ],
-        datetime: {
-          id: 'Nu',
-          label: 'Nu',
-        },
-        location: {
-          address: {
-            openbare_ruimte: 'Zwanenburgwal',
-            huisnummer: '15',
-            huisletter: '',
-            huisnummer_toevoeging: '',
-            postcode: '1011VW',
-            woonplaats: 'Amsterdam',
-          },
-          address_text: 'Zwanenburgwal 15, 1011VW Amsterdam',
-          buurt_code: 'A04i',
-          stadsdeel: 'A',
-          geometrie: {
-            type: 'Point',
-            coordinates: [4.899258613586427, 52.36784357172409],
-          },
-        },
-        sharing_allowed: {
-          value: true,
-        },
-        phone: '0000',
-      },
+      incident: mock,
       preview: {
         beschrijf: {
           plain_text: {
             label: 'Plain text',
-            render: ({ value }) => value,
+            render: ({ value }: { value: string }) => <span>{value}</span>,
           },
           objectValue: {
             label: 'Object value',
-            render: ({ value }) => value.label,
+            render: ({ value }: { value: { label?: string } }) => (
+              <span>{value?.label}</span>
+            ),
           },
           listObjectValue: {
             label: 'List object value',
@@ -215,16 +178,17 @@ describe('<IncidentPreview />', () => {
             render: PreviewComponents.MapPreview,
           },
         },
+        vulaan: {},
         contact: {
           sharing_allowed: {
             optional: true,
             label: 'foo bar',
-            render: ({ value }) => (value.value ? 'Ja' : 'Nee'),
+            render: PreviewComponents.ListObjectValue,
           },
           phone: {
             optional: true,
             label: 'phone',
-            render: ({ value }) => value,
+            render: ({ value }: { value: string }) => <span>{value}</span>,
           },
         },
       },
@@ -232,26 +196,26 @@ describe('<IncidentPreview />', () => {
 
     it('expect to render correctly', async () => {
       const { queryByText, findByTestId } = render(
+        // Disabling linter; ts compiler is complaining about untyped components. When all components have been ported to TS, the comments can be removed
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
         withAppContext(<IncidentPreview {...allTypesProps} />)
       )
 
       await findByTestId('incidentPreview')
 
       const { incident } = allTypesProps
-      const step = allTypesProps.preview.beschrijf
+      const { beschrijf, contact } = allTypesProps.preview
 
-      expect(queryByText(step.plain_text.label)).toBeInTheDocument()
-      expect(queryByText(incident.plain_text)).toBeInTheDocument()
+      expect(queryByText(beschrijf.plain_text.label)).toBeInTheDocument()
 
-      expect(queryByText(step.objectValue.label)).toBeInTheDocument()
-      expect(queryByText(incident.objectValue.label)).toBeInTheDocument()
-
-      expect(queryByText(incident.listObjectValue[0].label)).toBeInTheDocument()
-      expect(queryByText(incident.listObjectValue[1].label)).toBeInTheDocument()
+      expect(queryByText(beschrijf.objectValue.label)).toBeInTheDocument()
+      expect(queryByText(contact.sharing_allowed.label)).toBeInTheDocument()
 
       expect(queryByText(incident.datetime.label)).toBeInTheDocument()
       expect(
-        queryByText(formatAddress(incident.location.address))
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion,@typescript-eslint/no-non-null-asserted-optional-chain
+        queryByText(formatAddress(incident.location?.address!))
       ).toBeInTheDocument()
     })
   })

--- a/src/signals/incident/components/IncidentPreview/IncidentPreview.tsx
+++ b/src/signals/incident/components/IncidentPreview/IncidentPreview.tsx
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2018 - 2021 Gemeente Amsterdam
-import PropTypes from 'prop-types'
 import { Fragment } from 'react'
 import styled from 'styled-components'
 import { Link } from 'react-router-dom'
@@ -12,7 +11,9 @@ import {
   breakpoint,
 } from '@amsterdam/asc-ui'
 
-import { incidentType } from 'shared/types'
+import type { FC } from 'react'
+import type { Incident, ValueObject } from 'types/incident'
+
 import { getIsAuthenticated } from 'shared/services/auth/auth'
 
 const Section = styled.section`
@@ -66,13 +67,46 @@ const Wrapper = styled.div`
   word-break: normal;
 `
 
-const IncidentPreview = ({ incident, preview, sectionLabels }) => (
+type Sections = 'beschrijf' | 'vulaan' | 'contact'
+
+type Section = {
+  authenticated?: boolean
+  label: string
+  optional?: boolean
+  render: FC<{ value: any; incident: Incident }> | FC<{ value: any }>
+}
+
+type Preview = {
+  [Key in Sections]: Record<string, Section>
+}
+
+type SectionLabels = {
+  [Key in 'heading' | 'edit']: {
+    [Key in Sections]: string
+  }
+}
+
+export interface IncidentPreviewProps {
+  incident: Incident
+  preview: Preview
+  sectionLabels: SectionLabels
+}
+
+const IncidentPreview: FC<IncidentPreviewProps> = ({
+  incident,
+  preview,
+  sectionLabels,
+}) => (
   <Wrapper data-testid="incidentPreview">
     {Object.entries(preview).map(([section, value]) => {
-      const editLinkLabel = sectionLabels.edit[section]
-      const sectionHeadingLabel = sectionLabels.heading[section]
+      const editLinkLabel = sectionLabels.edit[section as keyof Preview]
+      const sectionHeadingLabel =
+        sectionLabels.heading[section as keyof Preview]
+
       const visibleEntries = Object.entries(value).filter(
         ([entryKey, { optional, authenticated }]) => {
+          const incidentProp = entryKey as keyof Incident
+
           if (authenticated && !getIsAuthenticated()) {
             return false
           }
@@ -81,21 +115,24 @@ const IncidentPreview = ({ incident, preview, sectionLabels }) => (
             return true
           }
 
-          if (Array.isArray(incident[entryKey])) {
-            return incident[entryKey].length > 0
+          if (Array.isArray(incident[incidentProp])) {
+            return (incident[incidentProp] as []).length > 0
           }
 
           try {
             if (
-              Object.prototype.hasOwnProperty.call(incident[entryKey], 'value')
+              Object.prototype.hasOwnProperty.call(
+                incident[incidentProp],
+                'value'
+              )
             ) {
-              return incident[entryKey].value
+              return (incident[incidentProp] as ValueObject).value
             }
           } catch {
             // no-op
           }
 
-          return Boolean(incident[entryKey])
+          return Boolean(incident[incidentProp])
         }
       )
 
@@ -109,7 +146,6 @@ const IncidentPreview = ({ incident, preview, sectionLabels }) => (
                 </Heading>
               </Header>
             )}
-
             <Dl>
               {visibleEntries.map(([itemKey, itemValue]) => (
                 <Fragment key={itemKey}>
@@ -117,7 +153,7 @@ const IncidentPreview = ({ incident, preview, sectionLabels }) => (
                   <dd>
                     {itemValue.render({
                       ...itemValue,
-                      value: incident[itemKey],
+                      value: incident[itemKey as keyof Incident],
                       incident,
                     })}
                   </dd>
@@ -136,14 +172,5 @@ const IncidentPreview = ({ incident, preview, sectionLabels }) => (
     })}
   </Wrapper>
 )
-
-IncidentPreview.propTypes = {
-  incident: incidentType.isRequired,
-  preview: PropTypes.object,
-  sectionLabels: PropTypes.shape({
-    heading: PropTypes.object,
-    edit: PropTypes.object,
-  }),
-}
 
 export default IncidentPreview

--- a/src/signals/incident/components/IncidentPreview/IncidentPreview.tsx
+++ b/src/signals/incident/components/IncidentPreview/IncidentPreview.tsx
@@ -98,10 +98,10 @@ const IncidentPreview: FC<IncidentPreviewProps> = ({
   sectionLabels,
 }) => (
   <Wrapper data-testid="incidentPreview">
-    {Object.entries(preview).map(([section, value]) => {
-      const editLinkLabel = sectionLabels.edit[section as keyof Preview]
+    {Object.entries(preview).map(([sectionId, value]) => {
+      const editLinkLabel = sectionLabels.edit[sectionId as keyof Preview]
       const sectionHeadingLabel =
-        sectionLabels.heading[section as keyof Preview]
+        sectionLabels.heading[sectionId as keyof Preview]
 
       const visibleEntries = Object.entries(value).filter(
         ([entryKey, { optional, authenticated }]) => {
@@ -137,15 +137,16 @@ const IncidentPreview: FC<IncidentPreviewProps> = ({
       )
 
       return (
-        visibleEntries.length > 0 && (
-          <Section key={section}>
-            {sectionHeadingLabel && (
-              <Header>
-                <Heading as="h2" styleAs="h3">
-                  {sectionHeadingLabel}
-                </Heading>
-              </Header>
-            )}
+        <Section key={sectionId}>
+          {sectionHeadingLabel && (
+            <Header>
+              <Heading as="h2" styleAs="h3">
+                {sectionHeadingLabel}
+              </Heading>
+            </Header>
+          )}
+
+          {visibleEntries.length > 0 ? (
             <Dl>
               {visibleEntries.map(([itemKey, itemValue]) => (
                 <Fragment key={itemKey}>
@@ -160,14 +161,16 @@ const IncidentPreview: FC<IncidentPreviewProps> = ({
                 </Fragment>
               ))}
             </Dl>
+          ) : (
+            'U heeft geen gegevens ingevuld'
+          )}
 
-            <LinkContainer>
-              <AscLink as={Link} to={`/incident/${section}`} variant="inline">
-                {editLinkLabel}
-              </AscLink>
-            </LinkContainer>
-          </Section>
-        )
+          <LinkContainer>
+            <AscLink as={Link} to={`/incident/${sectionId}`} variant="inline">
+              {editLinkLabel}
+            </AscLink>
+          </LinkContainer>
+        </Section>
       )
     })}
   </Wrapper>

--- a/src/signals/incident/components/IncidentPreview/components/DateTime/__snapshots__/index.test.js.snap
+++ b/src/signals/incident/components/IncidentPreview/components/DateTime/__snapshots__/index.test.js.snap
@@ -1,7 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Preview component <DateTime /> should render earlier date correctly 1`] = `"Woensdag 21 februari, 6:06"`;
+exports[`Preview component <DateTime /> should render earlier date correctly 1`] = `
+<span>
+  Woensdag 21 februari, 6:06
+</span>
+`;
 
-exports[`Preview component <DateTime /> should render earlier today correctly 1`] = `"Vandaag, 13:45"`;
+exports[`Preview component <DateTime /> should render earlier today correctly 1`] = `
+<span>
+  Vandaag, 13:45
+</span>
+`;
 
-exports[`Preview component <DateTime /> should render now correctly 1`] = `"Nu"`;
+exports[`Preview component <DateTime /> should render now correctly 1`] = `
+<span>
+  Nu
+</span>
+`;

--- a/src/signals/incident/components/IncidentPreview/components/DateTime/index.js
+++ b/src/signals/incident/components/IncidentPreview/components/DateTime/index.js
@@ -27,7 +27,9 @@ const getValue = (value, incident) => {
   )}, ${time}`
 }
 
-const DateTime = ({ value, incident }) => getValue(value, incident)
+const DateTime = ({ value, incident }) => (
+  <span>{getValue(value, incident)}</span>
+)
 
 DateTime.propTypes = {
   value: PropTypes.shape({}),

--- a/src/signals/incident/components/IncidentPreview/components/ListObjectValue/index.js
+++ b/src/signals/incident/components/IncidentPreview/components/ListObjectValue/index.js
@@ -8,9 +8,10 @@ const StyledList = styled(List)`
   margin-bottom: 0;
 `
 
-const ListObjectValue = ({ value }) =>
-  Array.isArray(value) &&
-  value.length > 0 && (
+const ListObjectValue = ({ value }) => {
+  if (!(Array.isArray(value) && value.length > 0)) return null
+
+  return (
     <StyledList>
       {value
         .filter(({ label }) => Boolean(label))
@@ -19,6 +20,7 @@ const ListObjectValue = ({ value }) =>
         ))}
     </StyledList>
   )
+}
 
 ListObjectValue.propTypes = {
   value: PropTypes.arrayOf(

--- a/src/signals/incident/components/IncidentPreview/components/MapPreview/MapPreview.test.tsx
+++ b/src/signals/incident/components/IncidentPreview/components/MapPreview/MapPreview.test.tsx
@@ -97,7 +97,17 @@ describe('signals/incident/components/IncidentPreview/components/MapPreview', ()
 
   it('should render interactive map with useStaticMapServer disabled', () => {
     configuration.featureFlags.useStaticMapServer = false
-    render(withAppContext(<MapPreview {...props} />))
+    const noAddress = {
+      ...props,
+      incident: {
+        ...incident,
+        location: {
+          ...incident.location,
+          address: undefined,
+        },
+      },
+    }
+    render(withAppContext(<MapPreview {...noAddress} />))
 
     expect(screen.getByText('Locatie gepind op de kaart')).toBeInTheDocument()
     expect(screen.queryByTestId('mapStatic')).not.toBeInTheDocument()

--- a/src/signals/incident/components/IncidentPreview/index.ts
+++ b/src/signals/incident/components/IncidentPreview/index.ts
@@ -1,0 +1,1 @@
+export { default } from './IncidentPreview'

--- a/src/types/incident.ts
+++ b/src/types/incident.ts
@@ -2,20 +2,32 @@
 // Copyright (C) 2021 Vereniging van Nederlandse Gemeenten, Gemeente Amsterdam
 import type { LatLngLiteral, LatLngTuple } from 'leaflet'
 import type { Address } from './address'
+
+export type ValueObject = {
+  label: string
+  value: boolean
+}
+
 export interface Incident {
-  priority: Priority
-  classification: Classification
-  incident_time_hours: number
-  handling_message: string
-  location: Location
-  type: Priority
-  incident_time_minutes: number
-  incident_date: string
-  datetime: Datetime
-  email: string
-  description: string
   category: string
+  classification: Classification | null
+  datetime: Datetime
+  description: string
+  email: string
+  handling_message: string
+  images: string[]
+  images_previews: string[]
+  incident_date: string
+  incident_time_hours: number
+  incident_time_minutes: number
+  location: Location
+  phone?: string
+  priority: Priority
+  questions?: []
+  sharing_allowed?: ValueObject
+  source?: string
   subcategory: string
+  type: Priority
 }
 
 export interface Classification {
@@ -45,7 +57,7 @@ export interface Priority {
   label: string
 }
 
-export const mock = {
+export const mock: Incident = {
   priority: {
     id: 'normal',
     label: 'Normaal',
@@ -65,14 +77,17 @@ export const mock = {
   handling_message:
     'Wij bekijken uw melding en zorgen dat het juiste onderdeel van de gemeente deze gaat behandelen. Heeft u contactgegevens achtergelaten? Dan nemen wij bij onduidelijkheid contact met u op.',
   phone: '14 020',
-  locatie: {
-    type: 'not-on-map',
-  },
   images_previews: [],
   location: {
     coordinates: {
       lat: 52.38931218069618,
       lng: 4.933903676810628,
+    },
+    address: {
+      openbare_ruimte: "'s-Gravenhekje",
+      huisnummer: '9',
+      postcode: '1011TG',
+      woonplaats: 'Amsterdam',
     },
   },
   images: [],


### PR DESCRIPTION
This PR:
- converts the `IncidentPreview` component to TS
- adds a fallback message in said component when a section doesn't have entries to display