### PR TITLE
[SIG 4661] Fix hamburger menu, hide attribution text, remove space above map

### DIFF
--- a/src/components/SiteHeader/incidentMapStyles.ts
+++ b/src/components/SiteHeader/incidentMapStyles.ts
@@ -1,7 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2022 Gemeente Amsterdam
 import styled from 'styled-components'
-import { breakpoint, themeColor, themeSpacing } from '@amsterdam/asc-ui'
+import {
+  breakpoint,
+  MenuToggle,
+  themeColor,
+  themeSpacing,
+} from '@amsterdam/asc-ui'
 
 export const IncidentMapHeaderWrapper = styled.div`
   position: relative;
@@ -23,9 +28,23 @@ export const IncidentMapHeader = styled.div`
   align-items: center;
   display: flex;
   flex-direction: row;
-  padding: 0 ${themeSpacing(6)};
   width: 100%;
   height: 100%;
+  padding: 0 ${themeSpacing(6)};
+  @media screen and (${breakpoint('max-width', 'tabletS')}) {
+    padding: 0 0 0 ${themeSpacing(6)};
+  }
+`
+
+export const StyledMenuToggle = styled(MenuToggle)`
+  button {
+    background-color: ${themeColor('tint', 'level2')};
+    width: ${themeSpacing(14)};
+    height: ${themeSpacing(14)};
+  }
+  ul {
+    top: ${themeSpacing(14)} !important;
+  }
 `
 
 export const Title = styled.div`

--- a/src/components/SiteHeader/index.js
+++ b/src/components/SiteHeader/index.js
@@ -28,6 +28,7 @@ import useIsIncidentMap from 'hooks/useIsIncidentMap'
 import {
   IncidentMapHeader,
   IncidentMapHeaderWrapper,
+  StyledMenuToggle,
   Title,
   Wrapper,
 } from './incidentMapStyles'
@@ -325,9 +326,9 @@ export const SiteHeader = (props) => {
   const IncidentMapNavigation = () => (
     <>
       <Hidden minBreakpoint="tabletS">
-        <MenuToggle align="right" open={menuOpen} onExpand={setMenuOpen}>
+        <StyledMenuToggle align="right" open={menuOpen} onExpand={setMenuOpen}>
           <IncidentMapMenuItems />
-        </MenuToggle>
+        </StyledMenuToggle>
       </Hidden>
       <Hidden maxBreakpoint="tabletS">
         <IncidentMapMenuItems />

--- a/src/signals/IncidentMap/components/IncidentMap.tsx
+++ b/src/signals/IncidentMap/components/IncidentMap.tsx
@@ -7,11 +7,11 @@ import IncidentLayer from './IncidentLayer'
 
 const Wrapper = styled.div`
   position: absolute;
-  top: 65px; // to leave room for the heading
+  top: 0;
   left: 0;
   right: 0;
   bottom: 0;
-  height: calc(100% - 65px);
+  height: 100%;
   width: 100%;
   max-width: 1400px;
   margin-left: auto;
@@ -31,7 +31,7 @@ const IncidentMap = () => (
       data-testid="incidentMap"
       hasZoomControls
       fullScreen
-      mapOptions={{ ...MAP_OPTIONS, zoom: 9 }}
+      mapOptions={{ ...MAP_OPTIONS, zoom: 9, attributionControl: false }}
     >
       <IncidentLayer />
     </StyledMap>


### PR DESCRIPTION
As discussed with Linda, several adjustments were made:
- The hamburger menu always has a grey background (not just on hover).
- The hamburger height equals the height of the navigation bar and is a square.
- The hamburger is positioned with 0px padding to the right.
- The menu item list appears below the navigation bar.
- The attribution text of the map is hidden.
- The space between the navigation bar and the map has been removed.

## Signalen

Before opening a pull request, please ensure:

- [x] Double-check your branch is based on `develop` and targets `develop`
- [x] Pull request has tests (we are going for 100% coverage!)
- [x] Code is well-commented, linted and follows project conventions
- [x] Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
