### PR TITLE
Make hardcoded "overig" categories Amsterdam-specific

### DIFF
--- a/app.amsterdam.json
+++ b/app.amsterdam.json
@@ -8,6 +8,7 @@
     "enableNearIncidents": true,
     "enablePublicSignalMap": false,
     "enableReporter": true,
+    "enableAmsterdamSpecificOverigCategories": true,
     "fetchDistrictsFromBackend": false,
     "fetchQuestionsFromBackend": false,
     "mapFilter24Hours": true,

--- a/app.base.json
+++ b/app.base.json
@@ -9,6 +9,7 @@
     "enableNearIncidents": false,
     "enablePublicSignalMap": false,
     "enableReporter": false,
+    "enableAmsterdamSpecificOverigCategories": false,
     "fetchDistrictsFromBackend": false,
     "fetchQuestionsFromBackend": false,
     "mapFilter24Hours": false,

--- a/internals/schemas/app.schema.json
+++ b/internals/schemas/app.schema.json
@@ -88,6 +88,10 @@
           "description": "Feature switch to enable showing incident reporter context, like other incidents reported by the given reporter or feedback results. Needs to have the feature flags 'API_SIGNAL_CONTEXT' and 'API_SIGNAL_CONTEXT_REPORTER' enabled in the backend.",
           "type": "boolean"
         },
+        "enableAmsterdamSpecificOverigCategories": {
+          "description": "Enable category translations that are specific for Amsterdam.",
+          "type": "boolean"
+        },
         "fetchDistrictsFromBackend": {
           "description": "Feature switch to use the areas endpoint to fetch districts, instead of using the hardcoded stadsdelen",
           "type": "boolean"
@@ -128,6 +132,7 @@
         "enableNearIncidents",
         "enablePublicSignalMap",
         "enableReporter",
+        "enableAmsterdamSpecificOverigCategories",
         "fetchDistrictsFromBackend",
         "fetchQuestionsFromBackend",
         "mapFilter24Hours",

--- a/src/shared/services/resolveClassification/index.js
+++ b/src/shared/services/resolveClassification/index.js
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2020 - 2021 Gemeente Amsterdam
+import configuration from 'shared/services/configuration/configuration'
+
 export const MINIMUM_CERTAINTY = 0.41
 export const DEFAULT_CLASSIFICATION = 'overig'
 
@@ -38,62 +40,83 @@ const resolveClassification = ({
 
   if (hoofdrubriekMeetsMinimumCertainty) {
     const [, category] = hoofdrubriek[0][0].match(reCategory)
-    let subcategory
 
-    switch (category) {
-      case 'afval':
-        subcategory = 'overig-afval'
-        break
-
-      case 'schoon':
-        subcategory = 'veegzwerfvuil'
-        break
-
-      case 'openbaar-groen-en-water':
-        subcategory = 'overig-groen-en-water'
-        break
-
-      case 'overlast-bedrijven-en-horeca':
-        subcategory = 'overig-horecabedrijven'
-        break
-
-      case 'overlast-in-de-openbare-ruimte':
-        subcategory = 'overig-openbare-ruimte'
-        break
-
-      case 'overlast-op-het-water':
-        subcategory = 'overig-boten'
-        break
-
-      case 'overlast-van-dieren':
-        subcategory = 'overig-dieren'
-        break
-
-      case 'overlast-van-en-door-personen-of-groepen':
-        subcategory = 'overige-overlast-door-personen'
-        break
-
-      case 'wegen-verkeer-straatmeubilair':
-        subcategory = 'overig-wegen-verkeer-straatmeubilair'
-        break
-
-      case 'wonen':
-        subcategory = 'wonen-overig'
-        break
-
-      default:
-        subcategory = DEFAULT_CLASSIFICATION
+    if (configuration.featureFlags.enableAmsterdamSpecificOverigCategories) {
+      return amsterdamSpecificOverigCategory(category)
     }
+
+    const genericOverigSubcategory = `${DEFAULT_CLASSIFICATION}-${category}`
 
     return {
       category,
-      subcategory,
+      subcategory: genericOverigSubcategory,
     }
   }
 
   return {
     category: DEFAULT_CLASSIFICATION,
     subcategory: DEFAULT_CLASSIFICATION,
+  }
+}
+
+/**
+ * Get Amsterdam-specific "overig" categories
+ *
+ * @param {String} category - The main category
+ *
+ * @returns {Object} With keys `category`, `subcategory`
+ */
+const amsterdamSpecificOverigCategory = (category) => {
+  let subcategory
+
+  switch (category) {
+    case 'afval':
+      subcategory = 'overig-afval'
+      break
+
+    case 'schoon':
+      subcategory = 'veegzwerfvuil'
+      break
+
+    case 'openbaar-groen-en-water':
+      subcategory = 'overig-groen-en-water'
+      break
+
+    case 'overlast-bedrijven-en-horeca':
+      subcategory = 'overig-horecabedrijven'
+      break
+
+    case 'overlast-in-de-openbare-ruimte':
+      subcategory = 'overig-openbare-ruimte'
+      break
+
+    case 'overlast-op-het-water':
+      subcategory = 'overig-boten'
+      break
+
+    case 'overlast-van-dieren':
+      subcategory = 'overig-dieren'
+      break
+
+    case 'overlast-van-en-door-personen-of-groepen':
+      subcategory = 'overige-overlast-door-personen'
+      break
+
+    case 'wegen-verkeer-straatmeubilair':
+      subcategory = 'overig-wegen-verkeer-straatmeubilair'
+      break
+
+    case 'wonen':
+      subcategory = 'wonen-overig'
+      break
+
+    default:
+      subcategory = DEFAULT_CLASSIFICATION
+  }
+
+  return {
+    category,
+    subcategory,
   }
 }
 

--- a/src/shared/services/resolveClassification/index.test.js
+++ b/src/shared/services/resolveClassification/index.test.js
@@ -1,15 +1,20 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2020 - 2021 Gemeente Amsterdam
+import configuration from 'shared/services/configuration/configuration'
 import resolveClassification, {
   MINIMUM_CERTAINTY,
   DEFAULT_CLASSIFICATION,
 } from '.'
+
+jest.mock('shared/services/configuration/configuration')
 
 describe('The resolve classification service', () => {
   let hoofdrubriek
   let subrubriek
 
   beforeEach(() => {
+    configuration.featureFlags.enableAmsterdamSpecificOverigCategories = false
+
     subrubriek = [
       [
         'https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/overlast-in-de-openbare-ruimte/sub_categories/hondenpoep',
@@ -27,6 +32,10 @@ describe('The resolve classification service', () => {
       ],
       [0.39, 0.1424216693948545, 0.04586915076913858],
     ]
+  })
+
+  afterEach(() => {
+    configuration.__reset()
   })
 
   it('should return the default classifications', () => {
@@ -60,6 +69,8 @@ describe('The resolve classification service', () => {
   describe('use main classification when sub category fails', () => {
     describe('afval', () => {
       it('should return overig-afval when minimum subcategory chance is not met and maincategory chance is met', () => {
+        configuration.featureFlags.enableAmsterdamSpecificOverigCategories = true
+
         hoofdrubriek[0][0] =
           'https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/afval'
         hoofdrubriek[1][0] = MINIMUM_CERTAINTY
@@ -73,6 +84,8 @@ describe('The resolve classification service', () => {
 
     describe('schoon', () => {
       it('should return veegzwerfvuil when minimum subcategory chance is not met and maincategory chance is met', () => {
+        configuration.featureFlags.enableAmsterdamSpecificOverigCategories = true
+
         hoofdrubriek[0][0] =
           'https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/schoon'
         hoofdrubriek[1][0] = MINIMUM_CERTAINTY
@@ -86,6 +99,8 @@ describe('The resolve classification service', () => {
 
     describe('openbaar-groen-en-water', () => {
       it('should return overig-groen-en-water when minimum subcategory chance is not met and maincategory chance is met', () => {
+        configuration.featureFlags.enableAmsterdamSpecificOverigCategories = true
+
         hoofdrubriek[0][0] =
           'https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/openbaar-groen-en-water'
         hoofdrubriek[1][0] = MINIMUM_CERTAINTY
@@ -99,6 +114,8 @@ describe('The resolve classification service', () => {
 
     describe('overlast-bedrijven-en-horeca', () => {
       it('should return overig-horecabedrijven when minimum subcategory chance is not met and maincategory chance is met', () => {
+        configuration.featureFlags.enableAmsterdamSpecificOverigCategories = true
+
         hoofdrubriek[0][0] =
           'https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/overlast-bedrijven-en-horeca'
         hoofdrubriek[1][0] = MINIMUM_CERTAINTY
@@ -112,6 +129,8 @@ describe('The resolve classification service', () => {
 
     describe('overlast-in-de-openbare-ruimte', () => {
       it('should return overig-openbare-ruimte when minimum subcategory chance is not met and maincategory chance is met', () => {
+        configuration.featureFlags.enableAmsterdamSpecificOverigCategories = true
+
         hoofdrubriek[0][0] =
           'https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/overlast-in-de-openbare-ruimte'
         hoofdrubriek[1][0] = MINIMUM_CERTAINTY
@@ -125,6 +144,8 @@ describe('The resolve classification service', () => {
 
     describe('overlast-op-het-water', () => {
       it('should return overig-boten when minimum subcategory chance is not met and maincategory chance is met', () => {
+        configuration.featureFlags.enableAmsterdamSpecificOverigCategories = true
+
         hoofdrubriek[0][0] =
           'https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/overlast-op-het-water'
         hoofdrubriek[1][0] = MINIMUM_CERTAINTY
@@ -138,6 +159,8 @@ describe('The resolve classification service', () => {
 
     describe('overlast-van-dieren', () => {
       it('should return overig-dieren when minimum subcategory chance is not met and maincategory chance is met', () => {
+        configuration.featureFlags.enableAmsterdamSpecificOverigCategories = true
+
         hoofdrubriek[0][0] =
           'https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/overlast-van-dieren'
         hoofdrubriek[1][0] = MINIMUM_CERTAINTY
@@ -151,6 +174,8 @@ describe('The resolve classification service', () => {
 
     describe('overlast-van-en-door-personen-of-groepen', () => {
       it('should return overige-overlast-door-personen when minimum subcategory chance is not met and maincategory chance is met', () => {
+        configuration.featureFlags.enableAmsterdamSpecificOverigCategories = true
+
         hoofdrubriek[0][0] =
           'https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/overlast-van-en-door-personen-of-groepen'
         hoofdrubriek[1][0] = MINIMUM_CERTAINTY
@@ -164,6 +189,8 @@ describe('The resolve classification service', () => {
 
     describe('wegen-verkeer-straatmeubilair', () => {
       it('should return overig-wegen-verkeer-straatmeubilair when minimum subcategory chance is not met and maincategory chance is met', () => {
+        configuration.featureFlags.enableAmsterdamSpecificOverigCategories = true
+
         hoofdrubriek[0][0] =
           'https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair'
         hoofdrubriek[1][0] = MINIMUM_CERTAINTY
@@ -177,6 +204,8 @@ describe('The resolve classification service', () => {
 
     describe('wonen', () => {
       it('should return wonen-overig when minimum subcategory chance is not met and maincategory chance is met', () => {
+        configuration.featureFlags.enableAmsterdamSpecificOverigCategories = true
+
         hoofdrubriek[0][0] =
           'https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/wonen'
         hoofdrubriek[1][0] = MINIMUM_CERTAINTY
@@ -188,8 +217,10 @@ describe('The resolve classification service', () => {
       })
     })
 
-    describe('unknown-category', () => {
+    describe('unknown-category-with-amsterdam-overig-categories-on', () => {
       it('should return overig when minimum subcategory chance is not met and maincategory chance is met', () => {
+        configuration.featureFlags.enableAmsterdamSpecificOverigCategories = true
+
         hoofdrubriek[0][0] =
           'https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/unknown-category'
         hoofdrubriek[1][0] = MINIMUM_CERTAINTY
@@ -197,6 +228,21 @@ describe('The resolve classification service', () => {
         expect(resolveClassification({ subrubriek, hoofdrubriek })).toEqual({
           category: 'unknown-category',
           subcategory: 'overig',
+        })
+      })
+    })
+
+    describe('unknown-category-with-amsterdam-overig-categories-off', () => {
+      it('should return overig when minimum subcategory chance is not met and maincategory chance is met', () => {
+        configuration.featureFlags.enableAmsterdamSpecificOverigCategories = false
+
+        hoofdrubriek[0][0] =
+          'https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/unknown-category'
+        hoofdrubriek[1][0] = MINIMUM_CERTAINTY
+
+        expect(resolveClassification({ subrubriek, hoofdrubriek })).toEqual({
+          category: 'unknown-category',
+          subcategory: 'overig-unknown-category',
         })
       })
     })


### PR DESCRIPTION
Currently we have some hardcoded "overig" categories in the frontend for Amsterdam. This results in incorrect fallback behavior of the overig category within a main category for the other municipalities. It will always fall back to `overig` when the `MINIMUM_CERTAINTY` of a subcategory is not met, instead of the overig category of the main category (`overig-{main-slug}`).

This PR fixes this behavior and also still supports the Amsterdam-specific naming convention of overige categories, by adding feature flag called `enableAmsterdamSpecificOverigCategories`. When the feature flag is disabled, the consistent naming of overige categories that is used by the other municipalities is used.