### PR TITLE
[SIG-4274] Object not on map

### DIFF
--- a/src/signals/incident/components/IncidentPreview/components/MapPreview/MapPreview.test.tsx
+++ b/src/signals/incident/components/IncidentPreview/components/MapPreview/MapPreview.test.tsx
@@ -47,13 +47,14 @@ const coordinates = {
   lng: 4,
 }
 const value = {
-  incident,
-  location: {
-    coordinates,
+  selection: {
+    location: {
+      coordinates,
+    },
+    id: 'noop',
+    type: 'Rest',
+    label: 'Rest - noop',
   },
-  id: 'noop',
-  type: 'Rest',
-  label: 'Rest - noop',
 }
 const props = {
   incident,

--- a/src/signals/incident/components/IncidentPreview/components/MapPreview/MapPreview.tsx
+++ b/src/signals/incident/components/IncidentPreview/components/MapPreview/MapPreview.tsx
@@ -40,13 +40,12 @@ const StyledMarker = styled(Marker)`
 
 interface MapPreviewProps {
   incident: Incident
-  value: Item & { selection: Item }
+  value: { selection: Item }
   featureTypes?: FeatureType[]
 }
 
 const MapPreview: FC<MapPreviewProps> = ({ incident, value, featureTypes }) => {
   const { address, coordinates } = incident.location
-  const objectValue = value?.selection || value
 
   const options = {
     ...MAP_OPTIONS,
@@ -57,9 +56,9 @@ const MapPreview: FC<MapPreviewProps> = ({ incident, value, featureTypes }) => {
 
   let iconSrc = undefined
 
-  if (selectionIsObject(value)) {
+  if (selectionIsObject(value.selection)) {
     const featureType = featureTypes?.find(
-      ({ typeValue }) => typeValue === objectValue.type
+      ({ typeValue }) => typeValue === value.selection.type
     )
 
     if (featureType) {

--- a/src/signals/incident/components/IncidentPreview/components/MapPreview/MapPreview.tsx
+++ b/src/signals/incident/components/IncidentPreview/components/MapPreview/MapPreview.tsx
@@ -40,12 +40,13 @@ const StyledMarker = styled(Marker)`
 
 interface MapPreviewProps {
   incident: Incident
-  value: Item
+  value: Item & { selection: Item }
   featureTypes?: FeatureType[]
 }
 
 const MapPreview: FC<MapPreviewProps> = ({ incident, value, featureTypes }) => {
   const { address, coordinates } = incident.location
+  const objectValue = value?.selection || value
 
   const options = {
     ...MAP_OPTIONS,
@@ -58,7 +59,7 @@ const MapPreview: FC<MapPreviewProps> = ({ incident, value, featureTypes }) => {
 
   if (selectionIsObject(value)) {
     const featureType = featureTypes?.find(
-      ({ typeValue }) => typeValue === value.type
+      ({ typeValue }) => typeValue === objectValue.type
     )
 
     if (featureType) {

--- a/src/signals/incident/components/IncidentPreview/components/MapPreview/MapPreview.tsx
+++ b/src/signals/incident/components/IncidentPreview/components/MapPreview/MapPreview.tsx
@@ -56,7 +56,7 @@ const MapPreview: FC<MapPreviewProps> = ({ incident, value, featureTypes }) => {
 
   let iconSrc = undefined
 
-  if (selectionIsObject(value.selection)) {
+  if (value?.selection && selectionIsObject(value.selection)) {
     const featureType = featureTypes?.find(
       ({ typeValue }) => typeValue === value.selection.type
     )

--- a/src/signals/incident/components/IncidentPreview/components/MapPreview/MapPreview.tsx
+++ b/src/signals/incident/components/IncidentPreview/components/MapPreview/MapPreview.tsx
@@ -18,6 +18,7 @@ import type {
   FeatureType,
   Item,
 } from 'signals/incident/components/form/MapSelectors/types'
+import { selectionIsObject } from 'signals/incident/components/form/MapSelectors/constants'
 
 const mapWidth = 640
 const mapHeight = 300
@@ -55,7 +56,7 @@ const MapPreview: FC<MapPreviewProps> = ({ incident, value, featureTypes }) => {
 
   let iconSrc = undefined
 
-  if (value?.type !== 'not-on-map') {
+  if (selectionIsObject(value)) {
     const featureType = featureTypes?.find(
       ({ typeValue }) => typeValue === value.type
     )

--- a/src/signals/incident/components/form/MapSelectors/Asset/AssetSelect.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/AssetSelect.test.tsx
@@ -12,7 +12,11 @@ import reverseGeocoderService from 'shared/services/reverse-geocoder'
 import { mocked } from 'ts-jest/utils'
 
 import type { Location } from 'types/incident'
-import { UNREGISTERED_TYPE as mockUNREGISTERED_TYPE } from '../constants'
+import {
+  UNKNOWN_TYPE,
+  UNREGISTERED_TYPE as mockUNREGISTERED_TYPE,
+  UNREGISTERED_TYPE,
+} from '../constants'
 import type { Item } from '../types'
 import type { AssetSelectProps } from './AssetSelect'
 
@@ -29,6 +33,7 @@ const mockItem = {
   type: 'not-mapped-or-something',
   label: 'foo bar',
 }
+const mockItemCoordinates = { lat: 4, lng: 36 }
 
 jest.mock('shared/services/reverse-geocoder')
 
@@ -39,7 +44,7 @@ jest.mock('./Selector', () => () => {
   const item: Item = {
     ...mockItem,
     location: {
-      coordinates: { lat: 4, lng: 36 },
+      coordinates: mockItemCoordinates,
     },
     label: 'foo bar',
   }
@@ -184,18 +189,15 @@ describe('AssetSelect', () => {
     render(
       withAppContext(
         <AssetSelect
-          {...{
-            ...props,
-            handler: () => ({
-              value: {
-                id: 'PL734',
-                type: 'plastic',
-                description: 'Plastic asset',
-                location: {},
-                iconUrl: '',
-                label: 'foo bar',
-              },
-            }),
+          {...props}
+          value={{
+            selection: {
+              id: 'PL734',
+              type: 'plastic',
+              description: 'Plastic asset',
+              iconUrl: '',
+              label: 'foo bar',
+            },
           }}
         />
       )
@@ -211,18 +213,17 @@ describe('AssetSelect', () => {
       .mockImplementationOnce(() => mockLatLng)
       .mockImplementationOnce(() => mockAddress)
 
-    render(
-      withAppContext(
-        <AssetSelect
-          {...{
-            ...props,
-            handler: () => ({
-              value: undefined,
-            }),
-          }}
-        />
-      )
-    )
+    const value = {
+      selection: {
+        type: UNREGISTERED_TYPE,
+      },
+      location: {
+        coordinates: mockLatLng,
+        address: mockAddress,
+      },
+    }
+
+    render(withAppContext(<AssetSelect {...props} value={value} />))
 
     expect(screen.queryByTestId('assetSelectSelector')).not.toBeInTheDocument()
     expect(screen.queryByTestId('assetSelectSummary')).toBeInTheDocument()
@@ -244,9 +245,14 @@ describe('AssetSelect', () => {
     userEvent.click(assetSelectSelector)
 
     const payload = {
-      [props.meta.name as string]: undefined,
       location: {
         coordinates: mockLatLng,
+      },
+      [props.meta.name as string]: {
+        selection: undefined,
+        location: {
+          coordinates: mockLatLng,
+        },
       },
     }
 
@@ -255,14 +261,22 @@ describe('AssetSelect', () => {
 
     await screen.findByTestId('assetSelectSelector')
 
-    expect(updateIncident).toHaveBeenCalledTimes(2)
-    expect(updateIncident).toHaveBeenLastCalledWith({
-      ...payload,
+    const payloadWithAddress = {
       location: {
-        ...payload.location,
-        address: geocodedResponse.data.address,
+        coordinates: mockLatLng,
+        address: mockAddress,
       },
-    })
+      [props.meta.name as string]: {
+        selection: undefined,
+        location: {
+          coordinates: mockLatLng,
+          address: mockAddress,
+        },
+      },
+    }
+
+    expect(updateIncident).toHaveBeenCalledTimes(2)
+    expect(updateIncident).toHaveBeenLastCalledWith(payloadWithAddress)
   })
 
   it('handles click on map when point does not have an associated address', async () => {
@@ -285,8 +299,11 @@ describe('AssetSelect', () => {
     await screen.findByTestId('assetSelectSelector')
 
     expect(updateIncident).toHaveBeenCalledWith({
-      [props.meta.name as string]: undefined,
       location: { coordinates: mockLatLng, address: undefined },
+      [props.meta.name as string]: {
+        selection: undefined,
+        location: { coordinates: mockLatLng, address: undefined },
+      },
     })
   })
 
@@ -295,12 +312,15 @@ describe('AssetSelect', () => {
       Promise.resolve(geocodedResponse)
     )
 
-    jest
-      .spyOn(reactRedux, 'useSelector')
-      .mockReturnValueOnce(mockLatLng)
-      .mockReturnValueOnce(undefined)
-      .mockReturnValueOnce(mockLatLng)
-      .mockReturnValueOnce(undefined)
+    const value = {
+      selection: {
+        type: UNKNOWN_TYPE,
+      },
+      location: {
+        coordinates: mockLatLng,
+        address: mockAddress,
+      },
+    }
 
     const meta = {
       ...contextValue.meta,
@@ -308,7 +328,7 @@ describe('AssetSelect', () => {
     }
 
     const { rerender } = render(
-      withAssetSelectContext(<AssetSelect {...props} />, {
+      withAssetSelectContext(<AssetSelect {...props} value={value} />, {
         ...contextValue,
         meta,
       })
@@ -332,14 +352,7 @@ describe('AssetSelect', () => {
     // the AssetSelect component, so we need to do that as well:
     rerender(
       withAssetSelectContext(
-        <AssetSelect
-          {...{
-            ...props,
-            handler: () => ({
-              value: item,
-            }),
-          }}
-        />,
+        <AssetSelect {...props} value={{ selection: item }} />,
         {
           ...contextValue,
           meta,
@@ -354,7 +367,13 @@ describe('AssetSelect', () => {
 
     expect(updateIncident).toHaveBeenCalledTimes(3)
     expect(updateIncident).toHaveBeenLastCalledWith({
-      [props.meta.name as string]: undefined,
+      Zork: {
+        selection: undefined,
+        location: {
+          address: mockAddress,
+          coordinates: mockLatLng,
+        },
+      },
       location: {
         address: mockAddress,
         coordinates: mockLatLng,
@@ -363,14 +382,19 @@ describe('AssetSelect', () => {
   })
 
   it('handles setting a selected item', () => {
-    jest
-      .spyOn(reactRedux, 'useSelector')
-      .mockReturnValueOnce(mockLatLng)
-      .mockReturnValueOnce(undefined)
-      .mockReturnValueOnce(mockLatLng)
-      .mockReturnValueOnce(undefined)
+    const location = {
+      coordinates: mockLatLng,
+    }
 
-    render(withAssetSelectContext(<AssetSelect {...props} />))
+    const value = {
+      selection: {
+        type: UNKNOWN_TYPE,
+        id: '08u2349823',
+      },
+      location,
+    }
+
+    render(withAssetSelectContext(<AssetSelect {...props} value={value} />))
 
     userEvent.click(screen.getByTestId('mapEditButton'))
 
@@ -380,28 +404,33 @@ describe('AssetSelect', () => {
 
     userEvent.click(setItemContainer)
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { location, ...restItem } = mockItem
-
-    expect(updateIncident).toHaveBeenCalledTimes(1)
     expect(updateIncident).toHaveBeenCalledWith({
-      location: {
-        coordinates: { lat: 4, lng: 36 },
-        address: undefined,
+      location,
+      Zork: {
+        location,
+        selection: {
+          ...mockItem,
+          location: {
+            coordinates: mockItemCoordinates,
+          },
+        },
       },
-      Zork: restItem,
     })
   })
 
   it('handles setting a selected, unregistered item', () => {
-    jest
-      .spyOn(reactRedux, 'useSelector')
-      .mockReturnValueOnce(mockLatLng)
-      .mockReturnValueOnce(undefined)
-      .mockReturnValueOnce(mockLatLng)
-      .mockReturnValueOnce(undefined)
+    const location = {
+      coordinates: mockLatLng,
+    }
+    const value = {
+      selection: {
+        type: UNREGISTERED_TYPE,
+        id: '08u2349823',
+      },
+      location,
+    }
 
-    render(withAssetSelectContext(<AssetSelect {...props} />))
+    render(withAssetSelectContext(<AssetSelect {...props} value={value} />))
 
     userEvent.click(screen.getByTestId('mapEditButton'))
 
@@ -413,29 +442,33 @@ describe('AssetSelect', () => {
 
     userEvent.click(setItemContainerUnregistered)
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { location, ...restItem } = mockItem
-
     expect(updateIncident).toHaveBeenCalledTimes(1)
     expect(updateIncident).toHaveBeenCalledWith({
-      location: {
-        coordinates: mockLatLng,
-        address: undefined,
-      },
+      location,
       Zork: {
-        ...restItem,
-        type: mockUNREGISTERED_TYPE,
+        location,
+        selection: {
+          ...mockItem,
+          type: mockUNREGISTERED_TYPE,
+          location,
+        },
       },
     })
   })
 
   it('handles removing a selected item', () => {
-    jest
-      .spyOn(reactRedux, 'useSelector')
-      .mockReturnValueOnce(mockLatLng)
-      .mockReturnValueOnce(undefined)
+    const location = {
+      coordinates: mockLatLng,
+    }
+    const value = {
+      selection: {
+        type: UNREGISTERED_TYPE,
+        id: '08u2349823',
+      },
+      location,
+    }
 
-    render(withAssetSelectContext(<AssetSelect {...props} />))
+    render(withAssetSelectContext(<AssetSelect {...props} value={value} />))
 
     userEvent.click(screen.getByTestId('mapEditButton'))
 
@@ -447,15 +480,22 @@ describe('AssetSelect', () => {
 
     expect(updateIncident).toHaveBeenCalledTimes(1)
     expect(updateIncident).toHaveBeenCalledWith({
-      location: {},
+      location: undefined,
       Zork: undefined,
     })
   })
 
   it('handles setting a location, without having to fetch the address', () => {
-    render(withAssetSelectContext(<AssetSelect {...props} />))
+    const value = {
+      selection: {
+        type: UNKNOWN_TYPE,
+        id: '08u2349823',
+      },
+    }
 
-    userEvent.click(screen.getByText(/kies op kaart/i))
+    render(withAssetSelectContext(<AssetSelect {...props} value={value} />))
+
+    userEvent.click(screen.getByTestId('mapEditButton'))
 
     const addressSelectContainer = screen.getByTestId('addressSelectContainer')
 
@@ -469,7 +509,16 @@ describe('AssetSelect', () => {
         coordinates: mockLatLng,
         address: mockAddress,
       },
-      Zork: undefined,
+      Zork: {
+        selection: {
+          type: UNKNOWN_TYPE,
+          id: '08u2349823',
+        },
+        location: {
+          coordinates: mockLatLng,
+          address: mockAddress,
+        },
+      },
     })
   })
 })

--- a/src/signals/incident/components/form/MapSelectors/Asset/AssetSelect.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/AssetSelect.test.tsx
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2020 - 2021 Gemeente Amsterdam
-import type { ChangeEvent } from 'react'
 import { useContext as mockUseContext } from 'react'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
@@ -34,14 +33,8 @@ const mockItem = {
 jest.mock('shared/services/reverse-geocoder')
 
 jest.mock('./Selector', () => () => {
-  const {
-    fetchLocation,
-    close,
-    removeItem,
-    setItem,
-    setLocation,
-    setNotOnMap,
-  } = mockUseContext(mockAssetSelectContext)
+  const { fetchLocation, close, removeItem, setItem, setLocation } =
+    mockUseContext(mockAssetSelectContext)
 
   const item: Item = {
     ...mockItem,
@@ -109,13 +102,6 @@ jest.mock('./Selector', () => () => {
         role="button"
         tabIndex={0}
       />
-      <input
-        type="checkbox"
-        data-testid="setNotOnMapCheckbox"
-        onChange={(event: ChangeEvent<HTMLInputElement>) => {
-          setNotOnMap(event.target.checked)
-        }}
-      />
     </>
   )
 })
@@ -145,9 +131,7 @@ describe('AssetSelect', () => {
 
   beforeEach(() => {
     props = {
-      handler: () => ({
-        value: undefined,
-      }),
+      value: undefined,
       meta: {
         ...initialValue.meta,
         name: 'Zork',
@@ -486,57 +470,6 @@ describe('AssetSelect', () => {
         address: mockAddress,
       },
       Zork: undefined,
-    })
-  })
-
-  it('handles the indication that an object is not visible on the map', () => {
-    const { rerender } = render(
-      withAssetSelectContext(<AssetSelect {...props} />)
-    )
-
-    userEvent.click(screen.getByText(/kies op kaart/i))
-
-    const setNotOnMapCheckbox = screen.getByTestId('setNotOnMapCheckbox')
-    expect(setNotOnMapCheckbox).not.toBeChecked()
-
-    expect(updateIncident).not.toHaveBeenCalled()
-
-    userEvent.click(setNotOnMapCheckbox)
-    expect(setNotOnMapCheckbox).toBeChecked()
-
-    expect(updateIncident).toHaveBeenCalledWith({
-      Zork: {
-        type: mockUNREGISTERED_TYPE,
-      },
-    })
-
-    userEvent.click(setNotOnMapCheckbox)
-    expect(setNotOnMapCheckbox).not.toBeChecked()
-
-    expect(updateIncident).toHaveBeenCalledTimes(2)
-    expect(updateIncident).toHaveBeenLastCalledWith({
-      Zork: undefined,
-    })
-
-    jest
-      .spyOn(reactRedux, 'useSelector')
-      .mockImplementationOnce(() => mockLatLng)
-      .mockImplementationOnce(() => mockAddress)
-
-    rerender(withAssetSelectContext(<AssetSelect {...props} />))
-
-    userEvent.click(setNotOnMapCheckbox)
-    expect(setNotOnMapCheckbox).toBeChecked()
-
-    expect(updateIncident).toHaveBeenCalledTimes(3)
-    expect(updateIncident).toHaveBeenLastCalledWith({
-      location: {
-        coordinates: mockLatLng,
-        address: mockAddress,
-      },
-      Zork: {
-        type: mockUNREGISTERED_TYPE,
-      },
     })
   })
 })

--- a/src/signals/incident/components/form/MapSelectors/Asset/AssetSelectRenderer/AssetSelectRenderer.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/AssetSelectRenderer/AssetSelectRenderer.tsx
@@ -22,7 +22,7 @@ const AssetSelectRenderer: FunctionComponent<AssetSelectRendererProps> = ({
       hasError={hasError}
       getError={getError}
     >
-      <AssetSelect handler={handler} meta={meta} parent={parent} />
+      <AssetSelect value={handler().value} meta={meta} parent={parent} />
     </FormField>
   ) : null
 

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/SelectionPanel/SelectionPanel.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/SelectionPanel/SelectionPanel.test.tsx
@@ -5,7 +5,7 @@ import { withAppContext } from 'test/utils'
 
 import userEvent from '@testing-library/user-event'
 
-import { UNREGISTERED_TYPE } from '../../../constants'
+import { UNKNOWN_TYPE } from '../../../constants'
 import withAssetSelectContext, {
   contextValue,
 } from '../../__tests__/withAssetSelectContext'
@@ -43,12 +43,12 @@ describe('SelectionPanel', () => {
     },
     idField: 'id',
     typeField: 'type',
-    typeValue: UNREGISTERED_TYPE,
+    typeValue: UNKNOWN_TYPE,
   }
   const UNREGISTERED_CONTAINER = {
     description: 'Het object staat niet op de kaart',
     id: '',
-    type: 'not-on-map',
+    type: UNKNOWN_TYPE,
   }
   const GLAS_CONTAINER = {
     id: 'GLAS123',
@@ -77,7 +77,7 @@ describe('SelectionPanel', () => {
   }
 
   afterEach(() => {
-    jest.clearAllMocks()
+    jest.resetAllMocks()
   })
 
   it('renders the panel', () => {
@@ -151,27 +151,33 @@ describe('SelectionPanel', () => {
       screen.queryByText('Nummer van de container')
     ).not.toBeInTheDocument()
 
+    expect(contextValue.setItem).not.toHaveBeenCalled()
+
     userEvent.click(
       screen.getByRole('checkbox', {
         name: 'Het object staat niet op de kaart',
       })
     )
+    expect(contextValue.setItem).toHaveBeenCalledTimes(1)
+    expect(contextValue.setItem).toHaveBeenCalledWith({
+      id: '',
+      label: 'Het object staat niet op de kaart',
+      type: UNKNOWN_TYPE,
+    })
 
     expect(screen.getByText('Nummer van de container')).toBeInTheDocument()
 
     const unregisteredObjectId = '8976238'
 
-    expect(contextValue.setItem).not.toHaveBeenCalled()
-
     userEvent.type(screen.getByRole('textbox'), unregisteredObjectId)
 
     fireEvent.blur(screen.getByRole('textbox'))
 
-    expect(contextValue.setItem).toHaveBeenCalledWith({
+    expect(contextValue.setItem).toHaveBeenCalledTimes(2)
+    expect(contextValue.setItem).toHaveBeenLastCalledWith({
       id: unregisteredObjectId,
-      location: {},
-      type: UNREGISTERED_TYPE,
-      label: `De container staat niet op de kaart - ${unregisteredObjectId}`,
+      type: UNKNOWN_TYPE,
+      label: `Het object staat niet op de kaart - ${unregisteredObjectId}`,
     })
   })
 
@@ -213,9 +219,8 @@ describe('SelectionPanel', () => {
 
     expect(contextValue.setItem).toHaveBeenCalledWith({
       id: '5',
-      location: {},
-      type: UNREGISTERED_TYPE,
-      label: 'De container staat niet op de kaart - 5',
+      type: UNKNOWN_TYPE,
+      label: 'Het object staat niet op de kaart - 5',
     })
     expect(contextValue.close).toHaveBeenCalled()
   })

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/SelectionPanel/SelectionPanel.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/SelectionPanel/SelectionPanel.tsx
@@ -18,7 +18,11 @@ import {
 } from '@amsterdam/asc-ui'
 
 import type { FeatureType } from 'signals/incident/components/form/MapSelectors/types'
-import { UNREGISTERED_TYPE } from 'signals/incident/components/form/MapSelectors/constants'
+import {
+  selectionIsObject,
+  selectionIsUndetermined,
+  UNKNOWN_TYPE,
+} from 'signals/incident/components/form/MapSelectors/constants'
 import AssetList from '../../AssetList'
 import AssetSelectContext from '../../../Asset/context'
 
@@ -52,41 +56,53 @@ const SelectionPanel: FC<SelectionPanelProps> = ({
   featureTypes,
   language = {},
 }) => {
-  const { selection, removeItem, setItem, close, setNotOnMap } =
+  const { selection, removeItem, setItem, close } =
     useContext(AssetSelectContext)
 
   const selectionOnMap =
-    selection && selection.type !== UNREGISTERED_TYPE ? selection : undefined
+    selection && selectionIsObject(selection) ? selection : undefined
 
   const unregisteredAsset =
-    selection && selection.type === UNREGISTERED_TYPE ? selection : undefined
+    selection && selectionIsUndetermined(selection) ? selection : undefined
 
   const [showObjectIdInput, setShowObjectIdInput] = useState(
-    unregisteredAsset !== undefined
+    selection?.type === UNKNOWN_TYPE
   )
   const [unregisteredAssetValue, setUnregisteredAssetValue] = useState(
     unregisteredAsset?.id || ''
   )
 
-  const onChange = (event: ChangeEvent<HTMLInputElement>) => {
-    setUnregisteredAssetValue(event.currentTarget.value)
-  }
+  const unregisteredLabel =
+    language.unregistered || 'Het object staat niet op de kaart'
 
-  const onCheck = useCallback(() => {
-    setShowObjectIdInput(!showObjectIdInput)
-    setNotOnMap(!showObjectIdInput)
-  }, [setNotOnMap, showObjectIdInput])
+  const onChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setUnregisteredAssetValue(event.currentTarget.value.trim())
+  }
 
   const onSetItem = useCallback(() => {
     setItem({
-      location: {},
       id: unregisteredAssetValue,
-      type: UNREGISTERED_TYPE,
-      label: ['De container staat niet op de kaart', unregisteredAssetValue]
+      type: UNKNOWN_TYPE,
+      label: [unregisteredLabel, unregisteredAssetValue]
         .filter(Boolean)
         .join(' - '),
     })
-  }, [setItem, unregisteredAssetValue])
+  }, [unregisteredLabel, setItem, unregisteredAssetValue])
+
+  const onCheck = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      setShowObjectIdInput(event.target.checked)
+
+      if (event.target.checked) {
+        onSetItem()
+      } else {
+        setItem({
+          type: UNKNOWN_TYPE,
+        })
+      }
+    },
+    [onSetItem, setItem]
+  )
 
   const onKeyUp = useCallback(
     (event: KeyboardEvent<HTMLInputElement>) => {
@@ -129,7 +145,7 @@ const SelectionPanel: FC<SelectionPanelProps> = ({
           />
           <Label
             htmlFor="unregisteredAssetCheckbox"
-            label={language.unregistered || 'Het object staat niet op de kaart'}
+            label={unregisteredLabel}
           />
 
           {showObjectIdInput && language.unregisteredId && (

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/Selector.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/Selector.tsx
@@ -27,7 +27,7 @@ import configuration from 'shared/services/configuration/configuration'
 import AssetSelectContext from 'signals/incident/components/form/MapSelectors/Asset/context'
 import MapCloseButton from 'components/MapCloseButton'
 
-import { UNREGISTERED_TYPE } from '../../constants'
+import { selectionIsUndetermined, UNREGISTERED_TYPE } from '../../constants'
 import { ZoomMessage } from '../../components/MapMessage'
 import LegendToggleButton from './LegendToggleButton'
 import LegendPanel from './LegendPanel'
@@ -107,7 +107,7 @@ const Selector = () => {
   const hasFeatureTypes = meta.featureTypes.length > 0
 
   const showMarker =
-    coordinates && (!selection || selection.type === UNREGISTERED_TYPE)
+    coordinates && (!selection || selectionIsUndetermined(selection))
 
   const mapClick = useCallback(
     ({ latlng }: LeafletMouseEvent) => {

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/AssetLayer/AssetLayer.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/AssetLayer/AssetLayer.tsx
@@ -5,7 +5,7 @@ import type { FC } from 'react'
 import L from 'leaflet'
 
 import type { FeatureCollection } from 'geojson'
-import type { Geometrie } from 'types/incident'
+import type { Geometrie, Location } from 'types/incident'
 
 import reverseGeocoderService from 'shared/services/reverse-geocoder'
 import AssetSelectContext from 'signals/incident/components/form/MapSelectors/Asset/context'
@@ -64,25 +64,27 @@ export const AssetLayer: FC<DataLayerProps> = ({ featureTypes }) => {
       }
 
       const isReported = feature.properties.meldingstatus === 1
+      const location: Location = {
+        coordinates,
+      }
 
       const item: Item = {
         id,
         type: typeValue,
         description,
         isReported,
-        location: {
-          coordinates,
-        },
         label: [description, id].filter(Boolean).join(' - '),
       }
+
+      setItem(item, location)
 
       const response = await reverseGeocoderService(coordinates)
 
       if (response) {
-        item.location.address = response.data.address
+        location.address = response.data.address
       }
 
-      setItem(item)
+      setItem(item, location)
     }
 
     return (

--- a/src/signals/incident/components/form/MapSelectors/Asset/Summary/Summary.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Summary/Summary.tsx
@@ -15,6 +15,7 @@ import { markerIcon } from 'shared/services/configuration/map-markers'
 import AssetSelectContext from 'signals/incident/components/form/MapSelectors/Asset/context'
 import { formatAddress } from 'shared/services/format-address'
 import configuration from 'shared/services/configuration/configuration'
+import { selectionIsUndetermined } from '../../constants'
 
 const mapWidth = 640
 const mapHeight = 180
@@ -44,27 +45,35 @@ const StyledMarker = styled(Marker)`
   cursor: none;
 `
 
+const defaultCenter = {
+  lat: configuration.map.options.center[0],
+  lng: configuration.map.options.center[1],
+}
+
 const Summary: FC = () => {
   const { address, coordinates, selection, edit, meta } =
     useContext(AssetSelectContext)
   const { id, type } = selection || {}
   const { description } =
     meta.featureTypes.find(({ typeValue }) => typeValue === type) ?? {}
+  const center = coordinates || defaultCenter
 
   const options = {
     ...MAP_OPTIONS,
     zoom: mapZoom,
     attributionControl: false,
-    center: coordinates,
+    center,
   }
 
   const summaryDescription = [description, id].filter(Boolean).join(' - ')
-  const summaryAddress = address
-    ? formatAddress(address)
-    : 'Locatie is gepind op de kaart'
+  let summaryAddress = address ? formatAddress(address) : ''
+  summaryAddress =
+    !summaryAddress && coordinates
+      ? 'Locatie is gepind op de kaart'
+      : summaryAddress
 
   const iconSrc = useMemo(() => {
-    if (!selection?.type || selection.type === 'not-on-map') {
+    if (!selection?.type || selectionIsUndetermined(selection)) {
       return undefined
     }
 
@@ -73,7 +82,7 @@ const Summary: FC = () => {
     )
 
     return featureType && featureType.icon.iconUrl
-  }, [selection?.type, meta.featureTypes])
+  }, [selection, meta.featureTypes])
 
   const onKeyUp = useCallback(
     (event: KeyboardEvent<HTMLAnchorElement>) => {
@@ -86,19 +95,18 @@ const Summary: FC = () => {
 
   return (
     <Wrapper data-testid="assetSelectSummary">
-      {coordinates &&
-        (configuration.featureFlags.useStaticMapServer ? (
-          <StyledMapStatic
-            height={mapHeight}
-            iconSrc={iconSrc}
-            width={mapWidth}
-            coordinates={coordinates}
-          />
-        ) : (
-          <StyledMap mapOptions={options}>
-            <StyledMarker args={[coordinates]} options={{ icon: markerIcon }} />
-          </StyledMap>
-        ))}
+      {configuration.featureFlags.useStaticMapServer ? (
+        <StyledMapStatic
+          height={mapHeight}
+          iconSrc={iconSrc}
+          width={mapWidth}
+          coordinates={center}
+        />
+      ) : (
+        <StyledMap mapOptions={options}>
+          <StyledMarker args={[center]} options={{ icon: markerIcon }} />
+        </StyledMap>
+      )}
 
       {selection && (
         <div data-testid="assetSelectSummaryDescription">

--- a/src/signals/incident/components/form/MapSelectors/Asset/__tests__/withAssetSelectContext.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/__tests__/withAssetSelectContext.tsx
@@ -31,7 +31,6 @@ export const contextValue: AssetSelectValue = {
   fetchLocation: jest.fn(),
   setLocation: jest.fn(),
   setMessage: jest.fn(),
-  setNotOnMap: jest.fn(),
 }
 
 const withAssetSelectContext = (Component: ReactNode, context = contextValue) =>

--- a/src/signals/incident/components/form/MapSelectors/Asset/context.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/context.tsx
@@ -21,7 +21,6 @@ export const initialValue: AssetSelectValue = {
   setMessage: /* istanbul ignore next */ () => {},
   setItem: /* istanbul ignore next */ () => {},
   removeItem: /* istanbul ignore next */ () => {},
-  setNotOnMap: /* istanbul ignore next */ () => {},
 }
 
 const AssetSelectContext = createContext(initialValue)

--- a/src/signals/incident/components/form/MapSelectors/Asset/types.ts
+++ b/src/signals/incident/components/form/MapSelectors/Asset/types.ts
@@ -18,11 +18,10 @@ export interface AssetSelectValue {
   meta: Meta
   removeItem: () => void
   selection?: Item
-  setItem: (item: Item) => void
+  setItem: (item: Item, location?: Location) => void
   fetchLocation: (latLng: LatLngLiteral) => void
   setLocation: (location: Location) => void
   setMessage: (message?: string) => void
-  setNotOnMap: (itemNotPresentOnMap?: boolean) => void
 }
 
 export interface AssetSelectRendererProps extends FormFieldProps {

--- a/src/signals/incident/components/form/MapSelectors/Caterpillar/CaterpillarLayer/CaterpillarLayer.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Caterpillar/CaterpillarLayer/CaterpillarLayer.test.tsx
@@ -73,18 +73,21 @@ describe('CaterpillarLayer', () => {
 
     userEvent.click(tree)
 
-    expect(setItem).toHaveBeenCalledWith({
-      id: featureId,
-      isReported: true,
-      isChecked: false,
-      description: 'Eikenboom',
-      type: 'Eikenboom',
-      GlobalID: feature?.properties.GlobalID,
-      location: {
-        coordinates,
+    expect(setItem).toHaveBeenCalledWith(
+      {
+        id: featureId,
+        isReported: true,
+        isChecked: false,
+        description: 'Eikenboom',
+        type: 'Eikenboom',
+        GlobalID: feature?.properties.GlobalID,
+        location: {
+          coordinates,
+        },
+        label: `Eikenboom - ${featureId}`,
       },
-      label: `Eikenboom - ${featureId}`,
-    })
+      { coordinates }
+    )
 
     expect(
       screen.queryByAltText(

--- a/src/signals/incident/components/form/MapSelectors/Caterpillar/CaterpillarLayer/CaterpillarLayer.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Caterpillar/CaterpillarLayer/CaterpillarLayer.tsx
@@ -71,6 +71,9 @@ export const CaterpillarLayer: FC = () => {
         }
 
         const { description, typeValue } = featureType
+        const location = {
+          coordinates,
+        }
 
         const item: Item = {
           id: featureId,
@@ -78,9 +81,7 @@ export const CaterpillarLayer: FC = () => {
           description,
           isReported,
           isChecked,
-          location: {
-            coordinates,
-          },
+          location,
           label: [description, featureId].filter(Boolean).join(' - '),
         }
 
@@ -88,7 +89,7 @@ export const CaterpillarLayer: FC = () => {
           item[propertyKey] = feature.properties[propertyKey]
         })
 
-        setItem(item)
+        setItem(item, location)
       }
 
       return (

--- a/src/signals/incident/components/form/MapSelectors/Caterpillar/CaterpillarSelectRenderer/CaterpillarSelectRenderer.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Caterpillar/CaterpillarSelectRenderer/CaterpillarSelectRenderer.tsx
@@ -17,7 +17,7 @@ const CaterpillarSelectRenderer: FunctionComponent<AssetSelectRendererProps> =
         getError={getError}
       >
         <AssetSelect
-          handler={handler}
+          value={handler().value}
           meta={meta}
           parent={parent}
           layer={Layer}

--- a/src/signals/incident/components/form/MapSelectors/Clock/ClockSelectRenderer/ClockSelectRenderer.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Clock/ClockSelectRenderer/ClockSelectRenderer.tsx
@@ -24,7 +24,7 @@ const ClockSelectRenderer: FunctionComponent<AssetSelectRendererProps> = ({
       getError={getError}
     >
       <AssetSelect
-        handler={handler}
+        value={handler().value}
         meta={meta}
         parent={parent}
         layer={Layer}

--- a/src/signals/incident/components/form/MapSelectors/Streetlight/StreetlightSelectRenderer/StreetlightSelectRenderer.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Streetlight/StreetlightSelectRenderer/StreetlightSelectRenderer.tsx
@@ -17,7 +17,7 @@ const StreetlightSelectRenderer: FunctionComponent<AssetSelectRendererProps> =
         getError={getError}
       >
         <AssetSelect
-          handler={handler}
+          value={handler().value}
           meta={meta}
           parent={parent}
           layer={Layer}

--- a/src/signals/incident/components/form/MapSelectors/constants.ts
+++ b/src/signals/incident/components/form/MapSelectors/constants.ts
@@ -1,1 +1,10 @@
+import type { Item } from './types'
+
 export const UNREGISTERED_TYPE = 'not-on-map'
+export const UNKNOWN_TYPE = 'unknown'
+
+export const selectionIsObject = (selection: Item) =>
+  selection.type !== UNKNOWN_TYPE && selection.type !== UNREGISTERED_TYPE
+
+export const selectionIsUndetermined = (selection: Item) =>
+  !selectionIsObject(selection)

--- a/src/signals/incident/components/form/MapSelectors/types.ts
+++ b/src/signals/incident/components/form/MapSelectors/types.ts
@@ -3,9 +3,7 @@
 import type { MouseEvent, KeyboardEvent } from 'react'
 import type { IconOptions } from 'leaflet'
 import type { Point, Feature as GeoJSONFeature } from 'geojson'
-import type { Address } from 'types/address'
-import type { LatLngLiteral } from 'leaflet'
-import type { UNREGISTERED_TYPE } from './constants'
+import type { UNKNOWN_TYPE, UNREGISTERED_TYPE } from './constants'
 
 export type EventHandler = (
   event:
@@ -20,16 +18,12 @@ export interface BaseItem {
 }
 
 export interface Item extends Record<string, unknown> {
-  location: {
-    address?: Address
-    coordinates?: LatLngLiteral
-  }
   description?: string
-  id: string | number
+  id?: string | number
   isReported?: boolean
   isChecked?: boolean
-  type?: typeof UNREGISTERED_TYPE | string
-  label: string
+  type?: typeof UNREGISTERED_TYPE | typeof UNKNOWN_TYPE | string
+  label?: string
 }
 
 export interface FeatureType {

--- a/src/signals/incident/containers/IncidentContainer/selectors.js
+++ b/src/signals/incident/containers/IncidentContainer/selectors.js
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2018 - 2021 Gemeente Amsterdam
 import { createSelector } from 'reselect'
-import { getIn } from 'immutable'
 import { initialState } from './reducer'
 
 export const getClassificationData = (
@@ -25,26 +24,4 @@ export const selectIncidentContainerDomain = (state) =>
 export const makeSelectIncidentContainer = createSelector(
   selectIncidentContainerDomain,
   (substate) => substate.toJS()
-)
-
-export const makeSelectCoordinates = createSelector(
-  selectIncidentContainerDomain,
-  (state) => {
-    const coordinates = getIn(
-      state,
-      ['incident', 'location', 'coordinates'],
-      undefined
-    )
-
-    return coordinates?.toJS ? coordinates.toJS() : coordinates
-  }
-)
-
-export const makeSelectAddress = createSelector(
-  selectIncidentContainerDomain,
-  (state) => {
-    const address = getIn(state, ['incident', 'location', 'address'], undefined)
-
-    return address?.toJS ? address.toJS() : address
-  }
 )

--- a/src/signals/incident/containers/IncidentContainer/selectors.test.js
+++ b/src/signals/incident/containers/IncidentContainer/selectors.test.js
@@ -5,8 +5,6 @@ import { initialState } from './reducer'
 import {
   selectIncidentContainerDomain,
   makeSelectIncidentContainer,
-  makeSelectCoordinates,
-  makeSelectAddress,
 } from './selectors'
 
 describe('signals/incident/containers/IncidentContainer/selectors', () => {
@@ -35,69 +33,6 @@ describe('signals/incident/containers/IncidentContainer/selectors', () => {
       const mockedState = fromJS(state)
 
       expect(makeSelectIncidentContainer.resultFunc(mockedState)).toEqual(state)
-    })
-  })
-
-  describe('makeSelectCoordinates', () => {
-    const state = {
-      incident: {
-        category: 'poep',
-        location: undefined,
-      },
-    }
-
-    it('returns nothing', () => {
-      const mockedState = fromJS(state)
-
-      expect(makeSelectCoordinates.resultFunc(mockedState)).toBeUndefined()
-    })
-
-    it('returns coordinates', () => {
-      const coordinates = [4.899295459015508, 52.37211092764973]
-      const location = {
-        coordinates,
-      }
-      const stateWithLocation = { ...state }
-      stateWithLocation.incident.location = location
-
-      const mockedState = fromJS(stateWithLocation)
-
-      expect(makeSelectCoordinates.resultFunc(mockedState)).toStrictEqual(
-        coordinates
-      )
-    })
-  })
-
-  describe('makeSelectAddress', () => {
-    const state = {
-      incident: {
-        categoy: 'poep',
-        location: undefined,
-      },
-    }
-
-    it('returns nothing', () => {
-      const mockedState = fromJS(state)
-
-      expect(makeSelectAddress.resultFunc(mockedState)).toBeUndefined()
-    })
-
-    it('returns an address', () => {
-      const address = {
-        postcode: '1000 AA',
-        huisnummer: 100,
-        woonplaats: 'Amsterdam',
-        openbare_ruimte: 'West',
-      }
-      const location = {
-        address,
-      }
-      const stateWithAddress = { ...state }
-      stateWithAddress.incident.location = location
-
-      const mockedState = fromJS(stateWithAddress)
-
-      expect(makeSelectAddress.resultFunc(mockedState)).toStrictEqual(address)
     })
   })
 })

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/afval-container.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/afval-container.ts
@@ -5,6 +5,7 @@ import type { IconOptions } from 'leaflet'
 import { validateObjectLocation } from 'signals/incident/services/custom-validators'
 import configuration from 'shared/services/configuration/configuration'
 import { QuestionFieldType } from 'types/question'
+import { UNKNOWN_TYPE } from 'signals/incident/components/form/MapSelectors/constants'
 
 export const ICON_SIZE = 40
 
@@ -131,7 +132,7 @@ export const controls = {
           },
           idField: 'id',
           typeField: 'type',
-          typeValue: 'not-on-map',
+          typeValue: UNKNOWN_TYPE,
         },
       ],
     },

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/openbaarGroenEnWater.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/openbaarGroenEnWater.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2018 - 2021 Gemeente Amsterdam
 import type { IconOptions } from 'leaflet'
+import { UNKNOWN_TYPE } from 'signals/incident/components/form/MapSelectors/constants'
 import { QuestionFieldType } from 'types/question'
 import { validateObjectLocation } from '../../services/custom-validators'
 
@@ -73,7 +74,7 @@ export const controls = {
             options,
             iconUrl: '/assets/images/featureUnknownMarker.svg',
           },
-          typeValue: 'not-on-map',
+          typeValue: UNKNOWN_TYPE,
           typeField: '',
         },
       ],

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/straatverlichting-klokken.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/straatverlichting-klokken.ts
@@ -4,6 +4,7 @@ import appConfiguration from 'shared/services/configuration/configuration'
 
 import { QuestionFieldType } from 'types/question'
 import type { IconOptions } from 'leaflet'
+import { UNKNOWN_TYPE } from 'signals/incident/components/form/MapSelectors/constants'
 import type ConfigurationType from '../../../../../app.amsterdam.json'
 
 import { validateObjectLocation } from '../../services/custom-validators'
@@ -128,7 +129,7 @@ const straatverlichtingKlokken = {
           },
           idField: 'id',
           typeField: 'type',
-          typeValue: 'not-on-map',
+          typeValue: UNKNOWN_TYPE,
         },
       ],
       pathMerge: 'extra_properties',
@@ -275,7 +276,7 @@ const straatverlichtingKlokken = {
           },
           idField: 'id',
           typeField: 'type',
-          typeValue: 'not-on-map',
+          typeValue: UNKNOWN_TYPE,
         },
       ],
       pathMerge: 'extra_properties',

--- a/src/signals/incident/services/convert-value/index.js
+++ b/src/signals/incident/services/convert-value/index.js
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2019 - 2021 Gemeente Amsterdam
+import isObject from 'lodash/isObject'
+
 const convertValue = (value) => {
   if (value === 0) {
     return 0
@@ -11,6 +13,10 @@ const convertValue = (value) => {
 
   if (value === false) {
     return 'nee'
+  }
+
+  if (isObject(value) && value.selection) {
+    return value.selection
   }
 
   return value

--- a/src/signals/incident/services/convert-value/index.test.js
+++ b/src/signals/incident/services/convert-value/index.test.js
@@ -3,34 +3,45 @@
 import convertValue from '.'
 
 describe('The convert value service', () => {
-  it('should return undefined by default', () => {
+  it('returnd undefined by default', () => {
     expect(convertValue()).toBeUndefined()
   })
 
-  it('should return text', () => {
+  it('returns a string', () => {
     expect(convertValue('This is a beautiful phrase')).toBe(
       'This is a beautiful phrase'
     )
   })
 
-  it('should return 0', () => {
-    expect(convertValue(0)).toBe(0)
+  it('returns 0', () => {
+    expect(convertValue(0)).toStrictEqual(0)
   })
 
-  it('should return "ja"', () => {
-    expect(convertValue(true)).toBe('ja')
+  it('returns "ja" for a truthy value', () => {
+    expect(convertValue(true)).toStrictEqual('ja')
   })
 
-  it('should return "nee"', () => {
-    expect(convertValue(false)).toBe('nee')
+  it('returns "nee" for a falsy value', () => {
+    expect(convertValue(false)).toStrictEqual('nee')
   })
 
-  it('should pass through an array', () => {
+  it('returns selection prop from object', () => {
+    const selection = {
+      foo: 'bar',
+    }
+    const value = {
+      selection,
+    }
+
+    expect(convertValue(value)).toStrictEqual(selection)
+  })
+
+  it('does not convert array values', () => {
     const array = [42, 'foo', 'bar']
-    expect(convertValue(array)).toBe(array)
+    expect(convertValue(array)).toStrictEqual(array)
   })
 
-  it('should pass through an object', () => {
+  it('does not convert object values', () => {
     const object = {
       foo: 1,
       bar: {
@@ -38,6 +49,6 @@ describe('The convert value service', () => {
         y: 42,
       },
     }
-    expect(convertValue(object)).toBe(object)
+    expect(convertValue(object)).toStrictEqual(object)
   })
 })

--- a/src/signals/incident/services/custom-validators/custom-validators.ts
+++ b/src/signals/incident/services/custom-validators/custom-validators.ts
@@ -27,7 +27,7 @@ export const createRequired = (message: string) =>
 
 export const validateObjectLocation = (objectType: string) =>
   function required(control: AbstractControl) {
-    if (control.value) return null
+    if (control.value?.location?.coordinates) return null
 
     return {
       custom: `Kies een locatie of een ${objectType} op de kaart of vul een adres in`,

--- a/src/signals/incident/services/custom-validators/custom-validators.ts
+++ b/src/signals/incident/services/custom-validators/custom-validators.ts
@@ -27,7 +27,11 @@ export const createRequired = (message: string) =>
 
 export const validateObjectLocation = (objectType: string) =>
   function required(control: AbstractControl) {
-    if (control.value?.location?.coordinates) return null
+    if (
+      control.value?.location?.coordinates?.lng &&
+      control.value?.location?.coordinates?.lat
+    )
+      return null
 
     return {
       custom: `Kies een locatie of een ${objectType} op de kaart of vul een adres in`,

--- a/src/signals/incident/services/custom-validators/index.test.ts
+++ b/src/signals/incident/services/custom-validators/index.test.ts
@@ -84,8 +84,16 @@ describe('The custom validators service', () => {
 
     it('returns null when valid', () => {
       const validationFunc = validateObjectLocation('zork')
+      const value = {
+        location: {
+          coordinates: {
+            lat: 52.3731081,
+            lng: 4.8932945,
+          },
+        },
+      }
 
-      expect(validationFunc({ value: 'foobar' } as AbstractControl)).toBeNull()
+      expect(validationFunc({ value } as AbstractControl)).toBeNull()
     })
 
     it('returns a custom error message when invalid', () => {

--- a/src/types/incident.ts
+++ b/src/types/incident.ts
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2021 Vereniging van Nederlandse Gemeenten, Gemeente Amsterdam
+import { UNKNOWN_TYPE } from 'signals/incident/components/form/MapSelectors/constants'
+
 import type { LatLngLiteral, LatLngTuple } from 'leaflet'
+import type { Item } from 'signals/incident/components/form/MapSelectors/types'
 import type { Address } from './address'
 
 export type ValueObject = {
@@ -8,7 +11,14 @@ export type ValueObject = {
   value: boolean
 }
 
-export interface Incident {
+type ExtraProps = {
+  [key: string]: {
+    [prop: string]: any
+    selection?: Item
+    location?: Location
+  }
+}
+export interface Incident extends Record<string, any>, ExtraProps {
   category: string
   classification: Classification | null
   datetime: Datetime
@@ -78,6 +88,13 @@ export const mock: Incident = {
     'Wij bekijken uw melding en zorgen dat het juiste onderdeel van de gemeente deze gaat behandelen. Heeft u contactgegevens achtergelaten? Dan nemen wij bij onduidelijkheid contact met u op.',
   phone: '14 020',
   images_previews: [],
+  extra_container: {
+    selection: {
+      id: '0872453',
+      label: 'Dit is het object',
+      type: UNKNOWN_TYPE,
+    },
+  },
   location: {
     coordinates: {
       lat: 52.38931218069618,


### PR DESCRIPTION
This PR fixes an issue where selecting a location on the map and ticking the 'not on the map' checkbox conflicted. To make it work, a new object type was added and the existing type was renamed. The asset select component now distinguishes `OBJECT_UNKNOWN` (was `UNREGISTERED_TYPE`) and `OBJECT_NOT_ON_MAP`.

Another issue was the validation of the form field; the way the validation works is that only the active form field can be validated. The field validation also needs the selected location (coordinates and address) to validate the field, because having coordinates is the only requirement. Because of this, the global state was altered so that the selected object, or item, on the map now also contains the selected coordinates.

**State before**
```
incidentContainer: {
  incident: {
    ...
    extra_container: {
      id: '56756756',
      type: 'unknown',
      label: 'De container staat niet op de kaart - 56756756'
    },
  },
}
```

**State after**
```
incidentContainer: {
  incident: {
    ...
    extra_container: {
      selection: {
        id: '56756756',
        type: 'unknown',
        label: 'De container staat niet op de kaart - 56756756'
      },
      location: {
        coordinates: {
          lat: 52.38513193119507,
          lng: 4.902998679381279
        },
        address: {
          openbare_ruimte: 'Bercylaan',
          huisnummer: '7',
          postcode: '1031KP',
          woonplaats: 'Amsterdam'
        }
      }
    },
  },
}
```