### PR TITLE
Use zoom levels from config for asset select

### DIFF
--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -27,7 +27,7 @@ const StyledViewerContainer = styled(ViewerContainer)`
   z-index: 0;
 `
 
-interface MapProps {
+export interface MapProps {
   className?: string
   'data-testid'?: string
   /**

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/Selector.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/Selector.test.tsx
@@ -39,7 +39,7 @@ jest.mock('./LegendPanel', () => ({ onClose }: LegendPanelProps) => (
   </span>
 ))
 
-let actualMapOptions: MapOptions
+let actualMapOptions: MapOptions | null = null
 jest.mock('components/Map', () => {
   const originalModule = jest.requireActual('components/Map')
   return {
@@ -56,6 +56,7 @@ describe('signals/incident/components/form/AssetSelect/Selector', () => {
     fetchMock.resetMocks()
     fetchMock.mockResponseOnce(JSON.stringify(assetsJson), { status: 200 })
     mockShowDesktopVariant = false
+    actualMapOptions = null
   })
 
   afterEach(() => {

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/Selector.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/Selector.test.tsx
@@ -10,12 +10,15 @@ import type { FC } from 'react'
 
 import assetsJson from 'utils/__tests__/fixtures/assets.json'
 import configuration from 'shared/services/configuration/configuration'
+import MAP_OPTIONS from 'shared/services/configuration/map-options'
+import type { MapOptions } from 'leaflet'
+import type { MapProps } from 'components/Map/Map'
 import withAssetSelectContext, {
   contextValue,
 } from '../__tests__/withAssetSelectContext'
 import type { LegendPanelProps } from './LegendPanel/LegendPanel'
 
-import Selector from './Selector'
+import Selector, { MAP_LOCATION_ZOOM } from './Selector'
 
 jest.useFakeTimers()
 
@@ -35,6 +38,18 @@ jest.mock('./LegendPanel', () => ({ onClose }: LegendPanelProps) => (
     <input type="button" name="closeLegend" onClick={onClose} />
   </span>
 ))
+
+let actualMapOptions: MapOptions
+jest.mock('components/Map', () => {
+  const originalModule = jest.requireActual('components/Map')
+  return {
+    __esModule: true,
+    default: ({ mapOptions, ...props }: MapProps) => {
+      actualMapOptions = mapOptions
+      return originalModule.default({ mapOptions, ...props })
+    },
+  }
+})
 
 describe('signals/incident/components/form/AssetSelect/Selector', () => {
   beforeEach(() => {
@@ -65,6 +80,44 @@ describe('signals/incident/components/form/AssetSelect/Selector', () => {
     )
 
     expect(screen.getByTestId('testLayer')).toBeInTheDocument()
+  })
+
+  describe('zoom levels', () => {
+    it('should use configuration defaults when no coordinates', async () => {
+      render(
+        withAssetSelectContext(<Selector />, {
+          ...contextValue,
+          coordinates: undefined,
+        })
+      )
+      await screen.findByTestId('assetSelectSelector')
+      expect(actualMapOptions).toEqual(
+        expect.objectContaining({
+          maxZoom: configuration.map.options.maxZoom,
+          minZoom: configuration.map.options.minZoom,
+          zoom: configuration.map.options.zoom,
+        })
+      )
+    })
+
+    it('should zoom to MAP_LOCATION_ZOOM', async () => {
+      render(withAssetSelectContext(<Selector />))
+      await screen.findByTestId('assetSelectSelector')
+      expect(actualMapOptions).toEqual(
+        expect.objectContaining({ zoom: MAP_LOCATION_ZOOM })
+      )
+    })
+
+    it('should not zoom in further than maxZoom in config', async () => {
+      const maxZoom = MAP_OPTIONS.maxZoom
+      MAP_OPTIONS.maxZoom = MAP_LOCATION_ZOOM - 1
+      render(withAssetSelectContext(<Selector />))
+      await screen.findByTestId('assetSelectSelector')
+      expect(actualMapOptions).toEqual(
+        expect.objectContaining({ zoom: MAP_OPTIONS.maxZoom })
+      )
+      MAP_OPTIONS.maxZoom = maxZoom
+    })
   })
 
   it('should call close when closing the selector', async () => {

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/Selector.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/Selector.tsx
@@ -50,7 +50,12 @@ const MAP_CONTAINER_ZOOM_LEVEL: ZoomLevel = {
   max: 13,
 }
 
-const MAP_LOCATION_ZOOM = 14
+export const MAP_LOCATION_ZOOM = Math.min(
+  14,
+  MAP_OPTIONS.maxZoom || Number.POSITIVE_INFINITY
+)
+
+const MAP_NO_LOCATION_ZOOM = MAP_OPTIONS.zoom
 
 const Selector: FC = () => {
   // to be replaced with MOUNT_NODE
@@ -78,12 +83,7 @@ const Selector: FC = () => {
       dragging: true,
       zoomControl: false,
       scrollWheelZoom: true,
-      zoom: coordinates
-        ? Math.min(
-            MAP_LOCATION_ZOOM,
-            MAP_OPTIONS.maxZoom || Number.POSITIVE_INFINITY
-          )
-        : MAP_OPTIONS.zoom,
+      zoom: coordinates ? MAP_LOCATION_ZOOM : MAP_NO_LOCATION_ZOOM,
     }),
     [center, coordinates]
   )

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/Selector.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/Selector.tsx
@@ -50,12 +50,7 @@ const MAP_CONTAINER_ZOOM_LEVEL: ZoomLevel = {
   max: 13,
 }
 
-export const MAP_LOCATION_ZOOM = Math.min(
-  14,
-  MAP_OPTIONS.maxZoom || Number.POSITIVE_INFINITY
-)
-
-const MAP_NO_LOCATION_ZOOM = MAP_OPTIONS.zoom
+export const MAP_LOCATION_ZOOM = 14
 
 const Selector: FC = () => {
   // to be replaced with MOUNT_NODE
@@ -83,7 +78,12 @@ const Selector: FC = () => {
       dragging: true,
       zoomControl: false,
       scrollWheelZoom: true,
-      zoom: coordinates ? MAP_LOCATION_ZOOM : MAP_NO_LOCATION_ZOOM,
+      zoom: coordinates
+        ? Math.min(
+            MAP_LOCATION_ZOOM,
+            MAP_OPTIONS.maxZoom || Number.POSITIVE_INFINITY
+          )
+        : MAP_OPTIONS.zoom,
     }),
     [center, coordinates]
   )
@@ -130,8 +130,8 @@ const Selector: FC = () => {
   useLayoutEffect(() => {
     if (!map || !coordinates) return
 
-    map.flyTo(coordinates, MAP_LOCATION_ZOOM)
-  }, [coordinates, map])
+    map.flyTo(coordinates, mapOptions.zoom)
+  }, [coordinates, map, mapOptions.zoom])
 
   useEffect(() => {
     global.window.scrollTo(0, 0)

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/Selector.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/Selector.tsx
@@ -51,7 +51,6 @@ const MAP_CONTAINER_ZOOM_LEVEL: ZoomLevel = {
 }
 
 const MAP_LOCATION_ZOOM = 14
-const MAP_NO_LOCATION_ZOOM = 9
 
 const Selector: FC = () => {
   // to be replaced with MOUNT_NODE
@@ -72,14 +71,14 @@ const Selector: FC = () => {
 
   const mapOptions: MapOptions = useMemo(
     () => ({
+      minZoom: 7,
+      maxZoom: 16,
       ...MAP_OPTIONS,
       center,
       dragging: true,
       zoomControl: false,
       scrollWheelZoom: true,
-      minZoom: 7,
-      maxZoom: 16,
-      zoom: coordinates ? MAP_LOCATION_ZOOM : MAP_NO_LOCATION_ZOOM,
+      zoom: coordinates ? MAP_LOCATION_ZOOM : MAP_OPTIONS.zoom,
     }),
     [center, coordinates]
   )

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/Selector.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/Selector.tsx
@@ -78,7 +78,12 @@ const Selector: FC = () => {
       dragging: true,
       zoomControl: false,
       scrollWheelZoom: true,
-      zoom: coordinates ? MAP_LOCATION_ZOOM : MAP_OPTIONS.zoom,
+      zoom: coordinates
+        ? Math.min(
+            MAP_LOCATION_ZOOM,
+            MAP_OPTIONS.maxZoom || Number.POSITIVE_INFINITY
+          )
+        : MAP_OPTIONS.zoom,
     }),
     [center, coordinates]
   )


### PR DESCRIPTION
closes Signalen/frontend#166

Have the Asset Select map use the min and max zoom levels as defined in the config.