### PR TITLE
Change maxLength validators to more descriptive ones.

### DIFF
--- a/src/signals/incident/definitions/wizard-step-1-beschrijf.js
+++ b/src/signals/incident/definitions/wizard-step-1-beschrijf.js
@@ -1,15 +1,16 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2018 - 2022 Gemeente Amsterdam
-import some from 'lodash/some'
 import memoize from 'lodash/memoize'
+import some from 'lodash/some'
+import { getIsAuthenticated } from 'shared/services/auth/auth'
+import configuration from 'shared/services/configuration/configuration'
 import {
   priorityList,
   typesList,
 } from 'signals/incident-management/definitions'
-import configuration from 'shared/services/configuration/configuration'
-import { getIsAuthenticated } from 'shared/services/auth/auth'
-import IncidentNavigation from '../components/IncidentNavigation'
+
 import FormComponents from '../components/form'
+import IncidentNavigation from '../components/IncidentNavigation'
 import checkVisibility from '../services/checkVisibility'
 import getStepControls from '../services/get-step-controls'
 
@@ -67,7 +68,7 @@ const getControls = memoize(
           maxLength: 1000,
         },
         options: {
-          validators: ['required', '1000'],
+          validators: ['required', ['maxLength', 1000]],
         },
         render: FormComponents.DescriptionInputRenderer,
       },

--- a/src/signals/incident/definitions/wizard-step-3-contact.js
+++ b/src/signals/incident/definitions/wizard-step-3-contact.js
@@ -31,7 +31,7 @@ export default {
         },
         render: FormComponents.WithHeading,
         options: {
-          validators: [validatePhoneNumber, '17'],
+          validators: [validatePhoneNumber, ['maxLength', 17]],
         },
       },
       email: {
@@ -48,7 +48,7 @@ export default {
         },
         render: FormComponents.WithHeading,
         options: {
-          validators: ['email', '254'],
+          validators: ['email', ['maxLength', 100]],
         },
       },
       privacy_text: {

--- a/src/signals/incident/services/yup-resolver/index.test.ts
+++ b/src/signals/incident/services/yup-resolver/index.test.ts
@@ -31,11 +31,6 @@ describe('Yup resolver takes a bunch of controls and returns it into a schema', 
           validators: ['email'],
         },
       },
-      maxlen1: {
-        options: {
-          validators: ['required', '1'],
-        },
-      },
       maxlen2: {
         options: {
           validators: ['required', ['maxLength', 1]],
@@ -67,9 +62,6 @@ describe('Yup resolver takes a bunch of controls and returns it into a schema', 
     await expect(
       schema.validateAt('email', { email: 'blackrosemarchesa@mail.com' })
     ).resolves.toBeTruthy()
-    await expect(
-      schema.validateAt('maxlen1', { maxlen1: 'aa' })
-    ).rejects.toBeTruthy()
     await expect(
       schema.validateAt('maxlen2', { maxlen2: 'b' })
     ).resolves.toBeTruthy()


### PR DESCRIPTION
### goals 

Remove confocusing maxlength validators

### for devs 

one form of validators is chosen instead of multiple for matching the maxLength of a form field.

## Signalen

Before opening a pull request, please ensure:

- [x] Double-check your branch is based on `develop` and targets `develop`
- [x] Pull request has tests (we are going for 100% coverage!)
- [x] Code is well-commented, linted and follows project conventions
- [x] Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
