### PR TITLE
[SIG 4367] Fix double clicks in Asset select map

### DIFF
--- a/src/hooks/useDelayedDoubleClick.js
+++ b/src/hooks/useDelayedDoubleClick.js
@@ -8,7 +8,7 @@ import useDebounce from './useDebounce'
  * Increasing the value lead to a perceivable delay between click and the placement of the marker. Decreasing the value
  * could lead to a double click never being captured, because of the limited time to have both click registered.
  */
-export const CLICK_TIMEOUT = 200
+export const CLICK_TIMEOUT = 300
 
 const useDelayedDoubleClick = (clickFunc) => {
   const doubleClicking = useRef(false)

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/Selector.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/Selector.test.tsx
@@ -18,6 +18,8 @@ import type { LegendPanelProps } from './LegendPanel/LegendPanel'
 
 import Selector from './Selector'
 
+jest.useFakeTimers()
+
 jest.mock('../../hooks/useLayerVisible', () => ({
   __esModule: true,
   default: () => false,
@@ -171,6 +173,7 @@ describe('signals/incident/components/form/AssetSelect/Selector', () => {
 
   it('dispatches the location when the map is clicked', async () => {
     const { coordinates, fetchLocation } = contextValue
+    jest.spyOn(global, 'setTimeout')
 
     render(withAssetSelectContext(<Selector />))
 
@@ -183,11 +186,11 @@ describe('signals/incident/components/form/AssetSelect/Selector', () => {
       clientY: 10,
     })
 
-    setTimeout(() => {
-      expect(fetchLocation).toHaveBeenCalledWith(
-        expect.not.objectContaining(coordinates)
-      )
-    }, 300)
+    jest.runOnlyPendingTimers()
+
+    expect(fetchLocation).toHaveBeenCalledWith(
+      expect.not.objectContaining(coordinates)
+    )
   })
 
   it('dispatches the location when an address is selected', async () => {

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/Selector.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/Selector.test.tsx
@@ -173,7 +173,6 @@ describe('signals/incident/components/form/AssetSelect/Selector', () => {
 
   it('dispatches the location when the map is clicked', async () => {
     const { coordinates, fetchLocation } = contextValue
-    jest.spyOn(global, 'setTimeout')
 
     render(withAssetSelectContext(<Selector />))
 

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/Selector.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/Selector.test.tsx
@@ -183,9 +183,11 @@ describe('signals/incident/components/form/AssetSelect/Selector', () => {
       clientY: 10,
     })
 
-    expect(fetchLocation).toHaveBeenCalledWith(
-      expect.not.objectContaining(coordinates)
-    )
+    setTimeout(() => {
+      expect(fetchLocation).toHaveBeenCalledWith(
+        expect.not.objectContaining(coordinates)
+      )
+    }, 300)
   })
 
   it('dispatches the location when an address is selected', async () => {

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/Selector.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/Selector.tsx
@@ -15,6 +15,8 @@ import type { ZoomLevel } from '@amsterdam/arm-core/lib/types'
 import type { Variant } from '@amsterdam/arm-core/lib/components/MapPanel/MapPanelContext'
 import type { PdokResponse } from 'shared/services/map-location'
 
+import useDelayedDoubleClick from 'hooks/useDelayedDoubleClick'
+
 import { Marker } from '@amsterdam/react-maps'
 import { MapPanel, MapPanelDrawer, MapPanelProvider } from '@amsterdam/arm-core'
 import { SnapPoint } from '@amsterdam/arm-core/lib/components/MapPanel/constants'
@@ -93,6 +95,7 @@ const Selector = () => {
       center,
       dragging: true,
       zoomControl: false,
+      scrollWheelZoom: true,
       minZoom: 7,
       maxZoom: 16,
       zoom: coordinates ? MAP_LOCATION_ZOOM : MAP_NO_LOCATION_ZOOM,
@@ -115,6 +118,8 @@ const Selector = () => {
     },
     [fetchLocation]
   )
+
+  const { click, doubleClick } = useDelayedDoubleClick(mapClick)
 
   const toggleLegend = useCallback(() => {
     setShowLegendPanel(!showLegendPanel)
@@ -153,7 +158,7 @@ const Selector = () => {
         <StyledMap
           hasZoomControls={desktopView}
           mapOptions={mapOptions}
-          events={{ click: mapClick }}
+          events={{ click, dblclick: doubleClick }}
           setInstance={setMap}
           hasGPSControl
         >


### PR DESCRIPTION
- Used existing delay function for detecting double clicks in Asset select map
- Enabled zooming in and out through scroll wheel in Asset select map
- Increased the delay from 200 to 300 ms.