### PR TITLE
[SIG-4274] Object on map label

### DIFF
--- a/src/signals/incident/components/form/MapSelectors/Asset/AssetSelect.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/AssetSelect.test.tsx
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2020 - 2021 Gemeente Amsterdam
+import type { ChangeEvent } from 'react'
 import { useContext as mockUseContext } from 'react'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
@@ -33,8 +34,14 @@ const mockItem = {
 jest.mock('shared/services/reverse-geocoder')
 
 jest.mock('./Selector', () => () => {
-  const { fetchLocation, close, removeItem, setItem, setLocation } =
-    mockUseContext(mockAssetSelectContext)
+  const {
+    fetchLocation,
+    close,
+    removeItem,
+    setItem,
+    setLocation,
+    setNotOnMap,
+  } = mockUseContext(mockAssetSelectContext)
 
   const item: Item = {
     ...mockItem,
@@ -101,6 +108,13 @@ jest.mock('./Selector', () => () => {
         onClick={() => setLocation(location)}
         role="button"
         tabIndex={0}
+      />
+      <input
+        type="checkbox"
+        data-testid="setNotOnMapCheckbox"
+        onChange={(event: ChangeEvent<HTMLInputElement>) => {
+          setNotOnMap(event.target.checked)
+        }}
       />
     </>
   )
@@ -182,7 +196,7 @@ describe('AssetSelect', () => {
     expect(screen.queryByTestId('assetSelectSelector')).not.toBeInTheDocument()
   })
 
-  it('should render the Summary', () => {
+  it('renders the Summary when an object has been selected', () => {
     render(
       withAppContext(
         <AssetSelect
@@ -197,6 +211,29 @@ describe('AssetSelect', () => {
                 iconUrl: '',
                 label: 'foo bar',
               },
+            }),
+          }}
+        />
+      )
+    )
+
+    expect(screen.queryByTestId('assetSelectSelector')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('assetSelectSummary')).toBeInTheDocument()
+  })
+
+  it('renders the Summary when a location has been pinned', () => {
+    jest
+      .spyOn(reactRedux, 'useSelector')
+      .mockImplementationOnce(() => mockLatLng)
+      .mockImplementationOnce(() => mockAddress)
+
+    render(
+      withAppContext(
+        <AssetSelect
+          {...{
+            ...props,
+            handler: () => ({
+              value: undefined,
             }),
           }}
         />
@@ -450,6 +487,57 @@ describe('AssetSelect', () => {
 
     expect(updateIncident).toHaveBeenCalledTimes(1)
     expect(updateIncident).toHaveBeenCalledWith({
+      location: {
+        coordinates: mockLatLng,
+        address: mockAddress,
+      },
+      Zork: {
+        type: mockUNREGISTERED_TYPE,
+      },
+    })
+  })
+
+  it('handles the indication that an object is not visible on the map', () => {
+    const { rerender } = render(
+      withAssetSelectContext(<AssetSelect {...props} />)
+    )
+
+    userEvent.click(screen.getByText(/kies op kaart/i))
+
+    const setNotOnMapCheckbox = screen.getByTestId('setNotOnMapCheckbox')
+    expect(setNotOnMapCheckbox).not.toBeChecked()
+
+    expect(updateIncident).not.toHaveBeenCalled()
+
+    userEvent.click(setNotOnMapCheckbox)
+    expect(setNotOnMapCheckbox).toBeChecked()
+
+    expect(updateIncident).toHaveBeenCalledWith({
+      Zork: {
+        type: mockUNREGISTERED_TYPE,
+      },
+    })
+
+    userEvent.click(setNotOnMapCheckbox)
+    expect(setNotOnMapCheckbox).not.toBeChecked()
+
+    expect(updateIncident).toHaveBeenCalledTimes(2)
+    expect(updateIncident).toHaveBeenLastCalledWith({
+      Zork: undefined,
+    })
+
+    jest
+      .spyOn(reactRedux, 'useSelector')
+      .mockImplementationOnce(() => mockLatLng)
+      .mockImplementationOnce(() => mockAddress)
+
+    rerender(withAssetSelectContext(<AssetSelect {...props} />))
+
+    userEvent.click(setNotOnMapCheckbox)
+    expect(setNotOnMapCheckbox).toBeChecked()
+
+    expect(updateIncident).toHaveBeenCalledTimes(3)
+    expect(updateIncident).toHaveBeenLastCalledWith({
       location: {
         coordinates: mockLatLng,
         address: mockAddress,

--- a/src/signals/incident/components/form/MapSelectors/Asset/AssetSelect.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/AssetSelect.test.tsx
@@ -260,9 +260,7 @@ describe('AssetSelect', () => {
     userEvent.click(assetSelectSelector)
 
     const payload = {
-      [props.meta.name as string]: {
-        type: mockUNREGISTERED_TYPE,
-      },
+      [props.meta.name as string]: undefined,
       location: {
         coordinates: mockLatLng,
       },
@@ -303,10 +301,8 @@ describe('AssetSelect', () => {
     await screen.findByTestId('assetSelectSelector')
 
     expect(updateIncident).toHaveBeenCalledWith({
-      [props.meta.name as string]: {
-        type: mockUNREGISTERED_TYPE,
-      },
-      location: { coordinates: mockLatLng },
+      [props.meta.name as string]: undefined,
+      location: { coordinates: mockLatLng, address: undefined },
     })
   })
 
@@ -335,7 +331,7 @@ describe('AssetSelect', () => {
     )
 
     // open map
-    userEvent.click(screen.getByText(/kies op kaart/i))
+    userEvent.click(screen.getByTestId('mapEditButton'))
 
     // select item
     userEvent.click(screen.getByTestId('setItemContainer'))
@@ -374,9 +370,7 @@ describe('AssetSelect', () => {
 
     expect(updateIncident).toHaveBeenCalledTimes(3)
     expect(updateIncident).toHaveBeenLastCalledWith({
-      [props.meta.name as string]: {
-        type: mockUNREGISTERED_TYPE,
-      },
+      [props.meta.name as string]: undefined,
       location: {
         address: mockAddress,
         coordinates: mockLatLng,
@@ -394,7 +388,7 @@ describe('AssetSelect', () => {
 
     render(withAssetSelectContext(<AssetSelect {...props} />))
 
-    userEvent.click(screen.getByText(/kies op kaart/i))
+    userEvent.click(screen.getByTestId('mapEditButton'))
 
     const setItemContainer = screen.getByTestId('setItemContainer')
 
@@ -425,7 +419,7 @@ describe('AssetSelect', () => {
 
     render(withAssetSelectContext(<AssetSelect {...props} />))
 
-    userEvent.click(screen.getByText(/kies op kaart/i))
+    userEvent.click(screen.getByTestId('mapEditButton'))
 
     const setItemContainerUnregistered = screen.getByTestId(
       'setItemContainerUnregistered'
@@ -459,7 +453,7 @@ describe('AssetSelect', () => {
 
     render(withAssetSelectContext(<AssetSelect {...props} />))
 
-    userEvent.click(screen.getByText(/kies op kaart/i))
+    userEvent.click(screen.getByTestId('mapEditButton'))
 
     const removeItemContainer = screen.getByTestId('removeItemContainer')
 
@@ -491,9 +485,7 @@ describe('AssetSelect', () => {
         coordinates: mockLatLng,
         address: mockAddress,
       },
-      Zork: {
-        type: mockUNREGISTERED_TYPE,
-      },
+      Zork: undefined,
     })
   })
 

--- a/src/signals/incident/components/form/MapSelectors/Asset/AssetSelect.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/AssetSelect.tsx
@@ -60,7 +60,34 @@ const AssetSelect: FC<AssetSelectProps> = ({
   const [featureTypes, setFeatureTypes] = useState<FeatureType[]>([])
   const coordinates = useSelector(makeSelectCoordinates)
   const address = useSelector(makeSelectAddress)
+  const hasSelection = selection || (address && coordinates)
 
+  /**
+   * Indicate that an object is not visible on the map
+   */
+  const setNotOnMap = useCallback(
+    (itemNotPresentOnMap?: boolean) => {
+      const payload: Record<string, any> = {}
+
+      if (address && coordinates) {
+        payload.location = {
+          coordinates,
+          address,
+        }
+      }
+
+      payload[meta.name as string] = itemNotPresentOnMap
+        ? { type: UNREGISTERED_TYPE }
+        : undefined
+
+      parent.meta.updateIncident(payload)
+    },
+    [address, coordinates, meta.name, parent.meta]
+  )
+
+  /**
+   * Selecting an object on the map
+   */
   const setItem = useCallback(
     (item: Item) => {
       const { location, ...restItem } = item
@@ -130,6 +157,9 @@ const AssetSelect: FC<AssetSelectProps> = ({
     [address, getUpdatePayload, parent.meta]
   )
 
+  /**
+   * Address auto complete selection
+   */
   const setLocation = useCallback(
     (location: Location) => {
       const payload = getUpdatePayload(location)
@@ -195,13 +225,14 @@ const AssetSelect: FC<AssetSelectProps> = ({
         setItem,
         fetchLocation,
         setMessage,
+        setNotOnMap,
       }}
     >
-      {!showMap && !selection && <Intro />}
+      {!showMap && !hasSelection && <Intro />}
 
       {showMap && <Selector />}
 
-      {!showMap && selection && <Summary />}
+      {!showMap && hasSelection && <Summary />}
     </AssetSelectProvider>
   )
 }

--- a/src/signals/incident/components/form/MapSelectors/Asset/AssetSelect.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/AssetSelect.tsx
@@ -60,7 +60,7 @@ const AssetSelect: FC<AssetSelectProps> = ({
   const [featureTypes, setFeatureTypes] = useState<FeatureType[]>([])
   const coordinates = useSelector(makeSelectCoordinates)
   const address = useSelector(makeSelectAddress)
-  const hasSelection = selection || (address && coordinates)
+  const hasSelection = selection || coordinates
 
   /**
    * Indicate that an object is not visible on the map
@@ -69,7 +69,7 @@ const AssetSelect: FC<AssetSelectProps> = ({
     (itemNotPresentOnMap?: boolean) => {
       const payload: Record<string, any> = {}
 
-      if (address && coordinates) {
+      if (coordinates) {
         payload.location = {
           coordinates,
           address,
@@ -118,9 +118,8 @@ const AssetSelect: FC<AssetSelectProps> = ({
       const payload: Record<string, any> = {}
 
       // Clicking the map should unset a previous selection and preset it with an item that we know
-      // doesn't exist on the map. By setting UNREGISTERED_TYPE, the checkbox in the selection panel
-      // will be checked whenever a click on the map is registered
-      payload[meta.name as string] = { type: UNREGISTERED_TYPE }
+      // doesn't exist on the map.
+      payload[meta.name as string] = undefined
 
       payload.location = location
 
@@ -148,11 +147,9 @@ const AssetSelect: FC<AssetSelectProps> = ({
 
       const response = await reverseGeocoderService(latLng)
 
-      if (response) {
-        payload.location.address = response.data.address
+      payload.location.address = response?.data?.address
 
-        parent.meta.updateIncident(payload)
-      }
+      parent.meta.updateIncident(payload)
     },
     [address, getUpdatePayload, parent.meta]
   )

--- a/src/signals/incident/components/form/MapSelectors/Asset/Intro/Intro.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Intro/Intro.test.tsx
@@ -7,19 +7,14 @@ import { AssetSelectProvider } from 'signals/incident/components/form/MapSelecto
 import type { AssetSelectValue } from '../types'
 import type { Meta } from '../../types'
 
+import { contextValue as assetSelectContextValue } from '../__tests__/withAssetSelectContext'
 import Intro from '../Intro'
 
 const contextValue: AssetSelectValue = {
+  ...assetSelectContextValue,
   selection: undefined,
   meta: {} as Meta,
   coordinates: { lat: 0, lng: 0 },
-  setItem: jest.fn(),
-  removeItem: jest.fn(),
-  edit: jest.fn(),
-  close: jest.fn(),
-  setMessage: jest.fn(),
-  fetchLocation: jest.fn(),
-  setLocation: jest.fn(),
 }
 
 export const withContext = (Component: JSX.Element, context = contextValue) =>

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/SelectionPanel/SelectionPanel.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/SelectionPanel/SelectionPanel.tsx
@@ -56,7 +56,7 @@ const SelectionPanel: FC<SelectionPanelProps> = ({
   featureTypes,
   language = {},
 }) => {
-  const { selection, removeItem, setItem, close } =
+  const { selection, removeItem, setItem, close, setNotOnMap } =
     useContext(AssetSelectContext)
 
   const selectionOnMap =
@@ -78,7 +78,8 @@ const SelectionPanel: FC<SelectionPanelProps> = ({
 
   const onCheck = useCallback(() => {
     setShowObjectIdInput(!showObjectIdInput)
-  }, [showObjectIdInput])
+    setNotOnMap(!showObjectIdInput)
+  }, [setNotOnMap, showObjectIdInput])
 
   const onSetItem = useCallback(() => {
     setItem({

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/WfsLayer.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/WfsLayer.test.tsx
@@ -18,6 +18,7 @@ import type { DataLayerProps } from '../../../types'
 import WfsLayer from '../WfsLayer'
 import * as useLayerVisible from '../../../hooks/useLayerVisible'
 import { AssetSelectProvider } from '../../context'
+import { contextValue as assetSelectContextValue } from '../../__tests__/withAssetSelectContext'
 
 import WfsDataContext, { NO_DATA } from './context'
 import { SRS_NAME } from './WfsLayer'
@@ -41,19 +42,13 @@ const consoleErrorSpy = jest.spyOn(global.console, 'error')
 const endpoint = 'https://endpoint/?version=2'
 const promise = Promise.resolve()
 const assetSelectProviderValue: AssetSelectValue = {
+  ...assetSelectContextValue,
   selection: undefined,
   coordinates: { lat: 0, lng: 0 },
   meta: {
     endpoint,
     featureTypes: [],
   },
-  setItem: jest.fn(() => promise),
-  removeItem: jest.fn(),
-  edit: jest.fn(),
-  close: jest.fn(),
-  setMessage: jest.fn(),
-  fetchLocation: jest.fn(),
-  setLocation: jest.fn(),
 }
 
 describe('src/signals/incident/components/form/AssetSelect/WfsLayer', () => {
@@ -150,6 +145,7 @@ describe('src/signals/incident/components/form/AssetSelect/WfsLayer', () => {
     const endpoint = 'https://endpoint/?version=2'
     const promise = Promise.resolve()
     const assetSelectProviderValue: AssetSelectValue = {
+      ...assetSelectContextValue,
       selection: undefined,
       coordinates: { lat: 0, lng: 0 },
       meta: {
@@ -157,12 +153,6 @@ describe('src/signals/incident/components/form/AssetSelect/WfsLayer', () => {
         featureTypes: [],
       },
       setItem: jest.fn(() => promise),
-      removeItem: jest.fn(),
-      edit: jest.fn(),
-      close: jest.fn(),
-      setMessage: jest.fn(),
-      fetchLocation: jest.fn(),
-      setLocation: jest.fn(),
     }
 
     render(
@@ -189,6 +179,7 @@ describe('src/signals/incident/components/form/AssetSelect/WfsLayer', () => {
     const expectedEndpoint = `https://endpoint/?version=2&srsName=${SRS_NAME}&bbox=52.37309163108818,4.879893974954347,52.37309163108818,4.879893974954347`
     const promise = Promise.resolve()
     const assetSelectProviderValue: AssetSelectValue = {
+      ...assetSelectContextValue,
       selection: undefined,
       coordinates: { lat: 0, lng: 0 },
       meta: {
@@ -196,12 +187,6 @@ describe('src/signals/incident/components/form/AssetSelect/WfsLayer', () => {
         featureTypes: [],
       },
       setItem: jest.fn(() => promise),
-      removeItem: jest.fn(),
-      edit: jest.fn(),
-      close: jest.fn(),
-      setMessage: jest.fn(),
-      fetchLocation: jest.fn(),
-      setLocation: jest.fn(),
     }
 
     render(
@@ -226,6 +211,7 @@ describe('src/signals/incident/components/form/AssetSelect/WfsLayer', () => {
     const wfsFilter =
       '<PropertyIsEqualTo><PropertyName>geometrie</PropertyName><gml:Envelope srsName="{srsName}"><lowerCorner>{west} {south}</lowerCorner><upperCorner>{east} {north}</upperCorner></gml:Envelope>'
     const assetSelectProviderValue: AssetSelectValue = {
+      ...assetSelectContextValue,
       selection: undefined,
       coordinates: { lat: 0, lng: 0 },
       meta: {
@@ -234,12 +220,6 @@ describe('src/signals/incident/components/form/AssetSelect/WfsLayer', () => {
         featureTypes: [],
       },
       setItem: jest.fn(() => promise),
-      removeItem: jest.fn(),
-      edit: jest.fn(),
-      close: jest.fn(),
-      setMessage: jest.fn(),
-      fetchLocation: jest.fn(),
-      setLocation: jest.fn(),
     }
 
     const urlWithFilter =

--- a/src/signals/incident/components/form/MapSelectors/Asset/Summary/Summary.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Summary/Summary.test.tsx
@@ -13,6 +13,8 @@ import { withAppContext } from 'test/utils'
 import type { MapStaticProps } from 'components/MapStatic/MapStatic'
 import type { AssetSelectValue } from '../types'
 
+import { contextValue as assetSelectContextValue } from '../__tests__/withAssetSelectContext'
+
 import Summary from '../Summary'
 
 jest.mock('shared/services/configuration/configuration')
@@ -42,6 +44,7 @@ const featureType = {
 }
 
 const contextValue: AssetSelectValue = {
+  ...assetSelectContextValue,
   selection,
   meta: {
     endpoint: '',
@@ -54,13 +57,6 @@ const contextValue: AssetSelectValue = {
     openbare_ruimte: 'West',
   },
   coordinates: { lat: 0, lng: 0 },
-  edit: jest.fn(),
-  close: jest.fn(),
-  setMessage: jest.fn(),
-  fetchLocation: jest.fn(),
-  setLocation: jest.fn(),
-  setItem: jest.fn(),
-  removeItem: jest.fn(),
 }
 
 export const withContext = (Component: JSX.Element, context = contextValue) =>
@@ -171,7 +167,14 @@ describe('signals/incident/components/form/AssetSelect/Summary', () => {
     ).not.toBeInTheDocument()
     expect(screen.getByText(formatAddress(address))).toBeInTheDocument()
 
-    rerender(withContext(<Summary />, { ...contextValue, address: undefined }))
+    rerender(
+      withContext(<Summary />, {
+        ...contextValue,
+        selection: undefined,
+        address: undefined,
+      })
+    )
+
     expect(
       screen.getByText('Locatie is gepind op de kaart')
     ).toBeInTheDocument()
@@ -179,6 +182,7 @@ describe('signals/incident/components/form/AssetSelect/Summary', () => {
     rerender(
       withContext(<Summary />, {
         ...contextValue,
+        selection: undefined,
         address: undefined,
         coordinates: undefined,
       })

--- a/src/signals/incident/components/form/MapSelectors/Asset/Summary/Summary.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Summary/Summary.test.tsx
@@ -178,18 +178,6 @@ describe('signals/incident/components/form/AssetSelect/Summary', () => {
     expect(
       screen.getByText('Locatie is gepind op de kaart')
     ).toBeInTheDocument()
-
-    rerender(
-      withContext(<Summary />, {
-        ...contextValue,
-        selection: undefined,
-        address: undefined,
-        coordinates: undefined,
-      })
-    )
-    expect(
-      screen.queryByText('Locatie is gepind op de kaart')
-    ).not.toBeInTheDocument()
     expect(screen.queryByText(formatAddress(address))).not.toBeInTheDocument()
   })
 

--- a/src/signals/incident/components/form/MapSelectors/Asset/Summary/Summary.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Summary/Summary.tsx
@@ -59,9 +59,9 @@ const Summary: FC = () => {
   }
 
   const summaryDescription = [description, id].filter(Boolean).join(' - ')
-  let summaryAddress =
-    coordinates && !selection ? 'Locatie is gepind op de kaart' : ''
-  if (address && !summaryAddress) summaryAddress = formatAddress(address)
+  const summaryAddress = address
+    ? formatAddress(address)
+    : 'Locatie is gepind op de kaart'
 
   const iconSrc = useMemo(() => {
     if (!selection?.type || selection.type === 'not-on-map') {
@@ -107,6 +107,7 @@ const Summary: FC = () => {
       )}
       <div data-testid="assetSelectSummaryAddress">{summaryAddress}</div>
       <StyledLink
+        data-testid="mapEditButton"
         onClick={edit}
         onKeyUp={onKeyUp}
         variant="inline"

--- a/src/signals/incident/components/form/MapSelectors/Asset/Summary/Summary.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Summary/Summary.tsx
@@ -59,8 +59,9 @@ const Summary: FC = () => {
   }
 
   const summaryDescription = [description, id].filter(Boolean).join(' - ')
-  let summaryAddress = coordinates ? 'Locatie is gepind op de kaart' : ''
-  if (address) summaryAddress = formatAddress(address)
+  let summaryAddress =
+    coordinates && !selection ? 'Locatie is gepind op de kaart' : ''
+  if (address && !summaryAddress) summaryAddress = formatAddress(address)
 
   const iconSrc = useMemo(() => {
     if (!selection?.type || selection.type === 'not-on-map') {

--- a/src/signals/incident/components/form/MapSelectors/Asset/__tests__/withAssetSelectContext.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/__tests__/withAssetSelectContext.tsx
@@ -31,6 +31,7 @@ export const contextValue: AssetSelectValue = {
   fetchLocation: jest.fn(),
   setLocation: jest.fn(),
   setMessage: jest.fn(),
+  setNotOnMap: jest.fn(),
 }
 
 const withAssetSelectContext = (Component: ReactNode, context = contextValue) =>

--- a/src/signals/incident/components/form/MapSelectors/Asset/context.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/context.tsx
@@ -21,6 +21,7 @@ export const initialValue: AssetSelectValue = {
   setMessage: /* istanbul ignore next */ () => {},
   setItem: /* istanbul ignore next */ () => {},
   removeItem: /* istanbul ignore next */ () => {},
+  setNotOnMap: /* istanbul ignore next */ () => {},
 }
 
 const AssetSelectContext = createContext(initialValue)

--- a/src/signals/incident/components/form/MapSelectors/Asset/types.ts
+++ b/src/signals/incident/components/form/MapSelectors/Asset/types.ts
@@ -22,6 +22,7 @@ export interface AssetSelectValue {
   fetchLocation: (latLng: LatLngLiteral) => void
   setLocation: (location: Location) => void
   setMessage: (message?: string) => void
+  setNotOnMap: (itemNotPresentOnMap?: boolean) => void
 }
 
 export interface AssetSelectRendererProps extends FormFieldProps {


### PR DESCRIPTION
This PR contains a change that simplifies the logic that shows the location description in the `Summary` component. For it to work, the "De container staat niet op de kaart" checkbox needed to clear the selection in the state when unchecked. That way it became possible to distinguish between no selected object and a selected, unknown, object.