### PR TITLE
[SIG-4422] Fix for incorrect incident start time

### DIFF
--- a/src/signals/incident/containers/IncidentContainer/reducer.js
+++ b/src/signals/incident/containers/IncidentContainer/reducer.js
@@ -19,7 +19,9 @@ import { getIncidentClassification } from './services'
 
 export const initialState = fromJS({
   incident: {
-    datetime: undefined,
+    datetime: {
+      id: 'Nu',
+    },
     incident_date: 'Vandaag',
     incident_time_hours: 9,
     incident_time_minutes: 0,

--- a/src/signals/incident/containers/IncidentContainer/reducer.test.js
+++ b/src/signals/incident/containers/IncidentContainer/reducer.test.js
@@ -28,6 +28,7 @@ describe('signals/incident/containers/IncidentContainer/reducer', () => {
   it('default wizard state should contain date, time, and priority', () => {
     expect(initialState.get('incident').toJS()).toEqual(
       expect.objectContaining({
+        datetime: { id: 'Nu' },
         incident_date: 'Vandaag',
         incident_time_hours: 9,
         incident_time_minutes: 0,


### PR DESCRIPTION
Fixes an issue where different timestamps are shown in the incident detail page