### PR TITLE
Add support for EPSG:4326 & EPSG:3857 projection

### DIFF
--- a/app.base.json
+++ b/app.base.json
@@ -59,6 +59,7 @@
   "map": {
     "municipality": "amsterdam",
     "options": {
+      "crs": "EPSG:28992",
       "center": [
         52.3731081,
         4.8932945

--- a/internals/schemas/app.schema.json
+++ b/internals/schemas/app.schema.json
@@ -399,6 +399,15 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "crs": {
+          "description": "The Coordinate Reference System (CRS) of the map",
+          "enum": [
+            "EPSG:28992",
+            "EPSG:3857",
+            "EPSG:4326"
+          ]
+
+        },
         "center": {
           "type": "array",
           "items": {
@@ -425,6 +434,7 @@
         }
       },
       "required": [
+        "crs",
         "center",
         "maxBounds",
         "maxZoom",
@@ -521,6 +531,9 @@
       "properties": {
         "attribution": {
           "type": "string"
+        },
+        "maxZoom": {
+          "type": "integer"
         },
         "maxNativeZoom": {
           "type": "integer"

--- a/src/shared/services/configuration/map-options.test.ts
+++ b/src/shared/services/configuration/map-options.test.ts
@@ -10,6 +10,7 @@ describe('shared/services/configuration/map-options', () => {
 
   it('should return an object with configuration props', () => {
     configuration.map.options = {
+      crs: 'EPSG:28992',
       zoom: 1,
       center: [2],
       maxBounds: [[3]],

--- a/src/shared/services/configuration/map-options.ts
+++ b/src/shared/services/configuration/map-options.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C)  - 2021 Gemeente Amsterdam
+import L from 'leaflet'
 import { getCrsRd } from '@amsterdam/arm-core'
 import type {
   LatLngBoundsExpression,
@@ -11,14 +12,20 @@ import configuration from 'shared/services/configuration/configuration'
 
 const mapOptions = configuration.map.options
 
+const crsCodeToProjection: { [key: string]: L.CRS } = {
+  'EPSG:28992': getCrsRd(),
+  'EPSG:3857': L.CRS.EPSG3857,
+  'EPSG:4326': L.CRS.EPSG4326,
+}
+
 const MAP_OPTIONS: MapOptions = {
+  crs: crsCodeToProjection[mapOptions.crs],
   center: mapOptions.center as LatLngExpression,
   maxBounds: mapOptions.maxBounds as LatLngBoundsExpression,
   maxZoom: mapOptions.maxZoom,
   minZoom: mapOptions.minZoom,
   zoom: mapOptions.zoom,
   attributionControl: true,
-  crs: getCrsRd(),
   zoomControl: false,
   dragging: !('ontouchstart' in window), // Touch users should not drag by default. Set to true if the map is full-screen.
 }


### PR DESCRIPTION
This adds support for EPSG:4326 & EPSG:3857 map projections. The map configuration defaults to EPSG:28992 to make the change non-breaking.

Currently municipalities can only configure EPSG:28992 base maps. Some municipalities are not happy with the default base maps provided by PDOK:  e.g. house numbers are lacking and coloring of the base map could be more intuïtive.

Therefore they would like to provide their own base map. By using [tileserver-gl](https://github.com/maptiler/tileserver-gl) they can easily provide their own base map, but this requires support for EPSG:4326 projection.

This change can be tested with the following app.json:

```json
{
  "map": {
    "options": {
      "crs": "EPSG:3857"
    },
    "tiles": {
      "args": [
        "https://service.pdok.nl/brt/achtergrondkaart/wmts/v2_0/standaard/EPSG:3857/{z}/{x}/{y}.png"
      ],
      "options": {
        "maxZoom": 19,
        "maxNativeZoom": 19
      }
    }
  }
}
```