### PR TITLE
[Sig-4621] show map with meldingen and generic pins

### DIFF
--- a/src/signals/IncidentMap/IncidentMapContainer.tsx
+++ b/src/signals/IncidentMap/IncidentMapContainer.tsx
@@ -13,7 +13,7 @@ const IncidentMapContainer = () => {
     <Row>
       <Column span={12}>
         <Suspense fallback={<LoadingIndicator />}>
-          <IncidentMap />
+          <IncidentMap hideButtons={true} />
         </Suspense>
       </Column>
     </Row>

--- a/src/signals/IncidentMap/components/IncidentMap.test.tsx
+++ b/src/signals/IncidentMap/components/IncidentMap.test.tsx
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (C) 2020 - 2021 Gemeente Amsterdam
+import fetchMock from 'jest-fetch-mock'
+import { render, act, screen } from '@testing-library/react'
+
+import type configurationType from 'shared/services/configuration/__mocks__/configuration'
+import configuration from 'shared/services/configuration/configuration'
+import { withMapContext } from 'test/utils'
+import geographyJSON from 'utils/__tests__/fixtures/geography.json'
+//
+// import * as reactRedux from "react-redux";
+// import withAssetSelectContext from "../../incident/components/form/MapSelectors/Asset/__tests__/withAssetSelectContext";
+// import DetailPanel from "../../incident/components/form/MapSelectors/Asset/Selector/DetailPanel";
+// import type {AssetSelectValue} from "../../incident/components/form/MapSelectors/Asset/types";
+// import type {
+//   DetailPanelProps
+// } from "../../incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel";
+import IncidentMap, { POLLING_INTERVAL } from './IncidentMap'
+// import MockInstance = jest.MockInstance
+
+const mockConfiguration = configuration as typeof configurationType
+const createdAfter = '1999-01-01T00:00:00'
+const createdBefore = '1999-01-05T00:00:00'
+
+let mockFilterParams: { created_after: string; created_before: string }
+
+jest.mock('shared/services/configuration/configuration')
+// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+jest.mock('signals/incident-management/selectors', () => ({
+  __esModule: true,
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  ...jest.requireActual('signals/incident-management/selectors')!,
+  makeSelectFilterParams: () => mockFilterParams,
+}))
+
+// const dispatch = jest.fn()
+
+describe('IncidentMap', () => {
+  beforeEach(() => {
+    fetchMock.mockResponse(JSON.stringify(geographyJSON))
+
+    mockFilterParams = {
+      created_after: createdAfter,
+      created_before: createdBefore,
+    }
+  })
+
+  afterEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
+    mockConfiguration.__reset()
+    fetchMock.resetMocks()
+  })
+
+  it('should render the map and the detailpanel', async () => {
+    render(withMapContext(<IncidentMap hideButtons={true} />))
+
+    await screen.findByTestId('incidentMap')
+
+    expect(screen.getByText('Zoek naar adres of postcode')).toBeInTheDocument()
+  })
+
+  it('renders the map without results for the past period', async () => {
+    // API will return a result, but with 'null' for the 'features' prop
+    fetchMock.mockResponse(
+      JSON.stringify({
+        type: 'FeatureCollection',
+        features: null,
+      })
+    )
+
+    render(withMapContext(<IncidentMap hideButtons={true} />))
+
+    await screen.findByTestId('incidentMap')
+
+    expect(screen.getByText('Zoek naar adres of postcode')).toBeInTheDocument()
+  })
+
+  // describe('DetailPanel', () => {
+  //
+  //   const props: DetailPanelProps = {
+  //     hideLegendButton: true
+  //   }
+  //
+  //
+  //   beforeEach(() => {
+  //     jest.spyOn(reactRedux, 'useDispatch').mockImplementation(() => dispatch)
+  //     const dispatchEventSpy: MockInstance<any, any> = jest.spyOn(
+  //       global.document,
+  //       'dispatchEvent'
+  //     )
+  //     dispatch.mockReset()
+  //     dispatchEventSpy.mockReset()
+  //   })
+  //
+  //   afterEach(() => {
+  //     jest.resetAllMocks()
+  //   })
+  //
+  //
+  //   it('dispatches the location when an address is selected', async () => {
+  //     const incidentMapContext: AssetSelectValue = {
+  //       coordinates: undefined,
+  //       message: undefined,
+  //       meta: {
+  //         endpoint: '',
+  //         featureTypes: [],
+  //         featureStatusTypes: [],
+  //         extraProperties: [],
+  //         maxNumberOfAssets: undefined,
+  //         language: {
+  //           title: ' ',
+  //           subTitle: ' ',
+  //           description:
+  //             'Op deze kaart staan meldingen in de openbare ruimte waarmee we ' +
+  //             'aan het werk zijn. Vanwege privacy staan niet alle meldingen op de kaart.',
+  //         },
+  //       },
+  //       selection: undefined,
+  //       fetchLocation: /* istanbul ignore next */ () => {
+  //       },
+  //       setLocation: jest.fn(),
+  //       setMessage: /* istanbul ignore next */ () => {
+  //       },
+  //       setItem: /* istanbul ignore next */ () => {
+  //       },
+  //       removeItem: /* istanbul ignore next */ () => {
+  //       },
+  //     }
+  //
+  //     render(
+  //       withAssetSelectContext(<DetailPanel {...props} />, {
+  //         ...incidentMapContext,
+  //       })
+  //     )
+  //
+  //     expect(incidentMapContext.setLocation).not.toHaveBeenCalled()
+  //
+  //     fireEvent.change(screen.getByTestId('inputAddress').firstChild,
+  //       {target: {value: 'Weesperstraat 3,1018DN Amsterdam'}}
+  //     )
+  //
+  //     expect(incidentMapContext.setLocation).toHaveBeenCalled()
+  //   })
+  // })
+
+  describe('request', () => {
+    const reDateTime = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/
+    const expectedFilterParams: Record<string, RegExp> = {
+      created_after: reDateTime,
+      created_before: reDateTime,
+      page_size: /4000/,
+    }
+
+    it('should fetch locations from endpoint', async () => {
+      const { rerender, unmount } = render(withMapContext(<IncidentMap />))
+
+      await screen.findByTestId('incidentMap')
+
+      expect(fetchMock.mock.calls).toHaveLength(1)
+
+      const requestUrl = new URL(fetchMock.mock.calls[0][0] as string)
+      const params = new URLSearchParams(requestUrl.search)
+      const endpoint = `${configuration.apiBaseUrl}${requestUrl.pathname}`
+
+      expect(endpoint).toBe(configuration.GEOGRAPHY_ENDPOINT)
+
+      Object.keys(expectedFilterParams).forEach((expectedKey) => {
+        const paramKeys = [...params.keys()]
+        expect(paramKeys.includes(expectedKey)).toBeTruthy()
+
+        const paramKey = paramKeys.find((key) => key === expectedKey)
+        expect(paramKey && params.get(paramKey)).toMatch(
+          expectedFilterParams[expectedKey]
+        )
+      })
+
+      expect(params.get('created_after')).toEqual(createdAfter)
+      expect(params.get('created_before')).toEqual(createdBefore)
+
+      unmount()
+
+      rerender(withMapContext(<IncidentMap />))
+
+      await screen.findByTestId('incidentMap')
+
+      expect(fetchMock.mock.calls).toHaveLength(2)
+    })
+
+    it('should not poll the endpoint by default', async () => {
+      jest.useFakeTimers()
+
+      render(withMapContext(<IncidentMap />))
+
+      await screen.findByTestId('incidentMap')
+
+      expect(fetchMock.mock.calls).toHaveLength(1)
+
+      act(() => {
+        jest.advanceTimersByTime(POLLING_INTERVAL)
+      })
+
+      await screen.findByTestId('incidentMap')
+
+      expect(fetchMock.mock.calls).toHaveLength(1)
+
+      jest.useRealTimers()
+    })
+
+    it('should poll the endpoint when refresh is true', async () => {
+      jest.useFakeTimers()
+
+      render(withMapContext(<IncidentMap refresh />))
+
+      await screen.findByTestId('incidentMap')
+
+      expect(fetchMock.mock.calls).toHaveLength(1)
+
+      act(() => {
+        jest.advanceTimersByTime(POLLING_INTERVAL)
+      })
+
+      await screen.findByTestId('incidentMap')
+
+      expect(fetchMock.mock.calls).toHaveLength(2)
+
+      jest.useRealTimers()
+    })
+  })
+
+  it('should overwrite date filter params with mapFilter24Hours enabled', async () => {
+    configuration.featureFlags.mapFilter24Hours = true
+    render(withMapContext(<IncidentMap />))
+
+    await screen.findByTestId('incidentMap')
+
+    const requestUrl = new URL(fetchMock.mock.calls[0][0] as string)
+    const params = new URLSearchParams(requestUrl.search)
+
+    expect(params.get('created_after')).not.toEqual(createdAfter)
+    expect(params.get('created_before')).not.toEqual(createdBefore)
+  })
+})

--- a/src/signals/IncidentMap/components/IncidentMap.tsx
+++ b/src/signals/IncidentMap/components/IncidentMap.tsx
@@ -1,61 +1,247 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2022 Gemeente Amsterdam
+// Copyright (C) 2020 - 2021 Gemeente Amsterdam
+import type { Dispatch, FC, SetStateAction } from 'react'
+import { memo, useState, useCallback, useEffect, useMemo } from 'react'
+import { useSelector } from 'react-redux'
+import format from 'date-fns/format'
+import subDays from 'date-fns/addDays'
 
-import { StyledMap } from 'signals/incident/components/form/MapSelectors/Asset/Selector/styled'
-import type { LatLngTuple, MapOptions } from 'leaflet'
-import { useLayoutEffect, useMemo, useState } from 'react'
-import type { Map as MapType } from 'leaflet'
-import MAP_OPTIONS from '../../../shared/services/configuration/map-options'
-import { MAP_LOCATION_ZOOM } from '../../incident/components/form/MapSelectors/Asset/Selector/Selector'
-import configuration from '../../../shared/services/configuration/configuration'
+import type {
+  Map as MapType,
+  MarkerCluster as MarkerClusterType,
+} from 'leaflet'
+import L from 'leaflet'
+import type { Geometrie } from 'types/incident'
 
-const IncidentMap = () => {
+import MAP_OPTIONS from 'shared/services/configuration/map-options'
+import configuration from 'shared/services/configuration/configuration'
+import { featureToCoordinates } from 'shared/services/map-location'
+import { makeSelectFilterParams } from 'signals/incident-management/selectors'
+import useFetch from 'hooks/useFetch'
+import {
+  incidentIcon,
+  markerIcon,
+} from 'shared/services/configuration/map-markers'
+import MarkerCluster from 'components/MarkerCluster/MarkerCluster'
+import DetailPanel from 'signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel'
+
+import type { IncidentSummary } from 'components/OverviewMap/types'
+import styled from 'styled-components'
+import { breakpoint } from '@amsterdam/asc-ui'
+import { AssetSelectProvider } from 'signals/incident/components/form/MapSelectors/Asset/context'
+import type { Location } from 'types/incident'
+import Map from '../../../components/Map'
+import type { AssetSelectValue } from '../../incident/components/form/MapSelectors/Asset/types'
+
+export const Wrapper = styled.div`
+  position: relative;
+  height: 100%;
+  width: 100%;
+  box-sizing: border-box; // Override box-sizing: content-box set by Leaflet
+  z-index: 2; // position over the site header
+  display: flex;
+
+  @media screen and ${breakpoint('max-width', 'tabletM')} {
+    flex-direction: column;
+  }
+`
+
+export const StyledMap = styled(Map)`
+  height: 800px;
+  width: 100%;
+  z-index: 0;
+`
+
+interface Feature {
+  geometry: Geometrie
+  properties: IncidentSummary
+}
+
+interface Data {
+  features: Feature[]
+}
+
+export const POLLING_INTERVAL = 5000
+
+/* istanbul ignore next */
+const clusterLayerOptions = {
+  zoomToBoundsOnClick: true,
+  chunkedLoading: true,
+}
+
+interface OverviewMapProps {
+  refresh?: boolean
+  hideButtons?: boolean
+}
+
+const IncidentMap: FC<OverviewMapProps> = ({
+  refresh,
+  hideButtons,
+  ...rest
+}) => {
+  const endpoint = configuration.GEOGRAPHY_ENDPOINT
+  const [initialMount, setInitialMount] = useState(false)
   const [map, setMap] = useState<MapType>()
+  const filterParams = useSelector(makeSelectFilterParams)
+  const { get, data, isLoading } = useFetch<Data>()
+  const [layerInstance, setLayerInstance] = useState<L.LayerGroup>()
+  const [pollingCount, setPollingCount] = useState(0)
 
-  const coordinates = undefined
-
-  const center =
-    coordinates || (configuration.map.options.center as LatLngTuple)
-
-  const mapOptions: MapOptions = useMemo(
-    () => ({
-      minZoom: 7,
-      maxZoom: 16,
-      ...MAP_OPTIONS,
-      center,
-      dragging: true,
-      zoomControl: false,
-      scrollWheelZoom: true,
-      zoom: coordinates
-        ? Math.min(
-            MAP_LOCATION_ZOOM,
-            MAP_OPTIONS.maxZoom || Number.POSITIVE_INFINITY
-          )
-        : MAP_OPTIONS.zoom,
-    }),
-    [center, coordinates]
+  /**
+   * AutoSuggest callback handler
+   *
+   * Note that testing this functionality resembles integration testing, hence disabling istanbul coverage
+   */
+  const onSelect = useCallback(
+    /* istanbul ignore next */ (location: Location) => {
+      if (map) {
+        const currentZoom = map.getZoom()
+        map.flyTo(location.coordinates, currentZoom < 11 ? 11 : currentZoom)
+      }
+    },
+    [map]
   )
 
-  useLayoutEffect(() => {
-    if (!map || !coordinates) return
+  const meldingenkaartContext: AssetSelectValue = {
+    coordinates: undefined,
+    message: undefined,
+    meta: {
+      endpoint: '',
+      featureTypes: [],
+      featureStatusTypes: [],
+      extraProperties: [],
+      maxNumberOfAssets: undefined,
+      language: {
+        title: ' ',
+        subTitle: ' ',
+        description:
+          'Op deze kaart staan meldingen in de openbare ruimte waarmee we ' +
+          'aan het werk zijn. Vanwege privacy staan niet alle meldingen op de kaart.',
+      },
+    },
+    selection: undefined,
+    fetchLocation: /* istanbul ignore next */ () => {},
+    setLocation: onSelect,
+    setMessage: /* istanbul ignore next */ () => {},
+    setItem: /* istanbul ignore next */ () => {},
+    removeItem: /* istanbul ignore next */ () => {},
+  }
 
-    const zoomLevel = mapOptions.zoom
-      ? Math.max(map.getZoom(), mapOptions.zoom)
-      : map.getZoom()
+  const params = useMemo(
+    () => ({
+      ...filterParams,
+      // fixed query period (24 hours, with featuere flag mapFilter24Hours enabled)
+      created_after: configuration.featureFlags.mapFilter24Hours
+        ? format(subDays(new Date(), -1), "yyyy-MM-dd'T'HH:mm:ss")
+        : (filterParams as Record<string, unknown>).created_after,
+      created_before: configuration.featureFlags.mapFilter24Hours
+        ? format(new Date(), "yyyy-MM-dd'T'HH:mm:ss")
+        : (filterParams as Record<string, unknown>).created_before,
+      // fixed page size (default is 50; 4000 is 2.5 times the highest daily average)
+      page_size: 4000,
+    }),
+    [filterParams]
+  )
 
-    map.flyTo(coordinates, zoomLevel)
-  }, [coordinates, map, mapOptions.zoom])
+  /* istanbul ignore next */
+  const resetMarkerIcons = useCallback(() => {
+    if (!map) return
+
+    map.eachLayer((markerClustLayer) => {
+      const layer = markerClustLayer as MarkerClusterType
+
+      if (typeof layer.getIcon === 'function' && !layer.getAllChildMarkers) {
+        layer.setIcon(incidentIcon)
+      }
+    })
+  }, [map])
+
+  useEffect(() => {
+    if (!refresh) {
+      return
+    }
+    let active = true
+    const pollingFn = () => {
+      /* istanbul ignore else */
+      if (active) setPollingCount(pollingCount + 1)
+    }
+    const intervalId = setInterval(pollingFn, POLLING_INTERVAL)
+    return () => {
+      active = false
+      clearInterval(intervalId)
+    }
+  }, [refresh, pollingCount, setPollingCount])
+
+  useEffect(() => {
+    if (isLoading || !initialMount) return
+
+    void get(`${endpoint}`, params)
+
+    // Only execute when the value of filterParams changes; disabling linter
+    // eslint-disable-next-line
+  }, [filterParams, pollingCount])
+
+  // request data on mount
+  useEffect(() => {
+    void get(`${endpoint}`, params)
+    setInitialMount(true)
+    // eslint-disable-next-line
+  }, [get])
+
+  useEffect(() => {
+    if (!data?.features || !layerInstance) return
+
+    data.features.forEach((feature) => {
+      const latlng = featureToCoordinates(feature.geometry)
+
+      const clusteredMarker = L.marker(latlng, {
+        icon: incidentIcon,
+      })
+
+      /* istanbul ignore next */
+      clusteredMarker.on(
+        'click',
+        (event: {
+          target: { setIcon: (icon: L.Icon<L.IconOptions>) => void }
+        }) => {
+          resetMarkerIcons()
+
+          event.target.setIcon(markerIcon)
+        }
+      )
+
+      layerInstance.addLayer(clusteredMarker)
+    })
+
+    return () => {
+      layerInstance.clearLayers()
+    }
+  })
 
   return (
-    <>
-      <div style={{ width: '800px', height: '500px' }}>
-        <StyledMap mapOptions={mapOptions} setInstance={setMap}></StyledMap>
-      </div>
-      <div>hier kan de kaart komen</div>
-    </>
+    <AssetSelectProvider value={meldingenkaartContext}>
+      <Wrapper {...rest}>
+        <DetailPanel
+          language={meldingenkaartContext.meta.language}
+          hideLegendButton={hideButtons}
+        />
+        <StyledMap
+          data-testid="overviewMap"
+          hasZoomControls
+          mapOptions={{
+            ...MAP_OPTIONS,
+            ...(configuration.map.optionsBackOffice || {}),
+          }}
+          setInstance={setMap}
+        >
+          <MarkerCluster
+            clusterOptions={clusterLayerOptions}
+            setInstance={setLayerInstance as Dispatch<SetStateAction<unknown>>}
+          />
+        </StyledMap>
+      </Wrapper>
+    </AssetSelectProvider>
   )
 }
 
-export default IncidentMap
-
-// const { mapActive } = useSelector(makeSelectIncidentContainer)
+export default memo(IncidentMap)

--- a/src/signals/IncidentMap/components/IncidentMap.tsx
+++ b/src/signals/IncidentMap/components/IncidentMap.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2020 - 2021 Gemeente Amsterdam
+// Copyright (C) 2022 Gemeente Amsterdam
 import type { Dispatch, FC, SetStateAction } from 'react'
 import { memo, useState, useCallback, useEffect, useMemo } from 'react'
 import { useSelector } from 'react-redux'
@@ -102,7 +102,7 @@ const IncidentMap: FC<OverviewMapProps> = ({
     [map]
   )
 
-  const meldingenkaartContext: AssetSelectValue = {
+  const incidentMapContext: AssetSelectValue = {
     coordinates: undefined,
     message: undefined,
     meta: {
@@ -219,14 +219,14 @@ const IncidentMap: FC<OverviewMapProps> = ({
   })
 
   return (
-    <AssetSelectProvider value={meldingenkaartContext}>
+    <AssetSelectProvider value={incidentMapContext}>
       <Wrapper {...rest}>
         <DetailPanel
-          language={meldingenkaartContext.meta.language}
+          language={incidentMapContext.meta.language}
           hideLegendButton={hideButtons}
         />
         <StyledMap
-          data-testid="overviewMap"
+          data-testid="incidentMap"
           hasZoomControls
           mapOptions={{
             ...MAP_OPTIONS,

--- a/src/signals/IncidentMap/components/IncidentMap.tsx
+++ b/src/signals/IncidentMap/components/IncidentMap.tsx
@@ -1,8 +1,61 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2022 Gemeente Amsterdam
 
+import { StyledMap } from 'signals/incident/components/form/MapSelectors/Asset/Selector/styled'
+import type { LatLngTuple, MapOptions } from 'leaflet'
+import { useLayoutEffect, useMemo, useState } from 'react'
+import type { Map as MapType } from 'leaflet'
+import MAP_OPTIONS from '../../../shared/services/configuration/map-options'
+import { MAP_LOCATION_ZOOM } from '../../incident/components/form/MapSelectors/Asset/Selector/Selector'
+import configuration from '../../../shared/services/configuration/configuration'
+
 const IncidentMap = () => {
-  return <>hier kan de kaart komen</>
+  const [map, setMap] = useState<MapType>()
+
+  const coordinates = undefined
+
+  const center =
+    coordinates || (configuration.map.options.center as LatLngTuple)
+
+  const mapOptions: MapOptions = useMemo(
+    () => ({
+      minZoom: 7,
+      maxZoom: 16,
+      ...MAP_OPTIONS,
+      center,
+      dragging: true,
+      zoomControl: false,
+      scrollWheelZoom: true,
+      zoom: coordinates
+        ? Math.min(
+            MAP_LOCATION_ZOOM,
+            MAP_OPTIONS.maxZoom || Number.POSITIVE_INFINITY
+          )
+        : MAP_OPTIONS.zoom,
+    }),
+    [center, coordinates]
+  )
+
+  useLayoutEffect(() => {
+    if (!map || !coordinates) return
+
+    const zoomLevel = mapOptions.zoom
+      ? Math.max(map.getZoom(), mapOptions.zoom)
+      : map.getZoom()
+
+    map.flyTo(coordinates, zoomLevel)
+  }, [coordinates, map, mapOptions.zoom])
+
+  return (
+    <>
+      <div style={{ width: '800px', height: '500px' }}>
+        <StyledMap mapOptions={mapOptions} setInstance={setMap}></StyledMap>
+      </div>
+      <div>hier kan de kaart komen</div>
+    </>
+  )
 }
 
 export default IncidentMap
+
+// const { mapActive } = useSelector(makeSelectIncidentContainer)

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.tsx
@@ -32,6 +32,7 @@ import { ScrollWrapper, Title } from '../styled'
 import {
   AddressPanel,
   Description,
+  DescriptionMeldingenkaart,
   LegendToggleButton,
   OptionsList,
   PanelContent,
@@ -43,6 +44,7 @@ import {
 
 export interface DetailPanelProps {
   language?: Record<string, string>
+  hideLegendButton?: boolean
 }
 
 const nearbyLegendItem = {
@@ -54,7 +56,10 @@ const nearbyLegendItem = {
   typeValue: NEARBY_TYPE,
 }
 
-const DetailPanel: FC<DetailPanelProps> = ({ language = {} }) => {
+const DetailPanel: FC<DetailPanelProps> = ({
+  language = {},
+  hideLegendButton,
+}) => {
   const shouldRenderAddressPanel = useMediaQuery({
     query: breakpoint('max-width', 'tabletM')({ theme: ascDefaultTheme }),
   })
@@ -168,11 +173,20 @@ const DetailPanel: FC<DetailPanelProps> = ({ language = {} }) => {
       <ScrollWrapper>
         <Paragraph strong gutterBottom={16}>
           {language.subTitle || 'U kunt maar een object kiezen'}
+        </Paragraph>
+        {!hideLegendButton ? (
           <Description>
             {language.description ||
               'Typ het dichtstbijzijnde adres, klik de locatie aan op de kaart of gebruik "Mijn locatie"'}
           </Description>
-        </Paragraph>
+        ) : (
+          <>
+            <DescriptionMeldingenkaart>
+              {language.description}
+            </DescriptionMeldingenkaart>
+            <Paragraph strong>Zoek naar adres of postcode</Paragraph>
+          </>
+        )}
 
         {!(showAddressPanel && shouldRenderAddressPanel) && (
           <StyledPDOKAutoSuggest
@@ -232,18 +246,19 @@ const DetailPanel: FC<DetailPanelProps> = ({ language = {} }) => {
             )}
           </div>
         )}
-
-        <StyledButton
-          onClick={() => dispatch(closeMap())}
-          variant="primary"
-          data-testid="assetSelectSubmitButton"
-          tabIndex={0}
-        >
-          {language.submit || 'Meld dit object'}
-        </StyledButton>
+        {!hideLegendButton && (
+          <StyledButton
+            onClick={() => dispatch(closeMap())}
+            variant="primary"
+            data-testid="assetSelectSubmitButton"
+            tabIndex={0}
+          >
+            {language.submit || 'Meld dit object'}
+          </StyledButton>
+        )}
       </ScrollWrapper>
 
-      {legendItems.length > 0 && (
+      {!hideLegendButton && legendItems.length > 0 && (
         <>
           <StyledLegendPanel
             onClose={toggleLegend}

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.tsx
@@ -197,6 +197,7 @@ const DetailPanel: FC<DetailPanelProps> = ({
             onSelect={onAddressSelect}
             value={addressValue}
             placeholder="Zoek adres of postcode"
+            data-testid="inputAddress"
           />
         )}
 

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/styled.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/styled.tsx
@@ -74,6 +74,14 @@ export const Description = styled.span`
   font-weight: 400;
 `
 
+export const DescriptionMeldingenkaart = styled.span`
+  color: ${themeColor('tint', 'level7')};
+  display: block;
+  font-size: 16px;
+  font-weight: 400;
+  margin-bottom: 16px;
+`
+
 export const StyledPDOKAutoSuggest = styled(PDOKAutoSuggest)`
   margin: ${themeSpacing(4, 0)};
   width: 100%;


### PR DESCRIPTION
PR made because of holiday. Now somebody else will be able to continue if they want. The thing missing is a test to zoom in on address when that is selected in the detailpanel. A double check on the placement of the zoom icons would not be amiss. 

Meldingenkaart now shows a map, it can zoom and it shows, just like the OverviewMap all the issues of the last 24 hours.


