### PR TITLE
Update municipality type to string only

### DIFF
--- a/app.amsterdam.json
+++ b/app.amsterdam.json
@@ -54,7 +54,7 @@
     "smallHeight": "29px"
   },
   "map": {
-    "municipality": ["amsterdam", "ouder-amstel", "weesp"],
+    "municipality": "amsterdam \"ouder-amstel\" weesp",
     "options": {
       "center": [
         52.3731081,

--- a/internals/schemas/app.schema.json
+++ b/internals/schemas/app.schema.json
@@ -343,10 +343,7 @@
       "properties": {
         "municipality": {
           "description": "Allows to filter address lookup by municipality. For example a value of 'amsterdam' will be used in the following format: `fq=gemeentenaam:(amsterdam)`. Separate multiple municipalities with a space. If a municipality has spaces, surround it by quotes, which in the config will look like `\"boxtel \\\"den bosch\\\"\"`. For more information see https://github.com/PDOK/locatieserver/wiki/API-Locatieserver",
-          "type": [
-            "string",
-            "array"
-          ]
+          "type": "string"
         },
         "options": {
           "$ref": "#/definitions/MapOptions"

--- a/src/components/PDOKAutoSuggest/PDOKAutoSuggest.tsx
+++ b/src/components/PDOKAutoSuggest/PDOKAutoSuggest.tsx
@@ -29,7 +29,7 @@ export interface PDOKAutoSuggestProps
     'url' | 'formatResponse' | 'numOptionsDeterminer'
   > {
   fieldList?: Array<string>
-  municipality?: string | Array<string>
+  municipality?: string
 }
 
 /**


### PR DESCRIPTION
The `configuration.map.municipality` was turned into a string in a [previous PR](https://github.com/Amsterdam/signals-frontend/pull/2059). This PR updates the type in the schema and updates the Amsterdam configuration.