### PR TITLE
Make Docker image to be able to run as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,7 @@ RUN yarn add @exodus/schemasafe lodash
 
 COPY --from=base /app/build/. /usr/share/nginx/html/
 
+COPY nginx.conf /etc/nginx/nginx.conf
 COPY default.conf /etc/nginx/conf.d/
 
 COPY start.sh /usr/local/bin/start.sh
@@ -77,4 +78,18 @@ COPY internals/scripts/helpers/config.js /internals/scripts/helpers/config.js
 RUN ln -sf /dev/stdout /var/log/nginx/access.log \
   && ln -sf /dev/stderr /var/log/nginx/error.log
 
+# Add non-privileged user
+RUN adduser -D -u 1001 appuser
+
+# Make sure appuser can change files that change in runtime
+RUN touch /run/nginx.pid && \
+    chown -R appuser \
+    /run/nginx.pid \
+    /var/cache/nginx \
+    /usr/share/nginx/html/index.html \
+    /usr/share/nginx/html/manifest.json
+
+USER appuser
+
 CMD ["/usr/local/bin/start.sh"]
+EXPOSE 8080

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ docker build -t signalen/frontend .
 Start the frontend server with a custom configuration as follows:
 
 ```bash
-docker run -d -p 8080:80 \
+docker run -d -p 8080:8080 \
   -v /branding/app.json:/app.json \
   -v /branding/logo.png:/usr/share/nginx/html/logo.png \
   -v /branding/favicon.png:/usr/share/nginx/html/favicon.png \

--- a/default.conf
+++ b/default.conf
@@ -1,6 +1,6 @@
 server {
-	listen 80;
-	server_name localhost;
+    listen 8080;
+    server_name localhost;
 
     root /usr/share/nginx/html/;
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - ./e2e-tests/app.json:/app.json
       - ./app.amsterdam.json:/app.base.json
     ports:
-      - 3001:80
+      - 3001:8080
     depends_on:
       - backend
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,25 @@
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log notice;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+
+    keepalive_timeout  65;
+
+    include /etc/nginx/conf.d/*.conf;
+}


### PR DESCRIPTION
To improve security and to comply with security policies of environments with more strict security requirements (e.g. the environment of Utrecht, but also the new Azure environment of Amsterdam) we require the frontend container to be able to run as non-root. This is also [considered best practice](https://docs.bitnami.com/tutorials/why-non-root-containers-are-important-for-security).

This PR changes the container user from root to appuser.

⚠️  This change is breaking and requires to make infrastructural changes when deploying. The container port changes from 80 to 8080, as a non-root container is not able to bind to port 80.