### PR TITLE
(Fix) Disabled icon color

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/components/EditButton/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/EditButton/index.js
@@ -9,7 +9,10 @@ const StyledButton = styled(Button)`
   top: 0;
   right: 0;
   padding: ${themeSpacing(0, 1.5)};
-  color: black;
+`
+
+const EditIcon = styled.img`
+  ${({ disabled }) => (disabled ? 'filter: invert(0.5);' : '')};
 `
 
 const EditButton = ({ className, disabled, onClick, ...rest }) => (
@@ -17,7 +20,13 @@ const EditButton = ({ className, disabled, onClick, ...rest }) => (
     className={className}
     data-testid={rest['data-testid'] || 'editButton'}
     disabled={disabled}
-    icon={<img src="/assets/images/icon-edit.svg" alt="Bewerken" />}
+    icon={
+      <EditIcon
+        disabled={disabled}
+        src="/assets/images/icon-edit.svg"
+        alt="Bewerken"
+      />
+    }
     iconSize={18}
     onClick={onClick}
     variant="application"


### PR DESCRIPTION
Will render the edit icon color as gray instead of black when the edit
button is supposed to be disabled