### PR TITLE
[SIG-4352] Close button position

### DIFF
--- a/src/components/GPSButton/GPSButton.tsx
+++ b/src/components/GPSButton/GPSButton.tsx
@@ -11,7 +11,7 @@ import { Button } from '@amsterdam/asc-ui'
 import GPS from '../../shared/images/icon-gps.svg'
 
 const StyledButton = styled(Button)`
-  border: 1px solid;
+  box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.1);
 `
 
 const GPSIcon = styled(GPS)`

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/Selector.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/Selector.tsx
@@ -25,6 +25,7 @@ import MAP_OPTIONS from 'shared/services/configuration/map-options'
 import { markerIcon } from 'shared/services/configuration/map-markers'
 import configuration from 'shared/services/configuration/configuration'
 import AssetSelectContext from 'signals/incident/components/form/MapSelectors/Asset/context'
+import MapCloseButton from 'components/MapCloseButton'
 
 import { UNREGISTERED_TYPE } from '../../constants'
 import { ZoomMessage } from '../../components/MapMessage'
@@ -34,7 +35,6 @@ import AssetLayer from './WfsLayer/AssetLayer'
 import WfsLayer from './WfsLayer'
 import SelectionPanel from './SelectionPanel'
 import {
-  CloseButton,
   StyledMap,
   StyledPDOKAutoSuggest,
   StyledViewerContainer,
@@ -173,7 +173,7 @@ const Selector = () => {
                 />
               ) : null
             }
-            topRight={<CloseButton onClick={close} />}
+            topRight={<MapCloseButton onClick={close} />}
           />
 
           <Panel data-testid={`panel${desktopView ? 'Desktop' : 'Mobile'}`}>

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/styled.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/styled.tsx
@@ -1,8 +1,7 @@
 import styled from 'styled-components'
-import { breakpoint, themeSpacing } from '@amsterdam/asc-ui'
+import { breakpoint } from '@amsterdam/asc-ui'
 
 import Map from 'components/Map'
-import MapCloseButton from 'components/MapCloseButton'
 import PDOKAutoSuggest from 'components/PDOKAutoSuggest'
 import ViewerContainer from 'components/ViewerContainer'
 
@@ -34,22 +33,11 @@ export const StyledPDOKAutoSuggest = styled(PDOKAutoSuggest)`
   z-index: 1;
 
   left: calc(44px + 8px);
-  //                  gps button width + left margin + right margin + margin to gps button - border width
-  width: calc(100vw - (44px + 16px + 16px + 8px - 2px));
-
-  @media screen and ${breakpoint('min-width', 'tabletS')} {
-    //                  gps button width + close button width + margin to gps button + left margin + right margin
-    width: calc(100vw - (44px + 44px + 8px + 16px + 16px + 8px));
-  }
+  //                  left page margin + gps button width + margin to gps button + margin to close button + close button width + right page margin
+  width: calc(100vw - (16px + 44px + 8px + 8px + 44px + 16px));
 
   @media screen and ${breakpoint('min-width', 'tabletM')} {
     width: 50vw;
     max-width: 375px;
-  }
-`
-
-export const CloseButton = styled(MapCloseButton)`
-  @media screen and ${breakpoint('max-width', 'tabletS')} {
-    margin-top: ${themeSpacing(11)};
   }
 `


### PR DESCRIPTION
This PR contains a change that will position the map close button to the top right of its parent viewercontainer component, effectively positioning the auto suggest field between the GPS button and the map close button.