### PR TITLE
[SIG-4700] change breakpoint searchbar overlay

### DIFF
--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.tsx
@@ -275,6 +275,7 @@ const DetailPanel: FC<DetailPanelProps> = ({ language = {} }) => {
               showInlineList={false}
               value={addressValue}
               placeholder="Zoek adres of postcode"
+              autoFocus={true}
             />
           </header>
 

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.tsx
@@ -56,7 +56,8 @@ const nearbyLegendItem = {
 
 const DetailPanel: FC<DetailPanelProps> = ({ language = {} }) => {
   const shouldRenderAddressPanel = useMediaQuery({
-    query: breakpoint('max-width', 'tabletM')({ theme: ascDefaultTheme }),
+    // Set breakpoint to mobile instead of tablet since desktop will get the mobile version when zoom on 200% which is not accesible with keyboard.
+    query: breakpoint('max-width', 'mobileL')({ theme: ascDefaultTheme }),
   })
   const [showLegendPanel, setShowLegendPanel] = useState(false)
   const [optionsList, setOptionsList] = useState(null)


### PR DESCRIPTION
## Context
When a user tried to search for an address on 200% zoom on a desktop, the mobile overlay (fuill screen search) was triggered because it is depending on the amount of pixels, but this is unaccessible with mobile. 

## Changes
- Changed the breakpoint to MobileL so the mobile overlay will only be triggered with mobiles and not tablets.
- Set autofocus to search input when overlay appears

## Signalen

- [x] Double-check your branch is based on `develop` and targets `develop`
- [x] Pull request has tests (we are going for 100% coverage!)
- [x] Code is well-commented, linted and follows project conventions
- [x] Committed source code is headed by the correct SPDX license expression