### PR TITLE
[CONFIG] enable meldingenkaart

### DIFF
--- a/app.amsterdam.json
+++ b/app.amsterdam.json
@@ -8,7 +8,7 @@
     "enableAmsterdamSpecificOverigCategories": true,
     "enableCsvExport": false,
     "enableNearIncidents": true,
-    "enablePublicIncidentsMap": false,
+    "enablePublicIncidentsMap": true,
     "enablePublicSignalMap": false,
     "enableReporter": true,
     "fetchDistrictsFromBackend": false,


### PR DESCRIPTION
This PR sets the featureFlag `enablePublicIncidentsMap` to `true`. Enabling the /meldingenkaart on acceptance.