### PR TITLE
[SIG-4482]_styling_checkbox_and_checkboxlabel_changed_in_StatusForm

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.tsx
@@ -8,7 +8,6 @@ import { useFetch, useEventEmitter } from 'hooks'
 
 import { changeStatusOptionList } from 'signals/incident-management/definitions/statusList'
 
-import Checkbox from 'components/Checkbox'
 import AddNote from 'components/AddNote'
 import ErrorMessage, { ErrorWrapper } from 'components/ErrorMessage'
 import LoadingIndicator from 'components/LoadingIndicator'
@@ -29,7 +28,9 @@ import type { IncidentChild, EmailTemplate } from '../../types'
 import DefaultTexts from './components/DefaultTexts'
 import {
   AddNoteWrapper,
+  StyledCheckbox,
   Form,
+  StyledCheckboxLabel,
   StandardTextsButton,
   StyledAlert,
   StyledButton,
@@ -329,20 +330,20 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
         {!state.flags.isSplitIncident && (
           <div>
             {state.flags.hasEmail ? (
-              <Label
+              <StyledCheckboxLabel
                 disabled={state.check.disabled}
                 htmlFor="send_email"
                 label={constants.MELDING_CHECKBOX_DESCRIPTION}
                 noActiveState
               >
-                <Checkbox
+                <StyledCheckbox
                   checked={state.check.checked}
                   data-testid="sendEmailCheckbox"
                   disabled={state.check.disabled}
                   id="send_email"
                   onClick={onCheck}
                 />
-              </Label>
+              </StyledCheckboxLabel>
             ) : (
               <div data-testid="no-email-warning">
                 {constants.NO_REPORTER_EMAIL}

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/styled.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/styled.tsx
@@ -3,6 +3,7 @@
 import styled, { css } from 'styled-components'
 import {
   Alert,
+  Checkbox,
   Heading,
   Label,
   Modal,
@@ -13,7 +14,6 @@ import {
 import type { AlertLevel } from '@amsterdam/asc-ui'
 
 import Button from 'components/Button'
-import Checkbox from 'components/Checkbox'
 
 export const AddNoteWrapper = styled.div`
   label.addNoteText {
@@ -84,12 +84,20 @@ export const StyledLabel = styled(Label)`
   font-weight: 700;
 `
 
-export const StyledCheckbox = styled(Checkbox)`
-  opacity: 0.3;
+export const StyledCheckboxLabel = styled(Label)<{ disabled: boolean }>`
+  ${({ disabled }) =>
+    disabled &&
+    css`
+      color: ${themeColor('tint', 'level5')};
+      opacity: 1;
+    `}
 `
-
-export const StyledCheckboxLabel = styled(Label)`
-  color: #767676;
+export const StyledCheckbox = styled(Checkbox)<{ disabled: boolean }>`
+  ${({ disabled }) =>
+    disabled &&
+    css`
+      opacity: 0.3;
+    `}
 `
 
 export const StyledModal = styled(Modal)`

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/styled.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/styled.tsx
@@ -13,6 +13,7 @@ import {
 import type { AlertLevel } from '@amsterdam/asc-ui'
 
 import Button from 'components/Button'
+import Checkbox from 'components/Checkbox'
 
 export const AddNoteWrapper = styled.div`
   label.addNoteText {
@@ -81,6 +82,14 @@ export const StyledH4 = styled(Heading)`
 
 export const StyledLabel = styled(Label)`
   font-weight: 700;
+`
+
+export const StyledCheckbox = styled(Checkbox)`
+  opacity: 0.3;
+`
+
+export const StyledCheckboxLabel = styled(Label)`
+  color: #767676;
 `
 
 export const StyledModal = styled(Modal)`


### PR DESCRIPTION
Styling needed to change of the checkbox and the label surrounding the checkbox. The checkbox needed to be opaque and the label needed to be color #767676. I

n StatusForm I changed a label to newly created StyledCheckboxLabel and changed Checkbox to newly created StyledCheckbox. In styled.tsx opacity: 0.3 added to styling of StyledCheckbox, and color: #767676 to StyledCheckboxLabel.



