### PR TITLE
[SIG 4599] Redirect Users wanting to request a new fietsnietje to the external website where this is possible

### DIFF
--- a/src/signals/incident/components/form/PlainText/index.js
+++ b/src/signals/incident/components/form/PlainText/index.js
@@ -35,6 +35,9 @@ const getStyle = (type) => {
       return css`
         background-color: ${themeColor('primary')};
         padding: ${themeSpacing(5)};
+        a:hover {
+          color: ${themeColor('tint', 'level1')};
+        }
 
         * {
           // Make sure links contrast with blue background

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/wegen-verkeer-straatmeubilair.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/wegen-verkeer-straatmeubilair.ts
@@ -220,11 +220,12 @@ Is het glad bij een trein-, bus- of metrostation? Neem dan contact op met de NS 
         subcategory: 'fietsrek-nietje',
         extra_fietsrek_aanvragen: 'ja',
       },
-      label: "Fietsenrek of 'nietje' aanvragen",
-      shortLabel: "Aanvraag fietsenrek of 'nietje'",
+      value:
+        'Een nieuw fietsenrek of ‘nietje’ kunt u aanvragen met het [aanvraagformulier](https://formulier.amsterdam.nl/thema/wonen/aanvraagformulier-fietsenrek-fietsvak).',
+      type: 'info',
       pathMerge: 'extra_properties',
     },
-    render: QuestionFieldType.TextareaInput,
+    render: QuestionFieldType.PlainText,
   },
 }
 


### PR DESCRIPTION
Extra_fietsrek_aanvraag has been changed so that users wanting to request a new fietsnietje will be directed to the website where this is possible. Website (https://formulier.amsterdam.nl/thema/wonen/aanvraagformulier-fietsenrek-fietsvak) is an external website, not under control of Signals-frontend.

