### PR TITLE
[SIG 4485] Set keyboard prop to false, to remove tabindices from marker.

### DIFF
--- a/src/components/AreaMap/AreaMap.tsx
+++ b/src/components/AreaMap/AreaMap.tsx
@@ -198,6 +198,7 @@ const AreaMap: FunctionComponent<AreaMapProps> = ({
             options={{
               icon: currentIncidentIcon,
               interactive: false,
+              keyboard: false,
               zIndexOffset: CURRENT_INCIDENT_MARKER_Z,
             }}
           />

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/NearbyLayer/NearbyLayer.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/NearbyLayer/NearbyLayer.tsx
@@ -156,6 +156,7 @@ export const NearbyLayer: FC<NearbyLayerProps> = ({ zoomLevel }) => {
           title: `${feature.properties.category.name}, ${formattedDate(
             feature.properties.created_at
           )}`,
+          keyboard: false,
         }
       )
 

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/StatusLayer/StatusLayer.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/StatusLayer/StatusLayer.tsx
@@ -46,6 +46,7 @@ const StatusLayer: FC<StatusLayerProps> = ({
           options={{
             zIndexOffset: 1000,
             icon,
+            keyboard: false,
             alt: altText,
           }}
         />

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/AssetLayer/AssetLayer.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/AssetLayer/AssetLayer.tsx
@@ -101,6 +101,7 @@ export const AssetLayer: FC = () => {
           alt: `${featureType.description}${
             isSelected ? ', is geselecteerd' : ''
           } (${id})`,
+          keyboard: false,
         }}
         latLng={coordinates}
         events={{

--- a/src/signals/incident/components/form/MapSelectors/Caterpillar/CaterpillarLayer/CaterpillarLayer.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Caterpillar/CaterpillarLayer/CaterpillarLayer.tsx
@@ -86,6 +86,7 @@ export const CaterpillarLayer: FC = () => {
           options={{
             icon,
             alt: altText,
+            keyboard: false,
           }}
           latLng={coordinates}
           events={{


### PR DESCRIPTION
## Signalen
https://datapunt.atlassian.net/browse/SIG-4495?atlOrigin=eyJpIjoiMjQ1ZDRiNzQ0NjhlNDc3YTkxNDhhYzRlNGNlNzFjOTUiLCJwIjoiaiJ9

**I added some props to unset de default tab indexes, a setting of leaflet.**

Before opening a pull request, please ensure:

- [x] Double-check your branch is based on `develop` and targets `develop`
- [x] Pull request has tests (we are going for 100% coverage!)
- [x] Code is well-commented, linted and follows project conventions
- [x] Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
