### PR TITLE
Postpone submit on loading questions from backend

### DIFF
--- a/src/signals/incident/components/IncidentForm/index.js
+++ b/src/signals/incident/components/IncidentForm/index.js
@@ -33,7 +33,9 @@ class IncidentForm extends Component {
       return null
     }
 
-    const loading = get(props, props.postponeSubmitWhenLoading)
+    const loading = Array.isArray(props.postponeSubmitWhenLoading)
+      ? props.postponeSubmitWhenLoading.some((prop) => get(props, prop))
+      : get(props, props.postponeSubmitWhenLoading)
     if (loading !== prevState.loading) {
       return {
         loading,
@@ -219,7 +221,10 @@ IncidentForm.propTypes = {
   removeQuestionData: PropTypes.func.isRequired,
   updateIncident: PropTypes.func.isRequired,
   createIncident: PropTypes.func.isRequired,
-  postponeSubmitWhenLoading: PropTypes.string,
+  postponeSubmitWhenLoading: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.arrayOf(PropTypes.string),
+  ]),
 }
 
 export default IncidentForm

--- a/src/signals/incident/components/IncidentForm/index.js
+++ b/src/signals/incident/components/IncidentForm/index.js
@@ -3,7 +3,6 @@
 import { createRef, Component } from 'react'
 import PropTypes from 'prop-types'
 import { FormGenerator } from 'react-reactive-form'
-import get from 'lodash/get'
 import isEqual from 'lodash/isEqual'
 import isObject from 'lodash/isObject'
 
@@ -28,22 +27,16 @@ class IncidentForm extends Component {
     this.setIncident = this.setIncident.bind(this)
   }
 
-  static getDerivedStateFromProps(props, prevState) {
-    if (!props.postponeSubmitWhenLoading) {
-      return null
-    }
-
-    const loading = Array.isArray(props.postponeSubmitWhenLoading)
-      ? props.postponeSubmitWhenLoading.some((prop) => get(props, prop))
-      : get(props, props.postponeSubmitWhenLoading)
-    if (loading !== prevState.loading) {
-      return {
-        loading,
-        submitting: !loading ? false : prevState.submitting,
-      }
-    }
-
-    return null
+  static getDerivedStateFromProps(
+    { incidentContainer: { loadingData } },
+    prevState
+  ) {
+    return loadingData === prevState.loading
+      ? null
+      : {
+          loading: loadingData,
+          submitting: loadingData ? prevState.submitting : false,
+        }
   }
 
   componentDidUpdate(prevProps, prevState) {
@@ -145,16 +138,14 @@ class IncidentForm extends Component {
     e.preventDefault()
 
     if (next) {
-      if (this.props.postponeSubmitWhenLoading) {
-        if (this.state.loading) {
-          this.setState({
-            submitting: true,
-            formAction,
-            next,
-          })
+      if (this.state.loading) {
+        this.setState({
+          submitting: true,
+          formAction,
+          next,
+        })
 
-          return
-        }
+        return
       }
 
       if (this.form.valid || this.form.status === 'DISABLED') {
@@ -210,7 +201,6 @@ IncidentForm.defaultProps = {
   fieldConfig: {
     controls: {},
   },
-  postponeSubmitWhenLoading: '',
 }
 
 IncidentForm.propTypes = {
@@ -221,10 +211,6 @@ IncidentForm.propTypes = {
   removeQuestionData: PropTypes.func.isRequired,
   updateIncident: PropTypes.func.isRequired,
   createIncident: PropTypes.func.isRequired,
-  postponeSubmitWhenLoading: PropTypes.oneOfType([
-    PropTypes.string,
-    PropTypes.arrayOf(PropTypes.string),
-  ]),
 }
 
 export default IncidentForm

--- a/src/signals/incident/components/IncidentForm/index.test.js
+++ b/src/signals/incident/components/IncidentForm/index.test.js
@@ -285,6 +285,97 @@ describe('<IncidentForm />', () => {
 
         expect(nextSpy).toHaveBeenCalledTimes(2)
       })
+
+      it('should postpone submit when postponeSubmitWhenLoading is defined for loadingQuestions', () => {
+        const props = {
+          ...defaultProps,
+          postponeSubmitWhenLoading: 'loadingQuestions',
+        }
+
+        const { rerender } = renderIncidentForm({
+          ...props,
+          loadingQuestions: true,
+        })
+
+        expect(nextSpy).toHaveBeenCalledTimes(1)
+        userEvent.click(screen.getByText(mockForm.nextButtonLabel))
+        expect(nextSpy).toHaveBeenCalledTimes(1)
+
+        renderIncidentForm(props, rerender)
+
+        expect(nextSpy).toHaveBeenCalledTimes(2)
+      })
+
+      it('should postpone submit when postponeSubmitWhenLoading is defined for both loadingClassification and loadingQuestions', () => {
+        const props = {
+          ...defaultProps,
+          postponeSubmitWhenLoading: [
+            'loadingClassification',
+            'loadingQuestions',
+          ],
+        }
+
+        const { rerender } = renderIncidentForm({
+          ...props,
+          loadingQuestions: true,
+          loadingClassification: true,
+        })
+
+        expect(nextSpy).toHaveBeenCalledTimes(1)
+        userEvent.click(screen.getByText(mockForm.nextButtonLabel))
+        expect(nextSpy).toHaveBeenCalledTimes(1)
+
+        renderIncidentForm(props, rerender)
+
+        expect(nextSpy).toHaveBeenCalledTimes(2)
+
+        renderIncidentForm(
+          {
+            ...props,
+            loadingQuestions: false,
+            loadingClassification: true,
+          },
+          rerender
+        )
+
+        expect(nextSpy).toHaveBeenCalledTimes(2)
+        userEvent.click(screen.getByText(mockForm.nextButtonLabel))
+        expect(nextSpy).toHaveBeenCalledTimes(2)
+
+        renderIncidentForm(props, rerender)
+
+        expect(nextSpy).toHaveBeenCalledTimes(3)
+
+        renderIncidentForm(
+          {
+            ...props,
+            loadingQuestions: true,
+            loadingClassification: false,
+          },
+          rerender
+        )
+
+        expect(nextSpy).toHaveBeenCalledTimes(3)
+        userEvent.click(screen.getByText(mockForm.nextButtonLabel))
+        expect(nextSpy).toHaveBeenCalledTimes(3)
+
+        renderIncidentForm(props, rerender)
+
+        expect(nextSpy).toHaveBeenCalledTimes(4)
+
+        renderIncidentForm(
+          {
+            ...props,
+            loadingQuestions: false,
+            loadingClassification: false,
+          },
+          rerender
+        )
+
+        expect(nextSpy).toHaveBeenCalledTimes(4)
+        userEvent.click(screen.getByText(mockForm.nextButtonLabel))
+        expect(nextSpy).toHaveBeenCalledTimes(5)
+      })
     })
 
     it('should not submit async when form is not valid after service call', () => {

--- a/src/signals/incident/components/IncidentForm/index.test.js
+++ b/src/signals/incident/components/IncidentForm/index.test.js
@@ -266,15 +266,15 @@ describe('<IncidentForm />', () => {
     })
 
     describe('async submit', () => {
-      it('should postpone submit when postponeSubmitWhenLoading is defined and no action defined', () => {
+      it('should postpone submit when loading data (classification or questions)', () => {
         const props = {
           ...defaultProps,
-          postponeSubmitWhenLoading: 'loadingClassification',
+          incidentContainer: { incident: {}, loadingData: false },
         }
 
         const { rerender } = renderIncidentForm({
           ...props,
-          loadingClassification: true,
+          incidentContainer: { incident: {}, loadingData: true },
         })
 
         expect(nextSpy).toHaveBeenCalledTimes(1)
@@ -284,97 +284,6 @@ describe('<IncidentForm />', () => {
         renderIncidentForm(props, rerender)
 
         expect(nextSpy).toHaveBeenCalledTimes(2)
-      })
-
-      it('should postpone submit when postponeSubmitWhenLoading is defined for loadingQuestions', () => {
-        const props = {
-          ...defaultProps,
-          postponeSubmitWhenLoading: 'loadingQuestions',
-        }
-
-        const { rerender } = renderIncidentForm({
-          ...props,
-          loadingQuestions: true,
-        })
-
-        expect(nextSpy).toHaveBeenCalledTimes(1)
-        userEvent.click(screen.getByText(mockForm.nextButtonLabel))
-        expect(nextSpy).toHaveBeenCalledTimes(1)
-
-        renderIncidentForm(props, rerender)
-
-        expect(nextSpy).toHaveBeenCalledTimes(2)
-      })
-
-      it('should postpone submit when postponeSubmitWhenLoading is defined for both loadingClassification and loadingQuestions', () => {
-        const props = {
-          ...defaultProps,
-          postponeSubmitWhenLoading: [
-            'loadingClassification',
-            'loadingQuestions',
-          ],
-        }
-
-        const { rerender } = renderIncidentForm({
-          ...props,
-          loadingQuestions: true,
-          loadingClassification: true,
-        })
-
-        expect(nextSpy).toHaveBeenCalledTimes(1)
-        userEvent.click(screen.getByText(mockForm.nextButtonLabel))
-        expect(nextSpy).toHaveBeenCalledTimes(1)
-
-        renderIncidentForm(props, rerender)
-
-        expect(nextSpy).toHaveBeenCalledTimes(2)
-
-        renderIncidentForm(
-          {
-            ...props,
-            loadingQuestions: false,
-            loadingClassification: true,
-          },
-          rerender
-        )
-
-        expect(nextSpy).toHaveBeenCalledTimes(2)
-        userEvent.click(screen.getByText(mockForm.nextButtonLabel))
-        expect(nextSpy).toHaveBeenCalledTimes(2)
-
-        renderIncidentForm(props, rerender)
-
-        expect(nextSpy).toHaveBeenCalledTimes(3)
-
-        renderIncidentForm(
-          {
-            ...props,
-            loadingQuestions: true,
-            loadingClassification: false,
-          },
-          rerender
-        )
-
-        expect(nextSpy).toHaveBeenCalledTimes(3)
-        userEvent.click(screen.getByText(mockForm.nextButtonLabel))
-        expect(nextSpy).toHaveBeenCalledTimes(3)
-
-        renderIncidentForm(props, rerender)
-
-        expect(nextSpy).toHaveBeenCalledTimes(4)
-
-        renderIncidentForm(
-          {
-            ...props,
-            loadingQuestions: false,
-            loadingClassification: false,
-          },
-          rerender
-        )
-
-        expect(nextSpy).toHaveBeenCalledTimes(4)
-        userEvent.click(screen.getByText(mockForm.nextButtonLabel))
-        expect(nextSpy).toHaveBeenCalledTimes(5)
       })
     })
 
@@ -382,8 +291,7 @@ describe('<IncidentForm />', () => {
       const props = {
         ...defaultProps,
         fieldConfig: requiredFieldConfig,
-        loadingClassification: true,
-        postponeSubmitWhenLoading: 'loadingClassification',
+        incidentContainer: { incident: {}, loadingData: true },
       }
 
       const { rerender } = renderIncidentForm(props)
@@ -400,6 +308,7 @@ describe('<IncidentForm />', () => {
           incident: {
             phone: '',
           },
+          loadingData: false,
         },
       }
 

--- a/src/signals/incident/components/IncidentWizard/IncidentWizard.tsx
+++ b/src/signals/incident/components/IncidentWizard/IncidentWizard.tsx
@@ -90,7 +90,6 @@ const IncidentWizard: FC<IncidentWizardProps> = ({
                         formFactory,
                         label,
                         subHeader,
-                        postponeSubmitWhenLoading,
                         previewFactory,
                         sectionLabels,
                       } = wizardDefinition[key as keyof WizardSection]
@@ -139,9 +138,6 @@ const IncidentWizard: FC<IncidentWizardProps> = ({
                                 updateIncident={updateIncident}
                                 createIncident={createIncident}
                                 wizard={wizardDefinition}
-                                postponeSubmitWhenLoading={
-                                  postponeSubmitWhenLoading
-                                }
                               />
                             )}
                           </FormWrapper>

--- a/src/signals/incident/containers/IncidentContainer/actions.js
+++ b/src/signals/incident/containers/IncidentContainer/actions.js
@@ -15,6 +15,7 @@ import {
   GET_QUESTIONS_ERROR,
   RESET_EXTRA_STATE,
   REMOVE_QUESTION_DATA,
+  SET_LOADING_DATA,
 } from './constants'
 
 export const updateIncident = (payload) => ({
@@ -77,6 +78,11 @@ export const getQuestionsSuccess = (payload) => ({
 
 export const getQuestionsError = (payload) => ({
   type: GET_QUESTIONS_ERROR,
+  payload,
+})
+
+export const setLoadingData = (payload) => ({
+  type: SET_LOADING_DATA,
   payload,
 })
 

--- a/src/signals/incident/containers/IncidentContainer/constants.ts
+++ b/src/signals/incident/containers/IncidentContainer/constants.ts
@@ -26,6 +26,7 @@ export const GET_QUESTIONS = 'sia/IncidentContainer/GET_QUESTIONS'
 export const GET_QUESTIONS_SUCCESS =
   'sia/IncidentContainer/GET_QUESTIONS_SUCCESS'
 export const GET_QUESTIONS_ERROR = 'sia/IncidentContainer/GET_QUESTIONS_ERROR'
+export const SET_LOADING_DATA = 'sia/IncidentContainer/SET_LOADING_DATA'
 
 export const FIELD_TYPE_MAP = {
   asset_select: QuestionFieldType.AssetSelect,

--- a/src/signals/incident/containers/IncidentContainer/reducer.js
+++ b/src/signals/incident/containers/IncidentContainer/reducer.js
@@ -16,6 +16,7 @@ import {
   GET_QUESTIONS_SUCCESS,
   REMOVE_QUESTION_DATA,
   GET_QUESTIONS_ERROR,
+  SET_LOADING_DATA,
 } from './constants'
 import { getIncidentClassification } from './services'
 
@@ -182,6 +183,9 @@ export default (state = initialState, action) => {
 
     case GET_QUESTIONS_ERROR:
       return state.set('loadingData', false)
+
+    case SET_LOADING_DATA:
+      return state.set('loadingData', action.payload)
 
     default:
       return state

--- a/src/signals/incident/containers/IncidentContainer/reducer.js
+++ b/src/signals/incident/containers/IncidentContainer/reducer.js
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2018 - 2021 Gemeente Amsterdam
 import { fromJS, Seq } from 'immutable'
+import configuration from 'shared/services/configuration/configuration'
 import {
   UPDATE_INCIDENT,
   RESET_INCIDENT,
@@ -47,6 +48,7 @@ export const initialState = fromJS({
     },
   },
   loadingClassification: false,
+  loadingQuestions: false,
   usePredictions: true,
   classificationPrediction: null,
 })
@@ -110,6 +112,10 @@ export default (state = initialState, action) => {
           })
         )
         .set('classificationPrediction', fromJS(classification))
+        .set(
+          'loadingQuestions',
+          configuration.featureFlags.fetchQuestionsFromBackend
+        )
     }
 
     case GET_CLASSIFICATION_ERROR: {
@@ -167,10 +173,12 @@ export default (state = initialState, action) => {
     }
 
     case GET_QUESTIONS_SUCCESS:
-      return state.set(
-        'incident',
-        state.get('incident').set('questions', action.payload.questions)
-      )
+      return state
+        .set(
+          'incident',
+          state.get('incident').set('questions', action.payload.questions)
+        )
+        .set('loadingQuestions', false)
 
     default:
       return state

--- a/src/signals/incident/containers/IncidentContainer/reducer.js
+++ b/src/signals/incident/containers/IncidentContainer/reducer.js
@@ -47,8 +47,8 @@ export const initialState = fromJS({
       label: 'Melding',
     },
   },
-  loadingClassification: false,
-  loadingQuestions: false,
+  loading: false,
+  loadingData: false,
   usePredictions: true,
   classificationPrediction: null,
 })
@@ -95,12 +95,15 @@ export default (state = initialState, action) => {
       return state.set('error', true).set('loading', false)
 
     case GET_CLASSIFICATION:
-      return state.set('loadingClassification', true)
+      return state.set('loadingData', true)
 
     case GET_CLASSIFICATION_SUCCESS: {
       const { classification } = action.payload
       return state
-        .set('loadingClassification', false)
+        .set(
+          'loadingData',
+          configuration.featureFlags.fetchQuestionsFromBackend
+        )
         .set(
           'incident',
           fromJS({
@@ -112,17 +115,13 @@ export default (state = initialState, action) => {
           })
         )
         .set('classificationPrediction', fromJS(classification))
-        .set(
-          'loadingQuestions',
-          configuration.featureFlags.fetchQuestionsFromBackend
-        )
     }
 
     case GET_CLASSIFICATION_ERROR: {
       const { category, subcategory, handling_message, classification } =
         action.payload
       return state
-        .set('loadingClassification', false)
+        .set('loadingData', false)
         .set(
           'incident',
           state
@@ -178,7 +177,7 @@ export default (state = initialState, action) => {
           'incident',
           state.get('incident').set('questions', action.payload.questions)
         )
-        .set('loadingQuestions', false)
+        .set('loadingData', false)
 
     default:
       return state

--- a/src/signals/incident/containers/IncidentContainer/reducer.js
+++ b/src/signals/incident/containers/IncidentContainer/reducer.js
@@ -15,6 +15,7 @@ import {
   RESET_EXTRA_STATE,
   GET_QUESTIONS_SUCCESS,
   REMOVE_QUESTION_DATA,
+  GET_QUESTIONS_ERROR,
 } from './constants'
 import { getIncidentClassification } from './services'
 
@@ -178,6 +179,9 @@ export default (state = initialState, action) => {
           state.get('incident').set('questions', action.payload.questions)
         )
         .set('loadingData', false)
+
+    case GET_QUESTIONS_ERROR:
+      return state.set('loadingData', false)
 
     default:
       return state

--- a/src/signals/incident/containers/IncidentContainer/reducer.test.js
+++ b/src/signals/incident/containers/IncidentContainer/reducer.test.js
@@ -18,6 +18,7 @@ import {
   RESET_EXTRA_STATE,
   REMOVE_QUESTION_DATA,
   GET_QUESTIONS_ERROR,
+  SET_LOADING_DATA,
 } from './constants'
 
 jest.mock('shared/services/configuration/configuration')
@@ -384,6 +385,42 @@ describe('signals/incident/containers/IncidentContainer/reducer', () => {
                 key1: {},
               },
             },
+          }
+        ).toJS()
+      ).toEqual({
+        incident: {},
+        loadingData: false,
+      })
+    })
+  })
+
+  describe('SET_LOADING_DATA', () => {
+    it('sets loading state', () => {
+      expect(
+        incidentContainerReducer(
+          fromJS({
+            incident: {},
+            loadingData: false,
+          }),
+          {
+            type: SET_LOADING_DATA,
+            payload: true,
+          }
+        ).toJS()
+      ).toEqual({
+        incident: {},
+        loadingData: true,
+      })
+
+      expect(
+        incidentContainerReducer(
+          fromJS({
+            incident: {},
+            loadingData: true,
+          }),
+          {
+            type: SET_LOADING_DATA,
+            payload: false,
           }
         ).toJS()
       ).toEqual({

--- a/src/signals/incident/containers/IncidentContainer/reducer.test.js
+++ b/src/signals/incident/containers/IncidentContainer/reducer.test.js
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2018 - 2021 Gemeente Amsterdam
 import { has, fromJS } from 'immutable'
+import configuration from 'shared/services/configuration/configuration'
 import incidentContainerReducer, { initialState } from './reducer'
 
 import {
@@ -18,7 +19,13 @@ import {
   REMOVE_QUESTION_DATA,
 } from './constants'
 
+jest.mock('shared/services/configuration/configuration')
+
 describe('signals/incident/containers/IncidentContainer/reducer', () => {
+  afterEach(() => {
+    configuration.__reset()
+  })
+
   it('returns the initial state', () => {
     expect(incidentContainerReducer(undefined, {})).toEqual(
       fromJS(initialState)
@@ -197,8 +204,20 @@ describe('signals/incident/containers/IncidentContainer/reducer', () => {
             handling_message,
           },
           loadingClassification: false,
+          loadingQuestions: false,
           classificationPrediction: classification,
         })
+      })
+
+      it('sets loadingQuestions with feature flag enabled', () => {
+        configuration.featureFlags.fetchQuestionsFromBackend = true
+
+        const newState = incidentContainerReducer(intermediateState, {
+          type: GET_CLASSIFICATION_SUCCESS,
+          payload,
+        })
+
+        expect(newState.get('loadingQuestions')).toEqual(true)
       })
 
       it('removes all extra_ props', () => {
@@ -328,6 +347,7 @@ describe('signals/incident/containers/IncidentContainer/reducer', () => {
         incidentContainerReducer(
           fromJS({
             incident: {},
+            loadingQuestions: true,
           }),
           {
             type: GET_QUESTIONS_SUCCESS,
@@ -344,6 +364,7 @@ describe('signals/incident/containers/IncidentContainer/reducer', () => {
             key1: {},
           },
         },
+        loadingQuestions: false,
       })
     })
   })

--- a/src/signals/incident/containers/IncidentContainer/reducer.test.js
+++ b/src/signals/incident/containers/IncidentContainer/reducer.test.js
@@ -17,6 +17,7 @@ import {
   GET_QUESTIONS_SUCCESS,
   RESET_EXTRA_STATE,
   REMOVE_QUESTION_DATA,
+  GET_QUESTIONS_ERROR,
 } from './constants'
 
 jest.mock('shared/services/configuration/configuration')
@@ -171,7 +172,7 @@ describe('signals/incident/containers/IncidentContainer/reducer', () => {
           }).toJS()
         ).toEqual({
           incident: {},
-          loadingClassification: true,
+          loadingData: true,
         })
       })
     })
@@ -203,13 +204,12 @@ describe('signals/incident/containers/IncidentContainer/reducer', () => {
             classification,
             handling_message,
           },
-          loadingClassification: false,
-          loadingQuestions: false,
+          loadingData: false,
           classificationPrediction: classification,
         })
       })
 
-      it('sets loadingQuestions with feature flag enabled', () => {
+      it('sets loadingData when feature flag enabled', () => {
         configuration.featureFlags.fetchQuestionsFromBackend = true
 
         const newState = incidentContainerReducer(intermediateState, {
@@ -217,7 +217,7 @@ describe('signals/incident/containers/IncidentContainer/reducer', () => {
           payload,
         })
 
-        expect(newState.get('loadingQuestions')).toEqual(true)
+        expect(newState.get('loadingData')).toEqual(true)
       })
 
       it('removes all extra_ props', () => {
@@ -310,7 +310,7 @@ describe('signals/incident/containers/IncidentContainer/reducer', () => {
             classification,
             handling_message,
           },
-          loadingClassification: false,
+          loadingData: false,
           classificationPrediction: null,
         })
       })
@@ -347,7 +347,7 @@ describe('signals/incident/containers/IncidentContainer/reducer', () => {
         incidentContainerReducer(
           fromJS({
             incident: {},
-            loadingQuestions: true,
+            loadingData: true,
           }),
           {
             type: GET_QUESTIONS_SUCCESS,
@@ -364,7 +364,31 @@ describe('signals/incident/containers/IncidentContainer/reducer', () => {
             key1: {},
           },
         },
-        loadingQuestions: false,
+        loadingData: false,
+      })
+    })
+  })
+
+  describe('GET_QUESTIONS_ERROR', () => {
+    it('resets loading state', () => {
+      expect(
+        incidentContainerReducer(
+          fromJS({
+            incident: {},
+            loadingData: true,
+          }),
+          {
+            type: GET_QUESTIONS_ERROR,
+            payload: {
+              questions: {
+                key1: {},
+              },
+            },
+          }
+        ).toJS()
+      ).toEqual({
+        incident: {},
+        loadingData: false,
       })
     })
   })

--- a/src/signals/incident/containers/IncidentContainer/saga.js
+++ b/src/signals/incident/containers/IncidentContainer/saga.js
@@ -20,7 +20,6 @@ import {
   CREATE_INCIDENT,
   GET_CLASSIFICATION,
   GET_CLASSIFICATION_SUCCESS,
-  UPDATE_INCIDENT,
 } from './constants'
 import {
   createIncidentSuccess,
@@ -66,15 +65,11 @@ export function* getClassification(action) {
 
 export function* getQuestionsSaga(action) {
   const incident = yield select(makeSelectIncidentContainer)
-  const { category, subcategory } =
-    action.type === UPDATE_INCIDENT
-      ? action.payload
-      : getIncidentClassification(incident, action.payload)
-  if (
-    !configuration.featureFlags.fetchQuestionsFromBackend ||
-    !category ||
-    !subcategory
-  ) {
+  const { category, subcategory } = getIncidentClassification(
+    incident,
+    action.payload
+  )
+  if (!configuration.featureFlags.fetchQuestionsFromBackend) {
     return
   }
   const url = `${configuration.QUESTIONS_ENDPOINT}?main_slug=${category}&sub_slug=${subcategory}`
@@ -206,7 +201,7 @@ export function* getPostData(action) {
 export default function* watchIncidentContainerSaga() {
   yield all([
     takeLatest(GET_CLASSIFICATION, getClassification),
-    takeLatest([GET_CLASSIFICATION_SUCCESS, UPDATE_INCIDENT], getQuestionsSaga),
+    takeLatest(GET_CLASSIFICATION_SUCCESS, getQuestionsSaga),
     takeLatest(CREATE_INCIDENT, createIncident),
   ])
 }

--- a/src/signals/incident/containers/IncidentContainer/saga.js
+++ b/src/signals/incident/containers/IncidentContainer/saga.js
@@ -28,6 +28,7 @@ import {
   getClassificationError,
   getQuestionsSuccess,
   getQuestionsError,
+  setLoadingData,
 } from './actions'
 
 export function* getClassification(action) {
@@ -74,7 +75,7 @@ export function* getQuestionsSaga(action) {
     !category ||
     !subcategory
   ) {
-    yield put(getQuestionsError())
+    yield put(setLoadingData(false))
     return
   }
   const url = `${configuration.QUESTIONS_ENDPOINT}?main_slug=${category}&sub_slug=${subcategory}`

--- a/src/signals/incident/containers/IncidentContainer/saga.js
+++ b/src/signals/incident/containers/IncidentContainer/saga.js
@@ -69,7 +69,12 @@ export function* getQuestionsSaga(action) {
     incident,
     action.payload
   )
-  if (!configuration.featureFlags.fetchQuestionsFromBackend) {
+  if (
+    !configuration.featureFlags.fetchQuestionsFromBackend ||
+    !category ||
+    !subcategory
+  ) {
+    yield put(getQuestionsError())
     return
   }
   const url = `${configuration.QUESTIONS_ENDPOINT}?main_slug=${category}&sub_slug=${subcategory}`

--- a/src/signals/incident/containers/IncidentContainer/saga.test.js
+++ b/src/signals/incident/containers/IncidentContainer/saga.test.js
@@ -212,7 +212,7 @@ describe('IncidentContainer saga', () => {
   describe('getQuestionsSaga', () => {
     const payload = resolvedPrediction
 
-    it('should dispatch error when fetchQuestionsFromBackend disabled', () =>
+    it('should dispatch loading state when fetchQuestionsFromBackend disabled', () =>
       expectSaga(getQuestionsSaga, {
         type: constants.GET_CLASSIFICATION_SUCCESS,
         payload,
@@ -230,10 +230,10 @@ describe('IncidentContainer saga', () => {
         ])
         .not.put.actionType(constants.GET_QUESTIONS_SUCCESS)
         .not.call(request)
-        .put.actionType(constants.GET_QUESTIONS_ERROR)
+        .put.actionType(constants.SET_LOADING_DATA)
         .run())
 
-    it('should dispatch error when category is falsy', () => {
+    it('should dispatch loading state when category is falsy', () => {
       configuration.featureFlags.fetchQuestionsFromBackend = true
       return expectSaga(getQuestionsSaga, {
         type: constants.GET_CLASSIFICATION_SUCCESS,
@@ -252,11 +252,11 @@ describe('IncidentContainer saga', () => {
         ])
         .not.put.actionType(constants.GET_QUESTIONS_SUCCESS)
         .not.call(request)
-        .put.actionType(constants.GET_QUESTIONS_ERROR)
+        .put.actionType(constants.SET_LOADING_DATA)
         .run()
     })
 
-    it('should dispatch error when subcategory is falsy', () => {
+    it('should dispatch loading state when subcategory is falsy', () => {
       configuration.featureFlags.fetchQuestionsFromBackend = true
       return expectSaga(getQuestionsSaga, {
         type: constants.GET_CLASSIFICATION_SUCCESS,
@@ -275,7 +275,7 @@ describe('IncidentContainer saga', () => {
         ])
         .not.call(request)
         .not.put.actionType(constants.GET_QUESTIONS_SUCCESS)
-        .put.actionType(constants.GET_QUESTIONS_ERROR)
+        .put.actionType(constants.SET_LOADING_DATA)
         .run()
     })
 

--- a/src/signals/incident/containers/IncidentContainer/saga.test.js
+++ b/src/signals/incident/containers/IncidentContainer/saga.test.js
@@ -162,10 +162,7 @@ describe('IncidentContainer saga', () => {
       .next()
       .all([
         takeLatest(constants.GET_CLASSIFICATION, getClassification),
-        takeLatest(
-          [constants.GET_CLASSIFICATION_SUCCESS, constants.UPDATE_INCIDENT],
-          getQuestionsSaga
-        ),
+        takeLatest(constants.GET_CLASSIFICATION_SUCCESS, getQuestionsSaga),
         takeLatest(constants.CREATE_INCIDENT, createIncident),
       ])
   })
@@ -215,24 +212,145 @@ describe('IncidentContainer saga', () => {
   describe('getQuestionsSaga', () => {
     const payload = resolvedPrediction
 
-    it('should do nothing when fetchQuestionsFromBackend disabled', () =>
-      expectSaga(getQuestionsSaga, { type: constants.UPDATE_INCIDENT, payload })
-        .not.put.actionType(constants.GET_QUESTIONS_SUCCESS)
-        .run())
-
-    it('should dispatch success on UPDATE_INCIDENT', () => {
-      configuration.featureFlags.fetchQuestionsFromBackend = true
-
-      return expectSaga(getQuestionsSaga, {
-        type: constants.UPDATE_INCIDENT,
+    it('should dispatch error when fetchQuestionsFromBackend disabled', () =>
+      expectSaga(getQuestionsSaga, {
+        type: constants.GET_CLASSIFICATION_SUCCESS,
         payload,
       })
         .provide([
-          [select(makeSelectIncidentContainer), {}],
+          [
+            select(makeSelectIncidentContainer),
+            {
+              classificationPrediction: { slug: 'slug' },
+              incident: { classification: { slug: 'slug' } },
+            },
+          ],
           [matchers.call.fn(request), { results: questionsResponse }],
           [matchers.call.fn(resolveQuestions), resolvedQuestions],
         ])
-        .select(makeSelectIncidentContainer)
+        .not.put.actionType(constants.GET_QUESTIONS_SUCCESS)
+        .not.call(request)
+        .put.actionType(constants.GET_QUESTIONS_ERROR)
+        .run())
+
+    it('should dispatch error when category is falsy', () => {
+      configuration.featureFlags.fetchQuestionsFromBackend = true
+      return expectSaga(getQuestionsSaga, {
+        type: constants.GET_CLASSIFICATION_SUCCESS,
+        payload: { subcategory: 'subcategory' },
+      })
+        .provide([
+          [
+            select(makeSelectIncidentContainer),
+            {
+              classificationPrediction: { slug: 'slug' },
+              incident: { classification: { slug: 'slug' } },
+            },
+          ],
+          [matchers.call.fn(request), { results: questionsResponse }],
+          [matchers.call.fn(resolveQuestions), resolvedQuestions],
+        ])
+        .not.put.actionType(constants.GET_QUESTIONS_SUCCESS)
+        .not.call(request)
+        .put.actionType(constants.GET_QUESTIONS_ERROR)
+        .run()
+    })
+
+    it('should dispatch error when subcategory is falsy', () => {
+      configuration.featureFlags.fetchQuestionsFromBackend = true
+      return expectSaga(getQuestionsSaga, {
+        type: constants.GET_CLASSIFICATION_SUCCESS,
+        payload: { category: 'category' },
+      })
+        .provide([
+          [
+            select(makeSelectIncidentContainer),
+            {
+              classificationPrediction: { slug: 'slug' },
+              incident: { classification: { slug: 'slug' } },
+            },
+          ],
+          [matchers.call.fn(request), { results: questionsResponse }],
+          [matchers.call.fn(resolveQuestions), resolvedQuestions],
+        ])
+        .not.call(request)
+        .not.put.actionType(constants.GET_QUESTIONS_SUCCESS)
+        .put.actionType(constants.GET_QUESTIONS_ERROR)
+        .run()
+    })
+
+    it('should dispatch success without classification prediction', () => {
+      configuration.featureFlags.fetchQuestionsFromBackend = true
+
+      return expectSaga(getQuestionsSaga, {
+        type: constants.GET_CLASSIFICATION_SUCCESS,
+        payload,
+      })
+        .provide([
+          [
+            select(makeSelectIncidentContainer),
+            {
+              classificationPrediction: null,
+              incident: { classification: { slug: 'slug' } },
+            },
+          ],
+          [matchers.call.fn(request), { results: questionsResponse }],
+          [matchers.call.fn(resolveQuestions), resolvedQuestions],
+        ])
+        .call(request, questionsUrl)
+        .call(resolveQuestions, questionsResponse)
+        .put({
+          type: constants.GET_QUESTIONS_SUCCESS,
+          payload: { questions: resolvedQuestions },
+        })
+        .run()
+    })
+
+    it('should dispatch success without incident classification', () => {
+      configuration.featureFlags.fetchQuestionsFromBackend = true
+
+      return expectSaga(getQuestionsSaga, {
+        type: constants.GET_CLASSIFICATION_SUCCESS,
+        payload,
+      })
+        .provide([
+          [
+            select(makeSelectIncidentContainer),
+            {
+              classificationPrediction: { slug: 'slug' },
+              incident: { classification: null },
+            },
+          ],
+          [matchers.call.fn(request), { results: questionsResponse }],
+          [matchers.call.fn(resolveQuestions), resolvedQuestions],
+        ])
+        .call(request, questionsUrl)
+        .call(resolveQuestions, questionsResponse)
+        .put({
+          type: constants.GET_QUESTIONS_SUCCESS,
+          payload: { questions: resolvedQuestions },
+        })
+        .run()
+    })
+
+    it('should dispatch success with matching classification prediction and incident classification', () => {
+      configuration.featureFlags.fetchQuestionsFromBackend = true
+
+      return expectSaga(getQuestionsSaga, {
+        type: constants.GET_CLASSIFICATION_SUCCESS,
+        payload,
+      })
+        .provide([
+          [
+            select(makeSelectIncidentContainer),
+            {
+              classificationPrediction: { slug: 'slug' },
+              incident: { classification: { slug: 'slug' } },
+            },
+          ],
+          [matchers.call.fn(request), { results: questionsResponse }],
+          [matchers.call.fn(resolveQuestions), resolvedQuestions],
+        ])
         .call(request, questionsUrl)
         .call(resolveQuestions, questionsResponse)
         .put({
@@ -246,149 +364,22 @@ describe('IncidentContainer saga', () => {
       configuration.featureFlags.fetchQuestionsFromBackend = true
 
       return expectSaga(getQuestionsSaga, {
-        type: constants.UPDATE_INCIDENT,
+        type: constants.GET_CLASSIFICATION_SUCCESS,
         payload,
       })
         .provide([
-          [select(makeSelectIncidentContainer), {}],
+          [
+            select(makeSelectIncidentContainer),
+            {
+              classificationPrediction: null,
+              incident: { classification: null },
+            },
+          ],
           [matchers.call.fn(request), throwError(new Error('whoops!!!1!'))],
         ])
         .call(request, questionsUrl)
         .put.actionType(constants.GET_QUESTIONS_ERROR)
         .run()
-    })
-
-    describe('GET_CLASSIFICATION_SUCCESS', () => {
-      it('should do nothing when fetchQuestionsFromBackend disabled', () =>
-        expectSaga(getQuestionsSaga, {
-          type: constants.GET_CLASSIFICATION_SUCCESS,
-          payload,
-        })
-          .not.put.actionType(constants.GET_QUESTIONS_SUCCESS)
-          .run())
-
-      it('should do nothing when category is falsy', () => {
-        configuration.featureFlags.fetchQuestionsFromBackend = true
-        return expectSaga(getQuestionsSaga, {
-          type: constants.GET_CLASSIFICATION_SUCCESS,
-          payload: { subcategory: 'subcategory' },
-        })
-          .not.put.actionType(constants.GET_QUESTIONS_SUCCESS)
-          .run()
-      })
-
-      it('should do nothing when subcategory is falsy', () => {
-        configuration.featureFlags.fetchQuestionsFromBackend = true
-        return expectSaga(getQuestionsSaga, {
-          type: constants.GET_CLASSIFICATION_SUCCESS,
-          payload: { category: 'category' },
-        })
-          .not.put.actionType(constants.GET_QUESTIONS_SUCCESS)
-          .run()
-      })
-
-      it('should dispatch success without classification prediction', () => {
-        configuration.featureFlags.fetchQuestionsFromBackend = true
-
-        return expectSaga(getQuestionsSaga, {
-          type: constants.GET_CLASSIFICATION_SUCCESS,
-          payload,
-        })
-          .provide([
-            [
-              select(makeSelectIncidentContainer),
-              {
-                classificationPrediction: null,
-                incident: { classification: { slug: 'slug' } },
-              },
-            ],
-            [matchers.call.fn(request), { results: questionsResponse }],
-            [matchers.call.fn(resolveQuestions), resolvedQuestions],
-          ])
-          .call(request, questionsUrl)
-          .call(resolveQuestions, questionsResponse)
-          .put({
-            type: constants.GET_QUESTIONS_SUCCESS,
-            payload: { questions: resolvedQuestions },
-          })
-          .run()
-      })
-
-      it('should dispatch success without incident classification', () => {
-        configuration.featureFlags.fetchQuestionsFromBackend = true
-
-        return expectSaga(getQuestionsSaga, {
-          type: constants.GET_CLASSIFICATION_SUCCESS,
-          payload,
-        })
-          .provide([
-            [
-              select(makeSelectIncidentContainer),
-              {
-                classificationPrediction: { slug: 'slug' },
-                incident: { classification: null },
-              },
-            ],
-            [matchers.call.fn(request), { results: questionsResponse }],
-            [matchers.call.fn(resolveQuestions), resolvedQuestions],
-          ])
-          .call(request, questionsUrl)
-          .call(resolveQuestions, questionsResponse)
-          .put({
-            type: constants.GET_QUESTIONS_SUCCESS,
-            payload: { questions: resolvedQuestions },
-          })
-          .run()
-      })
-
-      it('should dispatch success with matching classification prediction and incident classification', () => {
-        configuration.featureFlags.fetchQuestionsFromBackend = true
-
-        return expectSaga(getQuestionsSaga, {
-          type: constants.GET_CLASSIFICATION_SUCCESS,
-          payload,
-        })
-          .provide([
-            [
-              select(makeSelectIncidentContainer),
-              {
-                classificationPrediction: { slug: 'slug' },
-                incident: { classification: { slug: 'slug' } },
-              },
-            ],
-            [matchers.call.fn(request), { results: questionsResponse }],
-            [matchers.call.fn(resolveQuestions), resolvedQuestions],
-          ])
-          .call(request, questionsUrl)
-          .call(resolveQuestions, questionsResponse)
-          .put({
-            type: constants.GET_QUESTIONS_SUCCESS,
-            payload: { questions: resolvedQuestions },
-          })
-          .run()
-      })
-
-      it('should dispatch error', () => {
-        configuration.featureFlags.fetchQuestionsFromBackend = true
-
-        return expectSaga(getQuestionsSaga, {
-          type: constants.GET_CLASSIFICATION_SUCCESS,
-          payload,
-        })
-          .provide([
-            [
-              select(makeSelectIncidentContainer),
-              {
-                classificationPrediction: null,
-                incident: { classification: null },
-              },
-            ],
-            [matchers.call.fn(request), throwError(new Error('whoops!!!1!'))],
-          ])
-          .call(request, questionsUrl)
-          .put.actionType(constants.GET_QUESTIONS_ERROR)
-          .run()
-      })
     })
   })
 

--- a/src/signals/incident/definitions/wizard-step-1-beschrijf.js
+++ b/src/signals/incident/definitions/wizard-step-1-beschrijf.js
@@ -160,6 +160,9 @@ export default {
   },
   nextButtonLabel: 'Volgende',
   nextButtonClass: 'action primary arrow-right',
-  postponeSubmitWhenLoading: 'incidentContainer.loadingClassification',
+  postponeSubmitWhenLoading: [
+    'incidentContainer.loadingClassification',
+    'incidentContainer.loadingQuestions',
+  ],
   formFactory: (incident, sources) => getControls(sources),
 }

--- a/src/signals/incident/definitions/wizard-step-1-beschrijf.js
+++ b/src/signals/incident/definitions/wizard-step-1-beschrijf.js
@@ -160,9 +160,5 @@ export default {
   },
   nextButtonLabel: 'Volgende',
   nextButtonClass: 'action primary arrow-right',
-  postponeSubmitWhenLoading: [
-    'incidentContainer.loadingClassification',
-    'incidentContainer.loadingQuestions',
-  ],
   formFactory: (incident, sources) => getControls(sources),
 }

--- a/src/signals/incident/definitions/wizard.ts
+++ b/src/signals/incident/definitions/wizard.ts
@@ -28,7 +28,7 @@ export type WizardSection = {
     formFactory?: any
     label?: string
     subHeader?: string
-    postponeSubmitWhenLoading?: string
+    postponeSubmitWhenLoading?: string | string[]
     previewFactory?: (incident: Incident) => any
     sectionLabels?: SectionLabels
     previousButtonLabel?: string

--- a/src/signals/incident/definitions/wizard.ts
+++ b/src/signals/incident/definitions/wizard.ts
@@ -28,7 +28,6 @@ export type WizardSection = {
     formFactory?: any
     label?: string
     subHeader?: string
-    postponeSubmitWhenLoading?: string | string[]
     previewFactory?: (incident: Incident) => any
     sectionLabels?: SectionLabels
     previousButtonLabel?: string


### PR DESCRIPTION
closes Signalen/product-steering#93

Make sure to postpone submitting in step 1 in case the extra questions are coming from the backend and are still loading.