### PR TITLE
Remove area_type_code when area is null

### DIFF
--- a/src/signals/incident-management/__tests__/selectors.test.js
+++ b/src/signals/incident-management/__tests__/selectors.test.js
@@ -726,6 +726,29 @@ describe('signals/incident-management/selectors', () => {
       })
     })
 
+    it('should not add area_type_code when area is null', () => {
+      configuration.areaTypeCodeForDistrict = 'district'
+      const state = {
+        incidentManagement: fromJS({
+          ...initialState.toJS(),
+          activeFilter: {
+            ...areaFilter,
+            options: {
+              ...areaFilter.options,
+              area: ['null'],
+            },
+          },
+        }),
+      }
+
+      expect(makeSelectFilterParams(state)).toEqual({
+        ordering: '-created_at',
+        page: 1,
+        area_code: ['null'],
+        page_size: FILTER_PAGE_SIZE,
+      })
+    })
+
     it('should reformat days_open', () => {
       const state1 = {
         incidentManagement: fromJS({

--- a/src/signals/incident-management/selectors.js
+++ b/src/signals/incident-management/selectors.js
@@ -150,9 +150,10 @@ export const makeSelectFilterParams = createSelector(
       ordering: mapOrdering(ordering),
       page_size: FILTER_PAGE_SIZE,
     }
-    const filterOptions = filter.options.area
-      ? { ...filter.options, areaType: configuration.areaTypeCodeForDistrict }
-      : filter.options
+    const filterOptions =
+      filter.options.area && filter.options.area[0] !== 'null'
+        ? { ...filter.options, areaType: configuration.areaTypeCodeForDistrict }
+        : filter.options
 
     return {
       ...mapFilterParams(filterOptions),


### PR DESCRIPTION
closes Signalen/frontend#118

In case the option 'Niet toegewezen' is selected to filter incidents on district, `area_code` will be `'null'`. `area_type_code` still defaulted to 'district' though. For this filter to work `area_type_code` must also be `'null'`, or not be present at all. In this change I make sure that it is not present when `area_code` is `'null'`.