### PR TITLE
[SIG-4427] Clear autosuggest

### DIFF
--- a/src/components/AutoSuggest/AutoSuggest.test.tsx
+++ b/src/components/AutoSuggest/AutoSuggest.test.tsx
@@ -479,7 +479,7 @@ describe('src/components/AutoSuggest', () => {
     expect(onSelect).toHaveBeenCalledWith(firstOption)
   })
 
-  it('should call onClear', async () => {
+  it('calls onClear', async () => {
     const onClear = jest.fn()
     render(withAppContext(<AutoSuggest {...props} onClear={onClear} />))
     const input = screen.getByRole('textbox')
@@ -501,6 +501,21 @@ describe('src/components/AutoSuggest', () => {
     act(() => {
       jest.advanceTimersByTime(INPUT_DELAY)
     })
+
+    expect(onClear).toHaveBeenCalled()
+  })
+
+  it('calls onClear when ClearInput button clicked', async () => {
+    const onClear = jest.fn()
+    const value = 'Rembrandt van Rijnweg 2, 1191GG Ouderkerk aan de Amstel'
+
+    render(
+      withAppContext(<AutoSuggest {...props} value={value} onClear={onClear} />)
+    )
+
+    expect(onClear).not.toHaveBeenCalled()
+
+    userEvent.click(screen.getByTestId('clearInput'))
 
     expect(onClear).toHaveBeenCalled()
   })

--- a/src/components/AutoSuggest/styled.tsx
+++ b/src/components/AutoSuggest/styled.tsx
@@ -1,0 +1,41 @@
+import styled, { css } from 'styled-components'
+
+import InputBase from 'components/Input'
+import { Button } from '@amsterdam/asc-ui'
+import SuggestList from './components/SuggestList'
+
+export const Wrapper = styled.div`
+  position: relative;
+`
+
+export const Input = styled(InputBase)<{ defaultValue?: string }>`
+  border: 1px solid;
+
+  & input {
+    border: 0;
+    ${({ defaultValue }) =>
+      defaultValue &&
+      css`
+        padding-right: 60px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      `}
+  }
+
+  & > * {
+    margin: 0;
+  }
+`
+
+export const List = styled(SuggestList)`
+  position: absolute;
+  width: 100%;
+  background-color: white;
+  z-index: 2;
+`
+
+export const ClearInput = styled(Button)`
+  position: absolute;
+  top: 1px;
+  right: 1px;
+`

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2020 - 2021 Gemeente Amsterdam
 import styled, { css } from 'styled-components'
+import type { ButtonProps } from '@amsterdam/asc-ui'
 import {
   Button as AscButton,
   themeColor,
@@ -18,7 +19,7 @@ const Button = styled(AscButton)`
     fill: inherit;
   }
 
-  ${({ variant, type }) =>
+  ${({ variant, type }: ButtonProps) =>
     variant === 'application' &&
     type === 'button' &&
     css`

--- a/src/components/Button/index.ts
+++ b/src/components/Button/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Button'

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.test.tsx
@@ -48,9 +48,12 @@ const mockPDOKResponse: PdokResponse = {
 jest.mock(
   'components/PDOKAutoSuggest',
   () =>
-    ({ className, onSelect, value }: PDOKAutoSuggestProps) =>
+    ({ className, onSelect, value, onClear }: PDOKAutoSuggestProps) =>
       (
         <span data-testid="pdokAutoSuggest" className={className}>
+          <button data-testid="autoSuggestClear" onClick={onClear}>
+            Clear input
+          </button>
           <button onClick={() => onSelect(mockPDOKResponse)}>selectItem</button>
           <span>{value}</span>
         </span>
@@ -168,6 +171,23 @@ describe('DetailPanel', () => {
     expect(contextValue.removeItem).not.toHaveBeenCalled()
 
     userEvent.click(removeButton)
+
+    expect(contextValue.removeItem).toHaveBeenCalled()
+  })
+
+  it('calls remove on autosuggest clear', () => {
+    render(
+      withAssetSelectContext(<DetailPanel {...props} />, {
+        ...contextValue,
+        selection,
+      })
+    )
+
+    const autoSuggestClear = screen.getByTestId('autoSuggestClear')
+
+    expect(contextValue.removeItem).not.toHaveBeenCalled()
+
+    userEvent.click(autoSuggestClear)
 
     expect(contextValue.removeItem).toHaveBeenCalled()
   })

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.tsx
@@ -129,6 +129,7 @@ const DetailPanel: FC<DetailPanelProps> = ({ featureTypes, language = {} }) => {
         </Paragraph>
 
         <StyledPDOKAutoSuggest
+          onClear={removeItem}
           onSelect={onAddressSelect}
           placeholder="Zoek adres"
           value={addressValue}

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.tsx
@@ -131,7 +131,6 @@ const DetailPanel: FC<DetailPanelProps> = ({ featureTypes, language = {} }) => {
         <StyledPDOKAutoSuggest
           onClear={removeItem}
           onSelect={onAddressSelect}
-          placeholder="Zoek adres"
           value={addressValue}
         />
 


### PR DESCRIPTION
This PR:
- Adds a button to the `AutoSuggest` component that allows clearing the field
- Handles clearing the auto suggest field in the `DetailPanel` component. This will effectively clear the location in the global state and, subsequently, remove the marker from the map.