### PR TITLE
set feature flag appMode=false

### DIFF
--- a/app.amsterdam.json
+++ b/app.amsterdam.json
@@ -2,7 +2,6 @@
   "apiBaseUrl": "https://acc.api.data.amsterdam.nl",
   "areaTypeCodeForDistrict": "stadsdeel",
   "featureFlags": {
-    "appMode": true,
     "assignSignalToDepartment": false,
     "assignSignalToEmployee": false,
     "enableAmsterdamSpecificOverigCategories": true,


### PR DESCRIPTION
The feature flag appMode was accidently set to true in [this PR](https://github.com/Amsterdam/signals-frontend/commit/e04fb41fd6f493857ddd1722e6b9ca24f82a3694).