### PR TITLE
[SIG-4426] Move autosuggest

### DIFF
--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/styled.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/styled.tsx
@@ -2,6 +2,7 @@ import styled from 'styled-components'
 
 import { Button, themeSpacing, themeColor, breakpoint } from '@amsterdam/asc-ui'
 
+import PDOKAutoSuggest from 'components/PDOKAutoSuggest'
 import AssetList from '../../AssetList'
 import LegendToggle from '../LegendToggleButton'
 import LegendPanel from '../LegendPanel'
@@ -61,4 +62,8 @@ export const Description = styled.span`
   display: block;
   font-size: 16px;
   font-weight: 400;
+`
+
+export const StyledPDOKAutoSuggest = styled(PDOKAutoSuggest)`
+  margin: ${themeSpacing(4, 0)};
 `

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/Selector.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/Selector.test.tsx
@@ -6,10 +6,7 @@ import fetchMock from 'jest-fetch-mock'
 import userEvent from '@testing-library/user-event'
 
 import type { FC } from 'react'
-import type { PDOKAutoSuggestProps } from 'components/PDOKAutoSuggest'
-import type { PdokResponse } from 'shared/services/map-location'
 
-import { formatAddress } from 'shared/services/format-address'
 import assetsJson from 'utils/__tests__/fixtures/assets.json'
 import configuration from 'shared/services/configuration/configuration'
 import withAssetSelectContext, {
@@ -36,37 +33,6 @@ jest.mock('./LegendPanel', () => ({ onClose }: LegendPanelProps) => (
     <input type="button" name="closeLegend" onClick={onClose} />
   </span>
 ))
-
-const mockAddress = {
-  postcode: '1000 AA',
-  huisnummer: '100',
-  woonplaats: 'Amsterdam',
-  openbare_ruimte: 'West',
-}
-
-const mockPDOKResponse: PdokResponse = {
-  id: 'foo',
-  value: 'Zork',
-  data: {
-    location: {
-      lat: 12.282,
-      lng: 3.141,
-    },
-    address: mockAddress,
-  },
-}
-
-jest.mock(
-  'components/PDOKAutoSuggest',
-  () =>
-    ({ className, onSelect, value }: PDOKAutoSuggestProps) =>
-      (
-        <span data-testid="pdokAutoSuggest" className={className}>
-          <button onClick={() => onSelect(mockPDOKResponse)}>selectItem</button>
-          <span>{value}</span>
-        </span>
-      )
-)
 
 describe('signals/incident/components/form/AssetSelect/Selector', () => {
   beforeEach(() => {
@@ -159,25 +125,6 @@ describe('signals/incident/components/form/AssetSelect/Selector', () => {
     )
   })
 
-  it('dispatches the location when an address is selected', async () => {
-    const { setLocation } = contextValue
-
-    render(withAssetSelectContext(<Selector />))
-
-    await screen.findByTestId('pdokAutoSuggest')
-
-    expect(setLocation).not.toHaveBeenCalled()
-
-    const setLocationButton = screen.getByRole('button', { name: 'selectItem' })
-
-    userEvent.click(setLocationButton)
-
-    expect(setLocation).toHaveBeenCalledWith({
-      coordinates: mockPDOKResponse.data.location,
-      address: mockPDOKResponse.data.address,
-    })
-  })
-
   it('dispatches the location when a location is retrieved via geolocation', async () => {
     const coordinates = { lat: 52.3731081, lng: 4.8932945 }
     const coords = {
@@ -208,32 +155,11 @@ describe('signals/incident/components/form/AssetSelect/Selector', () => {
 
     userEvent.click(screen.getByTestId('gpsButton'))
 
-    await screen.findByTestId('pdokAutoSuggest')
+    await screen.findByTestId('gpsButton')
 
     expect(setLocation).toHaveBeenCalledWith({
       coordinates,
     })
-  })
-
-  it('renders already selected address', () => {
-    const predefinedAddress = {
-      postcode: '1234BR',
-      huisnummer: 1,
-      huisnummer_toevoeging: 'A',
-      woonplaats: 'Amsterdam',
-      openbare_ruimte: '',
-    }
-
-    render(
-      withAssetSelectContext(<Selector />, {
-        ...contextValue,
-        address: predefinedAddress,
-      })
-    )
-
-    expect(
-      screen.getByText(formatAddress(predefinedAddress))
-    ).toBeInTheDocument()
   })
 
   it('only renders the zoom message when feature types are available', () => {

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/styled.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/styled.tsx
@@ -7,7 +7,6 @@ import {
 } from '@amsterdam/asc-ui'
 
 import Map from 'components/Map'
-import PDOKAutoSuggest from 'components/PDOKAutoSuggest'
 import ViewerContainer from 'components/ViewerContainer'
 import { DETAIL_PANEL_WIDTH } from '../../constants'
 
@@ -40,28 +39,6 @@ export const StyledMap = styled(Map)`
   width: 100%;
   position: relative;
   z-index: 0;
-`
-
-export const StyledPDOKAutoSuggest = styled(PDOKAutoSuggest)`
-  position: relative;
-  z-index: 1;
-  max-width: 375px;
-  margin-left: ${themeSpacing(2)};
-
-  @media screen and ${breakpoint('max-width', 'tabletM')} {
-    width: calc(100vw - (16px + 44px + 8px) * 2);
-  }
-
-  @media screen and ${breakpoint('min-width', 'tabletM')} {
-    //                  detail panel width + (page margin + button width + button margin) * 2
-    width: calc(100vw - (${DETAIL_PANEL_WIDTH}px + (16px + 44px + 8px) * 2));
-  }
-`
-
-export const ControlWrapper = styled.div`
-  display: flex;
-  position: relative;
-  z-index: 401;
 `
 
 export const TopLeftWrapper = styled.div`


### PR DESCRIPTION
This PR moves the `PDOKAutoSuggest` component from the map (asset `Selector`) to the detail panel. Note that this change isn't the full set of changes that are required to completely move the functionality. Just an intermediate step.