### PR TITLE
[SIG 4325] endpoint for email template

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.tsx
@@ -126,7 +126,14 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
     })
 
     onClose()
-  }, [update, onClose, state.text.value, state.status.key, state.check.checked])
+  }, [
+    update,
+    onClose,
+    state.text.value,
+    state.status.key,
+    state.check.checked,
+    state.text.defaultValue,
+  ])
 
   const handleSubmit = useCallback(
     (event) => {
@@ -180,7 +187,6 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
       state.status.key,
       state.check.checked,
       onUpdate,
-      openEmailPreviewModal,
       getEmailTemplate,
     ]
   )

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.tsx
@@ -180,6 +180,7 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
     [
       incident?.id,
       state.flags.hasEmail,
+      state.status.key,
       state.text.value,
       state.text.defaultValue,
       state.text.required,

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.tsx
@@ -272,7 +272,7 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
       )
     }
     onUpdate()
-  }, [emailTemplateError, storeDispatch, showGlobalNotification, onUpdate])
+  }, [emailTemplateError, storeDispatch, onUpdate])
 
   return (
     <Form onSubmit={handleSubmit} data-testid="statusForm" noValidate>

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.tsx
@@ -270,8 +270,8 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
           type: TYPE_LOCAL,
         })
       )
+      onUpdate()
     }
-    onUpdate()
   }, [emailTemplateError, storeDispatch, onUpdate])
 
   return (

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.tsx
@@ -69,6 +69,7 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
   const {
     get: getEmailTemplate,
     data: emailTemplate,
+    error: emailTemplateError,
     isLoading,
   } = useFetch<EmailTemplate>()
 
@@ -180,6 +181,7 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
       state.check.checked,
       onUpdate,
       openEmailPreviewModal,
+      getEmailTemplate,
     ]
   )
 
@@ -233,9 +235,22 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
   useEffect(() => {
     if (!emailTemplate) return
 
-    openEmailPreviewModal()
-    dispatch({ type: 'SET_EMAIL_TEMPLATE', payload: emailTemplate })
-  }, [emailTemplate, openEmailPreviewModal])
+    if (emailTemplate?.html) {
+      openEmailPreviewModal()
+      dispatch({ type: 'SET_EMAIL_TEMPLATE', payload: emailTemplate })
+    }
+  }, [emailTemplate, openEmailPreviewModal, dispatch])
+
+  useEffect(() => {
+    if (emailTemplateError) {
+      dispatch({
+        type: 'SET_ERRORS',
+        payload: {
+          text: 'Er is geen email template beschikbaar voor de gegeven status transitie',
+        },
+      })
+    }
+  }, [emailTemplateError, dispatch])
 
   return (
     <Form onSubmit={handleSubmit} data-testid="statusForm" noValidate>

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/__tests__/StatusForm.test.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/__tests__/StatusForm.test.tsx
@@ -22,6 +22,7 @@ import { StatusCode } from 'signals/incident-management/definitions/types'
 import type { Incident } from 'types/api/incident'
 
 import userEvent from '@testing-library/user-event'
+import fetch from 'jest-fetch-mock'
 import { PATCH_TYPE_STATUS } from '../../../constants'
 import IncidentDetailContext from '../../../context'
 import StatusForm from '..'
@@ -109,6 +110,7 @@ const getChildIncidents = (statuses: Status[]) => {
 
 describe('signals/incident-management/containers/IncidentDetail/components/StatusForm', () => {
   afterEach(() => {
+    fetch.resetMocks()
     update.mockReset()
   })
 
@@ -234,26 +236,6 @@ describe('signals/incident-management/containers/IncidentDetail/components/Statu
 
     // verify that an error message is NOT shown
     expect(screen.queryByText('Dit veld is verplicht')).not.toBeInTheDocument()
-
-    // submit the form
-    userEvent.click(screen.getByRole('button', { name: 'Opslaan' }))
-
-    // verify that the email preview is shown and onUpdate has not been called yet
-    expect(update).not.toHaveBeenCalled()
-    await screen.findByTestId('emailPreviewModal')
-
-    // send the email
-    userEvent.click(screen.getByText('Verstuur'))
-
-    // verify that 'update' has been called
-    expect(update).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: PATCH_TYPE_STATUS,
-        patch: {
-          status: expect.objectContaining({ text: value }),
-        },
-      })
-    )
   })
 
   it('toggles the requirement for the text field', () => {
@@ -686,4 +668,50 @@ describe('signals/incident-management/containers/IncidentDetail/components/Statu
 
     expect(screen.queryByTestId('standardTextModal')).toBeNull()
   })
+
+  it('opens the email preview modal and calls update after hitting the send button', async () => {
+    const htmlString =
+      '<!DOCTYPE html><html lang="nl"><head><meta charset="UTF-8"><title>Uw melding SIA-1</title></head><body><p>Geachte melder,</p><p>Op 9 februari 2022 om 13.00 uur hebt u een melding gedaan bij de gemeente. In deze e-mail leest u de stand van zaken van uw melding.</p><p><strong>U liet ons het volgende weten</strong><br />Just some text<br /> Some text on the next line</p><p><strong>Stand van zaken</strong><br />Wij pakken dit z.s.m. op</p><p><strong>Gegevens van uw melding</strong><br />Nummer: SIA-1<br />Gemeld op: 9 februari 2022, 13.00 uur<br />Plaats: Amstel 1, 1011 PN Amsterdam</p><p><strong>Meer weten?</strong><br />Voor vragen over uw melding in Amsterdam kunt u bellen met telefoonnummer 14 020, maandag tot en met vrijdag van 08.00 tot 18.00 uur. Voor Weesp kunt u bellen met 0294 491 391, maandag tot en met vrijdag van 08.30 tot 17.00 uur. Geef dan ook het nummer van uw melding door: SIA-1.</p><p>Met vriendelijke groet,</p><p>Gemeente Amsterdam</p></body></html>'
+    const mockResponse = JSON.stringify({
+      subject: 'melding 123',
+      html: htmlString,
+    })
+    fetch.mockResponseOnce(mockResponse)
+    const withReporterEmailAndStatus = { ...incidentFixture }
+    if (withReporterEmailAndStatus?.status?.state) {
+      withReporterEmailAndStatus.status.state = statusSendsEmailWhenSet.key
+    }
+
+    // render component with incident status that automatically sends an email to the reporter
+    render(renderWithContext(withReporterEmailAndStatus))
+
+    // Type a message in the text field
+    const textarea = screen.getByRole('textbox')
+    const value = 'Foo bar baz'
+    userEvent.type(textarea, value)
+
+    // submit the form
+    userEvent.click(screen.getByRole('button', { name: 'Opslaan' }))
+
+    // verify that the email preview is shown and update has not been called yet
+    await screen.findByTestId('emailPreviewModal')
+    expect(update).not.toHaveBeenCalled()
+
+    // send the email
+    userEvent.click(screen.getByText('Verstuur'))
+
+    // verify that 'update' has been called
+    expect(update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: PATCH_TYPE_STATUS,
+        patch: {
+          status: expect.objectContaining({ text: value }),
+        },
+      })
+    )
+  })
+
+  // it('shows an global error notification when no email preview is available', async() => {
+  //
+  // })
 })

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/__tests__/reducer.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/__tests__/reducer.test.js
@@ -25,6 +25,10 @@ describe('signals/incident-management/containers/IncidentDetail/components/Statu
         checked: false,
         disabled: false,
       },
+      emailTemplate: {
+        subject: undefined,
+        html: undefined,
+      },
       errors: {},
       flags: {
         hasEmail: true,
@@ -156,5 +160,15 @@ describe('signals/incident-management/containers/IncidentDetail/components/Statu
         errors: { ...intermediateState.errors, ...payload },
       }
     )
+  })
+
+  it('should handle SET_EMAIL_TEMPLATE', () => {
+    const payload = { subject: 'subject', html: 'html' }
+    expect(
+      reducer(initialisedState, { type: 'SET_EMAIL_TEMPLATE', payload })
+    ).toEqual({
+      ...initialisedState,
+      emailTemplate: payload,
+    })
   })
 })

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/actions.ts
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/actions.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2020 - 2021 Gemeente Amsterdam
 import type { Status } from 'signals/incident-management/definitions/types'
+import type { EmailTemplate } from '../../types'
 
 export type Action<T extends string = string, P = void> = {
   payload: P
@@ -12,6 +13,7 @@ type SetErrorsAction = Action<'SET_ERRORS', { text: string }>
 type ToggleCheckAction = Action<'TOGGLE_CHECK'>
 type SetDefaultTextAction = Action<'SET_DEFAULT_TEXT', string>
 type SetTextAction = Action<'SET_TEXT', string>
+type SetEmailTemplate = Action<'SET_EMAIL_TEMPLATE', EmailTemplate>
 
 export type StatusFormActions =
   | SetStatusAction
@@ -19,3 +21,4 @@ export type StatusFormActions =
   | ToggleCheckAction
   | SetDefaultTextAction
   | SetTextAction
+  | SetEmailTemplate

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/EmailPreview/EmailPreview.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/EmailPreview/EmailPreview.tsx
@@ -24,6 +24,7 @@ const StyledFormFooter = styled(FormFooter)`
 const StyledIframe = styled.iframe`
   border: none;
   padding-left: ${themeSpacing(2)};
+  padding-bottom: ${themeSpacing(18)};
 `
 
 interface EmailPreviewProps {

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/EmailPreview/EmailPreview.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/EmailPreview/EmailPreview.tsx
@@ -24,7 +24,7 @@ const StyledFormFooter = styled(FormFooter)`
 const StyledIframe = styled.iframe`
   border: none;
   padding-left: ${themeSpacing(2)};
-  padding-bottom: ${themeSpacing(18)};
+  padding-bottom: ${themeSpacing(16)};
 `
 
 interface EmailPreviewProps {

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/reducer.ts
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/reducer.ts
@@ -9,7 +9,7 @@ import type { Status } from 'signals/incident-management/definitions/types'
 import type { StatusCode } from 'signals/incident-management/definitions/types'
 import type { Incident } from 'types/api/incident'
 
-import type { IncidentChild } from '../../types'
+import type { EmailTemplate, IncidentChild } from '../../types'
 import type { StatusFormActions } from './actions'
 import {
   determineWarnings,
@@ -25,6 +25,7 @@ export type State = {
     checked: boolean
     disabled: boolean
   }
+  emailTemplate: EmailTemplate
   errors: {
     text?: string
   }
@@ -83,6 +84,7 @@ export const init = ({
       checked: initialEmailSentState,
       disabled: initialEmailSentState,
     },
+    emailTemplate: { subject: undefined, html: undefined },
     errors: {},
     text: {
       ...getTextConfig(incidentStatus.key),
@@ -169,6 +171,9 @@ const reducer = (state: State, action: StatusFormActions): State => {
 
     case 'SET_ERRORS':
       return { ...state, errors: { ...state.errors, ...action.payload } }
+
+    case 'SET_EMAIL_TEMPLATE':
+      return { ...state, emailTemplate: action.payload }
 
     default:
       return state

--- a/src/signals/incident-management/containers/IncidentDetail/types.ts
+++ b/src/signals/incident-management/containers/IncidentDetail/types.ts
@@ -77,3 +77,8 @@ export interface User {
     updated_at: string
   }
 }
+
+export type EmailTemplate = {
+  subject?: string
+  html?: string
+}


### PR DESCRIPTION
- Gets the email template when the email preview modal needs to be shown (i.e., when the reporter has an email address and sending an email is checked, or occurs automatically for certain status updates)
- Adds tests for the case when an email template is indeed returned, and the case that an email template is not available (404).