### PR TITLE
[SIG-4808] Invalidate error messages after clearing input.

### DIFF
--- a/src/signals/incident/components/IncidentForm/index.test.js
+++ b/src/signals/incident/components/IncidentForm/index.test.js
@@ -310,12 +310,18 @@ describe('<IncidentForm />', () => {
 
     describe('form events', () => {
       it('should handle onchange and on blur event', () => {
+        const triggerSpy = jest.fn()
         const props = {
           ...defaultProps,
+          reactHookFormProps: {
+            trigger: triggerSpy,
+          },
           fieldConfig: requiredFieldConfig,
         }
 
         renderIncidentForm(props)
+
+        userEvent.click(screen.getByText(mockForm.nextButtonLabel))
 
         fireEvent.change(document.getElementById('phone'), {
           target: {
@@ -337,6 +343,14 @@ describe('<IncidentForm />', () => {
 
         // Because of meta.autoRemove updateIncident only gets called once
         expect(props.updateIncident).toHaveBeenCalledTimes(1)
+
+        fireEvent.change(document.getElementById('phone'), {
+          target: {
+            value: '',
+          },
+        })
+
+        expect(triggerSpy).toHaveBeenCalledTimes(3)
       })
     })
   })

--- a/src/signals/incident/components/IncidentForm/index.tsx
+++ b/src/signals/incident/components/IncidentForm/index.tsx
@@ -109,6 +109,7 @@ const IncidentForm = forwardRef<any, any>(
             Next needs to be part of the local state to rerender.
             When Sia will phase out react albus, this needs to be removed
           */
+            reactHookFormProps.reset()
             setNext(next)
             return
           }

--- a/src/signals/incident/components/IncidentForm/index.tsx
+++ b/src/signals/incident/components/IncidentForm/index.tsx
@@ -169,14 +169,11 @@ const IncidentForm = forwardRef<any, any>(
       },
     }
 
-    const getControls = (controls: any) =>
-      Object.fromEntries(
-        Object.entries(controls).filter(
-          ([key, value]: any) => value.meta?.isVisible || key === '$field_0'
-        )
+    const controls: any = Object.fromEntries(
+      Object.entries(fieldConfigModified.controls).filter(
+        ([key, value]: any) => value.meta?.isVisible || key === '$field_0'
       )
-
-    const controls: any = getControls(fieldConfigModified.controls)
+    )
 
     /**
     Set the yupresolver for the current step of the incident wizard
@@ -205,6 +202,9 @@ const IncidentForm = forwardRef<any, any>(
                           handler={() => ({
                             onChange: (e: BaseSyntheticEvent) => {
                               value.meta && onChange(e.target.value)
+                              if (submitting && !e.target.value) {
+                                reactHookFormProps.trigger()
+                              }
                             },
                             onBlur: (e: BaseSyntheticEvent) => {
                               value.meta && onChange(e.target.value)

--- a/src/signals/incident/components/IncidentWizard/IncidentWizard.tsx
+++ b/src/signals/incident/components/IncidentWizard/IncidentWizard.tsx
@@ -1,17 +1,19 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2018 - 2022 Gemeente Amsterdam
 import { useContext, useMemo, useRef } from 'react'
-import { Route } from 'react-router-dom'
-import { Wizard, Steps, Step } from 'react-albus'
-import { FormProvider, useForm } from 'react-hook-form'
+import type { FC } from 'react'
+
 import {
   StepByStepNav,
   breakpoint,
   Paragraph,
   ascDefaultTheme,
 } from '@amsterdam/asc-ui'
-
-import type { FC } from 'react'
+import LoadingIndicator from 'components/LoadingIndicator'
+import AppContext from 'containers/App/context'
+import { Wizard, Steps, Step } from 'react-albus'
+import { FormProvider, useForm } from 'react-hook-form'
+import { Route } from 'react-router-dom'
 import type {
   createIncident,
   getClassification,
@@ -20,16 +22,12 @@ import type {
   addToSelection,
   removeFromSelection,
 } from 'signals/incident/containers/IncidentContainer/actions'
-import type { Incident } from 'types/incident'
 import type { WizardSection } from 'signals/incident/definitions/wizard'
-
-import LoadingIndicator from 'components/LoadingIndicator'
-import AppContext from 'containers/App/context'
+import type { Incident } from 'types/incident'
 
 import IncidentForm from '../IncidentForm'
 import IncidentPreview from '../IncidentPreview'
 import onNext from './services/on-next'
-
 import {
   FormWrapper,
   Header,

--- a/src/signals/incident/definitions/wizard-step-3-contact.js
+++ b/src/signals/incident/definitions/wizard-step-3-contact.js
@@ -31,7 +31,7 @@ export default {
       phone: {
         meta: {
           // https://bytes.grubhub.com/disabling-safari-autofill-for-a-single-line-address-input-b83137b5b1c7
-          autoComplete: 'tel',
+          autoComplete: 'search_tel',
           autoRemove: /[^\d ()+-]/g,
           label: 'Wat is uw telefoonnummer?',
           path: 'reporter.phone',
@@ -46,7 +46,7 @@ export default {
       },
       email: {
         meta: {
-          autoComplete: 'email',
+          autoComplete: 'search_email',
           autoRemove: /[^\w!#$%&'*+./;=?@^`{|}~-]/g,
           label: 'Wat is uw e-mailadres?',
           path: 'reporter.email',

--- a/src/test/utils.js
+++ b/src/test/utils.js
@@ -65,7 +65,11 @@ export const withAppContext = (Component) => (
   </ThemeProvider>
 )
 
-export const FormProviderWithResolver = ({ fieldConfig, children }) => {
+export const FormProviderWithResolver = ({
+  fieldConfig,
+  children,
+  reactHookFormProps,
+}) => {
   const controls = Object.fromEntries(
     Object.entries(fieldConfig.controls).filter(
       ([key, value]) => value.meta?.isVisible || key === '$field_0'
@@ -80,7 +84,7 @@ export const FormProviderWithResolver = ({ fieldConfig, children }) => {
   return (
     <FormProvider {...formProps}>
       {React.cloneElement(children, {
-        reactHookFormProps: formProps,
+        reactHookFormProps: { ...formProps, ...reactHookFormProps },
       })}
     </FormProvider>
   )


### PR DESCRIPTION
Ticket: [SIG-4808](https://datapunt.atlassian.net/browse/SIG-4808)

## goal
Clear the error message by calling trigger after clearing an input field

## for testers
- make sure the error message goes away after clearing a field
- test also by going to different route

 
## Signalen

Before opening a pull request, please ensure:

- [x] Double-check your branch is based on `develop` and targets `develop`
- [x] Pull request has tests (we are going for 100% coverage!)
- [x] Code is well-commented, linted and follows project conventions
- [x] Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
