### PR TITLE
[SIG 4662] Styling cluster icons in meldingenkaart

### DIFF
--- a/src/components/MarkerCluster/style.css
+++ b/src/components/MarkerCluster/style.css
@@ -1,9 +1,13 @@
 /* SPDX-License-Identifier: MPL-2.0 */
-/* Copyright (C) 2021 Gemeente Amsterdam */
+/* Copyright (C) 2021 - 2022 Gemeente Amsterdam */
 .marker-cluster {
   color: #ffffff;
   background-color: #ffffff;
   box-shadow: 1px 1px 1px #666666;
+}
+
+.marker-cluster.large {
+  border-radius: 50%;
 }
 
 .marker-cluster div {
@@ -14,8 +18,23 @@
   background-color: #004699;
 }
 
+.marker-cluster.large div {
+  width: 48px;
+  height: 48px;
+  margin-top: 2px;
+  margin-left: 2px;
+  border-radius: 50%;
+}
+
 .marker-cluster span {
   line-height: 34px;
+}
+
+.marker-cluster.large span {
+  font-family: Avenir Next;
+  font-size: 16px;
+  font-weight: 500;
+  line-height: 48px;
 }
 
 .marker-cluster--selected > div {

--- a/src/signals/IncidentMap/components/IncidentLayer.tsx
+++ b/src/signals/IncidentMap/components/IncidentLayer.tsx
@@ -15,6 +15,7 @@ import { featureToCoordinates } from 'shared/services/map-location'
 import { MapMessage } from 'signals/incident/components/form/MapSelectors/components/MapMessage'
 import MarkerCluster from 'components/MarkerCluster'
 import { incidentIcon } from 'shared/services/configuration/map-markers'
+import type { MarkerCluster as MarkerClusterType } from 'leaflet'
 
 type Point = {
   type: 'Point'
@@ -32,6 +33,13 @@ type Properties = {
 const clusterLayerOptions = {
   zoomToBoundsOnClick: true,
   chunkedLoading: true,
+  iconCreateFunction: (cluster: MarkerClusterType) => {
+    return new L.DivIcon({
+      html: `<div><span>${cluster.getChildCount()}</span></div>`,
+      className: 'marker-cluster large',
+      iconSize: new L.Point(52, 52),
+    })
+  },
 }
 
 const IncidentLayer = () => {


### PR DESCRIPTION
Styling adjustments of cluster icons in meldingenkaart according Linda's specs:

Witte bol
Height: 52px
Width: 52px

Blauwe bol
Height: 48px
Width: 48px

Cijfer in de bol
Font-family: Avenir Next LT Pro (kan zijn dat dat in de code alleen Avenir Next is)
Font-size: 16px
Font-weight: 500 
Line-height: 48px

## Signalen

Before opening a pull request, please ensure:

- [x] Double-check your branch is based on `develop` and targets `develop`
- [x] Pull request has tests (we are going for 100% coverage!)
- [x] Code is well-commented, linted and follows project conventions
- [x] Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
