### PR TITLE
Make the PDOK type configurable

### DIFF
--- a/app.amsterdam.json
+++ b/app.amsterdam.json
@@ -54,7 +54,8 @@
     "smallHeight": "29px"
   },
   "map": {
-    "municipality": ["amsterdam", "ouder-amstel", "weesp"],
+    "municipality": "amsterdam \"ouder-amstel\" weesp",
+    "fieldType": "adres",
     "options": {
       "center": [
         52.3731081,

--- a/app.amsterdam.json
+++ b/app.amsterdam.json
@@ -54,7 +54,7 @@
     "smallHeight": "29px"
   },
   "map": {
-    "municipality": "amsterdam \"ouder-amstel\" weesp",
+    "municipality": ["amsterdam", "ouder-amstel", "weesp"],
     "fieldType": "adres",
     "options": {
       "center": [

--- a/app.base.json
+++ b/app.base.json
@@ -56,6 +56,7 @@
   },
   "map": {
     "municipality": "amsterdam",
+    "fieldType": "adres",
     "options": {
       "center": [
         52.3731081,

--- a/internals/schemas/app.schema.json
+++ b/internals/schemas/app.schema.json
@@ -343,7 +343,10 @@
       "properties": {
         "municipality": {
           "description": "Allows to filter address lookup by municipality. For example a value of 'amsterdam' will be used in the following format: `fq=gemeentenaam:(amsterdam)`. Separate multiple municipalities with a space. If a municipality has spaces, surround it by quotes, which in the config will look like `\"boxtel \\\"den bosch\\\"\"`. For more information see https://github.com/PDOK/locatieserver/wiki/API-Locatieserver",
-          "type": "string"
+          "type": [
+            "string",
+            "array"
+          ]
         },
         "fieldType": {
           "description": "Allows to specify what types the address lookup will return. For example a value of 'adres' will return only full addresses. Add the type 'weg', and you will also get roads (without house numbers) in your results. Separate multiple types by spaces. For more information see https://github.com/PDOK/locatieserver/wiki/API-Locatieserver",

--- a/internals/schemas/app.schema.json
+++ b/internals/schemas/app.schema.json
@@ -343,10 +343,11 @@
       "properties": {
         "municipality": {
           "description": "Allows to filter address lookup by municipality. For example a value of 'amsterdam' will be used in the following format: `fq=gemeentenaam:(amsterdam)`. Separate multiple municipalities with a space. If a municipality has spaces, surround it by quotes, which in the config will look like `\"boxtel \\\"den bosch\\\"\"`. For more information see https://github.com/PDOK/locatieserver/wiki/API-Locatieserver",
-          "type": [
-            "string",
-            "array"
-          ]
+          "type": "string"
+        },
+        "fieldType": {
+          "description": "Allows to specify what types the address lookup will return. For example a value of 'adres' will return only full addresses. Add the type 'weg', and you will also get roads (without house numbers) in your results. Separate multiple types by spaces. For more information see https://github.com/PDOK/locatieserver/wiki/API-Locatieserver",
+          "type": "string"
         },
         "options": {
           "$ref": "#/definitions/MapOptions"
@@ -386,6 +387,7 @@
       },
       "required": [
         "municipality",
+        "fieldType",
         "options",
         "tiles"
       ],

--- a/src/components/PDOKAutoSuggest/PDOKAutoSuggest.test.tsx
+++ b/src/components/PDOKAutoSuggest/PDOKAutoSuggest.test.tsx
@@ -13,6 +13,7 @@ const mockResponse = JSON.stringify(JSONResponse)
 
 const onSelect = jest.fn()
 const municipalityQs = 'fq=gemeentenaam:'
+const fieldTypeQs = 'fq=type:'
 const fieldListQs = 'fl='
 
 const renderAndSearch = async (value = 'Dam', props = {}) => {
@@ -64,6 +65,34 @@ describe('components/PDOKAutoSuggest', () => {
     it('should be called on change', async () => {
       await renderAndSearch()
       expect(fetch).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('fieldType', () => {
+    it('should call fetch with field type', async () => {
+      await renderAndSearch('Dam', { fieldType: 'adres' })
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining(`${fieldTypeQs}(adres)`),
+        expect.objectContaining({ method: 'GET' })
+      )
+    })
+
+    it('should work with multiple field types', async () => {
+      await renderAndSearch('Dam', { fieldType: 'adres weg' })
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining(`${fieldTypeQs}(adres weg)`),
+        expect.objectContaining({ method: 'GET' })
+      )
+    })
+
+    it('should ignore an empty string', async () => {
+      await renderAndSearch('Dam', {
+        fieldType: '',
+      })
+      expect(fetch).toHaveBeenCalledWith(
+        expect.not.stringContaining(fieldTypeQs),
+        expect.objectContaining({ method: 'GET' })
+      )
     })
   })
 

--- a/src/components/PDOKAutoSuggest/PDOKAutoSuggest.tsx
+++ b/src/components/PDOKAutoSuggest/PDOKAutoSuggest.tsx
@@ -29,7 +29,7 @@ export interface PDOKAutoSuggestProps
     'url' | 'formatResponse' | 'numOptionsDeterminer'
   > {
   fieldList?: Array<string>
-  municipality?: string
+  municipality?: string | Array<string>
   fieldType?: string
 }
 

--- a/src/components/PDOKAutoSuggest/PDOKAutoSuggest.tsx
+++ b/src/components/PDOKAutoSuggest/PDOKAutoSuggest.tsx
@@ -12,9 +12,9 @@ import {
 import configuration from 'shared/services/configuration/configuration'
 
 const municipalityFilterName = 'gemeentenaam'
+const fieldTypeFilterName = 'type'
 const serviceParams = [
   ['fq', 'bron:BAG'],
-  ['fq', 'type:adres'],
   ['q', ''],
 ]
 const serviceUrl =
@@ -29,7 +29,8 @@ export interface PDOKAutoSuggestProps
     'url' | 'formatResponse' | 'numOptionsDeterminer'
   > {
   fieldList?: Array<string>
-  municipality?: string | Array<string>
+  municipality?: string
+  fieldType?: string
 }
 
 /**
@@ -40,16 +41,26 @@ export interface PDOKAutoSuggestProps
 const PDOKAutoSuggest: FC<PDOKAutoSuggestProps> = ({
   fieldList = [],
   municipality = configuration.map.municipality,
+  fieldType = configuration.map.fieldType,
   ...rest
 }) => {
-  const fq = municipality
+  const fieldTypeParam = fieldType
+    ? [['fq', `${fieldTypeFilterName}:(${fieldType})`]]
+    : []
+  const municipalityParam = municipality
     ? [['fq', `${municipalityFilterName}:(${municipality})`]]
     : []
   // ['fl', '*'], // undocumented; requests all available field values from the API
   const fl = [
     ['fl', [...pdokResponseFieldList, ...(fieldList || [])].join(',')],
   ]
-  const params = [...fq, ...fl, ...serviceParams]
+
+  const params = [
+    ...fieldTypeParam,
+    ...municipalityParam,
+    ...fl,
+    ...serviceParams,
+  ]
   const queryParams = params.map(([key, val]) => `${key}=${val}`).join('&')
   const url = `${serviceUrl}${queryParams}`
 


### PR DESCRIPTION
closes Signalen/product-steering#107

The `type` for the call to PDOK was hardcoded to `adres`. Some municipalities need to be able to have roads as suggestions as well. (There exist roads without any specific address on them.) This PR makes that value configurable.