### PR TITLE
[SIG-4458] Get into Post request for email preview to enable more text

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.tsx
@@ -71,7 +71,7 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
   >(reducer, { incident: incidentAsIncident, childIncidents }, init)
 
   const {
-    get: getEmailTemplate,
+    post: getEmailTemplate,
     data: emailTemplate,
     error: emailTemplateError,
     isLoading,
@@ -184,7 +184,11 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
 
       if (incident?.id && state.flags.hasEmail && state.check.checked) {
         getEmailTemplate(
-          `${configuration.INCIDENTS_ENDPOINT}${incident.id}/email/preview/?status=${state.status.key}&text=${textValue}`
+          `${configuration.INCIDENTS_ENDPOINT}${incident.id}/email/preview`,
+          {
+            status: state.status.key,
+            text: textValue,
+          }
         )
       } else {
         onUpdate()

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/constants.ts
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/constants.ts
@@ -14,7 +14,7 @@ export const DEELMELDINGEN_STILL_OPEN_CONTENT = `Als je de hoofdmelding nu afhan
   Handel de hoofdmelding pas af als alle deelmeldingen zijn opgelost of als de deelmeldingen niet meer nodig zijn.`
 export const NO_REPORTER_EMAIL = `De melder heeft geen e-mailadres opgegeven, er wordt geen bericht verstuurd.`
 
-export const DEFAULT_TEXT_MAX_LENGTH = 1800
+export const DEFAULT_TEXT_MAX_LENGTH = 3000
 export const DEFAULT_TEXT_LABEL = 'Bericht aan melder'
 
 export const REPLY_MAIL_MAX_LENGTH = 400


### PR DESCRIPTION
- convert Get to Post request for email preview to handle large amounts of text.
- Restore number of characters for email text (DEFAULT_TEXT_MAX_LENGTH ) to 3000.

NB: this PR can only be merged in tandem with the backend PR
https://github.com/Amsterdam/signals/pull/947