### PR TITLE
Fix scrolling default texts modal on mobile

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.tsx
@@ -2,7 +2,7 @@
 // Copyright (C) 2019 - 2021 Gemeente Amsterdam
 import type { FunctionComponent, Reducer, SyntheticEvent } from 'react'
 import { useCallback, useReducer, useContext, useState, useEffect } from 'react'
-import { Alert, Heading, Label, Modal, Select } from '@amsterdam/asc-ui'
+import { Alert, Heading, Label, Select } from '@amsterdam/asc-ui'
 import { disablePageScroll, enablePageScroll } from 'scroll-lock'
 import { useFetch, useEventEmitter } from 'hooks'
 
@@ -382,7 +382,7 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
               )})`}</div>
             </StandardTextsButton>
             {modalStandardTextIsOpen && (
-              <Modal
+              <StyledModal
                 data-testid="standardTextModal"
                 open
                 onClose={closeStandardTextModal}
@@ -394,7 +394,7 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
                   status={state.status.key}
                   onClose={closeStandardTextModal}
                 />
-              </Modal>
+              </StyledModal>
             )}
 
             <AddNote

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/DefaultTexts/DefaultTexts.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/DefaultTexts/DefaultTexts.tsx
@@ -5,7 +5,13 @@ import type { DefaultText as DefaultTextType } from 'types/api/default-text'
 import type { StatusCode } from 'signals/incident-management/definitions/types'
 
 import ModalHeader from '../ModalHeader/ModalHeader'
-import { StyledDefaultText, StyledTitle, StyledLink, Wrapper } from './styled'
+import {
+  StyledDefaultText,
+  StyledTitle,
+  StyledLink,
+  Container,
+  Wrapper,
+} from './styled'
 
 export type DefaulTextsProps = {
   defaultTexts: Array<DefaultTextType>
@@ -28,9 +34,9 @@ const DefaultTexts: FC<DefaulTextsProps> = ({
     defaultTexts.find((text) => text.state === status)
 
   return (
-    <>
+    <Container>
       <ModalHeader title="Standaardtekst" onClose={onClose} />
-      <Wrapper>
+      <Wrapper data-scroll-lock-scrollable>
         {(!allText || allText.templates.length === 0) && (
           <StyledDefaultText key={`empty_${status}`} empty>
             Er is geen standaard tekst voor deze subcategorie en status
@@ -58,7 +64,7 @@ const DefaultTexts: FC<DefaulTextsProps> = ({
             </StyledDefaultText>
           ))}
       </Wrapper>
-    </>
+    </Container>
   )
 }
 

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/DefaultTexts/styled.ts
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/DefaultTexts/styled.ts
@@ -24,6 +24,14 @@ export const StyledTitle = styled.div`
   margin-bottom: ${themeSpacing(1)};
 `
 
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+`
+
 export const Wrapper = styled.div`
   padding: ${themeSpacing(5, 4)};
+  overflow: auto;
+  height: 100%;
 `


### PR DESCRIPTION
closes Signalen/product-steering#110

Fix scrolling through the default texts modal of the edit status for on the incident detail page by adding the `data-scroll-lock-scrollable` attribute to the right element. Also changed scrolling area to the content only, without the header.