### PR TITLE
add focus option to legend panel

### DIFF
--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.test.tsx
@@ -501,6 +501,14 @@ describe('DetailPanel', () => {
     expect(screen.getByTestId('legendPanel')).toHaveClass('in')
   })
 
+  it('renders the legend panel with focus on close button', () => {
+    render(withAssetSelectContext(<DetailPanel {...props} />))
+
+    userEvent.click(screen.getByTestId('legendToggleButton'))
+
+    expect(screen.getByTestId('close-button')).toHaveFocus()
+  })
+
   it('does not render the address panel', () => {
     jest.spyOn(reactResponsive, 'useMediaQuery').mockReturnValue(false)
     render(withAssetSelectContext(<DetailPanel {...props} />))

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2021 - 2022 Gemeente Amsterdam
-import { useCallback, useState, useContext } from 'react'
+import { useCallback, useState, useContext, useRef, useEffect } from 'react'
 import {
   Paragraph,
   Label,
@@ -60,6 +60,7 @@ const DetailPanel: FC<DetailPanelProps> = ({ language = {} }) => {
     query: breakpoint('max-width', 'mobileL')({ theme: ascDefaultTheme }),
   })
   const [showLegendPanel, setShowLegendPanel] = useState(false)
+  const buttonRef = useRef<HTMLButtonElement>(null)
   const [optionsList, setOptionsList] = useState(null)
 
   const [showAddressPanel, setShowAddressPanel] = useState(false)
@@ -159,6 +160,12 @@ const DetailPanel: FC<DetailPanelProps> = ({ language = {} }) => {
     setOptionsList(null)
   }, [removeItem])
 
+  useEffect(() => {
+    if (buttonRef?.current && showLegendPanel) {
+      buttonRef.current.focus()
+    }
+  }, [buttonRef, showLegendPanel])
+
   return (
     <PanelContent
       data-testid="detailPanel"
@@ -250,6 +257,7 @@ const DetailPanel: FC<DetailPanelProps> = ({ language = {} }) => {
             onClose={toggleLegend}
             slide={showLegendPanel ? 'in' : 'out'}
             items={legendItems}
+            buttonRef={buttonRef}
           />
 
           <LegendToggleButton onClick={toggleLegend} isOpen={showLegendPanel} />

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/LegendPanel/LegendPanel.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/LegendPanel/LegendPanel.test.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2021 Gemeente Amsterdam
+// Copyright (C) 2021 - 2022 Gemeente Amsterdam
 import { render, screen } from '@testing-library/react'
 import 'jest-styled-components'
 
@@ -18,6 +18,7 @@ describe('LegendPanel', () => {
         label: 'label',
       },
     ],
+    buttonRef: jest.fn(),
   }
 
   it('render correctly', () => {
@@ -31,7 +32,15 @@ describe('LegendPanel', () => {
   })
 
   it('renders with empty items', () => {
-    render(withAppContext(<LegendPanel items={[]} onClose={props.onClose} />))
+    render(
+      withAppContext(
+        <LegendPanel
+          items={[]}
+          onClose={props.onClose}
+          buttonRef={props.buttonRef}
+        />
+      )
+    )
 
     expect(screen.queryAllByRole('listitem').length).toBe(0)
   })

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/LegendPanel/LegendPanel.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/LegendPanel/LegendPanel.tsx
@@ -11,6 +11,7 @@ export interface LegendPanelProps {
   items: { id: string; iconUrl: string; label: string }[]
   onClose: () => void
   slide?: 'in' | 'out'
+  buttonRef: React.ForwardedRef<HTMLButtonElement>
 }
 
 const LegendPanel: FunctionComponent<LegendPanelProps> = ({
@@ -18,6 +19,7 @@ const LegendPanel: FunctionComponent<LegendPanelProps> = ({
   items,
   onClose,
   slide = 'out',
+  buttonRef,
 }) => (
   <Panel
     className={`${className} ${slide}`}
@@ -27,7 +29,13 @@ const LegendPanel: FunctionComponent<LegendPanelProps> = ({
   >
     <Title>Uitleg</Title>
 
-    <CloseBtn tabIndex={-1} title="Sluit uitleg" onClick={onClose} />
+    <CloseBtn
+      data-testid="close-button"
+      ref={buttonRef}
+      tabIndex={0}
+      title="Sluit uitleg"
+      onClick={onClose}
+    />
 
     <ScrollWrapper>
       <IconList data-testid="legendPanelList">


### PR DESCRIPTION
## Context
When the legend panel was open it was not possible to close it with a keyboard since you cannot focus on the close button.

## Changes
- set tabindex to 0
- added a ref to the button so it is focussed when the legend opens

## Signalen

- [x] Double-check your branch is based on `develop` and targets `develop`
- [x] Pull request has tests (we are going for 100% coverage!)
- [x] Code is well-commented, linted and follows project conventions
- [x] Committed source code is headed by the correct SPDX license expression
