### PR TITLE
Add feature flag to hide meldingenkaart url

### DIFF
--- a/app.amsterdam.json
+++ b/app.amsterdam.json
@@ -2,20 +2,22 @@
   "apiBaseUrl": "https://acc.api.data.amsterdam.nl",
   "areaTypeCodeForDistrict": "stadsdeel",
   "featureFlags": {
+    "appMode": true,
     "assignSignalToDepartment": false,
     "assignSignalToEmployee": false,
+    "enableAmsterdamSpecificOverigCategories": true,
     "enableCsvExport": false,
     "enableNearIncidents": true,
+    "enablePublicIncidentsMap": false,
     "enablePublicSignalMap": false,
     "enableReporter": true,
-    "enableAmsterdamSpecificOverigCategories": true,
     "fetchDistrictsFromBackend": false,
     "fetchQuestionsFromBackend": false,
     "mapFilter24Hours": true,
+    "reporterMailHandledNegativeContactEnabled": true,
     "showThorButton": true,
     "showVulaanControls": true,
-    "useProjectenSignalType": false,
-    "reporterMailHandledNegativeContactEnabled": true
+    "useProjectenSignalType": false
   },
   "head": {
     "androidIcon": "/icon_192x192.png",

--- a/app.base.json
+++ b/app.base.json
@@ -5,18 +5,19 @@
     "appMode": false,
     "assignSignalToDepartment": false,
     "assignSignalToEmployee": false,
+    "enableAmsterdamSpecificOverigCategories": false,
     "enableCsvExport": false,
     "enableNearIncidents": false,
+    "enablePublicIncidentsMap": false,
     "enablePublicSignalMap": false,
     "enableReporter": false,
-    "enableAmsterdamSpecificOverigCategories": false,
     "fetchDistrictsFromBackend": false,
     "fetchQuestionsFromBackend": false,
     "mapFilter24Hours": false,
+    "reporterMailHandledNegativeContactEnabled": true,
     "showThorButton": false,
     "showVulaanControls": false,
-    "useProjectenSignalType": false,
-    "reporterMailHandledNegativeContactEnabled": true
+    "useProjectenSignalType": false
   },
   "head": {
     "androidIcon": "/icon_192x192.png",

--- a/internals/schemas/app.schema.json
+++ b/internals/schemas/app.schema.json
@@ -92,6 +92,10 @@
           "description": "Enable category translations that are specific for Amsterdam.",
           "type": "boolean"
         },
+        "enablePublicIncidentsMap": {
+          "description": "Feature switch to enable the /meldingenkaart route where a public map is shown with all public available incidents.",
+          "type": "boolean"
+        },
         "fetchDistrictsFromBackend": {
           "description": "Feature switch to use the areas endpoint to fetch districts, instead of using the hardcoded stadsdelen",
           "type": "boolean"
@@ -118,10 +122,6 @@
         },
         "reporterMailHandledNegativeContactEnabled": {
           "description": "When true, will show a feedback text based on the satisfaction value yes or no.",
-          "type": "boolean"
-        },
-        "appMode": {
-          "description": "When true, will render the application in app mode, hiding specific UI elements",
           "type": "boolean"
         }
       },

--- a/src/containers/App/index.tsx
+++ b/src/containers/App/index.tsx
@@ -1,27 +1,26 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2018 - 2022 Gemeente Amsterdam
 import { Fragment, useEffect, lazy, Suspense, useMemo } from 'react'
-import styled from 'styled-components'
-import { Switch, Route, Redirect, useHistory } from 'react-router-dom'
+
 import { useDispatch, useSelector } from 'react-redux'
+import { Switch, Route, Redirect, useHistory } from 'react-router-dom'
+import styled from 'styled-components'
 
-import { getIsAuthenticated } from 'shared/services/auth/auth'
-
-import { fetchCategories as fetchCategoriesAction } from 'models/categories/actions'
-import { fetchDepartments as fetchDepartmentsAction } from 'models/departments/actions'
 import Footer from 'components/FooterContainer'
 import LoadingIndicator from 'components/LoadingIndicator'
-import ThemeProvider from 'components/ThemeProvider'
 import { Toegankelijkheidsverklaring } from 'components/pages/ArticlePage'
+import ThemeProvider from 'components/ThemeProvider'
 import SiteHeaderContainer from 'containers/SiteHeader'
+import useIsFrontOffice from 'hooks/useIsFrontOffice'
+import useLocationReferrer from 'hooks/useLocationReferrer'
+import { fetchCategories as fetchCategoriesAction } from 'models/categories/actions'
+import { fetchDepartments as fetchDepartmentsAction } from 'models/departments/actions'
+import { getIsAuthenticated } from 'shared/services/auth/auth'
 import configuration from 'shared/services/configuration/configuration'
 import IncidentContainer from 'signals/incident/containers/IncidentContainer'
-import IncidentReplyContainer from 'signals/incident/containers/IncidentReplyContainer'
-import IncidentOverviewContainer from 'signals/incident/containers/IncidentOverviewContainer'
-
 import { resetIncident } from 'signals/incident/containers/IncidentContainer/actions'
-import useLocationReferrer from 'hooks/useLocationReferrer'
-import useIsFrontOffice from 'hooks/useIsFrontOffice'
+import IncidentOverviewContainer from 'signals/incident/containers/IncidentOverviewContainer'
+import IncidentReplyContainer from 'signals/incident/containers/IncidentReplyContainer'
 
 import { getSources } from './actions'
 import AppContext from './context'
@@ -116,10 +115,12 @@ export const AppContainer = () => {
                 <Redirect exact from="/manage" to="/manage/incidents" />
                 <Route path="/manage" component={IncidentManagementModule} />
                 <Route path="/instellingen" component={SettingsModule} />
-                <Route
-                  path="/meldingenkaart"
-                  component={IncidentMapContainer}
-                />
+                {configuration.featureFlags.enablePublicIncidentsMap && (
+                  <Route
+                    path="/meldingenkaart"
+                    component={IncidentMapContainer}
+                  />
+                )}
                 <Route
                   path="/incident/reactie/:uuid"
                   component={IncidentReplyContainer}


### PR DESCRIPTION
## Context
The public incidents map is developed in fases. We do no want to show the url before it is functional.

## Changes
- Add feature flag `enablePublicIncidentsMap`
- remove duplicate "appMode" in app.schema.json
