### PR TITLE
[SIG 4412] Enable to make category publicly available

### DIFF
--- a/src/signals/settings/categories/Detail/Detail.test.js
+++ b/src/signals/settings/categories/Detail/Detail.test.js
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2020 - 2021 Gemeente Amsterdam
-import { render, act, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import * as reactRouterDom from 'react-router-dom'
 import * as reactRedux from 'react-redux'
 import userEvent from '@testing-library/user-event'
@@ -13,8 +13,8 @@ import { showGlobalNotification } from 'containers/App/actions'
 import * as appSelectors from 'containers/App/selectors'
 
 import { subCategories } from 'utils/__tests__/fixtures'
-import useConfirmedCancel from '../../../hooks/useConfirmedCancel'
-import CategoryDetailContainer from '..'
+import useConfirmedCancel from '../../hooks/useConfirmedCancel'
+import CategoryDetailContainer from '.'
 
 const categoryJSON = subCategories.find((sub) => sub?._links['sia:parent'])
 
@@ -33,7 +33,7 @@ jest.mock('models/categories/actions', () => ({
   ...jest.requireActual('models/categories/actions'),
 }))
 
-jest.mock('../../../hooks/useConfirmedCancel')
+jest.mock('../../hooks/useConfirmedCancel')
 
 const userCan = jest.fn(() => () => true)
 jest.spyOn(appSelectors, 'makeSelectUserCan').mockImplementation(userCan)
@@ -62,7 +62,7 @@ describe('signals/settings/categories/Detail', () => {
     fetch.mockClear()
   })
 
-  it('should render a backlink', async () => {
+  it('Renders a backlink', async () => {
     render(withAppContext(<CategoryDetailContainer />))
 
     const backLink = await screen.findByTestId('backlink')
@@ -70,7 +70,7 @@ describe('signals/settings/categories/Detail', () => {
     expect(backLink.getAttribute('href')).toEqual(routes.categories)
   })
 
-  it('should render a backlink with the proper referrer', async () => {
+  it('Renders a backlink with the proper referrer', async () => {
     const referrer = '/some-page-we-came-from'
 
     jest.spyOn(reactRouterDom, 'useLocation').mockImplementation(() => ({
@@ -84,14 +84,14 @@ describe('signals/settings/categories/Detail', () => {
     expect(backLink.getAttribute('href')).toEqual(referrer)
   })
 
-  it('should render the correct page title for a new category', async () => {
+  it('Renders the correct page title for a new category', async () => {
     render(withAppContext(<CategoryDetailContainer />))
 
     const title = await screen.findByText('Subcategorie toevoegen')
     expect(title).toBeInTheDocument()
   })
 
-  it('should render the correct page title for an existing category', async () => {
+  it('Renders the correct page title for an existing category', async () => {
     jest.spyOn(reactRouterDom, 'useParams').mockImplementation(() => ({
       categoryId: categoryJSON.id,
     }))
@@ -102,7 +102,7 @@ describe('signals/settings/categories/Detail', () => {
     expect(title).toBeInTheDocument()
   })
 
-  it('should render a form for a new category', () => {
+  it('Renders a form for a new category', () => {
     jest.spyOn(reactRouterDom, 'useParams').mockImplementation(() => ({
       categoryId: undefined,
     }))
@@ -117,7 +117,7 @@ describe('signals/settings/categories/Detail', () => {
     })
   })
 
-  it('should render a form for an existing category', async () => {
+  it('Renders a form for an existing category', async () => {
     jest.spyOn(reactRouterDom, 'useParams').mockImplementation(() => ({
       categoryId: 123,
     }))
@@ -132,7 +132,7 @@ describe('signals/settings/categories/Detail', () => {
     )
   })
 
-  it('should call confirmedCancel', async () => {
+  it('Calls confirmedCancel', async () => {
     jest.spyOn(reactRouterDom, 'useParams').mockImplementation(() => ({
       categoryId: 456,
     }))
@@ -144,41 +144,31 @@ describe('signals/settings/categories/Detail', () => {
     const nameField = screen.getByRole('textbox', { name: 'Naam' })
     const cancelButton = screen.getByTestId('cancelBtn')
 
-    act(() => {
-      // no changes to data in form fields
-      userEvent.click(cancelButton)
-    })
+    // no changes to data in form fields
+    userEvent.click(cancelButton)
 
     expect(confirmedCancel).toHaveBeenCalledTimes(1)
     expect(confirmedCancel).toHaveBeenCalledWith(true)
 
-    act(() => {
-      // changes made, but data remains the same
-      userEvent.clear(nameField)
-      userEvent.type(nameField, categoryJSON.name)
-    })
+    // changes made, but data remains the same
+    userEvent.clear(nameField)
+    userEvent.type(nameField, categoryJSON.name)
 
-    act(() => {
-      userEvent.click(cancelButton)
-    })
+    userEvent.click(cancelButton)
 
     expect(confirmedCancel).toHaveBeenCalledTimes(2)
     expect(confirmedCancel).toHaveBeenLastCalledWith(true)
 
-    act(() => {
-      // changes made, data differs from initial API data
-      userEvent.type(nameField, 'Some other value')
-    })
+    // changes made, data differs from initial API data
+    userEvent.type(nameField, 'Some other value')
 
-    act(() => {
-      userEvent.click(cancelButton)
-    })
+    userEvent.click(cancelButton)
 
     expect(confirmedCancel).toHaveBeenCalledTimes(3)
     expect(confirmedCancel).toHaveBeenLastCalledWith(false)
   })
 
-  it('should not update NULL values with empty string', async () => {
+  it('Does not update NULL values with empty string', async () => {
     jest.spyOn(reactRouterDom, 'useParams').mockImplementation(() => ({
       categoryId: 10101,
     }))
@@ -211,7 +201,41 @@ describe('signals/settings/categories/Detail', () => {
     })
   })
 
-  it('should call confirmedCancel when data has NULL values', async () => {
+  it("Converts stringified boolean values to actual booleans for 'is_active' and 'is_public_accessible'", async () => {
+    jest.spyOn(reactRouterDom, 'useParams').mockImplementation(() => ({
+      categoryId: 10101,
+    }))
+    const categoryData = {
+      ...categoryJSON,
+      is_active: 'true',
+      is_public_accessible: 'false',
+    }
+    fetch.resetMocks()
+    fetch.mockResponses(
+      [JSON.stringify(categoryData), { status: 200 }],
+      [JSON.stringify(historyJSON), { status: 200 }],
+      [JSON.stringify(categoryData), { status: 200 }]
+    )
+
+    render(withAppContext(<CategoryDetailContainer />))
+
+    await screen.findByTestId('detailCategoryForm')
+
+    userEvent.click(screen.getByTestId('submitBtn'))
+
+    const actualRequestBody = JSON.parse(
+      fetch.mock.calls[fetch.mock.calls.length - 1][1].body
+    )
+    expect(actualRequestBody).toEqual(
+      expect.objectContaining({ is_active: true, is_public_accessible: false })
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loadingIndicator')).toBeInTheDocument()
+    })
+  })
+
+  it('Calls confirmedCancel when data has NULL values', async () => {
     const dataWithNullValue = { ...categoryJSON, description: null }
 
     fetch.resetMocks()
@@ -235,44 +259,34 @@ describe('signals/settings/categories/Detail', () => {
     })
     const cancelButton = screen.getByTestId('cancelBtn')
 
-    act(() => {
-      // no changes to data in form fields
-      userEvent.click(cancelButton)
-    })
+    // no changes to data in form fields
+    userEvent.click(cancelButton)
 
     expect(confirmedCancel).toHaveBeenCalledTimes(1)
     expect(confirmedCancel).toHaveBeenCalledWith(true)
 
-    act(() => {
-      // changes made, but data remains the same
-      userEvent.clear(descriptionField)
-    })
+    // changes made, but data remains the same
+    userEvent.clear(descriptionField)
 
     await screen.findByTestId('detailCategoryForm')
 
-    act(() => {
-      userEvent.click(cancelButton)
-    })
+    userEvent.click(cancelButton)
 
     expect(confirmedCancel).toHaveBeenCalledTimes(2)
     expect(confirmedCancel).toHaveBeenLastCalledWith(true)
 
-    act(() => {
-      // changes made, data differs from initial API data
-      userEvent.type(descriptionField, 'Here be a description')
-    })
+    // changes made, data differs from initial API data
+    userEvent.type(descriptionField, 'Here be a description')
 
     await screen.findByTestId('detailCategoryForm')
 
-    act(() => {
-      userEvent.click(cancelButton)
-    })
+    userEvent.click(cancelButton)
 
     expect(confirmedCancel).toHaveBeenCalledTimes(3)
     expect(confirmedCancel).toHaveBeenLastCalledWith(false)
   })
 
-  it('should call patch on submit', async () => {
+  it('Calls patch on submit', async () => {
     fetch.resetMocks()
 
     fetch
@@ -293,9 +307,7 @@ describe('signals/settings/categories/Detail', () => {
 
     const submitBtn = screen.getByTestId('submitBtn')
 
-    act(() => {
-      userEvent.click(submitBtn)
-    })
+    userEvent.click(submitBtn)
 
     expect(dispatch).not.toHaveBeenCalled()
 
@@ -311,7 +323,7 @@ describe('signals/settings/categories/Detail', () => {
     expect(dispatch).toHaveBeenCalledWith(fetchCategories())
   })
 
-  it('should redirect on patch success', async () => {
+  it('Redirects on patch success', async () => {
     fetch.resetMocks()
 
     fetch
@@ -331,9 +343,7 @@ describe('signals/settings/categories/Detail', () => {
 
     const submitBtn = screen.getByTestId('submitBtn')
 
-    act(() => {
-      userEvent.click(submitBtn)
-    })
+    userEvent.click(submitBtn)
 
     expect(dispatch).not.toHaveBeenCalled()
     expect(push).not.toHaveBeenCalled()
@@ -347,7 +357,7 @@ describe('signals/settings/categories/Detail', () => {
     expect(push).toHaveBeenCalledTimes(1)
   })
 
-  it('does not request history when category is not passed', async () => {
+  it('Does not request history when category is not passed', async () => {
     jest.spyOn(reactRouterDom, 'useParams').mockImplementation(() => ({
       categoryId: undefined,
     }))
@@ -362,7 +372,7 @@ describe('signals/settings/categories/Detail', () => {
     )
   })
 
-  it('requests history for existing category', async () => {
+  it('Requests history for existing category', async () => {
     jest.spyOn(reactRouterDom, 'useParams').mockImplementation(() => ({
       categoryId: 900,
     }))

--- a/src/signals/settings/categories/Detail/components/CategoryForm/CategoryForm.test.tsx
+++ b/src/signals/settings/categories/Detail/components/CategoryForm/CategoryForm.test.tsx
@@ -5,8 +5,8 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { withAppContext } from 'test/utils'
 
-import CategoryForm from '..'
-import type { CategoryFormProps } from '../CategoryForm'
+import type { CategoryFormProps } from './CategoryForm'
+import CategoryForm from './CategoryForm'
 
 const mockDepartment = {
   can_view: true,
@@ -37,6 +37,7 @@ describe('signals/settings/categories/Detail/components/CategoryForm', () => {
       handling_message: 'Mock handling message',
       note: 'Mock note',
       is_active: true,
+      is_public_accessible: false,
       name: 'Mock name',
       sla: {
         n_days: 5,
@@ -55,7 +56,7 @@ describe('signals/settings/categories/Detail/components/CategoryForm', () => {
     jest.restoreAllMocks()
   })
 
-  it('should render the correct fields', () => {
+  it('Renders the correct fields', () => {
     render(withAppContext(<CategoryForm {...defaultProps} />))
 
     expect(screen.getByRole('textbox', { name: 'Naam' })).toHaveValue(
@@ -67,13 +68,18 @@ describe('signals/settings/categories/Detail/components/CategoryForm', () => {
     expect(screen.getByRole('textbox', { name: 'Notitie' })).toHaveValue(
       'Mock note'
     )
+    expect(
+      screen.getByRole('checkbox', {
+        name: 'Toon meldingen van deze subcategorie op een openbare kaart',
+      })
+    ).not.toBeChecked()
     expect(screen.getByRole('spinbutton')).toHaveValue(5)
     expect(screen.getByRole('combobox')).toHaveValue('0')
     expect(screen.getByRole('radio', { name: 'Actief' })).toBeChecked()
     expect(screen.getByRole('radio', { name: 'Niet actief' })).not.toBeChecked()
   })
 
-  it('should render category history', () => {
+  it('Renders category history', () => {
     const { rerender } = render(
       withAppContext(<CategoryForm {...defaultProps} />)
     )
@@ -98,7 +104,27 @@ describe('signals/settings/categories/Detail/components/CategoryForm', () => {
     expect(screen.getByTestId('history')).toBeInTheDocument()
   })
 
-  it('should make fields disabled', () => {
+  it('Renders the public name field when the is_public_accessible checkbox is checked', () => {
+    render(withAppContext(<CategoryForm {...defaultProps} />))
+
+    expect(
+      screen.queryByRole('textbox', { name: 'Naam openbaar' })
+    ).not.toBeInTheDocument()
+
+    const checkbox = screen.getByRole('checkbox', {
+      name: 'Toon meldingen van deze subcategorie op een openbare kaart',
+    })
+    expect(checkbox).not.toBeChecked()
+
+    userEvent.click(checkbox)
+
+    expect(checkbox).toBeChecked()
+    expect(
+      screen.getByRole('textbox', { name: 'Naam openbaar' })
+    ).toBeInTheDocument()
+  })
+
+  it('Disables fields', () => {
     const { rerender } = render(
       withAppContext(<CategoryForm {...defaultProps} />)
     )
@@ -107,6 +133,9 @@ describe('signals/settings/categories/Detail/components/CategoryForm', () => {
       expect(element).not.toBeDisabled()
     })
     screen.getAllByRole('spinbutton').forEach((element) => {
+      expect(element).not.toBeDisabled()
+    })
+    screen.getAllByRole('checkbox').forEach((element) => {
       expect(element).not.toBeDisabled()
     })
     screen.getAllByRole('combobox').forEach((element) => {
@@ -123,6 +152,9 @@ describe('signals/settings/categories/Detail/components/CategoryForm', () => {
     screen.getAllByRole('textbox').forEach((element) => {
       expect(element).toBeDisabled()
     })
+    screen.getAllByRole('checkbox').forEach((element) => {
+      expect(element).toBeDisabled()
+    })
     screen.getAllByRole('spinbutton').forEach((element) => {
       expect(element).toBeDisabled()
     })
@@ -137,7 +169,7 @@ describe('signals/settings/categories/Detail/components/CategoryForm', () => {
     ).not.toBeInTheDocument()
   })
 
-  it('should set field values', () => {
+  it('Sets field values', () => {
     const props: CategoryFormProps = {
       ...defaultProps,
       data: {
@@ -146,6 +178,8 @@ describe('signals/settings/categories/Detail/components/CategoryForm', () => {
         description: 'Bar',
         handling_message: 'foo@bar',
         is_active: true,
+        is_public_accessible: true,
+        public_name: 'Foo Bar',
         sla: {
           n_days: 10,
           use_calendar_days: false,
@@ -184,6 +218,15 @@ describe('signals/settings/categories/Detail/components/CategoryForm', () => {
     expect(screen.getByRole('textbox', { name: 'Servicebelofte' })).toHaveValue(
       'foo@bar'
     )
+    expect(
+      screen.getByRole('checkbox', {
+        name: 'Toon meldingen van deze subcategorie op een openbare kaart',
+      })
+    ).toBeChecked()
+    expect(screen.getByRole('textbox', { name: 'Naam openbaar' })).toHaveValue(
+      'Foo Bar'
+    )
+
     expect(screen.getByRole('spinbutton')).toHaveValue(props.data?.sla.n_days)
     expect(screen.getByRole('combobox')).toHaveValue('0')
     expect(screen.getByRole('radio', { name: 'Actief' })).toBeChecked()
@@ -212,7 +255,7 @@ describe('signals/settings/categories/Detail/components/CategoryForm', () => {
     expect(screen.getByRole('combobox')).toHaveValue('1')
   })
 
-  it('should call onCancel callback', () => {
+  it('Calls onCancel callback', () => {
     render(withAppContext(<CategoryForm {...defaultProps} />))
 
     expect(defaultProps.onCancel).not.toHaveBeenCalled()
@@ -220,7 +263,7 @@ describe('signals/settings/categories/Detail/components/CategoryForm', () => {
     expect(defaultProps.onCancel).toHaveBeenCalled()
   })
 
-  it('should call onSubmit callback', () => {
+  it('Calls onSubmit callback', () => {
     render(withAppContext(<CategoryForm {...defaultProps} />))
 
     expect(defaultProps.onSubmitForm).not.toHaveBeenCalled()

--- a/src/signals/settings/categories/Detail/components/CategoryForm/CategoryForm.tsx
+++ b/src/signals/settings/categories/Detail/components/CategoryForm/CategoryForm.tsx
@@ -1,7 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2020 - 2021 Gemeente Amsterdam
 import { useCallback, useMemo, useState } from 'react'
-import type { FunctionComponent, MouseEvent, ElementType } from 'react'
+import type {
+  ChangeEvent,
+  FunctionComponent,
+  MouseEvent,
+  ElementType,
+} from 'react'
 import { themeSpacing, Row, Column, Select, Label } from '@amsterdam/asc-ui'
 import styled from 'styled-components'
 
@@ -99,8 +104,8 @@ const CategoryForm: FunctionComponent<CategoryFormProps> = ({
   )
 
   const onCheck = useCallback(
-    (evt) => {
-      setIsPublicAccessible(evt.target.checked)
+    (event: ChangeEvent<HTMLInputElement>) => {
+      setIsPublicAccessible(event.target.checked)
     },
     [setIsPublicAccessible]
   )
@@ -169,7 +174,7 @@ const CategoryForm: FunctionComponent<CategoryFormProps> = ({
                     checked={isPublicAccessible}
                     name="is_public_accessible"
                     id="is_public_accessible"
-                    onClick={onCheck}
+                    onChange={onCheck}
                     value={isPublicAccessible.toString()}
                   />
                 </Label>

--- a/src/signals/settings/categories/Detail/components/CategoryForm/CategoryForm.tsx
+++ b/src/signals/settings/categories/Detail/components/CategoryForm/CategoryForm.tsx
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2020 - 2021 Gemeente Amsterdam
-import { useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import type { FunctionComponent, MouseEvent, ElementType } from 'react'
-import { themeSpacing, Row, Column, Select } from '@amsterdam/asc-ui'
+import { themeSpacing, Row, Column, Select, Label } from '@amsterdam/asc-ui'
 import styled from 'styled-components'
 
 import RadioButtonList from 'signals/incident-management/components/RadioButtonList'
 import type { History as HistoryType } from 'types/history'
 import type { Category as CategoryType } from 'types/category'
 
+import Checkbox from 'components/Checkbox'
 import History from 'components/History'
-import Label from 'components/Label'
 import Input from 'components/Input'
 import TextArea from 'components/TextArea'
 import FormFooter from 'components/FormFooter'
@@ -85,6 +85,8 @@ const CategoryForm: FunctionComponent<CategoryFormProps> = ({
   onSubmitForm,
   readOnly,
 }) => {
+  const [isPublicAccessible, setIsPublicAccessible] = useState(false)
+  const [publicName, setPublicName] = useState('')
   const responsibleDepartments = useMemo(
     () =>
       data
@@ -93,6 +95,27 @@ const CategoryForm: FunctionComponent<CategoryFormProps> = ({
             .map((department) => department.code)
         : [],
     [data]
+  )
+
+  useEffect(() => {
+    if (data?.is_public_accessible) {
+      setIsPublicAccessible(data.is_public_accessible)
+    }
+    if (data?.public_name) {
+      setPublicName(data.public_name)
+    }
+  }, [
+    data?.is_public_accessible,
+    data?.public_name,
+    setIsPublicAccessible,
+    setPublicName,
+  ])
+
+  const onCheck = useCallback(
+    (evt) => {
+      setIsPublicAccessible(evt.target.checked)
+    },
+    [setIsPublicAccessible]
   )
 
   return (
@@ -139,7 +162,40 @@ const CategoryForm: FunctionComponent<CategoryFormProps> = ({
             ) : null}
 
             <FieldGroup>
-              <Label>Afhandeltermijn</Label>
+              <StyledDefinitionTerm>
+                <strong>Openbaar tonen</strong>
+              </StyledDefinitionTerm>
+              <div>
+                <Label
+                  htmlFor="is_public_accessible"
+                  label="Toon meldingen van deze subcategorie op een openbare kaart"
+                  data-testid="subcategoryIsPublicAccessible"
+                >
+                  <Checkbox
+                    checked={isPublicAccessible}
+                    id="is_public_accessible"
+                    onClick={onCheck}
+                  />
+                </Label>
+              </div>
+            </FieldGroup>
+
+            {isPublicAccessible && (
+              <FieldGroup>
+                <Input
+                  defaultValue={publicName}
+                  id="public_name"
+                  label="Naam openbaar"
+                  name="public_name"
+                  type="text"
+                />
+              </FieldGroup>
+            )}
+
+            <FieldGroup>
+              <StyledDefinitionTerm>
+                <strong>Afhandeltermijn</strong>
+              </StyledDefinitionTerm>
 
               <CombinedFields>
                 <Input
@@ -178,7 +234,10 @@ const CategoryForm: FunctionComponent<CategoryFormProps> = ({
             </FieldGroup>
 
             <FieldGroup>
-              <Label as="span">Status</Label>
+              <StyledDefinitionTerm>
+                <strong>Status</strong>
+              </StyledDefinitionTerm>
+
               <RadioButtonList
                 defaultValue={
                   data?.is_active === undefined

--- a/src/signals/settings/categories/Detail/components/CategoryForm/CategoryForm.tsx
+++ b/src/signals/settings/categories/Detail/components/CategoryForm/CategoryForm.tsx
@@ -170,6 +170,7 @@ const CategoryForm: FunctionComponent<CategoryFormProps> = ({
                   htmlFor="is_public_accessible"
                   label="Toon meldingen van deze subcategorie op een openbare kaart"
                   data-testid="subcategoryIsPublicAccessible"
+                  disabled={readOnly}
                 >
                   <Checkbox
                     checked={isPublicAccessible}
@@ -188,6 +189,7 @@ const CategoryForm: FunctionComponent<CategoryFormProps> = ({
                   label="Naam openbaar"
                   name="public_name"
                   type="text"
+                  readOnly={readOnly}
                 />
               </FieldGroup>
             )}

--- a/src/signals/settings/categories/Detail/components/CategoryForm/CategoryForm.tsx
+++ b/src/signals/settings/categories/Detail/components/CategoryForm/CategoryForm.tsx
@@ -68,6 +68,13 @@ const StyledDefinitionTerm = styled.dt`
   margin-bottom: ${themeSpacing(1)};
 `
 
+const StyledHeading = styled.p`
+  margin-bottom: ${themeSpacing(1)};
+  font-weight: bold;
+  line-height: 22px;
+  font-size: 16px;
+`
+
 const statusOptions = [
   { key: 'true', value: 'Actief' },
   { key: 'false', value: 'Niet actief' },
@@ -154,9 +161,7 @@ const CategoryForm: FunctionComponent<CategoryFormProps> = ({
             ) : null}
 
             <FieldGroup>
-              <StyledDefinitionTerm>
-                <strong>Openbaar tonen</strong>
-              </StyledDefinitionTerm>
+              <StyledHeading>Openbaar tonen</StyledHeading>
               <>
                 <Label
                   htmlFor="is_public_accessible"
@@ -195,10 +200,7 @@ const CategoryForm: FunctionComponent<CategoryFormProps> = ({
             )}
 
             <FieldGroup>
-              <StyledDefinitionTerm>
-                <strong>Afhandeltermijn</strong>
-              </StyledDefinitionTerm>
-
+              <StyledHeading>Afhandeltermijn</StyledHeading>
               <CombinedFields>
                 <Input
                   defaultValue={data?.sla.n_days ?? undefined}
@@ -236,10 +238,7 @@ const CategoryForm: FunctionComponent<CategoryFormProps> = ({
             </FieldGroup>
 
             <FieldGroup>
-              <StyledDefinitionTerm>
-                <strong>Status</strong>
-              </StyledDefinitionTerm>
-
+              <StyledHeading>Status</StyledHeading>
               <RadioButtonList
                 defaultValue={
                   data?.is_active === undefined

--- a/src/signals/settings/categories/Detail/components/CategoryForm/CategoryForm.tsx
+++ b/src/signals/settings/categories/Detail/components/CategoryForm/CategoryForm.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2020 - 2021 Gemeente Amsterdam
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import type { FunctionComponent, MouseEvent, ElementType } from 'react'
 import { themeSpacing, Row, Column, Select, Label } from '@amsterdam/asc-ui'
 import styled from 'styled-components'
@@ -85,8 +85,10 @@ const CategoryForm: FunctionComponent<CategoryFormProps> = ({
   onSubmitForm,
   readOnly,
 }) => {
-  const [isPublicAccessible, setIsPublicAccessible] = useState(false)
-  const [publicName, setPublicName] = useState('')
+  const [isPublicAccessible, setIsPublicAccessible] = useState(
+    data?.is_public_accessible ?? false
+  )
+  // const [publicName, setPublicName] = useState(data.public_name)
   const responsibleDepartments = useMemo(
     () =>
       data
@@ -97,19 +99,19 @@ const CategoryForm: FunctionComponent<CategoryFormProps> = ({
     [data]
   )
 
-  useEffect(() => {
-    if (data?.is_public_accessible) {
-      setIsPublicAccessible(data.is_public_accessible)
-    }
-    if (data?.public_name) {
-      setPublicName(data.public_name)
-    }
-  }, [
-    data?.is_public_accessible,
-    data?.public_name,
-    setIsPublicAccessible,
-    setPublicName,
-  ])
+  // useEffect(() => {
+  //   // if (data?.is_public_accessible) {
+  //   //   setIsPublicAccessible(data.is_public_accessible)
+  //   // }
+  //   if (data?.public_name) {
+  //     setPublicName(data.public_name)
+  //   }
+  // }, [
+  //   // data?.is_public_accessible,
+  //   data?.public_name,
+  //   // setIsPublicAccessible,
+  //   setPublicName,
+  // ])
 
   const onCheck = useCallback(
     (evt) => {
@@ -165,26 +167,33 @@ const CategoryForm: FunctionComponent<CategoryFormProps> = ({
               <StyledDefinitionTerm>
                 <strong>Openbaar tonen</strong>
               </StyledDefinitionTerm>
-              <div>
+              <>
                 <Label
                   htmlFor="is_public_accessible"
                   label="Toon meldingen van deze subcategorie op een openbare kaart"
                   data-testid="subcategoryIsPublicAccessible"
-                  disabled={readOnly}
                 >
+                  <input
+                    type="hidden"
+                    name="is_public_accessible"
+                    value="false"
+                  />
+
                   <Checkbox
                     checked={isPublicAccessible}
+                    name="is_public_accessible"
                     id="is_public_accessible"
                     onClick={onCheck}
+                    value={isPublicAccessible.toString()}
                   />
                 </Label>
-              </div>
+              </>
             </FieldGroup>
 
             {isPublicAccessible && (
               <FieldGroup>
                 <Input
-                  defaultValue={publicName}
+                  defaultValue={data?.public_name ?? ''}
                   id="public_name"
                   label="Naam openbaar"
                   name="public_name"

--- a/src/signals/settings/categories/Detail/components/CategoryForm/CategoryForm.tsx
+++ b/src/signals/settings/categories/Detail/components/CategoryForm/CategoryForm.tsx
@@ -88,7 +88,6 @@ const CategoryForm: FunctionComponent<CategoryFormProps> = ({
   const [isPublicAccessible, setIsPublicAccessible] = useState(
     data?.is_public_accessible ?? false
   )
-  // const [publicName, setPublicName] = useState(data.public_name)
   const responsibleDepartments = useMemo(
     () =>
       data
@@ -98,20 +97,6 @@ const CategoryForm: FunctionComponent<CategoryFormProps> = ({
         : [],
     [data]
   )
-
-  // useEffect(() => {
-  //   // if (data?.is_public_accessible) {
-  //   //   setIsPublicAccessible(data.is_public_accessible)
-  //   // }
-  //   if (data?.public_name) {
-  //     setPublicName(data.public_name)
-  //   }
-  // }, [
-  //   // data?.is_public_accessible,
-  //   data?.public_name,
-  //   // setIsPublicAccessible,
-  //   setPublicName,
-  // ])
 
   const onCheck = useCallback(
     (evt) => {
@@ -172,6 +157,7 @@ const CategoryForm: FunctionComponent<CategoryFormProps> = ({
                   htmlFor="is_public_accessible"
                   label="Toon meldingen van deze subcategorie op een openbare kaart"
                   data-testid="subcategoryIsPublicAccessible"
+                  disabled={readOnly}
                 >
                   <input
                     type="hidden"

--- a/src/signals/settings/categories/Detail/index.js
+++ b/src/signals/settings/categories/Detail/index.js
@@ -42,10 +42,11 @@ const getTransformedData = (formData) => {
  * @returns {Boolean}
  */
 const isEqual = (
-  { description, handling_message, is_active, name, sla },
+  { description, handling_message, is_active, name, sla, is_public_accessible },
   othValue
 ) =>
   [
+    is_public_accessible === othValue.is_public_accessible,
     description === othValue.description,
     handling_message === othValue.handling_message,
     is_active === othValue.is_active,
@@ -96,7 +97,12 @@ const CategoryDetail = () => {
     (event) => {
       const formData = [...new FormData(event.target.form).entries()]
         // convert stringified boolean values to actual booleans
-        .map(([key, val]) => [key, key === 'is_active' ? val === 'true' : val])
+        .map(([key, val]) => [
+          key,
+          key === 'is_active' || key === 'is_public_accessible'
+            ? val === 'true'
+            : val,
+        ])
         // convert line endings
         // by spec, the HTML value should contain \r\n, but the API only contains \n
         .map(([key, val]) => [
@@ -116,6 +122,7 @@ const CategoryDetail = () => {
         use_calendar_days: Boolean(
           Number.parseInt(formData.use_calendar_days, 10)
         ),
+        isEqual,
       }
 
       delete formData.n_days

--- a/src/types/category.ts
+++ b/src/types/category.ts
@@ -32,4 +32,6 @@ export interface Category {
   }
   departments: CategoryDepartment[]
   note: string | null
+  is_public_accessible?: boolean
+  public_name?: string | null
 }

--- a/src/utils/__tests__/fixtures/categories_private.json
+++ b/src/utils/__tests__/fixtures/categories_private.json
@@ -34,6 +34,8 @@
       "name": "Afval",
       "slug": "afval",
       "is_active": true,
+      "is_public_accessible": false,
+      "public_name": null,
       "description": null,
       "handling_message": "Wij bekijken uw melding en zorgen dat het juiste onderdeel van de gemeente deze gaat behandelen. Heeft u contactgegevens achtergelaten? Dan nemen wij bij onduidelijkheid contact met u op.",
       "sla": {
@@ -69,6 +71,8 @@
       "name": "Afwatering brug",
       "slug": "afwatering-brug",
       "is_active": true,
+      "is_public_accessible": false,
+      "public_name": null,
       "description": "Dit is het verhaal van de brug die moest afwateren.",
       "handling_message": "Wij beoordelen uw melding. Urgente meldingen pakken we zo snel mogelijk op. Overige meldingen handelen we binnen een week af. We houden u op de hoogte via e-mail.",
       "sla": {
@@ -169,6 +173,8 @@
       "name": "Asbest / accu",
       "slug": "asbest-accu",
       "is_active": true,
+      "is_public_accessible": false,
+      "public_name": null,
       "description": "Alles met betrekking tot asbest gerelateerd afval en bijtende/corrosieve vloeistoffen. test 233",
       "handling_message": "We laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail. test",
       "sla": {
@@ -285,6 +291,8 @@
       "name": "Auto- / scooter- / bromfiets(wrak)",
       "slug": "auto-scooter-bromfietswrak",
       "is_active": true,
+      "is_public_accessible": false,
+      "public_name": null,
       "description": "Het wrak van een auto, scooter of bromfiets.",
       "handling_message": "We laten u binnen 3 weken weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail.",
       "sla": {
@@ -401,6 +409,8 @@
       "name": "Autom. Verzinkbare palen",
       "slug": "autom-verzinkbare-palen",
       "is_active": true,
+      "is_public_accessible": false,
+      "public_name": null,
       "description": "",
       "handling_message": "Wij handelen uw melding binnen drie weken af. U ontvangt dan geen apart bericht meer.\nEn anders hoort u - via e-mail - wanneer wij uw melding kunnen oppakken.",
       "sla": {
@@ -509,6 +519,8 @@
       "name": "Bedrijfsafval",
       "slug": "bedrijfsafval",
       "is_active": true,
+      "is_public_accessible": false,
+      "public_name": null,
       "description": "Afval van een bedrijf en andere gebouwen en dingen",
       "handling_message": "We laten u binnen 5 dagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail.",
       "sla": {
@@ -553,6 +565,8 @@
       "name": "Beplanting",
       "slug": "beplanting",
       "is_active": true,
+      "is_public_accessible": false,
+      "public_name": null,
       "description": "",
       "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail.",
       "sla": {
@@ -773,6 +787,8 @@
       "name": "Bewegwijzering",
       "slug": "bewegwijzering",
       "is_active": true,
+      "is_public_accessible": false,
+      "public_name": null,
       "description": "test",
       "handling_message": "Wij handelen uw melding binnen drie weken af. U ontvangt dan geen apart bericht meer.\nEn anders hoort u - via e-mail - wanneer wij uw melding kunnen oppakken.",
       "sla": {
@@ -881,6 +897,8 @@
       "name": "Blokkade van de vaarweg",
       "slug": "blokkade-van-de-vaarweg",
       "is_active": true,
+      "is_public_accessible": false,
+      "public_name": null,
       "description": "",
       "handling_message": "Gevaarlijke situaties pakken wij zo snel mogelijk op. We laten u binnen 3 werkdagen weten wat we hebben gedaan. We houden u op de hoogte via e-mail.",
       "sla": {
@@ -1077,6 +1095,8 @@
       "name": "Boom - aanvraag plaatsing",
       "slug": "boom-aanvraag-plaatsing",
       "is_active": true,
+      "is_public_accessible": false,
+      "public_name": null,
       "description": null,
       "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail.",
       "sla": {


### PR DESCRIPTION
- Checkbox and textfield for is_public_available and public_name respectively in CategoryForm
- Possible values for both variables are retrieved from the data and stored in the CategoryForm state
- New values for both values can be submitted and retrieved
- Tests for both fields