### PR TITLE
(Fix) iOS AddressPanel scroll

### DIFF
--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.tsx
@@ -144,7 +144,10 @@ const DetailPanel: FC<DetailPanelProps> = ({ featureTypes, language = {} }) => {
   }, [removeItem])
 
   return (
-    <PanelContent data-testid="detailPanel">
+    <PanelContent
+      data-testid="detailPanel"
+      posAbsolute={showAddressPanel && shouldRenderAddressPanel}
+    >
       <Title>{language.title || 'Locatie'}</Title>
 
       <ScrollWrapper>
@@ -156,14 +159,16 @@ const DetailPanel: FC<DetailPanelProps> = ({ featureTypes, language = {} }) => {
           </Description>
         </Paragraph>
 
-        <StyledPDOKAutoSuggest
-          onFocus={() => {
-            setShowAddressPanel(true)
-          }}
-          onClear={removeItem}
-          onSelect={onAddressSelect}
-          value={addressValue}
-        />
+        {!(showAddressPanel && shouldRenderAddressPanel) && (
+          <StyledPDOKAutoSuggest
+            onFocus={() => {
+              setShowAddressPanel(true)
+            }}
+            onClear={removeItem}
+            onSelect={onAddressSelect}
+            value={addressValue}
+          />
+        )}
 
         {selection && selectionOnMap && (
           <StyledAssetList
@@ -238,7 +243,6 @@ const DetailPanel: FC<DetailPanelProps> = ({ featureTypes, language = {} }) => {
               variant="blank"
             />
             <StyledPDOKAutoSuggest
-              autoFocus
               onClear={clearInput}
               onData={setOptionsList}
               onSelect={onAddressSelect}

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.tsx
@@ -146,7 +146,7 @@ const DetailPanel: FC<DetailPanelProps> = ({ featureTypes, language = {} }) => {
   return (
     <PanelContent
       data-testid="detailPanel"
-      posAbsolute={showAddressPanel && shouldRenderAddressPanel}
+      smallViewport={showAddressPanel && shouldRenderAddressPanel}
     >
       <Title>{language.title || 'Locatie'}</Title>
 

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/styled.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/styled.tsx
@@ -31,13 +31,13 @@ export const LegendToggleButton = styled(LegendToggle)`
   }
 `
 
-export const PanelContent = styled.div<{ posAbsolute?: boolean }>`
+export const PanelContent = styled.div<{ smallViewport?: boolean }>`
   background-color: white;
   padding: ${themeSpacing(4)};
   z-index: 1;
   position: relative;
-  ${({ posAbsolute }) =>
-    posAbsolute &&
+  ${({ smallViewport }) =>
+    smallViewport &&
     css`
       top: 0;
       left: 0;

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/styled.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/styled.tsx
@@ -1,4 +1,4 @@
-import styled, { keyframes } from 'styled-components'
+import styled, { css, keyframes } from 'styled-components'
 
 import { Button, themeSpacing, themeColor, breakpoint } from '@amsterdam/asc-ui'
 
@@ -31,17 +31,25 @@ export const LegendToggleButton = styled(LegendToggle)`
   }
 `
 
-export const PanelContent = styled.div`
+export const PanelContent = styled.div<{ posAbsolute?: boolean }>`
   background-color: white;
   padding: ${themeSpacing(4)};
-  position: relative;
   z-index: 1;
+  position: relative;
+  ${({ posAbsolute }) =>
+    posAbsolute &&
+    css`
+      top: 0;
+      left: 0;
+      position: absolute;
+      height: 100%;
+    `}
 
   @media only screen and ${breakpoint('max-width', 'tabletM')} {
     bottom: 0;
     box-shadow: 0 -2px 2px rgba(0, 0, 0, 0.1);
-    flex: 0 0 50vh;
-    max-height: 50vh;
+    flex: 0 0 50%;
+    max-height: 50%;
     order: 1;
     width: 100vw;
   }
@@ -80,13 +88,14 @@ const slideUp = keyframes`
 
 export const AddressPanel = styled.article`
   background-color: white;
-  position: fixed;
+  position: absolute;
   width: 100vw;
   height: 100vh;
   z-index: 2;
   left: 0;
   top: 0;
   animation: ${slideUp} 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  translate3d(0, 100%, 0);
 
   @media only screen and ${breakpoint('max-width', 'tabletM')} {
     transform: translate3d(0, 0, 0);


### PR DESCRIPTION
This PR fixes a scroll issue on iOS where, when an input element inside a fixed position element gets focus, the OS keyboard will push the fixed positioned element off-screen. To solve this, there are two options:
1. Turn all fixed elements into absolute positioned elements
2. Do not let the input field get focus

The first option is quite troublesome, because it requires a refactoring of most of the styled component that make up the detail panel and the address panel. The second option is the easiest, but it requires the user to tap the input field twice; once to toggle the full-screen panel and the second time to focus the input field.

For now, the second option is chosen. It this is considered to be too obtrusive, the first option will be implemented.