### PR TITLE
[SIG 4661] Improvements incident map header

### DIFF
--- a/src/components/SiteHeader/incidentMapStyles.ts
+++ b/src/components/SiteHeader/incidentMapStyles.ts
@@ -1,23 +1,29 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2022 Gemeente Amsterdam
 import styled from 'styled-components'
-import { MenuButton, themeColor, themeSpacing } from '@amsterdam/asc-ui'
+import { breakpoint, themeColor, themeSpacing } from '@amsterdam/asc-ui'
 
 export const IncidentMapHeaderWrapper = styled.div`
+  position: relative;
+  z-index: 9;
   display: flex;
-  height: ${themeSpacing(16)};
+  height: ${themeSpacing(20)};
   width: 100%;
   max-width: 1400px;
   margin-left: auto;
   margin-right: auto;
-  border-bottom: ${themeSpacing(1)} solid ${themeColor('tint', 'level3')};
+  box-shadow: 0 ${themeSpacing(1)} ${themeSpacing(1)} 0 rgba(0, 0, 0, 0.1);
+  @media screen and (${breakpoint('max-width', 'tabletS')}) {
+    height: ${themeSpacing(14)};
+  }
 `
 export const IncidentMapHeader = styled.div`
   background-color: ${themeColor('tint', 'level1')};
   justify-content: space-between;
+  align-items: center;
   display: flex;
   flex-direction: row;
-  padding: 0 ${themeSpacing(3)};
+  padding: 0 ${themeSpacing(6)};
   width: 100%;
   height: 100%;
 `
@@ -30,22 +36,24 @@ export const Title = styled.div`
 export const Wrapper = styled.div`
   display: flex;
   align-items: center;
-  padding: 10px 0;
+  padding: ${themeSpacing(5)} 0;
+  @media screen and (${breakpoint('max-width', 'tabletS')}) {
+    padding: ${themeSpacing(3)} 0;
+  }
   margin-right: ${themeSpacing(1)};
   a {
     height: 100%;
     width: auto;
+
     img {
-      display: inline-block;
+      display: flex;
       margin-right: ${themeSpacing(3)};
       height: 100%;
-      width: auto;
+      max-width: 90px;
     }
   }
-`
-
-export const IncidentMapMenuButton = styled(MenuButton)`
-  @media screen and (max-width: 576px) {
-    display: none;
+  h2 {
+    display: inline-flex;
+    margin: 0;
   }
 `

--- a/src/components/SiteHeader/index.js
+++ b/src/components/SiteHeader/index.js
@@ -27,12 +27,12 @@ import useIsIncidentMap from 'hooks/useIsIncidentMap'
 import {
   IncidentMapHeader,
   IncidentMapHeaderWrapper,
-  IncidentMapMenuButton,
   Title,
   Wrapper,
 } from './incidentMapStyles'
 
 const MENU_BREAKPOINT = 1320
+const INCIDENT_MAP_MENU_BREAKPOINT = 540
 
 const StyledHeader = styled(HeaderComponent)`
   ${({ isFrontOffice, tall }) =>
@@ -291,6 +291,9 @@ export const SiteHeader = (props) => {
   const rendersMenuToggle = useMediaQuery({
     query: `(max-width: ${MENU_BREAKPOINT}px)`,
   })
+  const rendersIncidentMapMenuToggle = useMediaQuery({
+    query: `(max-width: ${INCIDENT_MAP_MENU_BREAKPOINT}px)`,
+  })
   const isFrontOffice = useIsFrontOffice()
   const isIncidentMap = useIsIncidentMap()
   const tall = isFrontOffice && !getIsAuthenticated()
@@ -314,17 +317,22 @@ export const SiteHeader = (props) => {
     [props, menuOpen, rendersMenuToggle]
   )
 
-  const IncidentMapNavigation = () => (
+  const IncidentMapMenuItems = () => (
     <MenuItem>
-      <IncidentMapMenuButton
-        forwardedAs="a"
-        href="/incident/beschrijf"
-        target="_blank"
-      >
+      <MenuButton forwardedAs="a" href="/incident/beschrijf" target="_blank">
         Doe een melding
-      </IncidentMapMenuButton>
+      </MenuButton>
     </MenuItem>
   )
+
+  const IncidentMapNavigation = () =>
+    rendersIncidentMapMenuToggle ? (
+      <MenuToggle align="right" open={menuOpen} onExpand={setMenuOpen}>
+        <IncidentMapMenuItems />
+      </MenuToggle>
+    ) : (
+      <IncidentMapMenuItems />
+    )
 
   return !isIncidentMap ? (
     <>

--- a/src/components/SiteHeader/index.js
+++ b/src/components/SiteHeader/index.js
@@ -8,6 +8,7 @@ import { useMediaQuery } from 'react-responsive'
 import { Logout as LogoutIcon } from '@amsterdam/asc-assets'
 import {
   Header as HeaderComponent,
+  Hidden,
   MenuButton,
   MenuInline,
   MenuItem,
@@ -32,7 +33,6 @@ import {
 } from './incidentMapStyles'
 
 const MENU_BREAKPOINT = 1320
-const INCIDENT_MAP_MENU_BREAKPOINT = 540
 
 const StyledHeader = styled(HeaderComponent)`
   ${({ isFrontOffice, tall }) =>
@@ -291,9 +291,6 @@ export const SiteHeader = (props) => {
   const rendersMenuToggle = useMediaQuery({
     query: `(max-width: ${MENU_BREAKPOINT}px)`,
   })
-  const rendersIncidentMapMenuToggle = useMediaQuery({
-    query: `(max-width: ${INCIDENT_MAP_MENU_BREAKPOINT}px)`,
-  })
   const isFrontOffice = useIsFrontOffice()
   const isIncidentMap = useIsIncidentMap()
   const tall = isFrontOffice && !getIsAuthenticated()
@@ -325,14 +322,18 @@ export const SiteHeader = (props) => {
     </MenuItem>
   )
 
-  const IncidentMapNavigation = () =>
-    rendersIncidentMapMenuToggle ? (
-      <MenuToggle align="right" open={menuOpen} onExpand={setMenuOpen}>
+  const IncidentMapNavigation = () => (
+    <>
+      <Hidden minBreakpoint="tabletS">
+        <MenuToggle align="right" open={menuOpen} onExpand={setMenuOpen}>
+          <IncidentMapMenuItems />
+        </MenuToggle>
+      </Hidden>
+      <Hidden maxBreakpoint="tabletS">
         <IncidentMapMenuItems />
-      </MenuToggle>
-    ) : (
-      <IncidentMapMenuItems />
-    )
+      </Hidden>
+    </>
+  )
 
   return !isIncidentMap ? (
     <>

--- a/src/containers/App/index.tsx
+++ b/src/containers/App/index.tsx
@@ -30,6 +30,7 @@ import { makeSelectLoading, makeSelectSources } from './selectors'
 const ContentContainer = styled.div<{
   padding: { top: number; bottom: number }
 }>`
+  position: relative;
   background-color: #ffffff;
   flex: 1 0 auto;
   margin: 0 auto;


### PR DESCRIPTION
At `/meldingenkaart`
Implemented Linda's comments:

General
Lijn onder de navigatie is een drop-shadow

Desktop

Height navigatiebar: 80px
Margin logo top-bottom: 20px
Margin logo left: 24px

Mobiel

Height navigatiebar: 56px
Margin logo top-bottom: 12px
Margin logo left: 20px

Hamburger menu

Another request was to remove the footer. This has already been implemented in SIG-4621.

## Signalen

Before opening a pull request, please ensure:

- [x] Double-check your branch is based on `develop` and targets `develop`
- [x] Pull request has tests (we are going for 100% coverage!)
- [x] Code is well-commented, linted and follows project conventions
- [x] Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
