### PR TITLE
[SIG-427] Object not on map fix

### DIFF
--- a/src/signals/incident/components/IncidentPreview/components/MapPreview/MapPreview.test.tsx
+++ b/src/signals/incident/components/IncidentPreview/components/MapPreview/MapPreview.test.tsx
@@ -10,6 +10,7 @@ import type { Incident } from 'types/incident'
 import { mock } from 'types/incident'
 import type { FeatureType } from 'signals/incident/components/form/MapSelectors/types'
 import { formatAddress } from 'shared/services/format-address'
+import { OBJECT_UNKNOWN } from 'signals/incident/components/form/MapSelectors/constants'
 import MapPreview from '.'
 
 jest.mock('shared/services/configuration/configuration')
@@ -129,7 +130,7 @@ describe('signals/incident/components/IncidentPreview/components/MapPreview', ()
       ...props,
       value: {
         ...value,
-        type: 'not-on-map',
+        type: OBJECT_UNKNOWN,
       },
     }
 

--- a/src/signals/incident/components/IncidentPreview/components/MapPreview/MapPreview.tsx
+++ b/src/signals/incident/components/IncidentPreview/components/MapPreview/MapPreview.tsx
@@ -4,6 +4,13 @@ import styled from 'styled-components'
 import { themeSpacing } from '@amsterdam/asc-ui'
 import { Marker } from '@amsterdam/react-maps'
 
+import type { Incident } from 'types/incident'
+import type { FC } from 'react'
+import type {
+  FeatureType,
+  Item,
+} from 'signals/incident/components/form/MapSelectors/types'
+
 import { markerIcon } from 'shared/services/configuration/map-markers'
 import MAP_OPTIONS from 'shared/services/configuration/map-options'
 import configuration from 'shared/services/configuration/configuration'
@@ -11,13 +18,7 @@ import { formatAddress } from 'shared/services/format-address'
 
 import MapStatic from 'components/MapStatic'
 import Map from 'components/Map'
-
-import type { Incident } from 'types/incident'
-import type { FC } from 'react'
-import type {
-  FeatureType,
-  Item,
-} from 'signals/incident/components/form/MapSelectors/types'
+import { selectionIsObject } from 'signals/incident/components/form/MapSelectors/constants'
 
 const mapWidth = 640
 const mapHeight = 300
@@ -55,7 +56,7 @@ const MapPreview: FC<MapPreviewProps> = ({ incident, value, featureTypes }) => {
 
   let iconSrc = undefined
 
-  if (value?.type !== 'not-on-map') {
+  if (selectionIsObject(value)) {
     const featureType = featureTypes?.find(
       ({ typeValue }) => typeValue === value.type
     )

--- a/src/signals/incident/components/form/MapSelectors/Asset/AssetSelect.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/AssetSelect.test.tsx
@@ -13,7 +13,11 @@ import reverseGeocoderService from 'shared/services/reverse-geocoder'
 import { mocked } from 'ts-jest/utils'
 
 import type { Location } from 'types/incident'
-import { UNREGISTERED_TYPE as mockUNREGISTERED_TYPE } from '../constants'
+import {
+  OBJECT_NOT_ON_MAP,
+  OBJECT_UNKNOWN as mockOBJECT_UNKNOWN,
+  OBJECT_UNKNOWN,
+} from '../constants'
 import type { Item } from '../types'
 import type { AssetSelectProps } from './AssetSelect'
 
@@ -53,7 +57,7 @@ jest.mock('./Selector', () => () => {
 
   const unregisteredItem = {
     ...mockItem,
-    type: mockUNREGISTERED_TYPE,
+    type: mockOBJECT_UNKNOWN,
     location: {
       coordinates: mockLatLng,
     },
@@ -260,7 +264,9 @@ describe('AssetSelect', () => {
     userEvent.click(assetSelectSelector)
 
     const payload = {
-      [props.meta.name as string]: undefined,
+      [props.meta.name as string]: {
+        type: OBJECT_UNKNOWN,
+      },
       location: {
         coordinates: mockLatLng,
       },
@@ -301,7 +307,9 @@ describe('AssetSelect', () => {
     await screen.findByTestId('assetSelectSelector')
 
     expect(updateIncident).toHaveBeenCalledWith({
-      [props.meta.name as string]: undefined,
+      [props.meta.name as string]: {
+        type: OBJECT_UNKNOWN,
+      },
       location: { coordinates: mockLatLng, address: undefined },
     })
   })
@@ -370,7 +378,9 @@ describe('AssetSelect', () => {
 
     expect(updateIncident).toHaveBeenCalledTimes(3)
     expect(updateIncident).toHaveBeenLastCalledWith({
-      [props.meta.name as string]: undefined,
+      [props.meta.name as string]: {
+        type: OBJECT_UNKNOWN,
+      },
       location: {
         address: mockAddress,
         coordinates: mockLatLng,
@@ -440,7 +450,7 @@ describe('AssetSelect', () => {
       },
       Zork: {
         ...restItem,
-        type: mockUNREGISTERED_TYPE,
+        type: OBJECT_UNKNOWN,
       },
     })
   })
@@ -485,7 +495,9 @@ describe('AssetSelect', () => {
         coordinates: mockLatLng,
         address: mockAddress,
       },
-      Zork: undefined,
+      Zork: {
+        type: OBJECT_UNKNOWN,
+      },
     })
   })
 
@@ -506,7 +518,7 @@ describe('AssetSelect', () => {
 
     expect(updateIncident).toHaveBeenCalledWith({
       Zork: {
-        type: mockUNREGISTERED_TYPE,
+        type: OBJECT_NOT_ON_MAP,
       },
     })
 
@@ -515,7 +527,9 @@ describe('AssetSelect', () => {
 
     expect(updateIncident).toHaveBeenCalledTimes(2)
     expect(updateIncident).toHaveBeenLastCalledWith({
-      Zork: undefined,
+      Zork: {
+        type: OBJECT_UNKNOWN,
+      },
     })
 
     jest
@@ -535,7 +549,7 @@ describe('AssetSelect', () => {
         address: mockAddress,
       },
       Zork: {
-        type: mockUNREGISTERED_TYPE,
+        type: OBJECT_NOT_ON_MAP,
       },
     })
   })

--- a/src/signals/incident/components/form/MapSelectors/Asset/AssetSelect.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/AssetSelect.tsx
@@ -3,7 +3,7 @@
 import type { FC } from 'react'
 import { useEffect } from 'react'
 import { useCallback, useState } from 'react'
-import { shallowEqual, useSelector } from 'react-redux'
+import { useSelector } from 'react-redux'
 
 import reverseGeocoderService from 'shared/services/reverse-geocoder'
 import {
@@ -66,8 +66,7 @@ const AssetSelect: FC<AssetSelectProps> = ({ layer, meta, parent }) => {
     // ignoring linter till incident selectors are converted to TS
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    (state) => makeSelectExtraProperties(state, meta.name),
-    shallowEqual
+    (state) => makeSelectExtraProperties(state, meta.name)
   )
 
   const hasSelection = selection || coordinates

--- a/src/signals/incident/components/form/MapSelectors/Asset/AssetSelectRenderer/AssetSelectRenderer.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/AssetSelectRenderer/AssetSelectRenderer.tsx
@@ -6,7 +6,6 @@ import AssetSelect from '../AssetSelect'
 import type { AssetSelectRendererProps } from '../types'
 
 const AssetSelectRenderer: FunctionComponent<AssetSelectRendererProps> = ({
-  handler,
   touched,
   hasError,
   meta,
@@ -22,7 +21,7 @@ const AssetSelectRenderer: FunctionComponent<AssetSelectRendererProps> = ({
       hasError={hasError}
       getError={getError}
     >
-      <AssetSelect handler={handler} meta={meta} parent={parent} />
+      <AssetSelect meta={meta} parent={parent} />
     </FormField>
   ) : null
 

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/SelectionPanel/SelectionPanel.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/SelectionPanel/SelectionPanel.test.tsx
@@ -5,7 +5,7 @@ import { withAppContext } from 'test/utils'
 
 import userEvent from '@testing-library/user-event'
 
-import { UNREGISTERED_TYPE } from '../../../constants'
+import { OBJECT_NOT_ON_MAP, OBJECT_UNKNOWN } from '../../../constants'
 import withAssetSelectContext, {
   contextValue,
 } from '../../__tests__/withAssetSelectContext'
@@ -43,12 +43,12 @@ describe('SelectionPanel', () => {
     },
     idField: 'id',
     typeField: 'type',
-    typeValue: UNREGISTERED_TYPE,
+    typeValue: OBJECT_UNKNOWN,
   }
   const UNREGISTERED_CONTAINER = {
     description: 'Het object staat niet op de kaart',
     id: '',
-    type: 'not-on-map',
+    type: OBJECT_NOT_ON_MAP,
   }
   const GLAS_CONTAINER = {
     id: 'GLAS123',
@@ -81,9 +81,10 @@ describe('SelectionPanel', () => {
   })
 
   it('renders the panel', () => {
-    render(
+    const { rerender } = render(
       withAssetSelectContext(<SelectionPanel {...props} />, {
         ...contextValue,
+        coordinates: undefined,
         selection: undefined,
       })
     )
@@ -96,11 +97,23 @@ describe('SelectionPanel', () => {
       })
     ).toBeInTheDocument()
 
-    expect(
-      screen.queryByRole('button', { name: 'Meld dit object' })
-    ).toBeInTheDocument()
+    const submitButton = screen.queryByRole('button', {
+      name: 'Meld dit object',
+    })
+
+    expect(submitButton).toBeInTheDocument()
+    expect(submitButton).toBeDisabled()
 
     expect(screen.queryByTestId('assetList')).not.toBeInTheDocument()
+
+    rerender(
+      withAssetSelectContext(<SelectionPanel {...props} />, {
+        ...contextValue,
+        selection: undefined,
+      })
+    )
+
+    expect(submitButton).not.toBeDisabled()
   })
 
   it('renders selected asset', () => {
@@ -170,7 +183,7 @@ describe('SelectionPanel', () => {
     expect(contextValue.setItem).toHaveBeenCalledWith({
       id: unregisteredObjectId,
       location: {},
-      type: UNREGISTERED_TYPE,
+      type: OBJECT_NOT_ON_MAP,
       label: `De container staat niet op de kaart - ${unregisteredObjectId}`,
     })
   })
@@ -214,7 +227,7 @@ describe('SelectionPanel', () => {
     expect(contextValue.setItem).toHaveBeenCalledWith({
       id: '5',
       location: {},
-      type: UNREGISTERED_TYPE,
+      type: OBJECT_NOT_ON_MAP,
       label: 'De container staat niet op de kaart - 5',
     })
     expect(contextValue.close).toHaveBeenCalled()

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/SelectionPanel/SelectionPanel.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/SelectionPanel/SelectionPanel.tsx
@@ -71,7 +71,7 @@ const SelectionPanel: FC<SelectionPanelProps> = ({
   )
 
   const onChange = (event: ChangeEvent<HTMLInputElement>) => {
-    setUnknownObjectValue(event.currentTarget.value)
+    setUnknownObjectValue(event.currentTarget.value.trim())
   }
 
   const onCheck = useCallback(

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/Selector.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/Selector.tsx
@@ -27,7 +27,7 @@ import configuration from 'shared/services/configuration/configuration'
 import AssetSelectContext from 'signals/incident/components/form/MapSelectors/Asset/context'
 import MapCloseButton from 'components/MapCloseButton'
 
-import { UNREGISTERED_TYPE } from '../../constants'
+import { OBJECT_NOT_ON_MAP, selectionIsObject } from '../../constants'
 import { ZoomMessage } from '../../components/MapMessage'
 import LegendToggleButton from './LegendToggleButton'
 import LegendPanel from './LegendPanel'
@@ -107,7 +107,7 @@ const Selector = () => {
   const hasFeatureTypes = meta.featureTypes.length > 0
 
   const showMarker =
-    coordinates && (!selection || selection.type === UNREGISTERED_TYPE)
+    coordinates && (!selection || !selectionIsObject(selection))
 
   const mapClick = useCallback(
     ({ latlng }: LeafletMouseEvent) => {
@@ -188,7 +188,7 @@ const Selector = () => {
                 onClose={handleLegendCloseButton}
                 variant={panelVariant}
                 items={meta.featureTypes
-                  .filter(({ typeValue }) => typeValue !== UNREGISTERED_TYPE) // Filter the unknown icon from the legend
+                  .filter(({ typeValue }) => typeValue !== OBJECT_NOT_ON_MAP) // Filter the unknown icon from the legend
                   .map((featureType) => ({
                     label: featureType.label,
                     iconUrl: featureType.icon.iconUrl,

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/AssetLayer/AssetLayer.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/AssetLayer/AssetLayer.tsx
@@ -78,6 +78,11 @@ export const AssetLayer: FC<DataLayerProps> = ({ featureTypes }) => {
           .join(' - '),
       }
 
+      // Immediately set the known values before getting the address from the reverse geocoder
+      // service. This way the result of the click is reflected on the map right away; it
+      // can take up to a couple of seconds before the geocoder service responds.
+      setItem(item)
+
       const response = await reverseGeocoderService(coordinates)
 
       if (response) {

--- a/src/signals/incident/components/form/MapSelectors/Asset/Summary/Summary.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Summary/Summary.tsx
@@ -15,6 +15,7 @@ import { markerIcon } from 'shared/services/configuration/map-markers'
 import AssetSelectContext from 'signals/incident/components/form/MapSelectors/Asset/context'
 import { formatAddress } from 'shared/services/format-address'
 import configuration from 'shared/services/configuration/configuration'
+import { selectionIsObject } from '../../constants'
 
 const mapWidth = 640
 const mapHeight = 180
@@ -59,12 +60,13 @@ const Summary: FC = () => {
   }
 
   const summaryDescription = [description, id].filter(Boolean).join(' - ')
+
   const summaryAddress = address
     ? formatAddress(address)
     : 'Locatie is gepind op de kaart'
 
   const iconSrc = useMemo(() => {
-    if (!selection?.type || selection.type === 'not-on-map') {
+    if (!selection || !selectionIsObject(selection)) {
       return undefined
     }
 
@@ -73,7 +75,7 @@ const Summary: FC = () => {
     )
 
     return featureType && featureType.icon.iconUrl
-  }, [selection?.type, meta.featureTypes])
+  }, [selection, meta.featureTypes])
 
   const onKeyUp = useCallback(
     (event: KeyboardEvent<HTMLAnchorElement>) => {

--- a/src/signals/incident/components/form/MapSelectors/Caterpillar/CaterpillarSelectRenderer/CaterpillarSelectRenderer.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Caterpillar/CaterpillarSelectRenderer/CaterpillarSelectRenderer.tsx
@@ -7,7 +7,7 @@ import Layer from '../CaterpillarLayer'
 import type { AssetSelectRendererProps } from '../../Asset/types'
 
 const CaterpillarSelectRenderer: FunctionComponent<AssetSelectRendererProps> =
-  ({ handler, touched, hasError, meta, parent, getError, validatorsOrOpts }) =>
+  ({ touched, hasError, meta, parent, getError, validatorsOrOpts }) =>
     meta.isVisible ? (
       <FormField
         meta={meta}
@@ -16,12 +16,7 @@ const CaterpillarSelectRenderer: FunctionComponent<AssetSelectRendererProps> =
         hasError={hasError}
         getError={getError}
       >
-        <AssetSelect
-          handler={handler}
-          meta={meta}
-          parent={parent}
-          layer={Layer}
-        />
+        <AssetSelect meta={meta} parent={parent} layer={Layer} />
       </FormField>
     ) : null
 

--- a/src/signals/incident/components/form/MapSelectors/Clock/ClockSelectRenderer/ClockSelectRenderer.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Clock/ClockSelectRenderer/ClockSelectRenderer.tsx
@@ -7,7 +7,6 @@ import Layer from '../ClockLayer'
 import type { AssetSelectRendererProps } from '../../Asset/types'
 
 const ClockSelectRenderer: FunctionComponent<AssetSelectRendererProps> = ({
-  handler,
   touched,
   hasError,
   meta,
@@ -23,12 +22,7 @@ const ClockSelectRenderer: FunctionComponent<AssetSelectRendererProps> = ({
       hasError={hasError}
       getError={getError}
     >
-      <AssetSelect
-        handler={handler}
-        meta={meta}
-        parent={parent}
-        layer={Layer}
-      />
+      <AssetSelect meta={meta} parent={parent} layer={Layer} />
     </FormField>
   ) : null
 

--- a/src/signals/incident/components/form/MapSelectors/Streetlight/StreetlightSelectRenderer/StreetlightSelectRenderer.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Streetlight/StreetlightSelectRenderer/StreetlightSelectRenderer.tsx
@@ -7,7 +7,7 @@ import Layer from '../StreetlightLayer'
 import type { AssetSelectRendererProps } from '../../Asset/types'
 
 const StreetlightSelectRenderer: FunctionComponent<AssetSelectRendererProps> =
-  ({ handler, touched, hasError, meta, parent, getError, validatorsOrOpts }) =>
+  ({ touched, hasError, meta, parent, getError, validatorsOrOpts }) =>
     meta.isVisible ? (
       <FormField
         meta={meta}
@@ -16,12 +16,7 @@ const StreetlightSelectRenderer: FunctionComponent<AssetSelectRendererProps> =
         hasError={hasError}
         getError={getError}
       >
-        <AssetSelect
-          handler={handler}
-          meta={meta}
-          parent={parent}
-          layer={Layer}
-        />
+        <AssetSelect meta={meta} parent={parent} layer={Layer} />
       </FormField>
     ) : null
 

--- a/src/signals/incident/components/form/MapSelectors/constants.ts
+++ b/src/signals/incident/components/form/MapSelectors/constants.ts
@@ -1,1 +1,7 @@
-export const UNREGISTERED_TYPE = 'not-on-map'
+import type { Item } from './types'
+
+export const OBJECT_UNKNOWN = 'unknown'
+export const OBJECT_NOT_ON_MAP = 'not-on-map'
+
+export const selectionIsObject = (item: Item) =>
+  item.type !== OBJECT_UNKNOWN && item.type !== OBJECT_NOT_ON_MAP

--- a/src/signals/incident/components/form/MapSelectors/constants.ts
+++ b/src/signals/incident/components/form/MapSelectors/constants.ts
@@ -1,7 +1,7 @@
 import type { Item } from './types'
 
 export const OBJECT_UNKNOWN = 'unknown'
-export const OBJECT_NOT_ON_MAP = 'not-on-map'
+export const OBJECT_NOT_ON_MAP = 'not-on-map' // Note: the value of this constant is used by other SIA instances so it is NOT to be changed
 
 export const selectionIsObject = (item: Item) =>
   item.type !== OBJECT_UNKNOWN && item.type !== OBJECT_NOT_ON_MAP

--- a/src/signals/incident/components/form/MapSelectors/types.ts
+++ b/src/signals/incident/components/form/MapSelectors/types.ts
@@ -5,7 +5,7 @@ import type { IconOptions } from 'leaflet'
 import type { Point, Feature as GeoJSONFeature } from 'geojson'
 import type { Address } from 'types/address'
 import type { LatLngLiteral } from 'leaflet'
-import type { UNREGISTERED_TYPE } from './constants'
+import type { OBJECT_NOT_ON_MAP, OBJECT_UNKNOWN } from './constants'
 
 export type EventHandler = (
   event:
@@ -28,7 +28,7 @@ export interface Item extends Record<string, unknown> {
   id: string | number
   isReported?: boolean
   isChecked?: boolean
-  type?: typeof UNREGISTERED_TYPE | string
+  type?: typeof OBJECT_UNKNOWN | typeof OBJECT_NOT_ON_MAP | string
   label: string
 }
 

--- a/src/signals/incident/containers/IncidentContainer/selectors.js
+++ b/src/signals/incident/containers/IncidentContainer/selectors.js
@@ -48,3 +48,13 @@ export const makeSelectAddress = createSelector(
     return address?.toJS ? address.toJS() : address
   }
 )
+
+export const makeSelectExtraProperties = createSelector(
+  selectIncidentContainerDomain,
+  (_, extraPropName) => extraPropName,
+  (state, propName) => {
+    const extraProperties = getIn(state, ['incident', propName], undefined)
+
+    return extraProperties?.toJS ? extraProperties.toJS() : extraProperties
+  }
+)

--- a/src/signals/incident/containers/IncidentContainer/selectors.test.js
+++ b/src/signals/incident/containers/IncidentContainer/selectors.test.js
@@ -7,6 +7,7 @@ import {
   makeSelectIncidentContainer,
   makeSelectCoordinates,
   makeSelectAddress,
+  makeSelectExtraProperties,
 } from './selectors'
 
 describe('signals/incident/containers/IncidentContainer/selectors', () => {
@@ -98,6 +99,35 @@ describe('signals/incident/containers/IncidentContainer/selectors', () => {
       const mockedState = fromJS(stateWithAddress)
 
       expect(makeSelectAddress.resultFunc(mockedState)).toStrictEqual(address)
+    })
+  })
+
+  describe('makeSelectExtraProperties', () => {
+    const state = {
+      incident: {
+        extra_something: {
+          a: 'foo',
+          b: 'bar',
+        },
+      },
+    }
+
+    const mockedState = fromJS(state)
+
+    it('returns nothing', () => {
+      expect(makeSelectExtraProperties.resultFunc(mockedState)).toBeUndefined()
+      expect(
+        makeSelectExtraProperties.resultFunc(mockedState, 'extra_nothing')
+      ).toBeUndefined()
+    })
+
+    it('returns extra propperties', () => {
+      expect(
+        makeSelectExtraProperties.resultFunc(mockedState, 'extra_something')
+      ).toStrictEqual({
+        a: 'foo',
+        b: 'bar',
+      })
     })
   })
 })

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/afval-container.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/afval-container.ts
@@ -5,6 +5,7 @@ import type { IconOptions } from 'leaflet'
 import { validateObjectLocation } from 'signals/incident/services/custom-validators'
 import configuration from 'shared/services/configuration/configuration'
 import { QuestionFieldType } from 'types/question'
+import { OBJECT_NOT_ON_MAP } from 'signals/incident/components/form/MapSelectors/constants'
 
 export const ICON_SIZE = 40
 
@@ -131,7 +132,7 @@ export const controls = {
           },
           idField: 'id',
           typeField: 'type',
-          typeValue: 'not-on-map',
+          typeValue: OBJECT_NOT_ON_MAP,
         },
       ],
     },

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/openbaarGroenEnWater.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/openbaarGroenEnWater.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2018 - 2021 Gemeente Amsterdam
 import type { IconOptions } from 'leaflet'
+import { OBJECT_NOT_ON_MAP } from 'signals/incident/components/form/MapSelectors/constants'
 import { QuestionFieldType } from 'types/question'
 import { validateObjectLocation } from '../../services/custom-validators'
 
@@ -73,7 +74,7 @@ export const controls = {
             options,
             iconUrl: '/assets/images/featureUnknownMarker.svg',
           },
-          typeValue: 'not-on-map',
+          typeValue: OBJECT_NOT_ON_MAP,
           typeField: '',
         },
       ],

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/straatverlichting-klokken.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/straatverlichting-klokken.ts
@@ -4,6 +4,7 @@ import appConfiguration from 'shared/services/configuration/configuration'
 
 import { QuestionFieldType } from 'types/question'
 import type { IconOptions } from 'leaflet'
+import { OBJECT_NOT_ON_MAP } from 'signals/incident/components/form/MapSelectors/constants'
 import type ConfigurationType from '../../../../../app.amsterdam.json'
 
 import { validateObjectLocation } from '../../services/custom-validators'
@@ -128,7 +129,7 @@ const straatverlichtingKlokken = {
           },
           idField: 'id',
           typeField: 'type',
-          typeValue: 'not-on-map',
+          typeValue: OBJECT_NOT_ON_MAP,
         },
       ],
       pathMerge: 'extra_properties',
@@ -275,7 +276,7 @@ const straatverlichtingKlokken = {
           },
           idField: 'id',
           typeField: 'type',
-          typeValue: 'not-on-map',
+          typeValue: OBJECT_NOT_ON_MAP,
         },
       ],
       pathMerge: 'extra_properties',

--- a/src/utils/__tests__/fixtures/caterpillarsSelection.tsx
+++ b/src/utils/__tests__/fixtures/caterpillarsSelection.tsx
@@ -1,3 +1,5 @@
+import { OBJECT_NOT_ON_MAP } from 'signals/incident/components/form/MapSelectors/constants'
+
 export const selection = [
   {
     id: 308777,
@@ -9,7 +11,7 @@ export const selection = [
   },
   {
     id: 308779,
-    type: 'not-on-map',
+    type: OBJECT_NOT_ON_MAP,
     description: 'De boom staat niet op de kaart',
     isReported: false,
     location: {},


### PR DESCRIPTION
This PR fixes an issue where selecting a location on the map and ticking the 'not on the map' checkbox conflicted. To make it work, a new object type was added and the existing type was renamed. The asset select component now distinguishes `OBJECT_UNKNOWN` (was `UNREGISTERED_TYPE`) and `OBJECT_NOT_ON_MAP`. Also, because the map can be closed without having selected coordinates, the submit button

Please refer to the individual commits in this PR for all the information necessary for review.