### PR TITLE
Allow sorting on district

### DIFF
--- a/src/signals/incident-management/containers/IncidentOverviewPage/components/Sort/Sort.tsx
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/components/Sort/Sort.tsx
@@ -36,6 +36,8 @@ export enum SortOptions {
   ASSIGNED_USER_EMAIL_DESC = '-assigned_user_email',
   BUROUGH_ASC = 'stadsdeel',
   BUROUGH_DESC = '-stadsdeel',
+  DISTRICT_ASC = 'area_name',
+  DISTRICT_DESC = '-area_name',
   CREATED_AT_ASC = '-created_at',
   CREATED_AT_DESC = 'created_at',
   PRIORITY_ASC = 'priority',
@@ -75,10 +77,6 @@ const Sort: FC<SortProps> = ({
     onChangeOrdering(sort)
   }, [onChangeOrdering, sort])
 
-  const district = configuration.featureFlags.fetchDistrictsFromBackend
-    ? configuration.language.district
-    : 'Stadsdeel'
-
   return (
     <SelectContainer className={className}>
       <Select
@@ -94,8 +92,21 @@ const Sort: FC<SortProps> = ({
         <option value={SortOptions.SUBCATEGORY_DESC}>Subcategorie: Z-A</option>
         <option value={SortOptions.STATUS_ASC}>Status A-Z</option>
         <option value={SortOptions.STATUS_DESC}>Status Z-A</option>
-        <option value={SortOptions.BUROUGH_ASC}>{district} A-Z</option>
-        <option value={SortOptions.BUROUGH_DESC}>{district} Z-A</option>
+        {configuration.featureFlags.fetchDistrictsFromBackend ? (
+          <>
+            <option value={SortOptions.DISTRICT_ASC}>
+              {configuration.language.district} A-Z
+            </option>
+            <option value={SortOptions.DISTRICT_DESC}>
+              {configuration.language.district} Z-A
+            </option>
+          </>
+        ) : (
+          <>
+            <option value={SortOptions.BUROUGH_ASC}>Stadsdeel A-Z</option>
+            <option value={SortOptions.BUROUGH_DESC}>Stadsdeel Z-A</option>
+          </>
+        )}
         <option value={SortOptions.PRIORITY_ASC}>Urgentie: hoog - laag</option>
         <option value={SortOptions.PRIORITY_DESC}>Urgentie: laag - hoog</option>
         <option value={SortOptions.ADDRESS_ASC}>Adres A-Z</option>


### PR DESCRIPTION
closes Signalen/backend#166

Sorting on district (as opposed to 'stadsdeel') was not implemented yet (in incident overview).