### PR TITLE
[SIG 4453] Handle incident detail when extra properties answer is null

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/components/Detail/components/ExtraProperties/index.test.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/Detail/components/ExtraProperties/index.test.tsx
@@ -235,4 +235,53 @@ describe('<ExtraProperties />', () => {
       /^In huis$/
     )
   })
+
+  it('should handle null and undefined values in the answer property', () => {
+    const items = [
+      {
+        id: 'extra_bedrijven_horeca_terrassen',
+        label: 'Oorzaak overlast',
+        answer: null,
+        category_url:
+          '/signals/v1/public/terms/categories/overlast-bedrijven-en-horeca/sub_categories/overlast-terrassen',
+      },
+      {
+        id: 'extra_bedrijven_gezien',
+        label: 'Heeft u het gezien?',
+        category_url:
+          '/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/straatverlichting-openbare-klok',
+        answer: undefined,
+      },
+    ]
+
+    // this test is about handling unexpected values, therefore typing cannot be applied
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    render(<ExtraProperties items={items} />)
+
+    expect(screen.queryAllByTestId('extra-properties-definition')).toHaveLength(
+      Object.values(items).length
+    )
+  })
+
+  it('should handle null and undefined values in the array of the answer property', () => {
+    const items = [
+      {
+        id: 'extra_bedrijven_horeca_terrassen',
+        label: 'Oorzaak overlast',
+        answer: [null, undefined],
+        category_url:
+          '/signals/v1/public/terms/categories/overlast-bedrijven-en-horeca/sub_categories/overlast-terrassen',
+      },
+    ]
+
+    // this test is about handling unexpected values, therefore typing cannot be applied
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    render(<ExtraProperties items={items} />)
+
+    expect(screen.queryAllByTestId('extra-properties-definition')).toHaveLength(
+      Object.values(items).length
+    )
+  })
 })

--- a/src/signals/incident-management/containers/IncidentDetail/components/Detail/components/ExtraProperties/index.test.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/Detail/components/ExtraProperties/index.test.tsx
@@ -253,10 +253,6 @@ describe('<ExtraProperties />', () => {
         answer: undefined,
       },
     ]
-
-    // this test is about handling unexpected values, therefore typing cannot be applied
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
     render(<ExtraProperties items={items} />)
 
     expect(screen.queryAllByTestId('extra-properties-definition')).toHaveLength(
@@ -275,9 +271,6 @@ describe('<ExtraProperties />', () => {
       },
     ]
 
-    // this test is about handling unexpected values, therefore typing cannot be applied
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
     render(<ExtraProperties items={items} />)
 
     expect(screen.queryAllByTestId('extra-properties-definition')).toHaveLength(

--- a/src/signals/incident-management/containers/IncidentDetail/components/Detail/components/ExtraProperties/index.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/Detail/components/ExtraProperties/index.tsx
@@ -15,7 +15,8 @@ import type {
 
 const getValue = (answer: Answer | LegacyAnswer): string | JSX.Element[] => {
   if (Array.isArray(answer)) {
-    return answer.map((item) => {
+    const cleanAnswer = answer.filter((i) => i)
+    return cleanAnswer.map((item) => {
       if (typeof item === 'string') {
         return <div key={item}>{item}</div>
       }
@@ -36,6 +37,10 @@ const getValue = (answer: Answer | LegacyAnswer): string | JSX.Element[] => {
   }
 
   if (typeof answer !== 'string') {
+    if (answer === null || answer === undefined) {
+      return ''
+    }
+
     if (typeof (answer as CheckboxInput).value === 'boolean') {
       return (answer as CheckboxInput).value ? answer.label : 'Nee'
     }

--- a/src/signals/incident-management/containers/IncidentDetail/components/Detail/components/ExtraProperties/types.ts
+++ b/src/signals/incident-management/containers/IncidentDetail/components/Detail/components/ExtraProperties/types.ts
@@ -29,7 +29,9 @@ export type Answer =
   | TextInput
   | CheckboxInput
   | RadioInput
-  | (MapInput | ContainerMapInput | MultiCheckboxInput)[]
+  | null
+  | undefined
+  | (MapInput | ContainerMapInput | MultiCheckboxInput | null | undefined)[]
 
 export interface Item {
   id: string


### PR DESCRIPTION
Incident detail page cannot be displayed because answer contains an array with a null value.
The current fix handles this error.

https://sentry.data.amsterdam.nl/sentry/signals-frontend/issues/2721718/?query=is%3Aunresolved