### PR TITLE
(Chore) Replace PDOK API link

### DIFF
--- a/src/components/PDOKAutoSuggest/PDOKAutoSuggest.tsx
+++ b/src/components/PDOKAutoSuggest/PDOKAutoSuggest.tsx
@@ -35,7 +35,6 @@ export interface PDOKAutoSuggestProps
 /**
  * Geocoder component that specifically uses the PDOK location service to request information from
  *
- * @see {@link https://www.pdok.nl/restful-api/-/article/pdok-locatieserver#/paths/~1suggest/get}
  * @see {@link https://github.com/PDOK/locatieserver/wiki/API-Locatieserver}
  */
 const PDOKAutoSuggest: FC<PDOKAutoSuggestProps> = ({

--- a/src/components/PDOKAutoSuggest/PDOKAutoSuggest.tsx
+++ b/src/components/PDOKAutoSuggest/PDOKAutoSuggest.tsx
@@ -36,6 +36,7 @@ export interface PDOKAutoSuggestProps
  * Geocoder component that specifically uses the PDOK location service to request information from
  *
  * @see {@link https://www.pdok.nl/restful-api/-/article/pdok-locatieserver#/paths/~1suggest/get}
+ * @see {@link https://github.com/PDOK/locatieserver/wiki/API-Locatieserver}
  */
 const PDOKAutoSuggest: FC<PDOKAutoSuggestProps> = ({
   fieldList = [],


### PR DESCRIPTION
Previous link wasn't pointing to a valid documentation location any more