### PR TITLE
Sig 4533 checkbox active only when text + title in standard text

### DIFF
--- a/src/signals/incident-management/containers/DefaultTextsAdmin/components/DefaultTextsForm.test.tsx
+++ b/src/signals/incident-management/containers/DefaultTextsAdmin/components/DefaultTextsForm.test.tsx
@@ -93,7 +93,7 @@ describe('<DefaultTextsForm />', () => {
     const fields = {
       item0: FormBuilder.group({
         title: [''],
-        text: ['text'],
+        text: [''],
         is_active: [true],
       }),
     }
@@ -123,8 +123,26 @@ describe('<DefaultTextsForm />', () => {
       ).toBeInTheDocument()
 
       expect(screen.getByTestId(`is_active0`)).toBeDisabled()
-      const title0 = screen.getByTestId(`title0`)
-      fireEvent.change(title0, { target: { value: 'eenwaarde' } })
+      let title0 = screen.getByTestId(`title0`)
+      fireEvent.change(title0, {
+        target: { value: 'een titel in het titelveld' },
+      })
+
+      rerender(withAppContext(<DefaultTextsForm {...props} />))
+
+      expect(screen.getByTestId(`is_active0`)).toBeDisabled()
+      let text0 = screen.getByTestId(`text0`)
+      title0 = screen.getByTestId(`title0`)
+      fireEvent.change(title0, { target: { value: '' } })
+      fireEvent.change(text0, { target: { value: 'tekst in het tekstveld' } })
+
+      rerender(withAppContext(<DefaultTextsForm {...props} />))
+
+      expect(screen.getByTestId(`is_active0`)).toBeDisabled()
+      text0 = screen.getByTestId(`text0`)
+      title0 = screen.getByTestId(`title0`)
+      fireEvent.change(title0, { target: { value: 'titel in het titelveld' } })
+      fireEvent.change(text0, { target: { value: 'tekst in het tekstveld' } })
 
       rerender(withAppContext(<DefaultTextsForm {...props} />))
 

--- a/src/signals/incident-management/containers/DefaultTextsAdmin/components/DefaultTextsForm.test.tsx
+++ b/src/signals/incident-management/containers/DefaultTextsAdmin/components/DefaultTextsForm.test.tsx
@@ -88,4 +88,41 @@ describe('<DefaultTextsForm />', () => {
     )
     expect(props.changeOrdering).toHaveBeenCalledTimes(2)
   })
+
+  // describe('<checkbox disabled', () => {
+
+  //   const fields = {
+  //     item0: FormBuilder.group({
+  //     title: ['title'],
+  //     text: ['text'],
+  //     is_active: [true],
+  //   })}
+
+  //   const form = FormBuilder.group({
+  //     ...fields,
+  //     categoryUrl: null,
+  //     state: null,
+  //   })
+  //   const props = {
+  //     item: 'item0',
+  //     form: form as unknown as FormArray,
+  //     itemsLength: 1,
+  //     index: 0,
+  //     onCheck: jest.fn(),
+  //     changeOrdering: jest.fn(),
+  //   }
+
+  //   it('disables the checkbox correctly', () => {
+  // render(withAppContext(<DefaultTextsForm {...props} />))
+
+  // expect(screen.getByTestId(`defaultTextFormForm${props.index}`)).toBeInTheDocument()
+  // expect(screen.getByTestId(`is_active0`)).toBeDisabled()
+  // expect(screen.getByTestId(`is_active0`)).not.toBeDisabled()
+  // expect(screen.getByTestId(`is_active0`)).toBeDisabled()
+  // expect(screen.getByTestId(`is_active0`)).not.toBeDisabled
+  // form.get(`${props.item}.text`).value = `test 1`
+  // form.get(`${props.item}.title`).value = `text of test 1`
+
+  // })
+  // })
 })

--- a/src/signals/incident-management/containers/DefaultTextsAdmin/components/DefaultTextsForm.test.tsx
+++ b/src/signals/incident-management/containers/DefaultTextsAdmin/components/DefaultTextsForm.test.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2022 Gemeente Amsterdam
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { withAppContext } from 'test/utils'
 
@@ -89,40 +89,46 @@ describe('<DefaultTextsForm />', () => {
     expect(props.changeOrdering).toHaveBeenCalledTimes(2)
   })
 
-  // describe('<checkbox disabled', () => {
+  describe('<checkbox disabled', () => {
+    const fields = {
+      item0: FormBuilder.group({
+        title: [''],
+        text: ['text'],
+        is_active: [true],
+      }),
+    }
 
-  //   const fields = {
-  //     item0: FormBuilder.group({
-  //     title: ['title'],
-  //     text: ['text'],
-  //     is_active: [true],
-  //   })}
+    const form = FormBuilder.group({
+      ...fields,
+      categoryUrl: null,
+      state: null,
+    })
 
-  //   const form = FormBuilder.group({
-  //     ...fields,
-  //     categoryUrl: null,
-  //     state: null,
-  //   })
-  //   const props = {
-  //     item: 'item0',
-  //     form: form as unknown as FormArray,
-  //     itemsLength: 1,
-  //     index: 0,
-  //     onCheck: jest.fn(),
-  //     changeOrdering: jest.fn(),
-  //   }
+    const props = {
+      item: 'item0',
+      form: form as unknown as FormArray,
+      itemsLength: 1,
+      index: 0,
+      onCheck: jest.fn(),
+      changeOrdering: jest.fn(),
+    }
 
-  //   it('disables the checkbox correctly', () => {
-  // render(withAppContext(<DefaultTextsForm {...props} />))
+    it('disables the checkbox correctly', () => {
+      const { rerender } = render(
+        withAppContext(<DefaultTextsForm {...props} />)
+      )
 
-  // expect(screen.getByTestId(`defaultTextFormForm${props.index}`)).toBeInTheDocument()
-  // expect(screen.getByTestId(`is_active0`)).toBeDisabled()
-  // expect(screen.getByTestId(`is_active0`)).not.toBeDisabled()
-  // expect(screen.getByTestId(`is_active0`)).toBeDisabled()
-  // expect(screen.getByTestId(`is_active0`)).not.toBeDisabled
-  // form.get(`${props.item}.text`).value = `test 1`
-  // form.get(`${props.item}.title`).value = `text of test 1`
+      expect(
+        screen.getByTestId(`defaultTextFormForm${props.index}`)
+      ).toBeInTheDocument()
 
-  // })
-  // })
+      expect(screen.getByTestId(`is_active0`)).toBeDisabled()
+      const title0 = screen.getByTestId(`title0`)
+      fireEvent.change(title0, { target: { value: 'eenwaarde' } })
+
+      rerender(withAppContext(<DefaultTextsForm {...props} />))
+
+      expect(screen.getByTestId(`is_active0`)).not.toBeDisabled()
+    })
+  })
 })

--- a/src/signals/incident-management/containers/DefaultTextsAdmin/components/DefaultTextsForm.tsx
+++ b/src/signals/incident-management/containers/DefaultTextsAdmin/components/DefaultTextsForm.tsx
@@ -60,6 +60,10 @@ const DefaultTextsForm: FC<DefaultTextsFormProps> = ({
   changeOrdering,
 }) => {
   const checkedValue = form.get(`${item}.is_active`).value
+  const setDisabled =
+    form.get(`${item}.text`).value === '' ||
+    form.get(`${item}.title`).value === ''
+
   return (
     <>
       <StyledLeftColumn data-testid={`defaultTextFormForm${index}`}>
@@ -77,7 +81,11 @@ const DefaultTextsForm: FC<DefaultTextsFormProps> = ({
           control={form.get(`${item}.text`)}
         />
 
-        <StyledLabel htmlFor={`formis_active${index}`} label="Actief">
+        <StyledLabel
+          htmlFor={`formis_active${index}`}
+          disabled={setDisabled}
+          label="Actief"
+        >
           <Checkbox
             data-testid={`is_active${index}`}
             checked={checkedValue}


### PR DESCRIPTION
When title and/or text in a standard text is absent, the checkbox should be disabled. The attribute 'disabled'  is therefore added to the styledlabel. 

Tests are added that will test for no title and no text, for a title and no text, for no title and a text and, lastly, for a title and a text. The results should be resp. disabled, disabled, disabled and not-disabled.
