### PR TITLE
[SIG 3889] Show isChecked status in Caterpillar layer

### DIFF
--- a/src/components/IconList/IconList.tsx
+++ b/src/components/IconList/IconList.tsx
@@ -41,19 +41,19 @@ export const IconListItem: FunctionComponent<IconListItemProps> = ({
     {iconUrl && (
       <StyledImg alt="" height={iconSize} src={iconUrl} width={iconSize} />
     )}
-    {isReported && (
-      <StatusIcon
-        alt=""
-        height={20}
-        src="/assets/images/icon-reported-marker.svg"
-        width={20}
-      />
-    )}
-    {!isReported && isChecked && (
+    {isChecked && (
       <StatusIcon
         alt=""
         height={20}
         src="/assets/images/icon-checked-marker.svg"
+        width={20}
+      />
+    )}
+    {!isChecked && isReported && (
+      <StatusIcon
+        alt=""
+        height={20}
+        src="/assets/images/icon-reported-marker.svg"
         width={20}
       />
     )}

--- a/src/signals/incident/components/form/MapSelectors/Asset/AssetList/AssetList.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/AssetList/AssetList.tsx
@@ -68,10 +68,10 @@ const AssetList: FunctionComponent<AssetListProps> = ({
   const checkedFeatureType = getCheckedFeatureType(featureTypes)
 
   let extendedId = `assetListItem-${id}`
-  if (isReported) {
-    extendedId = `assetListItem-${id}-reported`
-  } else if (isChecked) {
+  if (isChecked) {
     extendedId = `assetListItem-${id}-checked`
+  } else if (isReported) {
+    extendedId = `assetListItem-${id}-reported`
   }
 
   return (
@@ -86,14 +86,14 @@ const AssetList: FunctionComponent<AssetListProps> = ({
         <ItemWrapper>
           <StyledLabel>
             {label}
-            {reportedFeatureType && isReported && (
-              <StyledStatusDescription isReported>
-                {reportedFeatureType.description}
-              </StyledStatusDescription>
-            )}
-            {checkedFeatureType && !isReported && isChecked && (
+            {checkedFeatureType && isChecked && (
               <StyledStatusDescription>
                 {checkedFeatureType.description}
+              </StyledStatusDescription>
+            )}
+            {!isChecked && reportedFeatureType && isReported && (
+              <StyledStatusDescription isReported>
+                {reportedFeatureType.description}
               </StyledStatusDescription>
             )}
           </StyledLabel>

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/StatusLayer/StatusLayer.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/StatusLayer/StatusLayer.tsx
@@ -32,25 +32,23 @@ const StatusLayer: FC<StatusLayerProps> = ({
     const latLng = featureToCoordinates(feature?.geometry as Geometrie)
 
     const isReported = getIsReported(feature, reportedFeatureType)
+    const isChecked = getIsChecked(feature, checkedFeatureType)
 
     const icon = L.icon({
       iconSize: [20, 20],
-      iconUrl: isReported
-        ? '/assets/images/icon-reported-marker.svg'
-        : '/assets/images/icon-checked-marker.svg',
+      iconUrl: isChecked
+        ? '/assets/images/icon-checked-marker.svg'
+        : '/assets/images/icon-reported-marker.svg',
       className: STATUS_CLASS_MODIFIER,
     })
 
     const featureId = feature.properties[reportedFeatureType.idField] || index
 
     let altText = ''
-    if (isReported) {
-      altText = `${reportedFeatureType.description} - ${featureId}`
-    } else if (
-      getIsChecked(feature, checkedFeatureType) &&
-      checkedFeatureType
-    ) {
+    if (isChecked && checkedFeatureType) {
       altText = `${checkedFeatureType.description} - ${featureId}`
+    } else if (isReported) {
+      altText = `${reportedFeatureType.description} - ${featureId}`
     }
 
     return (

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/StatusLayer/utils.test.ts
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/StatusLayer/utils.test.ts
@@ -43,7 +43,7 @@ describe('utils', () => {
 
   describe('getIsChecked', () => {
     it('should return if the feature has been checked or not', () => {
-      const checkedFeature = caterpillarsJson.features[1]
+      const checkedFeature = caterpillarsJson.features[2]
       const uncheckedFeature = caterpillarsJson.features[0]
 
       expect(

--- a/src/signals/incident/components/form/MapSelectors/Caterpillar/CaterpillarLayer/CaterpillarLayer.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Caterpillar/CaterpillarLayer/CaterpillarLayer.test.tsx
@@ -51,27 +51,30 @@ describe('CaterpillarLayer', () => {
       screen.getByAltText('Eikenboom, is geselecteerd (308777)')
     ).toBeInTheDocument()
     expect(
-      screen.getByAltText('Eikenboom, is gemeld (308779)')
+      screen.getByAltText('Eikenboom is reeds gemeld (308778)')
+    ).toBeInTheDocument()
+    expect(
+      screen.getByAltText('Vrij van eikenprocessierups (308780)')
     ).toBeInTheDocument()
 
     expect(screen.getByTestId('map-test')).toBeInTheDocument()
   })
 
   it('should handle selecting a tree', async () => {
-    const featureId = 308779
+    const featureId = 308778
     const feature = caterpillarsJson.features.find(({ id }) => id === featureId)
     const coordinates = featureToCoordinates(feature?.geometry as Geometrie)
 
     const { rerender } = render(withMapCaterpillar())
 
-    const tree = screen.getByAltText(`Eikenboom, is gemeld (${featureId})`)
+    const tree = screen.getByAltText(`Eikenboom is reeds gemeld (${featureId})`)
 
     userEvent.click(tree)
 
     expect(setItem).toHaveBeenCalledWith({
       id: featureId,
       isReported: true,
-      isChecked: true,
+      isChecked: false,
       description: 'Eikenboom',
       type: 'Eikenboom',
       GlobalID: feature?.properties.GlobalID,
@@ -83,7 +86,7 @@ describe('CaterpillarLayer', () => {
 
     expect(
       screen.queryByAltText(
-        `Eikenboom, is gemeld, is geselecteerd (${featureId})`
+        `Eikenboom is reeds gemeld, is geselecteerd (${featureId})`
       )
     ).not.toBeInTheDocument()
 
@@ -95,7 +98,7 @@ describe('CaterpillarLayer', () => {
 
     expect(
       screen.getByAltText(
-        `Eikenboom, is gemeld, is geselecteerd (${featureId})`
+        `Eikenboom is reeds gemeld, is geselecteerd (${featureId})`
       )
     ).toBeInTheDocument()
   })
@@ -111,7 +114,7 @@ describe('CaterpillarLayer', () => {
     )
 
     const tree = screen.getByAltText(
-      `Eikenboom, is gemeld, is geselecteerd (${308778})`
+      `Eikenboom is reeds gemeld, is geselecteerd (${308778})`
     )
 
     userEvent.click(tree)

--- a/src/signals/incident/components/form/MapSelectors/Caterpillar/CaterpillarLayer/CaterpillarLayer.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Caterpillar/CaterpillarLayer/CaterpillarLayer.tsx
@@ -46,11 +46,16 @@ export const CaterpillarLayer: FC = () => {
       const isReported = getIsReported(feature, reportedFeatureType)
       const isChecked = getIsChecked(feature, checkedFeatureType)
 
-      const altText = `${featureType.description}${
-        isReported ? ', is gemeld' : ''
-      }${!isReported && isChecked ? ', is opgelost' : ''}${
-        isSelected ? ', is geselecteerd' : ''
-      } (${featureId})`
+      let { description } = featureType
+      if (isChecked && checkedFeatureType) {
+        description = checkedFeatureType.description
+      } else if (isReported) {
+        description = reportedFeatureType.description
+      }
+
+      const altText = isSelected
+        ? `${description}, is geselecteerd (${featureId})`
+        : `${description} (${featureId})`
 
       const icon = L.icon({
         iconSize: [40, 40],

--- a/src/utils/__tests__/fixtures/caterpillars.json
+++ b/src/utils/__tests__/fixtures/caterpillars.json
@@ -28,7 +28,7 @@
         "OBJECTID": 308778,
         "GlobalID": "218b8c15-ef75-4851-9616-125132af7438",
         "BoomID": "584073",
-        "Registratie": "Geen EPR",
+        "Registratie": "",
         "PrioriteitRegistratie": null,
         "AMS_Meldingstatus": 1
       }


### PR DESCRIPTION
It was the case that if a tree was reported and was checked, the reported icon should be visible.
Now the checked icon has precedence, so if a tree is both reported and checked, the checked icon is shown.