### PR TITLE
(Chore) Filter out unknown legend items

### DIFF
--- a/src/signals/incident/definitions/wizard-step-2-vulaan/afval-container.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/afval-container.ts
@@ -5,7 +5,7 @@ import type { IconOptions } from 'leaflet'
 import configuration from 'shared/services/configuration/configuration'
 import { validateObjectLocation } from 'signals/incident/services/custom-validators'
 import { QuestionFieldType } from 'types/question'
-import { UNKNOWN_TYPE } from 'signals/incident/components/form/MapSelectors/constants'
+import { UNREGISTERED_TYPE } from 'signals/incident/components/form/MapSelectors/constants'
 
 export const ICON_SIZE = 40
 
@@ -132,7 +132,7 @@ export const controls = {
           },
           idField: 'id',
           typeField: 'type',
-          typeValue: UNKNOWN_TYPE,
+          typeValue: UNREGISTERED_TYPE,
         },
       ],
     },

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/openbaarGroenEnWater.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/openbaarGroenEnWater.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2018 - 2021 Gemeente Amsterdam
 import type { IconOptions } from 'leaflet'
-import { UNKNOWN_TYPE } from 'signals/incident/components/form/MapSelectors/constants'
+import { UNREGISTERED_TYPE } from 'signals/incident/components/form/MapSelectors/constants'
 import { QuestionFieldType } from 'types/question'
 import { validateObjectLocation } from '../../services/custom-validators'
 
@@ -74,7 +74,7 @@ export const controls = {
             options,
             iconUrl: '/assets/images/featureUnknownMarker.svg',
           },
-          typeValue: UNKNOWN_TYPE,
+          typeValue: UNREGISTERED_TYPE,
           typeField: '',
         },
       ],

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/straatverlichting-klokken.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/straatverlichting-klokken.ts
@@ -4,7 +4,7 @@ import appConfiguration from 'shared/services/configuration/configuration'
 
 import { QuestionFieldType } from 'types/question'
 import type { IconOptions } from 'leaflet'
-import { UNKNOWN_TYPE } from 'signals/incident/components/form/MapSelectors/constants'
+import { UNREGISTERED_TYPE } from 'signals/incident/components/form/MapSelectors/constants'
 import type ConfigurationType from '../../../../../app.amsterdam.json'
 
 import { validateObjectLocation } from '../../services/custom-validators'
@@ -129,7 +129,7 @@ const straatverlichtingKlokken = {
           },
           idField: 'id',
           typeField: 'type',
-          typeValue: UNKNOWN_TYPE,
+          typeValue: UNREGISTERED_TYPE,
         },
       ],
       pathMerge: 'extra_properties',
@@ -276,7 +276,7 @@ const straatverlichtingKlokken = {
           },
           idField: 'id',
           typeField: 'type',
-          typeValue: UNKNOWN_TYPE,
+          typeValue: UNREGISTERED_TYPE,
         },
       ],
       pathMerge: 'extra_properties',


### PR DESCRIPTION
This PR changes the type for unknown (or unregistered) object feature definitions that would show up in the legend panel. Showing them doesn't make sense since the objects won't show up on the map. They will only show up in the incident form's summary.