### PR TITLE
[SIG-4375] Location pinned on map

### DIFF
--- a/src/components/AutoSuggest/AutoSuggest.tsx
+++ b/src/components/AutoSuggest/AutoSuggest.tsx
@@ -316,7 +316,7 @@ const AutoSuggest: FC<AutoSuggestProps> = ({
           ref={inputRef}
           {...rest}
         />
-        {defaultValue && (
+        {(defaultValue || value) && (
           <ClearInput
             data-testid="clearInput"
             icon={<Close />}

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.test.tsx
@@ -446,6 +446,16 @@ describe('DetailPanel', () => {
     expect(screen.getByTestId('legendPanel')).toBeInTheDocument()
     expect(screen.getByTestId('legendToggleButton')).toBeInTheDocument()
 
+    const unregisteredAssetCheckbox = within(
+      screen.getByTestId('unregisteredObjectPanel')
+    ).getByRole('checkbox')
+
+    userEvent.click(unregisteredAssetCheckbox)
+    expect(unregisteredAssetCheckbox).toBeChecked()
+
+    userEvent.click(unregisteredAssetCheckbox)
+    expect(unregisteredAssetCheckbox).not.toBeChecked()
+
     rerender(
       withAssetSelectContext(<DetailPanel {...props} />, {
         ...noFeatureTypesContext,
@@ -533,5 +543,32 @@ describe('DetailPanel', () => {
 
     expect(screen.getByText(selection.label)).toBeInTheDocument()
     expect(screen.getByText(selection.description)).toBeInTheDocument()
+  })
+
+  it('shows pinned location label', () => {
+    // only when a location has been pinned on the map that does not have a corresponding address
+
+    const { rerender } = render(
+      withAssetSelectContext(<DetailPanel {...props} />, {
+        ...currentContextValue,
+        address: undefined,
+        coordinates: undefined,
+      })
+    )
+
+    expect(
+      screen.queryByText('Locatie is gepind op de kaart')
+    ).not.toBeInTheDocument()
+
+    rerender(
+      withAssetSelectContext(<DetailPanel {...props} />, {
+        ...currentContextValue,
+        address: undefined,
+      })
+    )
+
+    expect(
+      screen.getByText('Locatie is gepind op de kaart')
+    ).toBeInTheDocument()
   })
 })

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.tsx
@@ -51,12 +51,24 @@ const DetailPanel: FC<DetailPanelProps> = ({ language = {} }) => {
   const [showLegendPanel, setShowLegendPanel] = useState(false)
   const [optionsList, setOptionsList] = useState(null)
   const [showAddressPanel, setShowAddressPanel] = useState(false)
-  const { address, selection, removeItem, setItem, setLocation, close, meta } =
-    useContext(AssetSelectContext)
+  const {
+    coordinates,
+    address,
+    selection,
+    removeItem,
+    setItem,
+    setLocation,
+    close,
+    meta,
+  } = useContext(AssetSelectContext)
   const { featureTypes } = meta
   const featureStatusTypes = meta.featureStatusTypes || []
 
-  const addressValue = address ? formatAddress(address) : ''
+  let addressValue = address ? formatAddress(address) : ''
+  addressValue =
+    coordinates && !addressValue
+      ? 'Locatie is gepind op de kaart'
+      : addressValue
 
   const selectionOnMap =
     selection && selectionIsObject(selection) ? selection : undefined


### PR DESCRIPTION
Proposed changes will show "Locatie is gepind op de kaart" as the contents of the auto suggest field in the maps' detail panel whenever a selected location doesn't have a corresponding address.