### PR TITLE
(Chore) Show autosuggest clear button

### DIFF
--- a/src/components/AutoSuggest/AutoSuggest.test.tsx
+++ b/src/components/AutoSuggest/AutoSuggest.test.tsx
@@ -479,6 +479,28 @@ describe('src/components/AutoSuggest', () => {
     expect(onSelect).toHaveBeenCalledWith(firstOption)
   })
 
+  it('renders clear button when user types', async () => {
+    render(withAppContext(<AutoSuggest {...props} />))
+
+    expect(screen.queryByTestId('clearInput')).not.toBeInTheDocument()
+
+    const input = screen.getByRole('textbox')
+
+    userEvent.type(input, 'Rembrandt')
+
+    act(() => {
+      jest.advanceTimersByTime(INPUT_DELAY)
+    })
+
+    await screen.findByTestId('autoSuggest')
+
+    expect(screen.getByTestId('clearInput')).toBeInTheDocument()
+
+    userEvent.click(screen.getByTestId('clearInput'))
+
+    expect(screen.queryByTestId('clearInput')).not.toBeInTheDocument()
+  })
+
   it('calls onClear', async () => {
     const onClear = jest.fn()
     render(withAppContext(<AutoSuggest {...props} onClear={onClear} />))
@@ -519,7 +541,7 @@ describe('src/components/AutoSuggest', () => {
 
     expect(onClear).toHaveBeenCalled()
 
-    expect(screen.getByRole('textbox')).not.toHaveFocus()
+    expect(screen.getByRole('textbox')).toHaveFocus()
   })
 
   it('focuses the input on clear', async () => {

--- a/src/components/AutoSuggest/AutoSuggest.tsx
+++ b/src/components/AutoSuggest/AutoSuggest.tsx
@@ -322,7 +322,7 @@ const AutoSuggest: FC<AutoSuggestProps> = ({
             icon={<Close />}
             iconSize={20}
             onClick={clearInput}
-            size={44}
+            size={24}
             variant="blank"
           />
         )}

--- a/src/components/AutoSuggest/AutoSuggest.tsx
+++ b/src/components/AutoSuggest/AutoSuggest.tsx
@@ -98,11 +98,7 @@ const AutoSuggest: FC<AutoSuggestProps> = ({
     if (onClear) {
       onClear()
     }
-
-    if (onData) {
-      onData(null)
-    }
-  }, [onClear, onData])
+  }, [onClear])
 
   const handleKeyDown = useCallback(
     (event) => {

--- a/src/components/AutoSuggest/AutoSuggest.tsx
+++ b/src/components/AutoSuggest/AutoSuggest.tsx
@@ -60,6 +60,7 @@ const AutoSuggest: FC<AutoSuggestProps> = ({
   value = '',
   ...rest
 }) => {
+  const [defaultValue, setDefaultValue] = useState(value)
   const { get, data } = useFetch<RevGeo>()
   const [initialRender, setInitialRender] = useState(false)
   const [showList, setShowList] = useState(false)
@@ -87,18 +88,21 @@ const AutoSuggest: FC<AutoSuggestProps> = ({
     if (inputRef.current) {
       inputRef.current.value = ''
 
-      if (!showInlineList) {
-        inputRef.current.focus()
-      }
+      inputRef.current.focus()
     }
 
     setActiveIndex(-1)
     setShowList(false)
+    setDefaultValue('')
 
     if (onClear) {
       onClear()
     }
-  }, [onClear, showInlineList])
+
+    if (onData) {
+      onData(null)
+    }
+  }, [onClear, onData])
 
   const handleKeyDown = useCallback(
     (event) => {
@@ -196,6 +200,7 @@ const AutoSuggest: FC<AutoSuggestProps> = ({
   const onChange = useCallback(
     (event) => {
       event.persist()
+      setDefaultValue(event.target.value)
       debouncedServiceRequest(event.target.value)
     },
     [debouncedServiceRequest]
@@ -205,6 +210,7 @@ const AutoSuggest: FC<AutoSuggestProps> = ({
     (option) => {
       setActiveIndex(-1)
       setShowList(false)
+      setDefaultValue(option.value)
 
       if (inputRef.current) {
         inputRef.current.value = option.value
@@ -305,7 +311,7 @@ const AutoSuggest: FC<AutoSuggestProps> = ({
           aria-activedescendant={activeId.toString()}
           aria-autocomplete="list"
           autoComplete="off"
-          defaultValue={value}
+          defaultValue={defaultValue}
           disabled={disabled}
           id={id}
           onChange={onChange}
@@ -314,7 +320,7 @@ const AutoSuggest: FC<AutoSuggestProps> = ({
           ref={inputRef}
           {...rest}
         />
-        {value && (
+        {defaultValue && (
           <ClearInput
             data-testid="clearInput"
             icon={<Close />}

--- a/src/components/AutoSuggest/styled.tsx
+++ b/src/components/AutoSuggest/styled.tsx
@@ -36,6 +36,6 @@ export const List = styled(SuggestList)`
 
 export const ClearInput = styled(Button)`
   position: absolute;
-  top: 1px;
-  right: 1px;
+  top: 11px;
+  right: 11px;
 `

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.test.tsx
@@ -202,6 +202,8 @@ describe('DetailPanel', () => {
   })
 
   it('calls remove on autosuggest clear', () => {
+    jest.spyOn(reactResponsive, 'useMediaQuery').mockReturnValue(true)
+
     render(
       withAssetSelectContext(<DetailPanel {...props} />, {
         ...contextValue,
@@ -209,13 +211,27 @@ describe('DetailPanel', () => {
       })
     )
 
-    const autoSuggestClear = screen.getByTestId('autoSuggestClear')
+    userEvent.type(screen.getByTestId('autoSuggestInput'), 'Meeuw')
+
+    // simulate data retrieval
+    userEvent.click(
+      within(screen.getByTestId('addressPanel')).getByTestId(
+        'getDataMockButton'
+      )
+    )
+
+    expect(screen.getByTestId('optionsList')).toBeInTheDocument()
+
+    const autoSuggestClear = within(
+      screen.getByTestId('addressPanel')
+    ).getByTestId('autoSuggestClear')
 
     expect(contextValue.removeItem).not.toHaveBeenCalled()
 
     userEvent.click(autoSuggestClear)
 
     expect(contextValue.removeItem).toHaveBeenCalled()
+    expect(screen.queryByTestId('optionsList')).not.toBeInTheDocument()
   })
 
   it('adds asset not on map', () => {

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.tsx
@@ -138,6 +138,11 @@ const DetailPanel: FC<DetailPanelProps> = ({ featureTypes, language = {} }) => {
     [closeAddressPanel, setLocation]
   )
 
+  const clearInput = useCallback(() => {
+    removeItem()
+    setOptionsList(null)
+  }, [removeItem])
+
   return (
     <PanelContent data-testid="detailPanel">
       <Title>{language.title || 'Locatie'}</Title>
@@ -234,7 +239,7 @@ const DetailPanel: FC<DetailPanelProps> = ({ featureTypes, language = {} }) => {
             />
             <StyledPDOKAutoSuggest
               autoFocus
-              onClear={removeItem}
+              onClear={clearInput}
               onData={setOptionsList}
               onSelect={onAddressSelect}
               showInlineList={false}


### PR DESCRIPTION
This PR:
- always shows the auto suggest input clear button when user types in the input field
- makes sure that the list of auto suggest options is removed whenever the clear button is clicked