### PR TITLE
[SIG 4324] Not send email when email template is not available

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.tsx
@@ -270,9 +270,8 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
           type: TYPE_LOCAL,
         })
       )
-      onUpdate()
     }
-  }, [emailTemplateError, storeDispatch, onUpdate])
+  }, [emailTemplateError, storeDispatch])
 
   return (
     <Form onSubmit={handleSubmit} data-testid="statusForm" noValidate>

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/EmailPreview/EmailPreview.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/EmailPreview/EmailPreview.tsx
@@ -35,13 +35,18 @@ interface EmailPreviewProps {
   onUpdate: () => void
 }
 
-const styling =
-  '<style>*{font-family:"Avenir Next"; line-height: 22px;\n' +
-  '  overflow-wrap: break-word;\n' +
-  '  word-wrap: break-word;\n' +
-  '  -ms-word-break: break-all;\n' +
-  '  word-break: break-all;\n' +
-  '  word-break: break-word;}</style>'
+const styling = `
+<style>
+  *{
+    font-family:"Avenir Next";
+    line-height: 22px;
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+    word-break: break-all;
+    word-break: break-word;
+    hyphens: auto;
+  }
+</style>`
 const fontSrc =
   '<link rel="stylesheet" href="https://static.amsterdam.nl/fonts/fonts.css"/>'
 

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/EmailPreview/EmailPreview.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/EmailPreview/EmailPreview.tsx
@@ -35,7 +35,13 @@ interface EmailPreviewProps {
   onUpdate: () => void
 }
 
-const styling = '<style>*{font-family:"Avenir Next";}</style>'
+const styling =
+  '<style>*{font-family:"Avenir Next"; line-height: 22px;\n' +
+  '  overflow-wrap: break-word;\n' +
+  '  word-wrap: break-word;\n' +
+  '  -ms-word-break: break-all;\n' +
+  '  word-break: break-all;\n' +
+  '  word-break: break-word;}</style>'
 const fontSrc =
   '<link rel="stylesheet" href="https://static.amsterdam.nl/fonts/fonts.css"/>'
 

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/EmailPreview/EmailPreview.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/EmailPreview/EmailPreview.tsx
@@ -41,7 +41,6 @@ const styling = `
     font-family:"Avenir Next";
     line-height: 22px;
     overflow-wrap: break-word;
-    word-wrap: break-word;
     word-break: break-all;
     word-break: break-word;
     hyphens: auto;

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/constants.ts
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/constants.ts
@@ -14,7 +14,7 @@ export const DEELMELDINGEN_STILL_OPEN_CONTENT = `Als je de hoofdmelding nu afhan
   Handel de hoofdmelding pas af als alle deelmeldingen zijn opgelost of als de deelmeldingen niet meer nodig zijn.`
 export const NO_REPORTER_EMAIL = `De melder heeft geen e-mailadres opgegeven, er wordt geen bericht verstuurd.`
 
-export const DEFAULT_TEXT_MAX_LENGTH = 3000
+export const DEFAULT_TEXT_MAX_LENGTH = 1800
 export const DEFAULT_TEXT_LABEL = 'Bericht aan melder'
 
 export const REPLY_MAIL_MAX_LENGTH = 400

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/styled.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/styled.tsx
@@ -82,7 +82,7 @@ export const StyledLabel = styled(Label)`
 
 export const StyledModal = styled(Modal)`
   overflow: hidden;
-  height: 50%;
+  height: 75%;
 `
 
 export const StyledParagraph = styled.p`


### PR DESCRIPTION
- An email was send anyway as of the result of updating the status form, even if there was an error in the email preview endpoint. When no email template is available the email is no longer send. The text can still be saved when the recipient is removed, by unchecking the checkbox.
- The height of the email preview is increased to 75%. This was requested by Herjen.
- Styling has been added to increase the line height and to fix issues with sticking out urls.
- Max number of characters was decreased to 1800 temporarily until the endpoint is fixed.