### PR TITLE
[SIG 4454] Handle caterpillar api errors

### DIFF
--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/WfsLayer.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/WfsLayer.test.tsx
@@ -19,6 +19,7 @@ import * as useLayerVisible from '../../../hooks/useLayerVisible'
 import { AssetSelectProvider } from '../../context'
 import { contextValue as assetSelectContextValue } from '../../__tests__/withAssetSelectContext'
 
+import CaterpillarLayer from '../../../Caterpillar/CaterpillarLayer'
 import WfsDataContext, { NO_DATA } from './context'
 import { SRS_NAME } from './WfsLayer'
 
@@ -137,6 +138,36 @@ describe('src/signals/incident/components/form/AssetSelect/WfsLayer', () => {
     await screen.findByTestId('map-test')
     expect(consoleErrorSpy).toHaveBeenCalled()
     expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('Shows a map without objects and a console error when the caterpillar api returns an error', async () => {
+    jest.spyOn(global.console, 'error').mockImplementation()
+
+    const errorJson = {
+      error: {
+        code: 400,
+        message: 'Invalid URL',
+        details: [''],
+      },
+    }
+    fetchMock.mockResponse(JSON.stringify(errorJson))
+    render(
+      withMapAsset(
+        <AssetSelectProvider value={assetSelectProviderValue}>
+          <WfsLayer>
+            <CaterpillarLayer />
+          </WfsLayer>
+        </AssetSelectProvider>
+      )
+    )
+
+    await screen.findByTestId('map-test')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(console.error).toBeCalledTimes(1)
+    expect(console.error).toBeCalledWith(
+      'Unhandled Error in wfs call',
+      'Invalid URL'
+    )
   })
 
   it('supports no additional wfs filters', async () => {

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/WfsLayer.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/WfsLayer.tsx
@@ -73,6 +73,7 @@ const WfsLayer: FunctionComponent<WfsLayerProps> = ({
     request
       .then(async (result) => result.json())
       .then((result) => {
+        // to handle errors from the caterpillar api
         if (result.error) {
           // eslint-disable-next-line no-console
           console.error('Unhandled Error in wfs call', result.error.message)

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/WfsLayer.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/WfsLayer.tsx
@@ -73,7 +73,12 @@ const WfsLayer: FunctionComponent<WfsLayerProps> = ({
     request
       .then(async (result) => result.json())
       .then((result) => {
-        setData(result)
+        if (result.error) {
+          // eslint-disable-next-line no-console
+          console.error('Unhandled Error in wfs call', result.error.message)
+        } else {
+          setData(result)
+        }
         return null
       })
       .catch((error) => {

--- a/src/sw-proxy-config.js
+++ b/src/sw-proxy-config.js
@@ -228,4 +228,26 @@ const proxyConfig = [
       body: me,
     },
   },
+  {
+    request: {
+      url: 'https://services9.arcgis.com/YBT9ZoJBxXxS3cs6/arcgis/rest/services/EPR_2021_SIA_Amsterdam/FeatureServer/0/',
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    },
+    response: {
+      status: 400,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: {
+        error: {
+          code: 400,
+          message: 'Invalid URL',
+          details: [''],
+        },
+      },
+    },
+  },
 ]


### PR DESCRIPTION
This PR handles the case where the caterpillar api is not functioning.
In the sw-proxy-config I've added the case that occurred recently with the caterpillar api.
The reason why the error was not handled adequately (i.e., remained uncaught) was that the error was send in the request body.
The current PR now deals with this unconventional case in the WSF layer.
A test was added to show the adjustment.