### PR TITLE
Allow a negative term for municipality

### DIFF
--- a/app.amsterdam.json
+++ b/app.amsterdam.json
@@ -54,7 +54,7 @@
     "smallHeight": "29px"
   },
   "map": {
-    "municipality": ["amsterdam", "ouder-amstel"],
+    "municipality": "amsterdam \"ouder-amstel\"",
     "options": {
       "center": [
         52.3731081,

--- a/internals/schemas/app.schema.json
+++ b/internals/schemas/app.schema.json
@@ -342,6 +342,7 @@
       "additionalProperties": false,
       "properties": {
         "municipality": {
+          "description": "Allows to filter address lookup by municipality. For example a value of 'amsterdam' will be used in the following format: `fq=gemeentenaam:(amsterdam)`. If a municipality has spaces, surround it by quotes, which in the config will look like `\"\\\"den bosch\\\"\"`. In case of an array, the values will be joined with a space in between. For more information see https://www.pdok.nl/restful-api/-/article/pdok-locatieserver#/paths/~1suggest/get",
           "type": [
             "string",
             "array"

--- a/internals/schemas/app.schema.json
+++ b/internals/schemas/app.schema.json
@@ -342,7 +342,7 @@
       "additionalProperties": false,
       "properties": {
         "municipality": {
-          "description": "Allows to filter address lookup by municipality. For example a value of 'amsterdam' will be used in the following format: `fq=gemeentenaam:(amsterdam)`. If a municipality has spaces, surround it by quotes, which in the config will look like `\"\\\"den bosch\\\"\"`. In case of an array, the values will be joined with a space in between. For more information see https://www.pdok.nl/restful-api/-/article/pdok-locatieserver#/paths/~1suggest/get",
+          "description": "Allows to filter address lookup by municipality. For example a value of 'amsterdam' will be used in the following format: `fq=gemeentenaam:(amsterdam)`. Separate multiple municipalities with a space. If a municipality has spaces, surround it by quotes, which in the config will look like `\"boxtel \\\"den bosch\\\"\"`. For more information see https://www.pdok.nl/restful-api/-/article/pdok-locatieserver#/paths/~1suggest/get",
           "type": [
             "string",
             "array"

--- a/src/components/PDOKAutoSuggest/PDOKAutoSuggest.test.tsx
+++ b/src/components/PDOKAutoSuggest/PDOKAutoSuggest.test.tsx
@@ -76,17 +76,17 @@ describe('components/PDOKAutoSuggest', () => {
       )
     })
 
-    it('should work with an array for municipality', async () => {
-      await renderAndSearch('Dam', { municipality: ['utrecht', 'amsterdam'] })
+    it('should work with multiple municipalities', async () => {
+      await renderAndSearch('Dam', { municipality: 'utrecht amsterdam' })
       expect(fetch).toHaveBeenCalledWith(
         expect.stringContaining(`${municipalityQs}(utrecht amsterdam)`),
         expect.objectContaining({ method: 'GET' })
       )
     })
 
-    it('should work with quotes', async () => {
+    it('should work with quotes and negations', async () => {
       await renderAndSearch('Dam', {
-        municipality: ['"den bosch"', '-amsterdam'],
+        municipality: '"den bosch" -amsterdam',
       })
       expect(fetch).toHaveBeenCalledWith(
         expect.stringContaining(`${municipalityQs}("den bosch" -amsterdam)`),
@@ -97,36 +97,6 @@ describe('components/PDOKAutoSuggest', () => {
     it('should ignore an empty string', async () => {
       await renderAndSearch('Dam', {
         municipality: '',
-      })
-      expect(fetch).toHaveBeenCalledWith(
-        expect.not.stringContaining(municipalityQs),
-        expect.objectContaining({ method: 'GET' })
-      )
-    })
-
-    it('should ignore an empty array', async () => {
-      await renderAndSearch('Dam', {
-        municipality: [],
-      })
-      expect(fetch).toHaveBeenCalledWith(
-        expect.not.stringContaining(municipalityQs),
-        expect.objectContaining({ method: 'GET' })
-      )
-    })
-
-    it('should ignore an empty string in an array', async () => {
-      await renderAndSearch('Dam', {
-        municipality: ['', 'amsterdam', ''],
-      })
-      expect(fetch).toHaveBeenCalledWith(
-        expect.stringContaining(`${municipalityQs}(amsterdam)`),
-        expect.objectContaining({ method: 'GET' })
-      )
-    })
-
-    it('should ignore an array with only empty strings', async () => {
-      await renderAndSearch('Dam', {
-        municipality: ['', ''],
       })
       expect(fetch).toHaveBeenCalledWith(
         expect.not.stringContaining(municipalityQs),

--- a/src/components/PDOKAutoSuggest/PDOKAutoSuggest.test.tsx
+++ b/src/components/PDOKAutoSuggest/PDOKAutoSuggest.test.tsx
@@ -83,6 +83,14 @@ describe('components/PDOKAutoSuggest', () => {
         expect.objectContaining({ method: 'GET' })
       )
     })
+
+    it('should not put quotes around a value starting with "-"', async () => {
+      await renderAndSearch('Dam', { municipality: ['utrecht', '-amsterdam'] })
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining(`${municipalityQs}("utrecht" -amsterdam)`),
+        expect.objectContaining({ method: 'GET' })
+      )
+    })
   })
 
   describe('fieldList', () => {

--- a/src/components/PDOKAutoSuggest/PDOKAutoSuggest.test.tsx
+++ b/src/components/PDOKAutoSuggest/PDOKAutoSuggest.test.tsx
@@ -71,7 +71,7 @@ describe('components/PDOKAutoSuggest', () => {
     it('should call fetch with municipality', async () => {
       await renderAndSearch('Dam', { municipality: 'amsterdam' })
       expect(fetch).toHaveBeenCalledWith(
-        expect.stringContaining(`${municipalityQs}("amsterdam")`),
+        expect.stringContaining(`${municipalityQs}(amsterdam)`),
         expect.objectContaining({ method: 'GET' })
       )
     })
@@ -79,15 +79,57 @@ describe('components/PDOKAutoSuggest', () => {
     it('should work with an array for municipality', async () => {
       await renderAndSearch('Dam', { municipality: ['utrecht', 'amsterdam'] })
       expect(fetch).toHaveBeenCalledWith(
-        expect.stringContaining(`${municipalityQs}("utrecht" "amsterdam")`),
+        expect.stringContaining(`${municipalityQs}(utrecht amsterdam)`),
         expect.objectContaining({ method: 'GET' })
       )
     })
 
-    it('should not put quotes around a value starting with "-"', async () => {
-      await renderAndSearch('Dam', { municipality: ['utrecht', '-amsterdam'] })
+    it('should work with quotes', async () => {
+      await renderAndSearch('Dam', {
+        municipality: ['"den bosch"', '-amsterdam'],
+      })
       expect(fetch).toHaveBeenCalledWith(
-        expect.stringContaining(`${municipalityQs}("utrecht" -amsterdam)`),
+        expect.stringContaining(`${municipalityQs}("den bosch" -amsterdam)`),
+        expect.objectContaining({ method: 'GET' })
+      )
+    })
+
+    it('should ignore an empty string', async () => {
+      await renderAndSearch('Dam', {
+        municipality: '',
+      })
+      expect(fetch).toHaveBeenCalledWith(
+        expect.not.stringContaining(municipalityQs),
+        expect.objectContaining({ method: 'GET' })
+      )
+    })
+
+    it('should ignore an empty array', async () => {
+      await renderAndSearch('Dam', {
+        municipality: [],
+      })
+      expect(fetch).toHaveBeenCalledWith(
+        expect.not.stringContaining(municipalityQs),
+        expect.objectContaining({ method: 'GET' })
+      )
+    })
+
+    it('should ignore an empty string in an array', async () => {
+      await renderAndSearch('Dam', {
+        municipality: ['', 'amsterdam', ''],
+      })
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining(`${municipalityQs}(amsterdam)`),
+        expect.objectContaining({ method: 'GET' })
+      )
+    })
+
+    it('should ignore an array with only empty strings', async () => {
+      await renderAndSearch('Dam', {
+        municipality: ['', ''],
+      })
+      expect(fetch).toHaveBeenCalledWith(
+        expect.not.stringContaining(municipalityQs),
         expect.objectContaining({ method: 'GET' })
       )
     })

--- a/src/components/PDOKAutoSuggest/PDOKAutoSuggest.tsx
+++ b/src/components/PDOKAutoSuggest/PDOKAutoSuggest.tsx
@@ -42,13 +42,10 @@ const PDOKAutoSuggest: FC<PDOKAutoSuggestProps> = ({
   municipality = configuration.map.municipality,
   ...rest
 }) => {
-  const municipalityArray = Array.isArray(municipality)
-    ? municipality
-    : [municipality].filter(Boolean)
-  const municipalityString = municipalityArray
-    .map((item) => (item.indexOf('-') === 0 ? item : `"${item}"`))
-    .join(' ')
-  const fq = municipality
+  const municipalityString = Array.isArray(municipality)
+    ? municipality.filter(Boolean).join(' ')
+    : municipality
+  const fq = municipalityString
     ? [['fq', `${municipalityFilterName}:(${municipalityString})`]]
     : []
   // ['fl', '*'], // undocumented; requests all available field values from the API

--- a/src/components/PDOKAutoSuggest/PDOKAutoSuggest.tsx
+++ b/src/components/PDOKAutoSuggest/PDOKAutoSuggest.tsx
@@ -42,11 +42,8 @@ const PDOKAutoSuggest: FC<PDOKAutoSuggestProps> = ({
   municipality = configuration.map.municipality,
   ...rest
 }) => {
-  const municipalityString = Array.isArray(municipality)
-    ? municipality.filter(Boolean).join(' ')
-    : municipality
-  const fq = municipalityString
-    ? [['fq', `${municipalityFilterName}:(${municipalityString})`]]
+  const fq = municipality
+    ? [['fq', `${municipalityFilterName}:(${municipality})`]]
     : []
   // ['fl', '*'], // undocumented; requests all available field values from the API
   const fl = [

--- a/src/components/PDOKAutoSuggest/PDOKAutoSuggest.tsx
+++ b/src/components/PDOKAutoSuggest/PDOKAutoSuggest.tsx
@@ -46,7 +46,7 @@ const PDOKAutoSuggest: FC<PDOKAutoSuggestProps> = ({
     ? municipality
     : [municipality].filter(Boolean)
   const municipalityString = municipalityArray
-    .map((item) => `"${item}"`)
+    .map((item) => (item.indexOf('-') === 0 ? item : `"${item}"`))
     .join(' ')
   const fq = municipality
     ? [['fq', `${municipalityFilterName}:(${municipalityString})`]]


### PR DESCRIPTION
closes Signalen/frontend#167

For Groningen we ran into a problem.
`configuration.map.municipality` was set to `groningen`. Turns out there is also a municipality called "Midden-Groningen", having the same keyword `groningen` in there. Therefore the autosuggest of the address lookup gave results of both municipalities, while only results from the municipality of Groningen are desired.
Since an exact match on municipality is not possible with PDOK, the workaround could be to exclude the term "midden" in this case. This is done with a dash, as in `-midden`.

Double quotes are put around each term to accommodate spaces in a term, like `den bosch`. Putting double quotes around the term `-midden` would prevent it from being a negative search term. It should be `-midden`, or `-"midden"`. Not `"-midden"`.

## Thougt process

To fix this I chose to not put double quotes around a term in case it begins with a dash.

Other possible solutions could be:

- Never put quotes around a term. Then they need to be put explicitly in the configuration in case the term contains spaces.
- Always put quotes around a term. In case the term begins with a dash, put the dash in front of the quote.

## Final implementation

Finally decided to go for a fix that removes all magic. More power in the configuration.
For clarity, only string values are allowed now. Not an array anymore.

## BREAKING:

- Any configuration setup that has a municipality defined with spaces in it now needs to put double quotes around it.
So, `"den bosch"` should become `"\"den bosch\""`.
- Any configuration setup that has municipality defined as an array needs to convert it into a string, separating each municipality with a space.