### PR TITLE
[SIG 4576] Styling of object information and notifications has been changed

### DIFF
--- a/src/components/IconList/IconList.tsx
+++ b/src/components/IconList/IconList.tsx
@@ -8,6 +8,7 @@ import type { FeatureStatusType } from 'signals/incident/components/form/MapSele
 const StyledListItem = styled(ListItem)`
   display: flex;
   align-items: center;
+  margin: ${themeSpacing(3, 0, 0)};
 `
 
 const StyledImg = styled.img`

--- a/src/signals/incident/components/form/MapSelectors/Asset/AssetList/AssetList.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/AssetList/AssetList.tsx
@@ -59,18 +59,19 @@ const SelectionNearby = styled.div`
     color: ${themeColor('secondary')};
   }
   p {
+    font-weight: regular;
     display: block;
     margin: ${themeSpacing(2, 0, 0)};
   }
   span {
     display: block;
-    margin-bottom: ${themeSpacing(4)};
+    margin-bottom: ${themeSpacing(3)};
   }
 `
 
 const ListItem = styled.div`
+  padding-bottom: ${themeSpacing(3)};
   border-bottom: 1px solid ${themeColor('tint', 'level3')};
-  margin-bottom: ${themeSpacing(2)};
 `
 
 export interface AssetListProps {

--- a/src/signals/incident/components/form/MapSelectors/Asset/AssetList/AssetList.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/AssetList/AssetList.tsx
@@ -59,7 +59,6 @@ const SelectionNearby = styled.div`
     color: ${themeColor('secondary')};
   }
   p {
-    font-weight: regular;
     display: block;
     margin: ${themeSpacing(2, 0, 0)};
   }


### PR DESCRIPTION
When multiple objects are shown in the sidebar next to the map, the distances between these objects are enlarged in order to see more easily there are multiple objects. This includes information is that is giving within the object.

Margins are now 12px, 4px and 3 times 12px. Padding has been added to ensure a visual distance to the divider of 2 times 12px.  