### PR TITLE
[SIG4480] text_under_placeholder_removed

### DIFF
--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.test.tsx
@@ -482,6 +482,18 @@ describe('DetailPanel', () => {
     expect(screen.queryByTestId('addressPanel')).not.toBeInTheDocument()
   })
 
+  it('renders the address panel', () => {
+    jest.spyOn(reactResponsive, 'useMediaQuery').mockReturnValue(true)
+
+    render(withAssetSelectContext(<DetailPanel {...props} />))
+
+    expect(screen.queryByTestId('addressPanel')).not.toBeInTheDocument()
+
+    fireEvent.focus(screen.getByTestId('autoSuggestInput'))
+
+    expect(screen.getByTestId('addressPanel')).toBeInTheDocument()
+  })
+
   it('renders a list of options in the address panel', () => {
     jest.spyOn(reactResponsive, 'useMediaQuery').mockReturnValue(true)
 

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.test.tsx
@@ -482,20 +482,6 @@ describe('DetailPanel', () => {
     expect(screen.queryByTestId('addressPanel')).not.toBeInTheDocument()
   })
 
-  it('renders the address panel', () => {
-    jest.spyOn(reactResponsive, 'useMediaQuery').mockReturnValue(true)
-
-    render(withAssetSelectContext(<DetailPanel {...props} />))
-
-    expect(screen.queryByTestId('addressPanel')).not.toBeInTheDocument()
-
-    fireEvent.focus(screen.getByTestId('autoSuggestInput'))
-
-    expect(screen.getByTestId('addressPanel')).toBeInTheDocument()
-
-    expect(screen.getByText('Zoek adres of postcode')).toBeInTheDocument()
-  })
-
   it('renders a list of options in the address panel', () => {
     jest.spyOn(reactResponsive, 'useMediaQuery').mockReturnValue(true)
 

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.tsx
@@ -254,12 +254,8 @@ const DetailPanel: FC<DetailPanelProps> = ({ language = {} }) => {
             />
           </header>
 
-          {optionsList ? (
+          {optionsList && (
             <OptionsList data-testid="optionsList">{optionsList}</OptionsList>
-          ) : (
-            <Paragraph className="instruction">
-              Zoek adres of postcode
-            </Paragraph>
           )}
         </AddressPanel>
       )}


### PR DESCRIPTION
Removed text 'Zoek adres of Postcode'  below search field in mobile state. Now if there is a value for optionList, then the value will be displayed. 