### PR TITLE
[SIG-4697] changed alt text of logo in amsterdam.json file

### DIFF
--- a/app.amsterdam.json
+++ b/app.amsterdam.json
@@ -30,7 +30,7 @@
     "headerTitle": "",
     "helpText": "Wij zijn bereikbaar van maandag tot en met vrijdag van 8.00 tot 18.00 uur.",
     "helpTextHeader": "Lukt het niet om een melding te doen? Bel het telefoonnummer [14 020](tel:14020)",
-    "logoDescription": "Logo gemeente Amsterdam, naar amsterdam.nl",
+    "logoDescription": "Gemeente Amsterdam logo - Home",
     "mapDescription": "Weet u het adres niet, bel dan 14 020 om telefonisch de melding te maken.",
     "phoneNumber": "14 020",
     "shortTitle": "Meldingen",


### PR DESCRIPTION
Ticket: [SIG-4697](https://datapunt.atlassian.net/browse/SIG-4697)

## Context
The alt-text of the logo need to be 'gemeente' specific and should tell where it will redirect since it is also a link. 

## Changes
- changed the alt text in the app.amsterdam.json.

## Questions
- How do we make sure the other municipalities do the same?
- The SiteHeader renders a different header depending on the `isIncidentMap`. However, it also uses the Logo component differently. Resulting, for example, in double hrefs. Why is this?