### PR TITLE
[SIG-4704] added aria labels to buttons without explicit meaningful text

### DIFF
--- a/src/components/AutoSuggest/AutoSuggest.tsx
+++ b/src/components/AutoSuggest/AutoSuggest.tsx
@@ -325,6 +325,7 @@ const AutoSuggest: FC<AutoSuggestProps> = ({
         />
         {(defaultValue || value) && (
           <ClearInput
+            aria-label="Input verwijderen"
             data-testid="clearInput"
             icon={<Close />}
             iconSize={20}

--- a/src/components/AutoSuggest/AutoSuggest.tsx
+++ b/src/components/AutoSuggest/AutoSuggest.tsx
@@ -326,6 +326,7 @@ const AutoSuggest: FC<AutoSuggestProps> = ({
         {(defaultValue || value) && (
           <ClearInput
             aria-label="Input verwijderen"
+            title="Verwijderen"
             data-testid="clearInput"
             icon={<Close />}
             iconSize={20}

--- a/src/components/MapCloseButton/MapCloseButton.tsx
+++ b/src/components/MapCloseButton/MapCloseButton.tsx
@@ -22,7 +22,7 @@ const MapCloseButton: FunctionComponent<MapCloseButtonProps & React.HTMLProps<HT
     onClick={onClick}
     size={MAP_ICON_SIZE}
     title="Sluiten"
-    aria-label='Kaart sluiten'
+    aria-label="Kaart sluiten"
     variant="blank"
     className={className}
     tabIndex={tabIndex}

--- a/src/components/MapCloseButton/MapCloseButton.tsx
+++ b/src/components/MapCloseButton/MapCloseButton.tsx
@@ -22,6 +22,7 @@ const MapCloseButton: FunctionComponent<MapCloseButtonProps & React.HTMLProps<HT
     onClick={onClick}
     size={MAP_ICON_SIZE}
     title="Sluiten"
+    aria-label='Kaart sluiten'
     variant="blank"
     className={className}
     tabIndex={tabIndex}

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.tsx
@@ -259,10 +259,12 @@ const DetailPanel: FC<DetailPanelProps> = ({ language = {} }) => {
         <AddressPanel data-testid="addressPanel">
           <header>
             <Button
+              aria-label="Terug"
               icon={<ChevronLeft />}
               iconSize={16}
               onClick={closeAddressPanel}
               size={24}
+              title="Terug"
               variant="blank"
             />
             <StyledPDOKAutoSuggest


### PR DESCRIPTION
Ticket: [SIG-4704](https://datapunt.atlassian.net/browse/SIG-4704)

## Context
With two buttons the screenreader could not identify the roles of the buttons.

## Changes
- added two aria-labels
