### PR TITLE
[SIG 4364] Do not show status in item label

### DIFF
--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/AssetLayer/AssetLayer.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/AssetLayer/AssetLayer.tsx
@@ -73,9 +73,7 @@ export const AssetLayer: FC<DataLayerProps> = ({ featureTypes }) => {
         location: {
           coordinates,
         },
-        label: [description, isReported && 'is gemeld', id]
-          .filter(Boolean)
-          .join(' - '),
+        label: [description, id].filter(Boolean).join(' - '),
       }
 
       const response = await reverseGeocoderService(coordinates)


### PR DESCRIPTION
Status was visible in object description for streetlight objects in the backoffice.
This is now removed by adjusting the item label in the asset layer.