### PR TITLE
[SIG-4507] Clear address when changed location has no address

### DIFF
--- a/src/components/MapInput/__tests__/MapInput.test.js
+++ b/src/components/MapInput/__tests__/MapInput.test.js
@@ -232,7 +232,10 @@ describe('components/MapInput', () => {
     })
 
     expect(onChange).toHaveBeenCalledTimes(1)
-    expect(onChange).toHaveBeenCalledWith({ coordinates: expect.any(Object) })
+    expect(onChange).toHaveBeenCalledWith({
+      coordinates: expect.any(Object),
+      address: {},
+    })
   })
 
   it('should render marker and center the map', async () => {

--- a/src/components/MapInput/index.js
+++ b/src/components/MapInput/index.js
@@ -105,9 +105,7 @@ const MapInput = ({
       const addressText = response?.value || ''
       const address = response?.data?.address || ''
 
-      if (response) {
-        onChangePayload.address = response.data.address
-      }
+      onChangePayload.address = response ? response.data.address : {}
 
       dispatch(setValuesAction({ addressText, address }))
 


### PR DESCRIPTION
When the location of an incident is changed from a location with an address to a location without address, the old address was not removed. This PR fixes that by clearing the address.