### PR TITLE
(Chore) Allow Browserstack tunnel

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "prebuild": "npm run build:clean && npm run proj4compile",
     "pretest": "npm run test:clean",
     "prestart:prod": "npm run build",
-    "start": "cross-env NODE_ENV=development npx webpack s --config ./internals/webpack/webpack.dev.babel --port=3001 --hot --compress --history-api-fallback --watch-files=./src/* --watch-files=./src/**/*",
+    "start": "cross-env NODE_ENV=development npx webpack s --allowed-hosts localhost bs-local.com --config ./internals/webpack/webpack.dev.babel --port=3001 --hot --compress --history-api-fallback --watch-files=./src/* --watch-files=./src/**/*",
     "test": "cross-env NODE_ENV=test jest --coverage --runInBand",
     "test:logHeapUsage": "cross-env NODE_ENV=test node --expose-gc ./node_modules/.bin/jest --runInBand --logHeapUsage",
     "test:clean": "rimraf ./coverage",


### PR DESCRIPTION
The proposed change in this PR allows testing local URLs on iOS with Browserstack. iOS doesn't allow the use of `localhost`, but this can be circumvented by using the bs-local.com domain. See https://www.browserstack.com/docs/live/local-testing/test-using-local-testing for reference on local testing.
Note that, for this change to work, the hosts file on the development machine needs to be changed so that it accepts requests for bs-local.com and routes these to `127.0.0.1`.