### PR TITLE
[SIG 4326] Show email preview

### DIFF
--- a/src/components/FormFooter/FormFooter.tsx
+++ b/src/components/FormFooter/FormFooter.tsx
@@ -72,7 +72,7 @@ const FormFooter: FunctionComponent<FormFooterProps> = ({
   submitBtnLabel,
 }) => (
   <FooterWrapper data-testid="formFooter" className={className} inline={inline}>
-    <Row hasMargin={!inline}>
+    <Row hasMargin={!inline} className="formFooterRow">
       <ButtonContainer span={12}>
         {resetBtnLabel && (
           <ResetButton

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.tsx
@@ -38,6 +38,7 @@ import * as constants from './constants'
 import type { State } from './reducer'
 import reducer, { init } from './reducer'
 import type { StatusFormActions } from './actions'
+import EmailPreview from './components/EmailPreview/EmailPreview'
 
 interface StatusFormProps {
   defaultTexts: DefaultTextsType
@@ -46,6 +47,8 @@ interface StatusFormProps {
 }
 
 let lastActiveElement: HTMLElement | null = null
+const htmlString =
+  '<!DOCTYPE html><html lang="nl"><head><meta charset="UTF-8"><title>Uw melding SIA-1</title></head><body><p>Geachte melder,</p><p>Op 9 februari 2022 om 13.00 uur hebt u een melding gedaan bij de gemeente. In deze e-mail leest u de stand van zaken van uw melding.</p><p><strong>U liet ons het volgende weten</strong><br />Just some text<br /> Some text on the next line</p><p><strong>Stand van zaken</strong><br />Wij pakken dit z.s.m. op</p><p><strong>Gegevens van uw melding</strong><br />Nummer: SIA-1<br />Gemeld op: 9 februari 2022, 13.00 uur<br />Plaats: Amstel 1, 1011 PN Amsterdam</p><p><strong>Meer weten?</strong><br />Voor vragen over uw melding in Amsterdam kunt u bellen met telefoonnummer 14 020, maandag tot en met vrijdag van 08.00 tot 18.00 uur. Voor Weesp kunt u bellen met 0294 491 391, maandag tot en met vrijdag van 08.30 tot 17.00 uur. Geef dan ook het nummer van uw melding door: SIA-1.</p><p>Met vriendelijke groet,</p><p>Gemeente Amsterdam</p></body></html>'
 
 const StatusForm: FunctionComponent<StatusFormProps> = ({
   defaultTexts,
@@ -57,6 +60,8 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
   const { listenFor, unlisten } = useEventEmitter()
 
   const [modalStandardTextIsOpen, setModalStandardTextIsOpen] = useState(false)
+  const [modalEmailPreviewIsOpen, setModalEmailPreviewIsOpen] = useState(false)
+  const [emailBody, setEmailBody] = useState<string>('')
   const [state, dispatch] = useReducer<
     Reducer<State, StatusFormActions>,
     { incident: Incident; childIncidents: IncidentChild[] }
@@ -80,6 +85,21 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
       lastActiveElement.focus()
     }
   }, [setModalStandardTextIsOpen])
+
+  const openEmailPreviewModal = useCallback(() => {
+    disablePageScroll()
+    setModalEmailPreviewIsOpen(true)
+    lastActiveElement = document.activeElement as HTMLElement
+  }, [setModalEmailPreviewIsOpen])
+
+  const closeEmailPreviewModal = useCallback(() => {
+    enablePageScroll()
+    setModalEmailPreviewIsOpen(false)
+
+    if (lastActiveElement) {
+      lastActiveElement.focus()
+    }
+  }, [setModalEmailPreviewIsOpen])
 
   const escFunction = useCallback(
     (event) => {
@@ -128,18 +148,12 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
         return
       }
 
-      update({
-        type: PATCH_TYPE_STATUS,
-        patch: {
-          status: {
-            state: state.status.key,
-            text: textValue,
-            send_email: state.check.checked,
-          },
-        },
-      })
-
-      onClose()
+      if (state.flags.hasEmail && state.check.checked) {
+        setEmailBody(htmlString)
+        openEmailPreviewModal()
+      } else {
+        onUpdate()
+      }
     },
     [
       state.text.value,
@@ -148,10 +162,24 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
       state.text.maxLength,
       state.status.key,
       state.check.checked,
-      update,
-      onClose,
     ]
   )
+
+  const onUpdate = () => {
+    const textValue = state.text.value || state.text.defaultValue
+    update({
+      type: PATCH_TYPE_STATUS,
+      patch: {
+        status: {
+          state: state.status.key,
+          text: textValue,
+          send_email: state.check.checked,
+        },
+      },
+    })
+
+    onClose()
+  }
 
   const setDefaultText = useCallback((_event, text) => {
     dispatch({ type: 'SET_DEFAULT_TEXT', payload: text })
@@ -358,6 +386,20 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
         >
           Annuleer
         </StyledButton>
+        {modalEmailPreviewIsOpen && (
+          <Modal
+            data-testid="emailPreviewModal"
+            open
+            onClose={closeEmailPreviewModal}
+            title="Email Preview"
+          >
+            <EmailPreview
+              emailBody={emailBody}
+              onClose={onClose}
+              onUpdate={onUpdate}
+            />
+          </Modal>
+        )}
       </div>
     </Form>
   )

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.tsx
@@ -77,14 +77,15 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
     [setModalStandardTextIsOpen]
   )
 
-  const closeStandardTextModal = useCallback(() => {
+  const closeModal = useCallback(() => {
     enablePageScroll()
     setModalStandardTextIsOpen(false)
+    setModalEmailPreviewIsOpen(false)
 
     if (lastActiveElement) {
       lastActiveElement.focus()
     }
-  }, [setModalStandardTextIsOpen])
+  }, [setModalStandardTextIsOpen, setModalEmailPreviewIsOpen])
 
   const openEmailPreviewModal = useCallback(() => {
     disablePageScroll()
@@ -92,22 +93,13 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
     lastActiveElement = document.activeElement as HTMLElement
   }, [setModalEmailPreviewIsOpen])
 
-  const closeEmailPreviewModal = useCallback(() => {
-    enablePageScroll()
-    setModalEmailPreviewIsOpen(false)
-
-    if (lastActiveElement) {
-      lastActiveElement.focus()
-    }
-  }, [setModalEmailPreviewIsOpen])
-
   const escFunction = useCallback(
     (event) => {
       if (event.keyCode === 27) {
-        closeStandardTextModal()
+        closeModal()
       }
     },
-    [closeStandardTextModal]
+    [closeModal]
   )
 
   const disableSubmit = Boolean(
@@ -219,9 +211,9 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
   const useDefaultText = useCallback(
     (event: SyntheticEvent, text: string) => {
       setDefaultText(event, text)
-      closeStandardTextModal()
+      closeModal()
     },
-    [closeStandardTextModal, setDefaultText]
+    [closeModal, setDefaultText]
   )
 
   useEffect(() => {
@@ -346,14 +338,14 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
               <Modal
                 data-testid="standardTextModal"
                 open
-                onClose={closeStandardTextModal}
+                onClose={closeModal}
                 title="Standard texts"
               >
                 <DefaultTexts
                   defaultTexts={defaultTexts}
                   onHandleUseDefaultText={useDefaultText}
                   status={state.status.key}
-                  onClose={closeStandardTextModal}
+                  onClose={closeModal}
                 />
               </Modal>
             )}
@@ -393,7 +385,7 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
           <Modal
             data-testid="emailPreviewModal"
             open
-            onClose={closeEmailPreviewModal}
+            onClose={closeModal}
             title="Email Preview"
           >
             <EmailPreview

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.tsx
@@ -61,7 +61,7 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
 
   const [modalStandardTextIsOpen, setModalStandardTextIsOpen] = useState(false)
   const [modalEmailPreviewIsOpen, setModalEmailPreviewIsOpen] = useState(false)
-  const [emailBody, setEmailBody] = useState<string>('')
+  const [emailBody, setEmailBody] = useState('')
   const [state, dispatch] = useReducer<
     Reducer<State, StatusFormActions>,
     { incident: Incident; childIncidents: IncidentChild[] }
@@ -106,7 +106,7 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
     state.warnings.some(({ level }) => level === 'error')
   )
 
-  const onUpdate = () => {
+  const onUpdate = useCallback(() => {
     const textValue = state.text.value || state.text.defaultValue
     update({
       type: PATCH_TYPE_STATUS,
@@ -120,7 +120,7 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
     })
 
     onClose()
-  }
+  }, [update, onClose, state.text.value, state.status.key, state.check.checked])
 
   const handleSubmit = useCallback(
     (event) => {

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.tsx
@@ -114,6 +114,22 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
     state.warnings.some(({ level }) => level === 'error')
   )
 
+  const onUpdate = () => {
+    const textValue = state.text.value || state.text.defaultValue
+    update({
+      type: PATCH_TYPE_STATUS,
+      patch: {
+        status: {
+          state: state.status.key,
+          text: textValue,
+          send_email: state.check.checked,
+        },
+      },
+    })
+
+    onClose()
+  }
+
   const handleSubmit = useCallback(
     (event) => {
       event.preventDefault()
@@ -156,30 +172,17 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
       }
     },
     [
+      state.flags.hasEmail,
       state.text.value,
       state.text.defaultValue,
       state.text.required,
       state.text.maxLength,
       state.status.key,
       state.check.checked,
+      onUpdate,
+      openEmailPreviewModal,
     ]
   )
-
-  const onUpdate = () => {
-    const textValue = state.text.value || state.text.defaultValue
-    update({
-      type: PATCH_TYPE_STATUS,
-      patch: {
-        status: {
-          state: state.status.key,
-          text: textValue,
-          send_email: state.check.checked,
-        },
-      },
-    })
-
-    onClose()
-  }
 
   const setDefaultText = useCallback((_event, text) => {
     dispatch({ type: 'SET_DEFAULT_TEXT', payload: text })

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.tsx
@@ -120,7 +120,14 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
     })
 
     onClose()
-  }, [update, onClose, state.text.value, state.status.key, state.check.checked])
+  }, [
+    update,
+    onClose,
+    state.text.value,
+    state.status.key,
+    state.check.checked,
+    state.text.defaultValue,
+  ])
 
   const handleSubmit = useCallback(
     (event) => {
@@ -169,7 +176,6 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
       state.text.defaultValue,
       state.text.required,
       state.text.maxLength,
-      state.status.key,
       state.check.checked,
       onUpdate,
       openEmailPreviewModal,

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/__tests__/StatusForm.test.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/__tests__/StatusForm.test.tsx
@@ -240,7 +240,7 @@ describe('signals/incident-management/containers/IncidentDetail/components/Statu
 
     // verify that the email preview is shown and onUpdate has not been called yet
     expect(update).not.toHaveBeenCalled()
-    await screen.findByTestId('emailPreviewModal')
+    expect(screen.getByTestId('emailPreviewModal')).toBeInTheDocument()
 
     // send the email
     userEvent.click(screen.getByText('Verstuur'))

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/__tests__/StatusForm.test.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/__tests__/StatusForm.test.tsx
@@ -238,7 +238,12 @@ describe('signals/incident-management/containers/IncidentDetail/components/Statu
     // submit the form
     userEvent.click(screen.getByRole('button', { name: 'Opslaan' }))
 
-    await screen.findByTestId('statusForm')
+    // verify that the email preview is shown and onUpdate has not been called yet
+    expect(update).not.toHaveBeenCalled()
+    await screen.findByTestId('emailPreviewModal')
+
+    // send the email
+    userEvent.click(screen.getByText('Verstuur'))
 
     // verify that 'update' has been called
     expect(update).toHaveBeenCalledWith(

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/DefaultTexts/DefaultTexts.test.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/DefaultTexts/DefaultTexts.test.tsx
@@ -43,10 +43,8 @@ describe('<DefaultTexts />', () => {
       <DefaultTexts {...props} />
     )
 
-    expect(queryAllByTestId('defaultTextsTitle')).toHaveLength(1)
-    expect(queryByTestId('defaultTextsTitle')).toHaveTextContent(
-      /^Standaardtekst$/
-    )
+    expect(queryAllByTestId('modalTitle')).toHaveLength(1)
+    expect(queryByTestId('modalTitle')).toHaveTextContent(/^Standaardtekst$/)
 
     expect(queryAllByTestId('defaultTextsItemText')).toHaveLength(3)
     expect(queryAllByTestId('defaultTextsItemTitle')[0]).toHaveTextContent(

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/DefaultTexts/DefaultTexts.test.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/DefaultTexts/DefaultTexts.test.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2018 - 2021 Gemeente Amsterdam
-import { render, fireEvent } from '@testing-library/react'
+import { screen, render, fireEvent } from '@testing-library/react'
 
 import { StatusCode } from 'signals/incident-management/definitions/types'
 
@@ -39,12 +39,11 @@ describe('<DefaultTexts />', () => {
   })
 
   it('should render correctly', () => {
-    const { queryByTestId, queryAllByTestId } = render(
-      <DefaultTexts {...props} />
-    )
+    const { queryAllByTestId } = render(<DefaultTexts {...props} />)
 
-    expect(queryAllByTestId('modalTitle')).toHaveLength(1)
-    expect(queryByTestId('modalTitle')).toHaveTextContent(/^Standaardtekst$/)
+    expect(screen.getByTestId('modalTitle')).toHaveTextContent(
+      /^Standaardtekst$/
+    )
 
     expect(queryAllByTestId('defaultTextsItemText')).toHaveLength(3)
     expect(queryAllByTestId('defaultTextsItemTitle')[0]).toHaveTextContent(

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/DefaultTexts/DefaultTexts.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/DefaultTexts/DefaultTexts.tsx
@@ -3,16 +3,8 @@
 import type { FC, SyntheticEvent } from 'react'
 import type { DefaultText as DefaultTextType } from 'types/api/default-text'
 import type { StatusCode } from 'signals/incident-management/definitions/types'
-import { Close } from '@amsterdam/asc-assets'
-import {
-  CloseButton,
-  ModalHeader,
-  StyledHeading,
-  StyledDefaultText,
-  StyledTitle,
-  StyledLink,
-  Wrapper,
-} from './styled'
+import ModalHeader from '../ModalHeader/ModalHeader'
+import { StyledDefaultText, StyledTitle, StyledLink, Wrapper } from './styled'
 
 export type DefaulTextsProps = {
   defaultTexts: Array<DefaultTextType>
@@ -36,19 +28,7 @@ const DefaultTexts: FC<DefaulTextsProps> = ({
 
   return (
     <>
-      <ModalHeader>
-        <StyledHeading as="h3" data-testid="defaultTextsTitle">
-          Standaardtekst
-        </StyledHeading>
-        <CloseButton
-          variant="application"
-          onClick={onClose}
-          icon={<Close />}
-          size={20}
-          title="Sluiten"
-        />
-      </ModalHeader>
-
+      <ModalHeader title="Standaardtekst" onClose={onClose} />
       <Wrapper>
         {(!allText || allText.templates.length === 0) && (
           <StyledDefaultText key={`empty_${status}`} empty>

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/DefaultTexts/styled.ts
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/DefaultTexts/styled.ts
@@ -1,27 +1,5 @@
 import styled, { css } from 'styled-components'
-import {
-  Link,
-  Heading,
-  themeColor,
-  themeSpacing,
-  Button,
-} from '@amsterdam/asc-ui'
-
-export const CloseButton = styled(Button)`
-  border: none;
-  padding: 0;
-  width: 20px;
-  height: 20px;
-`
-
-export const ModalHeader = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: ${themeSpacing(3, 4, 3, 4)};
-  margin: 0;
-  border-bottom: 1px solid ${themeColor('tint', 'level5')};
-`
+import { Link, themeColor, themeSpacing } from '@amsterdam/asc-ui'
 
 export const StyledDefaultText = styled.div<{ empty?: boolean }>`
   margin-bottom: ${themeSpacing(5)};
@@ -31,10 +9,6 @@ export const StyledDefaultText = styled.div<{ empty?: boolean }>`
     css`
       color: ${themeColor('tint', 'level5')};
     `}
-`
-
-export const StyledHeading = styled(Heading)`
-  margin: 0;
 `
 
 export const StyledLink = styled(Link)`

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/EmailPreview/EmailPreview.test.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/EmailPreview/EmailPreview.test.tsx
@@ -24,10 +24,10 @@ describe('StatusForm EmailPreview component', () => {
     )
 
     expect(
-      screen.queryByText('Controleer bericht aan melder')
+      screen.getByText('Controleer bericht aan melder')
     ).toBeInTheDocument()
     expect(screen.getByTitle('Sluiten')).toBeInTheDocument()
-    expect(screen.queryByTestId('emailBodyIframe')).toBeInTheDocument()
+    expect(screen.getByTestId('emailBodyIframe')).toBeInTheDocument()
     expect(screen.getByText('Wijzig')).toBeInTheDocument()
 
     userEvent.click(screen.getByText('Verstuur'))

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/EmailPreview/EmailPreview.test.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/EmailPreview/EmailPreview.test.tsx
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (C) 2022 Gemeente Amsterdam
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { withAppContext } from 'test/utils'
+import EmailPreview from './EmailPreview'
+
+const emailBody =
+  '<!DOCTYPE html><html lang="nl"><head><meta charset="UTF-8"><title>Uw melding SIA-1</title></head><body><p>Geachte melder,</p><p>Op 9 februari 2022 om 13.00 uur hebt u een melding gedaan bij de gemeente. In deze e-mail leest u de stand van zaken van uw melding.</p><p><strong>U liet ons het volgende weten</strong><br />Just some text<br /> Some text on the next line</p><p><strong>Stand van zaken</strong><br />Wij pakken dit z.s.m. op</p><p><strong>Gegevens van uw melding</strong><br />Nummer: SIA-1<br />Gemeld op: 9 februari 2022, 13.00 uur<br />Plaats: Amstel 1, 1011 PN Amsterdam</p><p><strong>Meer weten?</strong><br />Voor vragen over uw melding in Amsterdam kunt u bellen met telefoonnummer 14 020, maandag tot en met vrijdag van 08.00 tot 18.00 uur. Voor Weesp kunt u bellen met 0294 491 391, maandag tot en met vrijdag van 08.30 tot 17.00 uur. Geef dan ook het nummer van uw melding door: SIA-1.</p><p>Met vriendelijke groet,</p><p>Gemeente Amsterdam</p></body></html>'
+
+describe('StatusForm EmailPreview component', () => {
+  const onUpdate = jest.fn()
+  const onClose = jest.fn()
+
+  it('renders the email preview and calls onUpdate when the send button is hit', () => {
+    render(
+      withAppContext(
+        <EmailPreview
+          onUpdate={onUpdate}
+          emailBody={emailBody}
+          onClose={onClose}
+        />
+      )
+    )
+
+    expect(
+      screen.queryByText('Controleer bericht aan melder')
+    ).toBeInTheDocument()
+    expect(screen.getByTitle('Sluiten')).toBeInTheDocument()
+    expect(screen.queryByTestId('emailBodyIframe')).toBeInTheDocument()
+    expect(screen.getByText('Wijzig')).toBeInTheDocument()
+
+    userEvent.click(screen.getByText('Verstuur'))
+    expect(onUpdate).toHaveBeenCalled()
+  })
+
+  it('calls onClose when the cancel button is hit', () => {
+    render(
+      withAppContext(
+        <EmailPreview
+          onUpdate={onUpdate}
+          emailBody={emailBody}
+          onClose={onClose}
+        />
+      )
+    )
+
+    userEvent.click(screen.getByText('Wijzig'))
+    expect(onClose).toHaveBeenCalled()
+  })
+})

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/EmailPreview/EmailPreview.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/EmailPreview/EmailPreview.tsx
@@ -2,24 +2,23 @@
 // Copyright (C) 2022 Gemeente Amsterdam
 import type { FC } from 'react'
 import styled from 'styled-components'
-import Button from 'components/Button'
-import { themeColor, themeSpacing } from '@amsterdam/asc-ui'
+import { themeSpacing } from '@amsterdam/asc-ui'
+import FormFooter from 'components/FormFooter'
 import ModalHeader from '../ModalHeader/ModalHeader'
-
-const ButtonWrapper = styled.div`
-  box-sizing: border-box;
-  padding: ${themeSpacing(4)};
-  border-top: 1px solid ${themeColor('tint', 'level4')};
-`
 
 const ModalContainer = styled.div`
   display: flex;
   flex-direction: column;
 `
 
-const StyledButton = styled(Button)`
-  height: ${themeSpacing(11)};
-  margin-right: ${themeSpacing(2)};
+const StyledFormFooter = styled(FormFooter)`
+  height: auto;
+  div {
+    padding-left: ${themeSpacing(4)};
+    div {
+      padding-left: 0;
+    }
+  }
 `
 
 const StyledIframe = styled.iframe`
@@ -39,35 +38,21 @@ const EmailPreview: FC<EmailPreviewProps> = ({
   emailBody,
   onUpdate,
   onClose,
-}) => {
-  return (
-    <ModalContainer>
-      <ModalHeader title="Controleer bericht aan melder" onClose={onClose} />
-      <StyledIframe
-        data-testid="emailBodyIframe"
-        srcDoc={emailBody.concat(fontStyling)}
-        height={'500vh'}
-      />
-      <ButtonWrapper>
-        <StyledButton
-          data-testid="emailPreviewSubmitButton"
-          type="submit"
-          variant="secondary"
-          onClick={onUpdate}
-        >
-          Verstuur
-        </StyledButton>
-
-        <StyledButton
-          data-testid="emailPreviewCancelButton"
-          variant="tertiary"
-          onClick={onClose}
-        >
-          Wijzig
-        </StyledButton>
-      </ButtonWrapper>
-    </ModalContainer>
-  )
-}
+}) => (
+  <ModalContainer>
+    <ModalHeader title="Controleer bericht aan melder" onClose={onClose} />
+    <StyledIframe
+      data-testid="emailBodyIframe"
+      srcDoc={emailBody.concat(fontStyling)}
+      height={'500vh'}
+    />
+    <StyledFormFooter
+      cancelBtnLabel="Wijzig"
+      onCancel={onClose}
+      submitBtnLabel="Verstuur"
+      onSubmitForm={onUpdate}
+    />
+  </ModalContainer>
+)
 
 export default EmailPreview

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/EmailPreview/EmailPreview.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/EmailPreview/EmailPreview.tsx
@@ -24,6 +24,7 @@ const StyledFormFooter = styled(FormFooter)`
 const StyledIframe = styled.iframe`
   border: none;
   padding-left: ${themeSpacing(2)};
+  padding-bottom: ${themeSpacing(16)};
 `
 
 interface EmailPreviewProps {
@@ -44,7 +45,7 @@ const EmailPreview: FC<EmailPreviewProps> = ({
     <StyledIframe
       data-testid="emailBodyIframe"
       srcDoc={emailBody.concat(fontStyling)}
-      height={'500vh'}
+      height="500"
     />
     <StyledFormFooter
       cancelBtnLabel="Wijzig"

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/EmailPreview/EmailPreview.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/EmailPreview/EmailPreview.tsx
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (C) 2022 Gemeente Amsterdam
+import type { FC } from 'react'
+import styled from 'styled-components'
+import Button from 'components/Button'
+import { themeColor, themeSpacing } from '@amsterdam/asc-ui'
+import ModalHeader from '../ModalHeader/ModalHeader'
+
+const ButtonWrapper = styled.div`
+  box-sizing: border-box;
+  padding: ${themeSpacing(4)};
+  border-top: 1px solid ${themeColor('tint', 'level4')};
+`
+
+const ModalContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+`
+
+const StyledButton = styled(Button)`
+  height: ${themeSpacing(11)};
+  margin-right: ${themeSpacing(2)};
+`
+
+const StyledIframe = styled.iframe`
+  border: none;
+  padding-left: ${themeSpacing(2)};
+`
+
+interface EmailPreviewProps {
+  emailBody: string
+  onClose: () => void
+  onUpdate: () => void
+}
+
+const fontStyling = '<style>*{font-family:Avenir Next;}</style>'
+
+const EmailPreview: FC<EmailPreviewProps> = ({
+  emailBody,
+  onUpdate,
+  onClose,
+}) => {
+  return (
+    <ModalContainer>
+      <ModalHeader title="Controleer bericht aan melder" onClose={onClose} />
+      <StyledIframe
+        data-testid="emailBodyIframe"
+        srcDoc={emailBody.concat(fontStyling)}
+        height={'500vh'}
+      />
+      <ButtonWrapper>
+        <StyledButton
+          data-testid="emailPreviewSubmitButton"
+          type="submit"
+          variant="secondary"
+          onClick={onUpdate}
+        >
+          Verstuur
+        </StyledButton>
+
+        <StyledButton
+          data-testid="emailPreviewCancelButton"
+          variant="tertiary"
+          onClick={onClose}
+        >
+          Wijzig
+        </StyledButton>
+      </ButtonWrapper>
+    </ModalContainer>
+  )
+}
+
+export default EmailPreview

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/EmailPreview/EmailPreview.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/EmailPreview/EmailPreview.tsx
@@ -6,6 +6,7 @@ import { themeSpacing } from '@amsterdam/asc-ui'
 import FormFooter from 'components/FormFooter'
 import ModalHeader from '../ModalHeader/ModalHeader'
 
+const formFooterHeight = 16
 const ModalContainer = styled.div`
   display: flex;
   flex-direction: column;
@@ -13,18 +14,14 @@ const ModalContainer = styled.div`
 
 const StyledFormFooter = styled(FormFooter)`
   height: auto;
-  div {
+  div.formFooterRow {
     padding-left: ${themeSpacing(4)};
-    div {
-      padding-left: 0;
-    }
   }
 `
 
 const StyledIframe = styled.iframe`
   border: none;
-  padding-left: ${themeSpacing(2)};
-  padding-bottom: ${themeSpacing(16)};
+  padding: ${themeSpacing(2, 0, formFooterHeight)};
 `
 
 interface EmailPreviewProps {

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/EmailPreview/EmailPreview.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/EmailPreview/EmailPreview.tsx
@@ -4,24 +4,24 @@ import type { FC } from 'react'
 import styled from 'styled-components'
 import { themeSpacing } from '@amsterdam/asc-ui'
 import FormFooter from 'components/FormFooter'
+import { FORM_FOOTER_HEIGHT } from 'components/FormFooter/FormFooter'
 import ModalHeader from '../ModalHeader/ModalHeader'
 
-const formFooterHeight = 16
 const ModalContainer = styled.div`
   display: flex;
   flex-direction: column;
 `
 
 const StyledFormFooter = styled(FormFooter)`
-  height: auto;
-  div.formFooterRow {
+  box-sizing: border-box;
+  .formFooterRow {
     padding-left: ${themeSpacing(4)};
   }
 `
 
 const StyledIframe = styled.iframe`
   border: none;
-  padding: ${themeSpacing(2, 0, formFooterHeight)};
+  padding: 0 ${themeSpacing(2)} ${FORM_FOOTER_HEIGHT}px;
 `
 
 interface EmailPreviewProps {

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/ModalHeader/ModalHeader.test.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/ModalHeader/ModalHeader.test.tsx
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (C) 2022 Gemeente Amsterdam
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { withAppContext } from 'test/utils'
+import ModalHeader from './ModalHeader'
+
+describe('StatusForm ModalHeader component', () => {
+  const title = 'This is a title'
+  const onClose = jest.fn()
+
+  it('renders a title and a close button', () => {
+    render(withAppContext(<ModalHeader title={title} onClose={onClose} />))
+
+    expect(screen.getByText(title)).toBeInTheDocument()
+
+    userEvent.click(screen.getByTitle('Sluiten'))
+
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('does not render a close button when onClose is not present', () => {
+    render(withAppContext(<ModalHeader title={title} />))
+
+    expect(screen.queryByTitle('Sluiten')).not.toBeInTheDocument()
+  })
+})

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/ModalHeader/ModalHeader.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/ModalHeader/ModalHeader.tsx
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (C) 2022 Gemeente Amsterdam
+import type { FC } from 'react'
+import styled from 'styled-components'
+import { Button, Heading, themeColor, themeSpacing } from '@amsterdam/asc-ui'
+import { Close } from '@amsterdam/asc-assets'
+
+export const CloseButton = styled(Button)`
+  border: none;
+  padding: 0;
+  width: 20px;
+  height: 20px;
+`
+
+export const Header = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: ${themeSpacing(3, 4, 3, 4)};
+  margin: 0;
+  border-bottom: 1px solid ${themeColor('tint', 'level5')};
+`
+
+export const StyledHeading = styled(Heading)`
+  margin: 0;
+`
+
+interface ModalHeaderProps {
+  title: string
+  onClose?: () => void
+}
+
+const ModalHeader: FC<ModalHeaderProps> = ({ title, onClose }) => {
+  return (
+    <Header>
+      <StyledHeading as="h3" data-testid="modalTitle">
+        {title}
+      </StyledHeading>
+      <CloseButton
+        variant="application"
+        onClick={onClose}
+        icon={<Close />}
+        size={20}
+        title="Sluiten"
+      />
+    </Header>
+  )
+}
+
+export default ModalHeader

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/ModalHeader/ModalHeader.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/ModalHeader/ModalHeader.tsx
@@ -1,18 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2022 Gemeente Amsterdam
 import type { FC } from 'react'
-import styled, { css } from 'styled-components'
+import styled from 'styled-components'
 import { Button, Heading, themeColor, themeSpacing } from '@amsterdam/asc-ui'
 import { Close } from '@amsterdam/asc-assets'
-
-export const CloseButton = styled(Button)<{ iconSize: number }>`
-  border: none;
-  padding: 0;
-  ${({ iconSize }) =>
-    css`
-      height: ${iconSize}px;
-    `}
-`
 
 export const Header = styled.div`
   display: flex;
@@ -38,11 +29,12 @@ const ModalHeader: FC<ModalHeaderProps> = ({ title, onClose }) => (
       {title}
     </StyledHeading>
     {onClose && (
-      <CloseButton
-        variant="application"
+      <Button
+        variant="blank"
         onClick={onClose}
         icon={<Close />}
         iconSize={20}
+        size={20}
         title="Sluiten"
       />
     )}

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/ModalHeader/ModalHeader.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/ModalHeader/ModalHeader.tsx
@@ -32,17 +32,19 @@ interface ModalHeaderProps {
 
 const ModalHeader: FC<ModalHeaderProps> = ({ title, onClose }) => {
   return (
-    <Header>
+    <Header data-testid="modalHeader">
       <StyledHeading as="h3" data-testid="modalTitle">
         {title}
       </StyledHeading>
-      <CloseButton
-        variant="application"
-        onClick={onClose}
-        icon={<Close />}
-        size={20}
-        title="Sluiten"
-      />
+      {onClose && (
+        <CloseButton
+          variant="application"
+          onClick={onClose}
+          icon={<Close />}
+          size={20}
+          title="Sluiten"
+        />
+      )}
     </Header>
   )
 }

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/ModalHeader/ModalHeader.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/ModalHeader/ModalHeader.tsx
@@ -30,23 +30,21 @@ interface ModalHeaderProps {
   onClose?: () => void
 }
 
-const ModalHeader: FC<ModalHeaderProps> = ({ title, onClose }) => {
-  return (
-    <Header data-testid="modalHeader">
-      <StyledHeading as="h3" data-testid="modalTitle">
-        {title}
-      </StyledHeading>
-      {onClose && (
-        <CloseButton
-          variant="application"
-          onClick={onClose}
-          icon={<Close />}
-          size={20}
-          title="Sluiten"
-        />
-      )}
-    </Header>
-  )
-}
+const ModalHeader: FC<ModalHeaderProps> = ({ title, onClose }) => (
+  <Header data-testid="modalHeader">
+    <StyledHeading as="h3" data-testid="modalTitle">
+      {title}
+    </StyledHeading>
+    {onClose && (
+      <CloseButton
+        variant="application"
+        onClick={onClose}
+        icon={<Close />}
+        size={20}
+        title="Sluiten"
+      />
+    )}
+  </Header>
+)
 
 export default ModalHeader

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/ModalHeader/ModalHeader.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/ModalHeader/ModalHeader.tsx
@@ -1,15 +1,17 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2022 Gemeente Amsterdam
 import type { FC } from 'react'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 import { Button, Heading, themeColor, themeSpacing } from '@amsterdam/asc-ui'
 import { Close } from '@amsterdam/asc-assets'
 
-export const CloseButton = styled(Button)`
+export const CloseButton = styled(Button)<{ iconSize: number }>`
   border: none;
   padding: 0;
-  width: 20px;
-  height: 20px;
+  ${({ iconSize }) =>
+    css`
+      height: ${iconSize}px;
+    `}
 `
 
 export const Header = styled.div`
@@ -40,7 +42,7 @@ const ModalHeader: FC<ModalHeaderProps> = ({ title, onClose }) => (
         variant="application"
         onClick={onClose}
         icon={<Close />}
-        size={20}
+        iconSize={20}
         title="Sluiten"
       />
     )}


### PR DESCRIPTION
In the status form, an email preview is shown in case an email is send to the reporter, before the email is send.

Please note that I've temporarily included a htmlString const to mock the email body, which will be removed when the endpoint to get the email body is working.