### PR TITLE
[SIG-4721] word added after comment from Linda

### DIFF
--- a/src/signals/incident/containers/KtoContainer/index.js
+++ b/src/signals/incident/containers/KtoContainer/index.js
@@ -73,7 +73,7 @@ export const successSections = configuration.featureFlags
     }
 
 export const contactAllowedText =
-  '\n U ontvangt direct een e-mail met een overzicht van uw reactie. Binnen 3 werkdagen leest u wat wij ermee doen.'
+  '\n U ontvangt direct een e-mail met een overzicht van uw reactie. Binnen 3 werkdagen leest u wat wij ermee gaan doen.'
 
 // eslint-disable-next-line consistent-return
 const reactReducer = (state, action) => {


### PR DESCRIPTION
**Context:**
Linda's comment after testing: @Siree Wijkstra Getest: alleen het woord gaan mist nog, in “wat wij ermee gaan doen”. Verder klopt het

**Changes:**
'gaan' has been added.
Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
