### PR TITLE
[SIG 4594] textareaInput provided when answer Overige in reports concerning clocks

### DIFF
--- a/src/signals/incident/definitions/wizard-step-2-vulaan/straatverlichting-klokken.test.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/straatverlichting-klokken.test.ts
@@ -14,6 +14,7 @@ describe('definition straatverlichting-klokken', () => {
       'extra_klok',
       'extra_klok_gevaar',
       'extra_klok_probleem',
+      'extra_klok_toelichting_overig',
     ])
   })
 })

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/straatverlichting-klokken.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/straatverlichting-klokken.ts
@@ -365,6 +365,17 @@ const straatverlichtingKlokken = {
     },
     render: QuestionFieldType.RadioInput,
   },
+  extra_klok_toelichting_overig: {
+    meta: {
+      ifAllOf: {
+        extra_klok_probleem: 'overig',
+      },
+      label: 'Toelichting',
+      shortLabel: 'Toelichting',
+      pathMerge: 'extra_properties',
+    },
+    render: QuestionFieldType.TextareaInput,
+  },
 }
 
 export default straatverlichtingKlokken


### PR DESCRIPTION

When an user answers with Overige in a report concerning clocks a textareaInput is provided so that the user can elaborate if she wants. The answer is shown in the backoffice as Toelichting.

Test has been updated.