### PR TITLE
Remove unnecessary `sort`

### DIFF
--- a/src/shared/services/map-location/map-location.test.ts
+++ b/src/shared/services/map-location/map-location.test.ts
@@ -53,7 +53,7 @@ describe('featureToCoordinates', () => {
 })
 
 describe('wktPointToLocation', () => {
-  it('should convert a WKT point to latlon location ', () => {
+  it('should convert a WKT point to latlon location with comma or space as separation', () => {
     expect(wktPointToLocation('POINT(4.90225668 52.36150435)')).toEqual({
       lat: 52.36150435,
       lng: 4.90225668,
@@ -74,6 +74,18 @@ describe('wktPointToLocation', () => {
     expect(wktPointToLocation('POINT(6.90225668,52.36150435)')).toEqual({
       lat: 52.36150435,
       lng: 6.90225668,
+    })
+  })
+
+  it('should use the smallest number of the two as longitude, expecting to be in the area of north west Europe', () => {
+    expect(wktPointToLocation('POINT(52.36150435 6.90225668)')).toEqual({
+      lat: 52.36150435,
+      lng: 6.90225668,
+    })
+
+    expect(wktPointToLocation('POINT(52.36150435,4.90225668)')).toEqual({
+      lat: 52.36150435,
+      lng: 4.90225668,
     })
   })
 

--- a/src/shared/services/map-location/map-location.test.ts
+++ b/src/shared/services/map-location/map-location.test.ts
@@ -65,6 +65,18 @@ describe('wktPointToLocation', () => {
     })
   })
 
+  it('should work when the lng is alphabetically bigger than the lon', () => {
+    expect(wktPointToLocation('POINT(6.90225668 52.36150435)')).toEqual({
+      lat: 52.36150435,
+      lng: 6.90225668,
+    })
+
+    expect(wktPointToLocation('POINT(6.90225668,52.36150435)')).toEqual({
+      lat: 52.36150435,
+      lng: 6.90225668,
+    })
+  })
+
   it('should throw an error', () => {
     expect(() => {
       wktPointToLocation('POLYGON(4.90225668 52.36150435)')

--- a/src/shared/services/map-location/map-location.ts
+++ b/src/shared/services/map-location/map-location.ts
@@ -38,7 +38,9 @@ export const wktPointToLocation = (wktPoint: string): LatLngLiteral => {
     throw new TypeError('Provided WKT geometry is not a point.')
   }
 
-  const [lat, lng] = pointMatch.reverse().map((str) => Number.parseFloat(str))
+  const [lng, lat] = pointMatch
+    .map((str) => Number.parseFloat(str))
+    .sort((a, b) => (a > b ? 1 : -1))
 
   return {
     lat,

--- a/src/shared/services/map-location/map-location.ts
+++ b/src/shared/services/map-location/map-location.ts
@@ -38,10 +38,7 @@ export const wktPointToLocation = (wktPoint: string): LatLngLiteral => {
     throw new TypeError('Provided WKT geometry is not a point.')
   }
 
-  const [lat, lng] = pointMatch
-    .sort()
-    .reverse()
-    .map((str) => Number.parseFloat(str))
+  const [lat, lng] = pointMatch.reverse().map((str) => Number.parseFloat(str))
 
   return {
     lat,


### PR DESCRIPTION
The lat lng conversion function unnecessarily used `sort` while `reverse` alone is enough to reverse lat and lng.
The `sort` caused a problem when the lng would be alphabetically 'bigger' than the lat.