### PR TITLE
(chore) Remove location watch

### DIFF
--- a/src/components/GPSButton/GPSButton.test.tsx
+++ b/src/components/GPSButton/GPSButton.test.tsx
@@ -3,12 +3,18 @@
 import { render, act, fireEvent, waitFor } from '@testing-library/react'
 import { withAppContext } from 'test/utils'
 
-import GPSButton from '..'
+import GPSButton from './GPSButton'
 
 describe('components/GPSButton', () => {
   it('should render button with icon', () => {
     const { container, getByTestId } = render(
-      withAppContext(<GPSButton onLocationSuccess={() => {}} />)
+      withAppContext(
+        <GPSButton
+          onLocationSuccess={() => {}}
+          onLocationError={() => {}}
+          onLocationOutOfBounds={() => {}}
+        />
+      )
     )
 
     const button = getByTestId('gpsButton')
@@ -39,7 +45,13 @@ describe('components/GPSButton', () => {
     const onLocationSuccess = jest.fn()
 
     const { getByTestId, queryByTestId } = render(
-      withAppContext(<GPSButton onLocationSuccess={onLocationSuccess} />)
+      withAppContext(
+        <GPSButton
+          onLocationSuccess={onLocationSuccess}
+          onLocationError={() => {}}
+          onLocationOutOfBounds={() => {}}
+        />
+      )
     )
 
     expect(getCurrentPosition).not.toHaveBeenCalled()
@@ -87,7 +99,13 @@ describe('components/GPSButton', () => {
     const onLocationSuccess = jest.fn()
 
     const { getByTestId } = render(
-      withAppContext(<GPSButton onLocationSuccess={onLocationSuccess} />)
+      withAppContext(
+        <GPSButton
+          onLocationSuccess={onLocationSuccess}
+          onLocationError={() => {}}
+          onLocationOutOfBounds={() => {}}
+        />
+      )
     )
 
     expect(onLocationSuccess).not.toHaveBeenCalled()
@@ -136,6 +154,7 @@ describe('components/GPSButton', () => {
         <GPSButton
           onLocationSuccess={onLocationSuccess}
           onLocationError={onLocationError}
+          onLocationOutOfBounds={() => {}}
         />
       )
     )
@@ -176,7 +195,13 @@ describe('components/GPSButton', () => {
     const onLocationSuccess = jest.fn()
 
     const { getByTestId, rerender, unmount } = render(
-      withAppContext(<GPSButton onLocationSuccess={onLocationSuccess} />)
+      withAppContext(
+        <GPSButton
+          onLocationSuccess={onLocationSuccess}
+          onLocationError={() => {}}
+          onLocationOutOfBounds={() => {}}
+        />
+      )
     )
 
     expect(onLocationOutOfBounds).not.toHaveBeenCalled()
@@ -194,6 +219,7 @@ describe('components/GPSButton', () => {
         <GPSButton
           onLocationSuccess={onLocationSuccess}
           onLocationOutOfBounds={onLocationOutOfBounds}
+          onLocationError={() => {}}
         />
       )
     )

--- a/src/components/GPSButton/GPSButton.test.tsx
+++ b/src/components/GPSButton/GPSButton.test.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2020 - 2021 Gemeente Amsterdam
-import { render, act, fireEvent, waitFor } from '@testing-library/react'
+import { render, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { withAppContext } from 'test/utils'
 
 import GPSButton from './GPSButton'
@@ -56,17 +57,13 @@ describe('components/GPSButton', () => {
 
     expect(getCurrentPosition).not.toHaveBeenCalled()
 
-    act(() => {
-      fireEvent.click(getByTestId('gpsButton'))
-    })
+    userEvent.click(getByTestId('gpsButton'))
 
     expect(getByTestId('loadingIndicator')).toBeInTheDocument()
 
     expect(getCurrentPosition).toHaveBeenCalledTimes(1)
 
-    act(() => {
-      fireEvent.click(getByTestId('gpsButton'))
-    })
+    userEvent.click(getByTestId('gpsButton'))
 
     expect(getCurrentPosition).toHaveBeenCalledTimes(1)
 
@@ -110,18 +107,14 @@ describe('components/GPSButton', () => {
 
     expect(onLocationSuccess).not.toHaveBeenCalled()
 
-    act(() => {
-      fireEvent.click(getByTestId('gpsButton'))
-    })
+    userEvent.click(getByTestId('gpsButton'))
 
     expect(onLocationSuccess).toHaveBeenCalledWith({
       ...coords,
       toggled: true,
     })
 
-    act(() => {
-      fireEvent.click(getByTestId('gpsButton'))
-    })
+    userEvent.click(getByTestId('gpsButton'))
 
     expect(onLocationSuccess).toHaveBeenLastCalledWith({
       toggled: false,
@@ -161,9 +154,7 @@ describe('components/GPSButton', () => {
 
     expect(onLocationError).not.toHaveBeenCalled()
 
-    act(() => {
-      fireEvent.click(getByTestId('gpsButton'))
-    })
+    userEvent.click(getByTestId('gpsButton'))
 
     expect(onLocationError).toHaveBeenCalledWith({
       code,
@@ -206,9 +197,7 @@ describe('components/GPSButton', () => {
 
     expect(onLocationOutOfBounds).not.toHaveBeenCalled()
 
-    act(() => {
-      fireEvent.click(getByTestId('gpsButton'))
-    })
+    userEvent.click(getByTestId('gpsButton'))
 
     expect(onLocationOutOfBounds).not.toHaveBeenCalled()
 
@@ -226,9 +215,7 @@ describe('components/GPSButton', () => {
 
     expect(onLocationOutOfBounds).not.toHaveBeenCalled()
 
-    act(() => {
-      fireEvent.click(getByTestId('gpsButton'))
-    })
+    userEvent.click(getByTestId('gpsButton'))
 
     expect(onLocationOutOfBounds).toHaveBeenCalled()
   })

--- a/src/components/GPSButton/GPSButton.tsx
+++ b/src/components/GPSButton/GPSButton.tsx
@@ -27,9 +27,9 @@ export interface LocationResult
 
 export interface GPSButtonProps {
   className?: string
-  onLocationSuccess?: (result: LocationResult) => void
-  onLocationError?: (error: GeolocationPositionError) => void
-  onLocationOutOfBounds?: () => void
+  onLocationSuccess: (result: LocationResult) => void
+  onLocationError: (error: GeolocationPositionError) => void
+  onLocationOutOfBounds: () => void
 }
 
 const GPSButton: FunctionComponent<GPSButtonProps> = ({
@@ -46,7 +46,7 @@ const GPSButton: FunctionComponent<GPSButtonProps> = ({
       const { accuracy, latitude, longitude } = coords
 
       if (pointWithinBounds([latitude, longitude])) {
-        onLocationSuccess?.({
+        onLocationSuccess({
           accuracy,
           latitude,
           longitude,
@@ -54,10 +54,7 @@ const GPSButton: FunctionComponent<GPSButtonProps> = ({
         })
         setToggled(!toggled)
       } else {
-        if (typeof onLocationOutOfBounds === 'function') {
-          onLocationOutOfBounds()
-        }
-
+        onLocationOutOfBounds()
         setToggled(false)
       }
 
@@ -68,7 +65,7 @@ const GPSButton: FunctionComponent<GPSButtonProps> = ({
 
   const onError: PositionErrorCallback = useCallback(
     (error) => {
-      onLocationError?.(error)
+      onLocationError(error)
       setToggled(false)
       setLoading(false)
     },
@@ -82,7 +79,7 @@ const GPSButton: FunctionComponent<GPSButtonProps> = ({
       if (loading) return
 
       if (toggled) {
-        onLocationSuccess?.({ toggled: false })
+        onLocationSuccess({ toggled: false })
         setToggled(false)
         return
       }

--- a/src/components/GPSButton/GPSButton.tsx
+++ b/src/components/GPSButton/GPSButton.tsx
@@ -27,7 +27,6 @@ export interface LocationResult
 
 export interface GPSButtonProps {
   className?: string
-  onLocationChange?: (result: LocationResult) => void
   onLocationSuccess?: (result: LocationResult) => void
   onLocationError?: (error: GeolocationPositionError) => void
   onLocationOutOfBounds?: () => void
@@ -35,21 +34,12 @@ export interface GPSButtonProps {
 
 const GPSButton: FunctionComponent<GPSButtonProps> = ({
   className,
-  onLocationChange,
   onLocationSuccess,
   onLocationError,
   onLocationOutOfBounds,
 }) => {
   const [loading, setLoading] = useState(false)
   const [toggled, setToggled] = useState(false)
-  const shouldWatch = typeof onLocationChange === 'function'
-  const successCallbackFunc = shouldWatch ? onLocationChange : onLocationSuccess
-
-  if (!shouldWatch && typeof onLocationSuccess !== 'function') {
-    throw new Error(
-      'Either one of onLocationChange or onLocationSuccess is required'
-    )
-  }
 
   const onClick = useCallback(
     (event) => {
@@ -58,7 +48,7 @@ const GPSButton: FunctionComponent<GPSButtonProps> = ({
       if (loading) return
 
       if (toggled) {
-        successCallbackFunc?.({ toggled: false })
+        onLocationSuccess?.({ toggled: false })
         setToggled(false)
         return
       }
@@ -67,7 +57,7 @@ const GPSButton: FunctionComponent<GPSButtonProps> = ({
         const { accuracy, latitude, longitude } = coords
 
         if (pointWithinBounds([latitude, longitude])) {
-          successCallbackFunc?.({
+          onLocationSuccess?.({
             accuracy,
             latitude,
             longitude,
@@ -93,17 +83,12 @@ const GPSButton: FunctionComponent<GPSButtonProps> = ({
 
       setLoading(true)
 
-      if (shouldWatch) {
-        global.navigator.geolocation.watchPosition(onSuccess, onError)
-      } else {
-        global.navigator.geolocation.getCurrentPosition(onSuccess, onError)
-      }
+      global.navigator.geolocation.getCurrentPosition(onSuccess, onError)
     },
     [
       onLocationError,
       onLocationOutOfBounds,
-      successCallbackFunc,
-      shouldWatch,
+      onLocationSuccess,
       toggled,
       loading,
     ]

--- a/src/components/GPSButton/__tests__/GPSButton.test.tsx
+++ b/src/components/GPSButton/__tests__/GPSButton.test.tsx
@@ -110,52 +110,6 @@ describe('components/GPSButton', () => {
     })
   })
 
-  it('should call onLocationChange', () => {
-    const coords = {
-      accuracy: 1234,
-      latitude: 52.3731081,
-      longitude: 4.8932945,
-    }
-    const mockGeolocation = {
-      watchPosition: jest.fn().mockImplementation((success) =>
-        Promise.resolve(
-          success({
-            coords,
-          })
-        )
-      ),
-    }
-
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    global.navigator.geolocation = mockGeolocation
-
-    const onLocationChange = jest.fn()
-
-    const { getByTestId } = render(
-      withAppContext(<GPSButton onLocationChange={onLocationChange} />)
-    )
-
-    expect(onLocationChange).not.toHaveBeenCalled()
-
-    act(() => {
-      fireEvent.click(getByTestId('gpsButton'))
-    })
-
-    expect(onLocationChange).toHaveBeenCalledWith({
-      ...coords,
-      toggled: true,
-    })
-
-    act(() => {
-      fireEvent.click(getByTestId('gpsButton'))
-    })
-
-    expect(onLocationChange).toHaveBeenLastCalledWith({
-      toggled: false,
-    })
-  })
-
   it('should call onLocationError', () => {
     const code = 1
     const message = 'User denied geolocation'
@@ -251,21 +205,5 @@ describe('components/GPSButton', () => {
     })
 
     expect(onLocationOutOfBounds).toHaveBeenCalled()
-  })
-
-  it('should throw an error', () => {
-    const logErrorMock = jest
-      .spyOn(global.console, 'error')
-      .mockImplementation(jest.fn())
-
-    expect(() => {
-      render(withAppContext(<GPSButton />))
-    }).toThrow()
-
-    expect(() => {
-      render(withAppContext(<GPSButton onLocationChange={() => {}} />))
-    }).not.toThrow()
-
-    logErrorMock.mockRestore()
   })
 })


### PR DESCRIPTION
The change in this PR removes the watch functionality from the `GPSButton` component; hasn't been used since the introduction of the component and likely never will be. Also, `clearWatch` wasn't implemented.