### PR TITLE
SIG-4703: add aria expended labels

### DIFF
--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.tsx
@@ -251,7 +251,7 @@ const DetailPanel: FC<DetailPanelProps> = ({ language = {} }) => {
             items={legendItems}
           />
 
-          <LegendToggleButton onClick={toggleLegend} />
+          <LegendToggleButton onClick={toggleLegend} isOpen={showLegendPanel} />
         </>
       )}
 
@@ -266,7 +266,7 @@ const DetailPanel: FC<DetailPanelProps> = ({ language = {} }) => {
               size={24}
               title="Terug"
               variant="blank"
-            />
+            /> 
             <StyledPDOKAutoSuggest
               onClear={clearInput}
               onData={setOptionsList}

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.tsx
@@ -256,10 +256,12 @@ const DetailPanel: FC<DetailPanelProps> = ({ language = {} }) => {
       )}
 
       {showAddressPanel && shouldRenderAddressPanel && (
-        <AddressPanel data-testid="addressPanel">
+        <AddressPanel data-testid="addressPanel" id="addressPanel">
           <header>
             <Button
               aria-label="Terug"
+              aria-expanded={showAddressPanel}
+              aria-controls="addressPanel"
               icon={<ChevronLeft />}
               iconSize={16}
               onClick={closeAddressPanel}

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.tsx
@@ -268,7 +268,7 @@ const DetailPanel: FC<DetailPanelProps> = ({ language = {} }) => {
               size={24}
               title="Terug"
               variant="blank"
-            /> 
+            />
             <StyledPDOKAutoSuggest
               onClear={clearInput}
               onData={setOptionsList}

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/LegendPanel/LegendPanel.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/LegendPanel/LegendPanel.tsx
@@ -22,6 +22,7 @@ const LegendPanel: FunctionComponent<LegendPanelProps> = ({
   <Panel
     className={`${className} ${slide}`}
     data-testid="legendPanel"
+    id="legendPanel"
     slide={slide}
   >
     <Title>Uitleg</Title>

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/LegendPanel/LegendPanel.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/LegendPanel/LegendPanel.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2021 Gemeente Amsterdam
+// Copyright (C) 2021- 2022 Gemeente Amsterdam
 import type { FunctionComponent } from 'react'
 import IconList, { IconListItem } from 'components/IconList/IconList'
 

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/LegendToggleButton/LegendToggleButton.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/LegendToggleButton/LegendToggleButton.test.tsx
@@ -15,7 +15,7 @@ describe('LegendToggleButton', () => {
   })
 
   it('handles onClick', () => {
-    render(withAppContext(<LegendToggleButton onClick={onClick} />))
+    render(withAppContext(<LegendToggleButton onClick={onClick} isOpen={false}/>))
 
     expect(onClick).not.toHaveBeenCalled()
 

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/LegendToggleButton/LegendToggleButton.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/LegendToggleButton/LegendToggleButton.test.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2021 Gemeente Amsterdam
+// Copyright (C) 2021 - 2022 Gemeente Amsterdam
 import userEvent from '@testing-library/user-event'
 import { render, screen } from '@testing-library/react'
 

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/LegendToggleButton/LegendToggleButton.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/LegendToggleButton/LegendToggleButton.tsx
@@ -9,6 +9,7 @@ import Button from 'components/Button'
 
 export interface LegendToggleButtonProps {
   className?: string
+  isOpen: boolean
   onClick: () => void
 }
 
@@ -24,15 +25,18 @@ const StyledButton = styled(Button)`
 
 const LegendToggleButton: FC<LegendToggleButtonProps> = ({
   className,
+  isOpen,
   onClick,
 }) => (
   <StyledButton
-    data-testid="legendToggleButton"
+    aria-controls="legendPanel"
+    aria-expanded={isOpen}
     className={className}
-    type="button"
-    variant="blank"
+    data-testid="legendToggleButton"
     onClick={onClick}
     tabIndex={0}
+    type="button"
+    variant="blank"
   >
     Uitleg
   </StyledButton>

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/LegendToggleButton/LegendToggleButton.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/LegendToggleButton/LegendToggleButton.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2021 Gemeente Amsterdam
+// Copyright (C) 2021 - 2022 Gemeente Amsterdam
 import styled from 'styled-components'
 import { themeColor } from '@amsterdam/asc-ui'
 


### PR DESCRIPTION
Ticket: [SIG-4703](https://datapunt.atlassian.net/browse/SIG-4703)

## Context
The "Uitleg" and mobile address search input overlay did not have an aria-expanded label.

## Changes
- Added the label to the "Uitleg" button that closes/opens the uitleg overlay
- Since there is not 1 button that controls the open/close of the search input I have put the aria-expanded label to the back button of the screen.

## Signalen

- [x] Double-check your branch is based on `develop` and targets `develop`
- [x] Pull request has tests (we are going for 100% coverage!)
- [x] Code is well-commented, linted and follows project conventions
- [x] Committed source code is headed by the correct SPDX license expression
