### PR TITLE
Set maxNativeZoom for PDOK tiles

### DIFF
--- a/app.base.json
+++ b/app.base.json
@@ -71,7 +71,7 @@
           5.10737
         ]
       ],
-      "maxZoom": 14,
+      "maxZoom": 16,
       "minZoom": 8,
       "zoom": 10
     },
@@ -86,6 +86,7 @@
       ],
       "options": {
         "attribution": "Kaartgegevens &copy; Kadaster",
+        "maxNativeZoom": 14,
         "tms": false
       }
     },

--- a/internals/schemas/app.schema.json
+++ b/internals/schemas/app.schema.json
@@ -517,6 +517,9 @@
         "attribution": {
           "type": "string"
         },
+        "maxNativeZoom": {
+          "type": "integer"
+        },
         "subdomains": {
           "type": "array",
           "items": {


### PR DESCRIPTION
closes Signalen/frontend#166

The map went gray when zooming in past level 14.
Setting the `maxNativeZoom` to `14` on the PDOK tiles layer fixes this.

Better solution than https://github.com/Amsterdam/signals-frontend/pull/2052 for Signalen/frontend#166.
https://github.com/Amsterdam/signals-frontend/pull/2052 is still a bug fix though.