### PR TITLE
[SIG 4347] Consistent texts and fix spelling error

### DIFF
--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/SelectionPanel/SelectionPanel.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/SelectionPanel/SelectionPanel.tsx
@@ -30,10 +30,6 @@ const StyledButton = styled(Button)`
   margin-top: ${themeSpacing(6)};
 `
 
-const StyledParagraph = styled(Paragraph)`
-  margin-top: ${themeSpacing(6)};
-`
-
 const StyledMapPanelContent = styled(MapPanelContent)`
   background: none;
 `
@@ -109,9 +105,10 @@ const SelectionPanel: FC<SelectionPanelProps> = ({
     >
       <Paragraph strong>
         {language.subTitle || 'U kunt maar een object kiezen'}
-        {language.description ? (
-          <Description>{language.description}</Description>
-        ) : null}
+        <Description>
+          {language.description ||
+            'Typ het dichtstbijzijnde adres of klik de locatie aan op de kaart'}
+        </Description>
       </Paragraph>
 
       {selection && selectionOnMap && (
@@ -136,10 +133,6 @@ const SelectionPanel: FC<SelectionPanelProps> = ({
 
           {showObjectIdInput && language.unregisteredId && (
             <>
-              <StyledParagraph>
-                Typ het dichtstbijzijnde adres of klik de locatie aan op de
-                kaart.
-              </StyledParagraph>
               <Label
                 htmlFor="unregisteredAssetInput"
                 label={

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/__snapshots__/locatie.test.ts.snap
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/__snapshots__/locatie.test.ts.snap
@@ -6,7 +6,7 @@ Object {
     "featureTypes": Array [],
     "label": "Waar is het?",
     "language": Object {
-      "description": "Typ het dichtsbijzijnde adres of klik de locatie aan op de kaart",
+      "description": "Typ het dichtstbijzijnde adres of klik de locatie aan op de kaart",
       "subTitle": "Waar is het?",
       "submit": "Gebruik deze locatie",
       "title": "Locatie",

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/afval-container.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/afval-container.ts
@@ -37,7 +37,7 @@ export const controls = {
         objectTypePlural: 'containers',
         submit: 'Gebruik deze locatie',
         description:
-          'Typ het dichtsbijzijnde adres of klik de locatie aan op de kaart',
+          'Typ het dichtstbijzijnde adres of klik de locatie aan op de kaart',
       },
       label: 'Kies de container waar het om gaat',
       shortLabel: 'Container(s)',

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/locatie.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/locatie.ts
@@ -8,7 +8,7 @@ const locatie = {
       title: 'Locatie',
       subTitle: 'Waar is het?',
       description:
-        'Typ het dichtsbijzijnde adres of klik de locatie aan op de kaart',
+        'Typ het dichtstbijzijnde adres of klik de locatie aan op de kaart',
       submit: 'Gebruik deze locatie',
     },
     shortLabel: 'Waar is het?',


### PR DESCRIPTION
Each object map should have the sentence “Typ het dichtstbijzijnde adres of klik de locatie aan op de kaart” below "kies een container op de kaart".
The same text below the checkbox should be removed.