### PR TITLE
Enable scrolling after submit

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.tsx
@@ -150,14 +150,16 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
       },
     })
 
+    closeEmailPreview()
     onClose()
   }, [
-    update,
-    onClose,
     state.text.value,
+    state.text.defaultValue,
     state.status.key,
     state.check.checked,
-    state.text.defaultValue,
+    update,
+    closeEmailPreview,
+    onClose,
   ])
 
   const handleSubmit = useCallback(


### PR DESCRIPTION
closes Signalen/product-steering#158

Scrolling did not get activated again after submitting the email preview form when changing the status of an incident (and sending a mail to the reporter).