### PR TITLE
Show read only department when only one

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/components/MetaList/MetaList.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/MetaList/MetaList.tsx
@@ -212,13 +212,13 @@ const MetaList: FC<MetaListProps> = ({ defaultTexts, childIncidents }) => {
     if (!configuration.featureFlags.assignSignalToDepartment) return []
 
     const options =
-      categoryDepartments?.length > 1 &&
+      categoryDepartments?.length > 0 &&
       categoryDepartments.map((department) => ({
         key: `${department?.id}`,
         value: department.name,
       }))
 
-    return routingDepartments
+    return routingDepartments || categoryDepartments?.length === 1
       ? options
       : options && [{ key: null, value: 'Niet gekoppeld' }, ...options]
   }, [categoryDepartments, routingDepartments])
@@ -406,6 +406,7 @@ const MetaList: FC<MetaListProps> = ({ defaultTexts, childIncidents }) => {
           <Highlight type="routing_departments">
             <ChangeValue
               component={SelectInput}
+              disabled={categoryDepartments?.length <= 1}
               display="Afdeling"
               options={departmentOptions}
               path="routing_departments"

--- a/src/signals/incident-management/containers/IncidentDetail/components/MetaList/__tests__/MetaList.test.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/MetaList/__tests__/MetaList.test.tsx
@@ -1028,7 +1028,7 @@ describe('MetaList', () => {
       expect(screen.queryByText(departmentLabel)).not.toBeInTheDocument()
     })
 
-    it('should not show assigned department with only one category department', () => {
+    it('should show assigned department when only one category department', () => {
       configuration.featureFlags.assignSignalToDepartment = true
       render(
         renderWithContext({
@@ -1040,10 +1040,10 @@ describe('MetaList', () => {
         })
       )
 
-      expect(screen.queryByText(departmentLabel)).not.toBeInTheDocument()
+      expect(screen.queryByText(departmentLabel)).toBeInTheDocument()
     })
 
-    it('should show assigned department with more than one category department and assignSignalToDepartment enabled', () => {
+    it('should show assigned department when more than one category department and assignSignalToDepartment enabled', () => {
       configuration.featureFlags.assignSignalToDepartment = true
       render(
         renderWithContext({
@@ -1063,7 +1063,29 @@ describe('MetaList', () => {
         configuration.featureFlags.assignSignalToDepartment = true
       })
 
-      it('should be visible', () => {
+      it('should be visible for one category department, but not editable', () => {
+        render(
+          renderWithContext({
+            ...incidentFixture,
+            category: {
+              ...incidentFixture.category,
+              departments: `${departmentAscCode}`,
+            },
+            routing_departments: [],
+          })
+        )
+
+        expect(
+          (screen.getByTestId('editRouting_departmentsButton') as any).disabled
+        ).toBe(true)
+        expect(screen.queryByText(notFound)).not.toBeInTheDocument()
+        expect(screen.queryByText(notLinked)).not.toBeInTheDocument()
+        expect(screen.getByText(departmentAscName)).toBeInTheDocument()
+        expect(screen.queryByText(departmentAegName)).not.toBeInTheDocument()
+        expect(screen.queryByText(departmentThoName)).not.toBeInTheDocument()
+      })
+
+      it('should be visible for more than one category department and be editable', () => {
         render(
           renderWithContext({
             ...incidentFixture,
@@ -1081,6 +1103,9 @@ describe('MetaList', () => {
           })
         )
 
+        expect(
+          (screen.getByTestId('editRouting_departmentsButton') as any).disabled
+        ).toBe(false)
         expect(screen.queryByText(notFound)).not.toBeInTheDocument()
         expect(screen.queryByText(notLinked)).not.toBeInTheDocument()
         expect(screen.getByText(departmentAscName)).toBeInTheDocument()


### PR DESCRIPTION
closes Signalen/product-steering#98

When the category of an incident is linked to only one department (there is no routing department) show that department with the edit button disabled.