### PR TITLE
[SIG-4428] Full-screen auto suggest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "react-media": "^1.10.0",
         "react-reactive-form": "1.0.27",
         "react-redux": "^7.2.3",
+        "react-responsive": "^9.0.0-beta.6",
         "react-router-dom": "^5.2.0",
         "redux": "^4.1.2",
         "redux-immutable": "4.0.0",
@@ -6258,8 +6259,7 @@
     "node_modules/css-mediaquery": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/css-mediaquery/-/css-mediaquery-0.1.2.tgz",
-      "integrity": "sha1-aiw3NEkoYYYxxUvTPO3TAdoYvqA=",
-      "dev": true
+      "integrity": "sha1-aiw3NEkoYYYxxUvTPO3TAdoYvqA="
     },
     "node_modules/css-minimizer-webpack-plugin": {
       "version": "3.0.2",
@@ -10397,6 +10397,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/hyphenate-style-name": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
+      "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -12804,6 +12809,14 @@
         "css-mediaquery": "^0.1.2",
         "exenv": "^1.2.0",
         "lodash": "^4.17.5"
+      }
+    },
+    "node_modules/matchmediaquery": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/matchmediaquery/-/matchmediaquery-0.3.1.tgz",
+      "integrity": "sha512-Hlk20WQHRIm9EE9luN1kjRjYXAQToHOIAHPJn9buxBwuhfTHoKUcX+lXBbxc85DVQfXYbEQ4HcwQdd128E3qHQ==",
+      "dependencies": {
+        "css-mediaquery": "^0.1.2"
       }
     },
     "node_modules/mdast-util-definitions": {
@@ -15508,6 +15521,23 @@
         }
       }
     },
+    "node_modules/react-responsive": {
+      "version": "9.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/react-responsive/-/react-responsive-9.0.0-beta.6.tgz",
+      "integrity": "sha512-Flk6UrnpBBByreva6ja/TsbXiXq4BXOlDEKL6Ur+nshUs3CcN5W0BpGe6ClFWrKcORkMZAAYy7A4N4xlMmpgVw==",
+      "dependencies": {
+        "hyphenate-style-name": "^1.0.0",
+        "matchmediaquery": "^0.3.0",
+        "prop-types": "^15.6.1",
+        "shallow-equal": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=0.10"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
     "node_modules/react-router": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.1.tgz",
@@ -16444,6 +16474,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/shallow-equal": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.1.tgz",
+      "integrity": "sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA=="
     },
     "node_modules/shallowequal": {
       "version": "1.1.0",
@@ -23898,8 +23933,7 @@
     "css-mediaquery": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/css-mediaquery/-/css-mediaquery-0.1.2.tgz",
-      "integrity": "sha1-aiw3NEkoYYYxxUvTPO3TAdoYvqA=",
-      "dev": true
+      "integrity": "sha1-aiw3NEkoYYYxxUvTPO3TAdoYvqA="
     },
     "css-minimizer-webpack-plugin": {
       "version": "3.0.2",
@@ -27013,6 +27047,11 @@
         }
       }
     },
+    "hyphenate-style-name": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
+      "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -28863,6 +28902,14 @@
         "css-mediaquery": "^0.1.2",
         "exenv": "^1.2.0",
         "lodash": "^4.17.5"
+      }
+    },
+    "matchmediaquery": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/matchmediaquery/-/matchmediaquery-0.3.1.tgz",
+      "integrity": "sha512-Hlk20WQHRIm9EE9luN1kjRjYXAQToHOIAHPJn9buxBwuhfTHoKUcX+lXBbxc85DVQfXYbEQ4HcwQdd128E3qHQ==",
+      "requires": {
+        "css-mediaquery": "^0.1.2"
       }
     },
     "mdast-util-definitions": {
@@ -30864,6 +30911,17 @@
         "react-is": "^17.0.2"
       }
     },
+    "react-responsive": {
+      "version": "9.0.0-beta.6",
+      "resolved": "https://registry.npmjs.org/react-responsive/-/react-responsive-9.0.0-beta.6.tgz",
+      "integrity": "sha512-Flk6UrnpBBByreva6ja/TsbXiXq4BXOlDEKL6Ur+nshUs3CcN5W0BpGe6ClFWrKcORkMZAAYy7A4N4xlMmpgVw==",
+      "requires": {
+        "hyphenate-style-name": "^1.0.0",
+        "matchmediaquery": "^0.3.0",
+        "prop-types": "^15.6.1",
+        "shallow-equal": "^1.2.1"
+      }
+    },
     "react-router": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.1.tgz",
@@ -31614,6 +31672,11 @@
       "requires": {
         "kind-of": "^6.0.2"
       }
+    },
+    "shallow-equal": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.1.tgz",
+      "integrity": "sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA=="
     },
     "shallowequal": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "react-media": "^1.10.0",
     "react-reactive-form": "1.0.27",
     "react-redux": "^7.2.3",
+    "react-responsive": "^9.0.0-beta.6",
     "react-router-dom": "^5.2.0",
     "redux": "^4.1.2",
     "redux-immutable": "4.0.0",

--- a/src/components/AutoSuggest/AutoSuggest.test.tsx
+++ b/src/components/AutoSuggest/AutoSuggest.test.tsx
@@ -542,4 +542,16 @@ describe('src/components/AutoSuggest', () => {
 
     await screen.findByTestId('autoSuggest')
   })
+
+  it('calls onFocus', () => {
+    const onFocus = jest.fn()
+
+    render(withAppContext(<AutoSuggest {...props} onFocus={onFocus} />))
+
+    expect(onFocus).not.toHaveBeenCalled()
+
+    fireEvent.focus(screen.getByRole('textbox'))
+
+    expect(onFocus).toHaveBeenCalled()
+  })
 })

--- a/src/components/AutoSuggest/AutoSuggest.test.tsx
+++ b/src/components/AutoSuggest/AutoSuggest.test.tsx
@@ -518,6 +518,47 @@ describe('src/components/AutoSuggest', () => {
     userEvent.click(screen.getByTestId('clearInput'))
 
     expect(onClear).toHaveBeenCalled()
+
+    expect(screen.getByRole('textbox')).not.toHaveFocus()
+  })
+
+  it('focuses the input on clear', async () => {
+    const onClear = jest.fn()
+    const value = 'Rembrandt van Rijnweg 2, 1191GG Ouderkerk aan de Amstel'
+
+    render(
+      withAppContext(
+        <AutoSuggest
+          {...props}
+          value={value}
+          onClear={onClear}
+          showInlineList={false}
+        />
+      )
+    )
+
+    userEvent.click(screen.getByTestId('clearInput'))
+
+    expect(screen.getByRole('textbox')).toHaveFocus()
+  })
+
+  it('calls onData', async () => {
+    const onData = jest.fn()
+
+    render(withAppContext(<AutoSuggest {...props} onData={onData} />))
+    const input = screen.getByRole('textbox')
+
+    userEvent.type(input, 'Rembrandt')
+
+    act(() => {
+      jest.advanceTimersByTime(INPUT_DELAY)
+    })
+
+    expect(onData).not.toHaveBeenCalled()
+
+    await screen.findByTestId('autoSuggest')
+
+    expect(onData).toHaveBeenCalled()
   })
 
   it('should work without onClear defined', async () => {

--- a/src/components/AutoSuggest/AutoSuggest.tsx
+++ b/src/components/AutoSuggest/AutoSuggest.tsx
@@ -20,6 +20,7 @@ export type AutoSuggestProps = {
   id?: string
   numOptionsDeterminer: (data?: RevGeo) => number
   onClear?: () => void
+  onFocus?: () => void
   onSelect: (option: PdokResponse) => void
   placeholder?: string
   url: string
@@ -46,6 +47,7 @@ const AutoSuggest: FC<AutoSuggestProps> = ({
   id = '',
   numOptionsDeterminer,
   onClear,
+  onFocus,
   onSelect,
   placeholder = '',
   url,
@@ -272,6 +274,7 @@ const AutoSuggest: FC<AutoSuggestProps> = ({
           disabled={disabled}
           id={id}
           onChange={onChange}
+          onFocus={onFocus}
           placeholder={placeholder}
           ref={inputRef}
           {...rest}

--- a/src/components/AutoSuggest/components/SuggestList/SuggestList.tsx
+++ b/src/components/AutoSuggest/components/SuggestList/SuggestList.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2020 - 2021 Gemeente Amsterdam
-import { Fragment, useEffect, useRef, useCallback } from 'react'
+import { useEffect, useRef, useCallback } from 'react'
 import styled from 'styled-components'
 import { themeColor, themeSpacing, Icon } from '@amsterdam/asc-ui'
 import { ChevronRight } from '@amsterdam/asc-assets'
@@ -49,12 +49,12 @@ type SuggestListProps = {
 }
 
 const SuggestList: FC<SuggestListProps> = ({
-  activeIndex,
-  className,
+  activeIndex = 0,
+  className = '',
   id,
   onSelectOption,
   options,
-  role,
+  role = 'listbox',
   ...rest
 }) => {
   const listRef = useRef<HTMLUListElement>(null)
@@ -121,22 +121,16 @@ const SuggestList: FC<SuggestListProps> = ({
           role="option"
           tabIndex={-1}
         >
-          <Fragment>
-            <StyledIcon size={12}>
+          <>
+            <StyledIcon className="chrevronIcon" size={12}>
               <Chevron />
             </StyledIcon>
             {option.value}
-          </Fragment>
+          </>
         </Li>
       ))}
     </StyledList>
   )
-}
-
-SuggestList.defaultProps = {
-  activeIndex: 0,
-  className: '',
-  role: 'listbox',
 }
 
 export default SuggestList

--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -23,8 +23,8 @@ const StyledMap = styled(MapComponent)`
   }
 `
 
-const StyledVieweContainer = styled(ViewerContainer)`
-  z-index: 402;
+const StyledViewerContainer = styled(ViewerContainer)`
+  z-index: 1;
 `
 
 interface MapProps {
@@ -90,7 +90,7 @@ const Map: FC<PropsWithChildren<MapProps>> = ({
       {children}
 
       {/* Render zoom buttons after children to maintain correct focus order */}
-      <StyledVieweContainer
+      <StyledViewerContainer
         bottomRight={
           showZoom && (
             <div data-testid="mapZoom">

--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -24,7 +24,7 @@ const StyledMap = styled(MapComponent)`
 `
 
 const StyledViewerContainer = styled(ViewerContainer)`
-  z-index: 1;
+  z-index: 0;
 `
 
 interface MapProps {

--- a/src/components/PDOKAutoSuggest/PDOKAutoSuggest.tsx
+++ b/src/components/PDOKAutoSuggest/PDOKAutoSuggest.tsx
@@ -29,6 +29,7 @@ export type PDOKAutoSuggestProps = {
   fieldList?: Array<string>
   municipality?: string | Array<string>
   onClear?: () => void
+  onFocus?: () => void
   onSelect: (option: PdokResponse) => void
   placeholder?: string
   value?: string
@@ -44,6 +45,7 @@ const PDOKAutoSuggest: FC<PDOKAutoSuggestProps> = ({
   fieldList,
   municipality,
   onClear,
+  onFocus,
   onSelect,
   placeholder,
   value,
@@ -72,6 +74,7 @@ const PDOKAutoSuggest: FC<PDOKAutoSuggestProps> = ({
       formatResponse={formatPDOKResponse}
       numOptionsDeterminer={numOptionsDeterminer}
       onClear={onClear}
+      onFocus={onFocus}
       onSelect={onSelect}
       placeholder={placeholder}
       url={url}

--- a/src/components/PDOKAutoSuggest/PDOKAutoSuggest.tsx
+++ b/src/components/PDOKAutoSuggest/PDOKAutoSuggest.tsx
@@ -3,8 +3,7 @@
 import type { FC } from 'react'
 import type { RevGeo } from 'types/pdok/revgeo'
 
-import type { PdokResponse } from 'shared/services/map-location'
-
+import type { AutoSuggestProps } from 'components/AutoSuggest'
 import AutoSuggest from 'components/AutoSuggest'
 import {
   pdokResponseFieldList,
@@ -24,15 +23,13 @@ const serviceUrl =
 const numOptionsDeterminer = (data?: RevGeo) =>
   data?.response?.docs?.length || 0
 
-export type PDOKAutoSuggestProps = {
-  className?: string
+export interface PDOKAutoSuggestProps
+  extends Omit<
+    AutoSuggestProps,
+    'url' | 'formatResponse' | 'numOptionsDeterminer'
+  > {
   fieldList?: Array<string>
   municipality?: string | Array<string>
-  onClear?: () => void
-  onFocus?: () => void
-  onSelect: (option: PdokResponse) => void
-  placeholder?: string
-  value?: string
 }
 
 /**
@@ -41,14 +38,8 @@ export type PDOKAutoSuggestProps = {
  * @see {@link https://www.pdok.nl/restful-api/-/article/pdok-locatieserver#/paths/~1suggest/get}
  */
 const PDOKAutoSuggest: FC<PDOKAutoSuggestProps> = ({
-  className,
-  fieldList,
-  municipality,
-  onClear,
-  onFocus,
-  onSelect,
-  placeholder,
-  value,
+  fieldList = [],
+  municipality = configuration.map.municipality,
   ...rest
 }) => {
   const municipalityArray = Array.isArray(municipality)
@@ -70,25 +61,12 @@ const PDOKAutoSuggest: FC<PDOKAutoSuggestProps> = ({
 
   return (
     <AutoSuggest
-      className={className}
+      {...rest}
+      url={url}
       formatResponse={formatPDOKResponse}
       numOptionsDeterminer={numOptionsDeterminer}
-      onClear={onClear}
-      onFocus={onFocus}
-      onSelect={onSelect}
-      placeholder={placeholder}
-      url={url}
-      value={value}
-      {...rest}
     />
   )
-}
-
-PDOKAutoSuggest.defaultProps = {
-  className: '',
-  fieldList: [],
-  municipality: configuration.map.municipality,
-  value: '',
 }
 
 export default PDOKAutoSuggest

--- a/src/signals/incident/components/form/MapSelectors/Asset/AssetList/AssetList.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/AssetList/AssetList.tsx
@@ -21,7 +21,7 @@ const StyledButton = styled(Button).attrs(() => ({
   size: 32,
   iconSize: 12,
 }))`
-  margin-left: 8px;
+  margin-right: 2px;
   flex-shrink: 0;
   box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.1);
   min-width: auto;

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/styled.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/styled.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components'
+import styled, { keyframes } from 'styled-components'
 
 import { Button, themeSpacing, themeColor, breakpoint } from '@amsterdam/asc-ui'
 
@@ -66,4 +66,68 @@ export const Description = styled.span`
 
 export const StyledPDOKAutoSuggest = styled(PDOKAutoSuggest)`
   margin: ${themeSpacing(4, 0)};
+  width: 100%;
+`
+const slideUp = keyframes`
+  from {
+    transform: translate3d(0, 100%, 0);
+  }
+
+  to {
+    transform: translate3d(0, 0, 0);
+  }
+`
+
+export const AddressPanel = styled.article`
+  background-color: white;
+  position: fixed;
+  width: 100vw;
+  height: 100vh;
+  z-index: 2;
+  left: 0;
+  top: 0;
+  animation: ${slideUp} 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+
+  @media only screen and ${breakpoint('max-width', 'tabletM')} {
+    transform: translate3d(0, 0, 0);
+  }
+
+  header {
+    border-bottom: 5px solid rgba(0, 0, 0, 0.1);
+    padding: ${themeSpacing(4)};
+    display: flex;
+    align-items: center;
+
+    > * {
+      margin: 0;
+    }
+
+    button {
+      border: 0;
+      margin-right: ${themeSpacing(4)};
+    }
+  }
+
+  .instruction {
+    color: ${themeColor('tint', 'level4')};
+    font-size: 18px;
+    margin-top: ${themeSpacing(6)};
+    text-align: center;
+  }
+`
+
+export const OptionsList = styled.div`
+  ul {
+    border: 0;
+    margin: ${themeSpacing(2, 0)};
+
+    li {
+      line-height: 22px;
+      padding: ${themeSpacing(2, 4)};
+    }
+  }
+
+  .chrevronIcon {
+    display: none;
+  }
 `

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/styled.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/styled.tsx
@@ -102,7 +102,7 @@ export const AddressPanel = styled.article`
       margin: 0;
     }
 
-    button {
+    > button {
       border: 0;
       margin-right: ${themeSpacing(4)};
     }

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/styled.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/styled.tsx
@@ -14,7 +14,7 @@ export const StyledViewerContainer = styled(ViewerContainer)`
   @media screen and ${breakpoint('min-width', 'tabletM')} {
     left: ${DETAIL_PANEL_WIDTH}px;
   }
-  z-index: 401;
+  z-index: 1;
 `
 
 export const Wrapper = styled.div`

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/styled.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/styled.tsx
@@ -53,7 +53,8 @@ export const ScrollWrapper = styled.div.attrs({
   -webkit-overflow-scrolling: touch;
   height: 100%;
   overflow-y: auto;
-  padding: ${themeSpacing(4, 0, 10)};
+  padding: ${themeSpacing(4, 4, 10)};
+  margin: ${themeSpacing(0, -4)};
 `
 
 export const Title = styled(Paragraph).attrs({

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/styled.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/styled.tsx
@@ -14,7 +14,7 @@ export const StyledViewerContainer = styled(ViewerContainer)`
   @media screen and ${breakpoint('min-width', 'tabletM')} {
     left: ${DETAIL_PANEL_WIDTH}px;
   }
-  z-index: 1;
+  z-index: 0;
 `
 
 export const Wrapper = styled.div`


### PR DESCRIPTION
This PR:
- Renders a full-screen address panel with auto suggest field on smaller screens
- Adds the [react-responsive](https://www.npmjs.com/package/react-responsive) dependency. This is meant to replace the [react-media](https://www.npmjs.com/package/react-media)`dep, which is not maintained anymore.
- Adjusts the `AutoSuggest` component so that it can render a list of suggestions (default) or return the list via callback so that implementing components can render the list in their own way.