### PR TITLE
Bug/assign to employee

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/components/MetaList/MetaList.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/MetaList/MetaList.tsx
@@ -205,7 +205,7 @@ const MetaList: FC<MetaListProps> = ({ defaultTexts, childIncidents }) => {
     userOptions &&
     (incident?.assigned_user_email ||
       (configuration.featureFlags.assignSignalToDepartment &&
-        incident?.routing_departments) ||
+        (incident?.routing_departments || categoryDepartments?.length === 1)) ||
       !configuration.featureFlags.assignSignalToDepartment)
 
   const departmentOptions = useMemo(() => {

--- a/src/signals/incident-management/containers/IncidentDetail/components/MetaList/__tests__/MetaList.test.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/MetaList/__tests__/MetaList.test.tsx
@@ -532,6 +532,29 @@ describe('MetaList', () => {
       ).not.toBeInTheDocument()
     })
 
+    it('should show assigned user with a category with only one department', async () => {
+      configuration.featureFlags.assignSignalToEmployee = true
+      configuration.featureFlags.assignSignalToDepartment = true
+      render(
+        renderWithContext({
+          ...incidentFixture,
+          category: {
+            ...incidentFixture.category,
+            departments: departmentAscCode,
+          },
+        })
+      )
+      await screen.findByTestId('meta-list-date-definition')
+
+      expect(
+        screen.getByTestId('meta-list-assigned_user_email-definition')
+      ).toBeInTheDocument()
+      expect(
+        screen.getByTestId('meta-list-assigned_user_email-value')
+      ).toBeInTheDocument()
+      expect(screen.getByText('Niet toegewezen')).toBeInTheDocument()
+    })
+
     it('should show assigned user with a selected department', async () => {
       configuration.featureFlags.assignSignalToEmployee = true
       configuration.featureFlags.assignSignalToDepartment = true


### PR DESCRIPTION
closes Signalen/product-steering#133

It was not possible to assign an incident to an employee anymore, in case the incident was in a category with only one department.