### PR TITLE
[SIG-4480] placeholder text address field

### DIFF
--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.tsx
@@ -167,6 +167,7 @@ const DetailPanel: FC<DetailPanelProps> = ({ language = {} }) => {
             onClear={removeItem}
             onSelect={onAddressSelect}
             value={addressValue}
+            placeholder="Zoek adres of postcode"
           />
         )}
 
@@ -249,6 +250,7 @@ const DetailPanel: FC<DetailPanelProps> = ({ language = {} }) => {
               onSelect={onAddressSelect}
               showInlineList={false}
               value={addressValue}
+              placeholder="Zoek adres of postcode"
             />
           </header>
 


### PR DESCRIPTION
## Signalen

To component StyledPDOKAutosuggest is placeholder with value ' Zoek adres of postcode' added. Both in mobile as desktop version of app is placeholder visible. 
