### PR TITLE
[SIG-4532] text modified in alert for change in Standaard teksten

### DIFF
--- a/src/signals/incident-management/containers/DefaultTextsAdmin/saga.js
+++ b/src/signals/incident-management/containers/DefaultTextsAdmin/saga.js
@@ -63,13 +63,9 @@ export function* storeDefaultTexts(action) {
 
     yield put(storeDefaultTextsSuccess(found?.templates || []))
 
-    const numStoredTemplates = found?.templates?.length || 0
-
     yield put(
       showGlobalNotification({
-        title: `${numStoredTemplates} Standaard tekst${
-          numStoredTemplates === 0 || numStoredTemplates > 1 ? 'en' : ''
-        } opgeslagen voor ${subcategory.value}, ${payload.status.value}`,
+        title: `Standaard teksten bijgewerkt voor ${subcategory.value}, ${payload.status.value}`,
         variant: VARIANT_SUCCESS,
         type: TYPE_LOCAL,
       })

--- a/src/signals/incident-management/containers/DefaultTextsAdmin/saga.test.js
+++ b/src/signals/incident-management/containers/DefaultTextsAdmin/saga.test.js
@@ -169,7 +169,7 @@ describe('/signals/incident-management/containers/DefaultTextsAdmin/saga', () =>
         .next()
         .put(
           actions.showGlobalNotification({
-            title: `1 Standaard tekst opgeslagen voor ${subcategory.value}, ${status.value}`,
+            title: `Standaard teksten bijgewerkt voor ${subcategory.value}, ${status.value}`,
             variant: VARIANT_SUCCESS,
             type: TYPE_LOCAL,
           })
@@ -195,7 +195,7 @@ describe('/signals/incident-management/containers/DefaultTextsAdmin/saga', () =>
         .next()
         .put(
           actions.showGlobalNotification({
-            title: `2 Standaard teksten opgeslagen voor ${subcategory.value}, ${status.value}`,
+            title: `Standaard teksten bijgewerkt voor ${subcategory.value}, ${status.value}`,
             variant: VARIANT_SUCCESS,
             type: TYPE_LOCAL,
           })
@@ -213,7 +213,7 @@ describe('/signals/incident-management/containers/DefaultTextsAdmin/saga', () =>
         .next()
         .put(
           actions.showGlobalNotification({
-            title: `0 Standaard teksten opgeslagen voor ${subcategory.value}, ${status.value}`,
+            title: `Standaard teksten bijgewerkt voor ${subcategory.value}, ${status.value}`,
             variant: VARIANT_SUCCESS,
             type: TYPE_LOCAL,
           })
@@ -240,7 +240,7 @@ describe('/signals/incident-management/containers/DefaultTextsAdmin/saga', () =>
         .next()
         .put(
           actions.showGlobalNotification({
-            title: `0 Standaard teksten opgeslagen voor ${subcategory.value}, ${status.value}`,
+            title: `Standaard teksten bijgewerkt voor ${subcategory.value}, ${status.value}`,
             variant: VARIANT_SUCCESS,
             type: TYPE_LOCAL,
           })

--- a/src/signals/incident-management/containers/DefaultTextsAdmin/saga.test.js
+++ b/src/signals/incident-management/containers/DefaultTextsAdmin/saga.test.js
@@ -177,32 +177,6 @@ describe('/signals/incident-management/containers/DefaultTextsAdmin/saga', () =>
         .next()
         .isDone()
 
-      const resultMoreThanOneTemplate = [
-        {
-          state: 'm',
-          templates: [
-            { title: 'gemend', text: 'foo' },
-            { title: 'foo bar baz', text: 'qux' },
-          ],
-        },
-      ]
-
-      testSaga(storeDefaultTexts, postAction)
-        .next()
-        .call(authPostCall, requestURL, [postAction.payload.post])
-        .next(resultMoreThanOneTemplate)
-        .put(storeDefaultTextsSuccess(resultMoreThanOneTemplate[0].templates))
-        .next()
-        .put(
-          actions.showGlobalNotification({
-            title: `Standaard teksten bijgewerkt voor ${subcategory.value}, ${status.value}`,
-            variant: VARIANT_SUCCESS,
-            type: TYPE_LOCAL,
-          })
-        )
-        .next()
-        .isDone()
-
       const resultNoTemplates = [{}]
 
       testSaga(storeDefaultTexts, postAction)


### PR DESCRIPTION

Alert message for change in Standaard tekst is modified  in three ways:

1. The number of texts being modified is no longer shown
2. 'teksten' is now always plural instead of single of only one text was modified and otherwise being plural
3. 'opgeslagen' is changed to ' bijgewerkt'  