### PR TITLE
[SIG 4621] Show map and markers

### DIFF
--- a/src/containers/App/index.tsx
+++ b/src/containers/App/index.tsx
@@ -22,6 +22,7 @@ import IncidentOverviewContainer from 'signals/incident/containers/IncidentOverv
 import { resetIncident } from 'signals/incident/containers/IncidentContainer/actions'
 import useLocationReferrer from 'hooks/useLocationReferrer'
 import useIsFrontOffice from 'hooks/useIsFrontOffice'
+import useIsIncidentMap from 'hooks/useIsIncidentMap'
 
 import { getSources } from './actions'
 import AppContext from './context'
@@ -75,6 +76,7 @@ export const AppContainer = () => {
   const isFrontOffice = useIsFrontOffice()
   const headerIsTall = isFrontOffice && !getIsAuthenticated()
   const contextValue = useMemo(() => ({ loading, sources }), [loading, sources])
+  const isIncidentMap = useIsIncidentMap()
 
   useEffect(() => {
     const { referrer } = location
@@ -152,7 +154,7 @@ export const AppContainer = () => {
             </Suspense>
           </ContentContainer>
           <FooterContent>
-            {!getIsAuthenticated() && <FooterContainer />}
+            {!getIsAuthenticated() && !isIncidentMap && <FooterContainer />}
           </FooterContent>
         </Fragment>
       </AppContext.Provider>

--- a/src/signals/IncidentMap/IncidentMapContainer.test.tsx
+++ b/src/signals/IncidentMap/IncidentMapContainer.test.tsx
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (C) 2022 Gemeente Amsterdam
+import { Suspense } from 'react'
+import { render } from '@testing-library/react'
+import { withAppContext } from 'test/utils'
+import IncidentMapContainer from './IncidentMapContainer'
+
+const withSuspense = () =>
+  withAppContext(
+    <Suspense fallback={<div>Loading...</div>}>
+      <IncidentMapContainer />
+    </Suspense>
+  )
+
+describe('signals/IncidentMap/IncidentMapContainer', () => {
+  it('should render correctly', async () => {
+    const { findByTestId, queryByTestId } = render(withSuspense())
+
+    await findByTestId('incidentMap')
+
+    expect(queryByTestId('incidentMap')).toBeInTheDocument()
+  })
+})

--- a/src/signals/IncidentMap/components/IncidentLayer.test.tsx
+++ b/src/signals/IncidentMap/components/IncidentLayer.test.tsx
@@ -62,4 +62,19 @@ describe('IncidentLayer', () => {
     const container = renderWithContext()
     expect(container.getAllByAltText('Huisafval')).toHaveLength(numFeatures)
   })
+
+  it('shows a message when the API returns an error', async () => {
+    jest.mocked(useFetch).mockImplementation(() => ({
+      ...useFetchResponse,
+      data: undefined,
+      error: true,
+    }))
+
+    renderWithContext()
+    await screen.findByTestId('incidentLayer')
+
+    expect(
+      screen.getByText('Er konden geen meldingen worden opgehaald.')
+    ).toBeInTheDocument()
+  })
 })

--- a/src/signals/IncidentMap/components/IncidentLayer.test.tsx
+++ b/src/signals/IncidentMap/components/IncidentLayer.test.tsx
@@ -1,0 +1,65 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+/* Copyright (C) 2022 Gemeente Amsterdam */
+import { render, screen } from '@testing-library/react'
+import configuration from 'shared/services/configuration/configuration'
+import useFetch from 'hooks/useFetch'
+import geography from 'utils/__tests__/fixtures/geography_public.json'
+import MAP_OPTIONS from 'shared/services/configuration/map-options'
+import Map from 'components/Map'
+import { withAppContext } from 'test/utils'
+import IncidentLayer from './IncidentLayer'
+import { get, mockUseMapInstance, useFetchResponse } from './mapTestUtils'
+
+jest.mock('@amsterdam/react-maps', () => ({
+  __esModule: true,
+  ...jest.requireActual('@amsterdam/react-maps'),
+  useMapInstance: jest.fn(() => mockUseMapInstance),
+}))
+
+jest.mock('hooks/useFetch')
+
+const numFeatures = geography.features.length
+
+const renderWithContext = () =>
+  render(
+    withAppContext(
+      <Map mapOptions={MAP_OPTIONS}>
+        <IncidentLayer />
+      </Map>
+    )
+  )
+
+describe('IncidentLayer', () => {
+  beforeEach(() => {
+    get.mockReset()
+    jest.mocked(useFetch).mockImplementation(() => useFetchResponse)
+  })
+
+  it('renders the incident layer', () => {
+    renderWithContext()
+
+    expect(screen.getByTestId('incidentLayer')).toBeInTheDocument()
+  })
+
+  it('sends a request to fetch public incidents', async () => {
+    expect(get).not.toHaveBeenCalled()
+
+    renderWithContext()
+    await screen.findByTestId('incidentLayer')
+
+    expect(get).toHaveBeenCalledTimes(1)
+    expect(get).toHaveBeenCalledWith(
+      expect.stringContaining(configuration.GEOGRAPHY_PUBLIC_ENDPOINT)
+    )
+  })
+
+  it('renders markers', async () => {
+    jest.mocked(useFetch).mockImplementation(() => ({
+      ...useFetchResponse,
+      data: geography,
+    }))
+
+    const container = renderWithContext()
+    expect(container.getAllByAltText('Huisafval')).toHaveLength(numFeatures)
+  })
+})

--- a/src/signals/IncidentMap/components/IncidentLayer.tsx
+++ b/src/signals/IncidentMap/components/IncidentLayer.tsx
@@ -58,7 +58,7 @@ const IncidentLayer = () => {
 
   useEffect(() => {
     if (error) setMapMessage('Er konden geen meldingen worden opgehaald.')
-  })
+  }, [get])
 
   useEffect(() => {
     if (!bbox) return

--- a/src/signals/IncidentMap/components/IncidentLayer.tsx
+++ b/src/signals/IncidentMap/components/IncidentLayer.tsx
@@ -1,0 +1,75 @@
+/* SPDX-License-Identifier: MPL-2.0 */
+/* Copyright (C) 2022 Gemeente Amsterdam */
+
+import type { FeatureCollection, Feature as GeoJSONFeature } from 'geojson'
+import type { LatLngTuple } from 'leaflet'
+import type { Geometrie } from 'types/incident'
+
+import { useFetch } from 'hooks'
+import { useEffect } from 'react'
+import useBoundingBox from 'signals/incident/components/form/MapSelectors/hooks/useBoundingBox'
+import configuration from 'shared/services/configuration/configuration'
+import L from 'leaflet'
+import { Marker } from '@amsterdam/arm-core'
+import { featureToCoordinates } from 'shared/services/map-location'
+
+type Point = {
+  type: 'Point'
+  coordinates: LatLngTuple
+}
+
+type Properties = {
+  category: {
+    name: string
+  }
+  created_at: string
+}
+
+type Feature = GeoJSONFeature<Point, Properties>
+
+const IncidentLayer = () => {
+  const bbox = useBoundingBox()
+  const { get, data } = useFetch<FeatureCollection<Point, Properties>>()
+
+  const getMarker = (feature: Feature) => {
+    const coordinates = featureToCoordinates(feature.geometry as Geometrie)
+    const icon = L.icon({
+      iconSize: [24, 32],
+      iconUrl: '/assets/images/area-map/icon-pin.svg',
+    })
+    const { name } = feature.properties.category
+    const { created_at } = feature.properties
+
+    return (
+      <Marker
+        key={created_at}
+        options={{
+          icon,
+          alt: name,
+          keyboard: false,
+        }}
+        latLng={coordinates}
+      />
+    )
+  }
+
+  useEffect(() => {
+    if (!bbox) return
+
+    const { west, south, east, north } = bbox
+    const searchParams = new URLSearchParams({
+      bbox: `${west},${south},${east},${north}`,
+    })
+
+    get(`${configuration.GEOGRAPHY_PUBLIC_ENDPOINT}?${searchParams.toString()}`)
+  }, [get, bbox])
+
+  return (
+    <>
+      <span data-testid="incidentLayer" />
+      {data?.features.map((feature) => getMarker(feature))}
+    </>
+  )
+}
+
+export default IncidentLayer

--- a/src/signals/IncidentMap/components/IncidentLayer.tsx
+++ b/src/signals/IncidentMap/components/IncidentLayer.tsx
@@ -58,7 +58,7 @@ const IncidentLayer = () => {
 
   useEffect(() => {
     if (error) setMapMessage('Er konden geen meldingen worden opgehaald.')
-  }, [get])
+  }, [get, error])
 
   useEffect(() => {
     if (!bbox) return

--- a/src/signals/IncidentMap/components/IncidentMap.test.tsx
+++ b/src/signals/IncidentMap/components/IncidentMap.test.tsx
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (C) 2022 Gemeente Amsterdam
+import { render, screen } from '@testing-library/react'
+import { withAppContext } from 'test/utils'
+import useFetch from 'hooks/useFetch'
+import IncidentMap from './IncidentMap'
+import { get, mockUseMapInstance, useFetchResponse } from './mapTestUtils'
+
+jest.mock('@amsterdam/react-maps', () => ({
+  __esModule: true,
+  ...jest.requireActual('@amsterdam/react-maps'),
+  useMapInstance: jest.fn(() => mockUseMapInstance),
+}))
+
+jest.mock('hooks/useFetch')
+
+describe('<IncidentMap />', () => {
+  beforeEach(() => {
+    get.mockReset()
+    jest.mocked(useFetch).mockImplementation(() => useFetchResponse)
+  })
+
+  it('should render the incident map correctly', () => {
+    render(withAppContext(<IncidentMap />))
+
+    expect(screen.getByTestId('incidentMap')).toBeInTheDocument()
+    expect(screen.getByTestId('incidentLayer')).toBeInTheDocument()
+    expect(screen.getByTestId('mapZoom')).toBeInTheDocument()
+  })
+})

--- a/src/signals/IncidentMap/components/IncidentMap.tsx
+++ b/src/signals/IncidentMap/components/IncidentMap.tsx
@@ -1,8 +1,38 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2022 Gemeente Amsterdam
+import styled from 'styled-components'
+import Map from 'components/Map'
+import MAP_OPTIONS from 'shared/services/configuration/map-options'
 
-const IncidentMap = () => {
-  return <>hier kan de kaart komen</>
-}
+const Wrapper = styled.div`
+  position: absolute;
+  top: 65px; // to leave room for the footer
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: calc(100% - 65px);
+  width: 100%;
+  max-width: 1400px;
+  margin-left: auto;
+  margin-right: auto;
+  box-sizing: border-box;
+  display: flex;
+`
+
+const StyledMap = styled(Map)`
+  height: 100%;
+  width: 100%;
+`
+
+const IncidentMap = () => (
+  <Wrapper>
+    <StyledMap
+      data-testid="overviewMap"
+      hasZoomControls
+      fullScreen
+      mapOptions={MAP_OPTIONS}
+    ></StyledMap>
+  </Wrapper>
+)
 
 export default IncidentMap

--- a/src/signals/IncidentMap/components/IncidentMap.tsx
+++ b/src/signals/IncidentMap/components/IncidentMap.tsx
@@ -3,6 +3,7 @@
 import styled from 'styled-components'
 import Map from 'components/Map'
 import MAP_OPTIONS from 'shared/services/configuration/map-options'
+import IncidentLayer from './IncidentLayer'
 
 const Wrapper = styled.div`
   position: absolute;
@@ -30,8 +31,10 @@ const IncidentMap = () => (
       data-testid="overviewMap"
       hasZoomControls
       fullScreen
-      mapOptions={MAP_OPTIONS}
-    ></StyledMap>
+      mapOptions={{ ...MAP_OPTIONS, zoom: 9 }}
+    >
+      <IncidentLayer />
+    </StyledMap>
   </Wrapper>
 )
 

--- a/src/signals/IncidentMap/components/IncidentMap.tsx
+++ b/src/signals/IncidentMap/components/IncidentMap.tsx
@@ -7,7 +7,7 @@ import IncidentLayer from './IncidentLayer'
 
 const Wrapper = styled.div`
   position: absolute;
-  top: 65px; // to leave room for the footer
+  top: 65px; // to leave room for the heading
   left: 0;
   right: 0;
   bottom: 0;

--- a/src/signals/IncidentMap/components/IncidentMap.tsx
+++ b/src/signals/IncidentMap/components/IncidentMap.tsx
@@ -28,7 +28,7 @@ const StyledMap = styled(Map)`
 const IncidentMap = () => (
   <Wrapper>
     <StyledMap
-      data-testid="overviewMap"
+      data-testid="incidentMap"
       hasZoomControls
       fullScreen
       mapOptions={{ ...MAP_OPTIONS, zoom: 9 }}

--- a/src/signals/IncidentMap/components/mapTestUtils.ts
+++ b/src/signals/IncidentMap/components/mapTestUtils.ts
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (C) 2022 Gemeente Amsterdam
+export const east = 4.899032528058569
+export const north = 52.36966337175116
+export const south = 52.36714374096002
+export const west = 4.8958566562555035
+
+export const mockGetBounds = jest.fn(() => ({
+  getEast: () => east,
+  getNorth: () => north,
+  getSouth: () => south,
+  getWest: () => west,
+}))
+
+export const mockUseMapInstance = {
+  addLayer: jest.fn(),
+  getBounds: mockGetBounds,
+  removeLayer: jest.fn(),
+  on: jest.fn(),
+  off: jest.fn(),
+  getZoom: jest.fn(),
+}
+
+export const get = jest.fn()
+export const patch = jest.fn()
+export const post = jest.fn()
+export const put = jest.fn()
+
+export const useFetchResponse = {
+  get,
+  patch,
+  post,
+  put,
+  data: undefined,
+  isLoading: false,
+  error: false,
+  isSuccess: false,
+}

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/NearbyLayer/NearbyLayer.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/NearbyLayer/NearbyLayer.test.tsx
@@ -11,48 +11,18 @@ import MAP_OPTIONS from 'shared/services/configuration/map-options'
 
 import Map from 'components/Map'
 import type { FeatureCollection } from 'geojson'
+import {
+  get,
+  mockUseMapInstance,
+  useFetchResponse,
+} from 'signals/IncidentMap/components/mapTestUtils'
 import * as useLayerVisible from '../../../hooks/useLayerVisible'
 import withAssetSelectContext from '../../__tests__/withAssetSelectContext'
 import { WfsDataProvider } from '../WfsLayer/context'
 import NearbyLayer, { findAssetMatch, nearbyMarkerIcon } from './NearbyLayer'
 
-const east = 4.899032528058569
-const north = 52.36966337175116
-const south = 52.36714374096002
-const west = 4.8958566562555035
-
-const mockGetBounds = jest.fn(() => ({
-  getEast: () => east,
-  getNorth: () => north,
-  getSouth: () => south,
-  getWest: () => west,
-}))
-
-const mockUseMapInstance = {
-  addLayer: jest.fn(),
-  getBounds: mockGetBounds,
-  removeLayer: jest.fn(),
-  on: jest.fn(),
-  off: jest.fn(),
-  getZoom: jest.fn(),
-}
 const category = 'afval'
 const subcategory = 'huisvuil'
-const get = jest.fn()
-const patch = jest.fn()
-const post = jest.fn()
-const put = jest.fn()
-
-const useFetchResponse = {
-  get,
-  patch,
-  post,
-  put,
-  data: undefined,
-  isLoading: false,
-  error: false,
-  isSuccess: false,
-}
 
 jest.mock('@amsterdam/react-maps', () => ({
   __esModule: true,


### PR DESCRIPTION
`/meldingenkaart` now shows the Amsterdam map and markers for all (publicly accessible) incidents

## Signalen

Before opening a pull request, please ensure:

- [x] Double-check your branch is based on `develop` and targets `develop`
- [x] Pull request has tests (we are going for 100% coverage!)
- [x] Code is well-commented, linted and follows project conventions
- [x] Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
