### PR TITLE
Hide inactive users

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/components/MetaList/MetaList.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/MetaList/MetaList.tsx
@@ -302,6 +302,7 @@ const MetaList: FC<MetaListProps> = ({ defaultTexts, childIncidents }) => {
     if (incidentDepartmentCodes && incidentDepartmentCodes.length) {
       getUsers(`${configuration.AUTOCOMPLETE_USERNAME_ENDPOINT}`, {
         profile_department_code: incidentDepartmentCodes,
+        is_active: true,
       })
     }
   }, [getUsers, incidentDepartmentCodes])


### PR DESCRIPTION
closes Signalen/product-steering#33

Hides inactive users from the list of users to assign an incident to on the incident detail page.