### PR TITLE
[refactor]: ran auto re-order imports

### DIFF
--- a/src/containers/App/reducer.test.ts
+++ b/src/containers/App/reducer.test.ts
@@ -1,9 +1,16 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2019 - 2021 Gemeente Amsterdam
-import userJson from 'utils/__tests__/fixtures/user.json'
 import { APPLY_FILTER } from 'signals/incident-management/constants'
-import type { ApplyFilterActionType } from './reducer'
-import appReducer, { initialState } from './reducer'
+import userJson from 'utils/__tests__/fixtures/user.json'
+
+import type {
+  DoLogoutAction,
+  GetSourcesAction,
+  GetSourcesFailedAction,
+  GetSourcesSuccessAction,
+  ResetSearchQueryAction,
+  SetSearchQueryAction,
+} from './actions'
 import {
   AUTHORIZE_USER,
   LOGIN_FAILED,
@@ -20,14 +27,8 @@ import {
   GET_SOURCES_FAILED,
   GET_SOURCES_SUCCESS,
 } from './constants'
-import type {
-  DoLogoutAction,
-  GetSourcesAction,
-  GetSourcesFailedAction,
-  GetSourcesSuccessAction,
-  ResetSearchQueryAction,
-  SetSearchQueryAction,
-} from './actions'
+import type { ApplyFilterActionType } from './reducer'
+import appReducer, { initialState } from './reducer'
 import type { Source } from './types'
 
 describe('containers/App/reducer', () => {

--- a/src/containers/App/reducer.ts
+++ b/src/containers/App/reducer.ts
@@ -1,7 +1,9 @@
-import { VARIANT_NOTICE, TYPE_LOCAL } from 'containers/Notification/constants'
 import type { Reducer } from 'redux'
+
+import { VARIANT_NOTICE, TYPE_LOCAL } from 'containers/Notification/constants'
 import { APPLY_FILTER } from 'signals/incident-management/constants'
 import type { Action } from 'types'
+
 import type { AppActionTypes } from './actions'
 import {
   LOGIN_FAILED,

--- a/src/containers/App/selectors.test.ts
+++ b/src/containers/App/selectors.test.ts
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2019 - 2021 Gemeente Amsterdam
 import cloneDeep from 'lodash/cloneDeep'
-import type { ApplicationRootState } from 'types'
 
+import type { ApplicationRootState } from 'types'
 import userJson from 'utils/__tests__/fixtures/user.json'
 
 import { initialState } from './reducer'

--- a/src/containers/App/selectors.ts
+++ b/src/containers/App/selectors.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2018 - 2021 Gemeente Amsterdam
 import { createSelector } from 'reselect'
+
 import type { ApplicationRootState } from 'types'
 
 import { initialState } from './reducer'

--- a/src/containers/App/services.test.ts
+++ b/src/containers/App/services.test.ts
@@ -4,7 +4,6 @@ import injectSagaModel from 'utils/injectSagaModel'
 
 import reducer from './reducer'
 import saga from './saga'
-
 import loadModel from './services'
 
 jest.mock('utils/injectReducerModel')

--- a/src/containers/App/services.ts
+++ b/src/containers/App/services.ts
@@ -1,6 +1,7 @@
 import type { InjectedStore } from 'types'
 import injectReducerModel from 'utils/injectReducerModel'
 import injectSagaModel from 'utils/injectSagaModel'
+
 import reducer from './reducer'
 import saga from './saga'
 

--- a/src/containers/IncidentOverviewTitle/__tests__/IncidentOverviewTitle.test.js
+++ b/src/containers/IncidentOverviewTitle/__tests__/IncidentOverviewTitle.test.js
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2019 - 2021 Gemeente Amsterdam
 import { render, screen } from '@testing-library/react'
+
 import { withAppContext } from 'test/utils'
+
 import IncidentOverviewTitleContainer, { IncidentOverviewTitle } from '..'
 
 describe('containers/IncidentOverviewTitle', () => {

--- a/src/containers/IncidentOverviewTitle/index.js
+++ b/src/containers/IncidentOverviewTitle/index.js
@@ -1,19 +1,20 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2019 - 2021 Gemeente Amsterdam
 import { Fragment, useMemo } from 'react'
+
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { compose } from 'redux'
 import { createStructuredSelector } from 'reselect'
 import styled from 'styled-components'
-import * as types from 'shared/types'
 
 import PageHeader from 'components/PageHeader'
+import { makeSelectSearchQuery } from 'containers/App/selectors'
+import * as types from 'shared/types'
 import {
   makeSelectActiveFilter,
   makeSelectIncidentsCount,
 } from 'signals/incident-management/selectors'
-import { makeSelectSearchQuery } from 'containers/App/selectors'
 
 import Refresh from '../../images/icon-refresh.svg'
 

--- a/src/containers/MapContext/__tests__/MapContext.test.js
+++ b/src/containers/MapContext/__tests__/MapContext.test.js
@@ -1,11 +1,13 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2020 - 2021 Gemeente Amsterdam
 import { useContext, useEffect } from 'react'
+
 import { render } from '@testing-library/react'
-import { initialState } from '../reducer'
+
 import MapContext from '..'
-import Context from '../context'
 import { setValuesAction } from '../actions'
+import Context from '../context'
+import { initialState } from '../reducer'
 
 describe('containers/MapContext/index', () => {
   const testLocation = { lat: 42, lng: 4 }

--- a/src/containers/MapContext/__tests__/reducer.test.js
+++ b/src/containers/MapContext/__tests__/reducer.test.js
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2020 - 2021 Gemeente Amsterdam
-import reducer, { initialState } from '../reducer'
 import {
   SET_LOCATION,
   SET_ADDRESS,
@@ -8,6 +7,7 @@ import {
   SET_LOADING,
   RESET_LOCATION,
 } from '../constants'
+import reducer, { initialState } from '../reducer'
 
 describe('containers/MapContext/reducer', () => {
   const testLocation = {

--- a/src/containers/MapContext/index.js
+++ b/src/containers/MapContext/index.js
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2020 - 2021 Gemeente Amsterdam
 import { useReducer, memo, useMemo } from 'react'
+
 import PropTypes from 'prop-types'
+
 import Context from './context'
 import reducer, { initialState } from './reducer'
 

--- a/src/containers/Notification/__tests__/Notification.test.js
+++ b/src/containers/Notification/__tests__/Notification.test.js
@@ -1,14 +1,13 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2019 - 2021 Gemeente Amsterdam
-import Enzyme, { mount } from 'enzyme'
-import Adapter from '@wojtekmaj/enzyme-adapter-react-17'
-
 import { render } from '@testing-library/react'
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17'
+import Enzyme, { mount } from 'enzyme'
+
 import { withAppContext } from 'test/utils'
 
-import { TYPE_GLOBAL, VARIANT_NOTICE } from '../constants'
-
 import NotificationContainer, { NotificationContainerComponent } from '..'
+import { TYPE_GLOBAL, VARIANT_NOTICE } from '../constants'
 
 Enzyme.configure({ adapter: new Adapter() })
 

--- a/src/containers/Notification/index.js
+++ b/src/containers/Notification/index.js
@@ -6,8 +6,8 @@ import { compose, bindActionCreators } from 'redux'
 import { createStructuredSelector } from 'reselect'
 
 import Notification from 'components/Notification'
-import { makeSelectNotification } from 'containers/App/selectors'
 import { resetGlobalNotification } from 'containers/App/actions'
+import { makeSelectNotification } from 'containers/App/selectors'
 
 export const NotificationContainerComponent = ({
   notification,

--- a/src/containers/SearchBar/__tests__/SearchBar.test.js
+++ b/src/containers/SearchBar/__tests__/SearchBar.test.js
@@ -1,9 +1,11 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2019 - 2021 Gemeente Amsterdam
-import Enzyme, { mount } from 'enzyme'
-import Adapter from '@wojtekmaj/enzyme-adapter-react-17'
 import { render, fireEvent, act } from '@testing-library/react'
+import Adapter from '@wojtekmaj/enzyme-adapter-react-17'
+import Enzyme, { mount } from 'enzyme'
+
 import { withAppContext } from 'test/utils'
+
 import SearchBarContainer, { SearchBarComponent } from '..'
 
 Enzyme.configure({ adapter: new Adapter() })

--- a/src/containers/SearchBar/index.js
+++ b/src/containers/SearchBar/index.js
@@ -1,15 +1,16 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2019 - 2021 Gemeente Amsterdam
 import { useCallback } from 'react'
-import PropTypes from 'prop-types'
+
 import { SearchBar, styles } from '@amsterdam/asc-ui'
+import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { compose, bindActionCreators } from 'redux'
 import { createStructuredSelector } from 'reselect'
+import styled from 'styled-components'
 
 import { setSearchQuery, resetSearchQuery } from 'containers/App/actions'
 import { makeSelectSearchQuery } from 'containers/App/selectors'
-import styled from 'styled-components'
 
 const StyledSearchBar = styled(SearchBar)`
   ${styles.TextFieldStyle} > input {

--- a/src/containers/SiteHeader/__tests__/SiteHeader.test.js
+++ b/src/containers/SiteHeader/__tests__/SiteHeader.test.js
@@ -1,12 +1,13 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2019 - 2021 Gemeente Amsterdam
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import * as reactRedux from 'react-redux'
+
 import * as appSelectors from 'containers/App/selectors'
 import * as auth from 'shared/services/auth/auth'
-
 import { withAppContext } from 'test/utils'
-import userEvent from '@testing-library/user-event'
+
 import SiteHeader from '..'
 
 describe('containers/SiteHeader', () => {

--- a/src/containers/SiteHeader/index.js
+++ b/src/containers/SiteHeader/index.js
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2019 - 2021 Gemeente Amsterdam
 import { useDispatch, useSelector } from 'react-redux'
+
+import SiteHeader from 'components/SiteHeader'
 import {
   makeSelectUserCan,
   makeSelectUserCanAccess,
 } from 'containers/App/selectors'
-import SiteHeader from 'components/SiteHeader'
 
 import { doLogout } from '../App/actions'
 

--- a/src/hooks/__tests__/useFetch.test.ts
+++ b/src/hooks/__tests__/useFetch.test.ts
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2020 - 2022 Vereniging van Nederlandse Gemeenten, Gemeente Amsterdam
-import fetchMock from 'jest-fetch-mock'
 import { renderHook, act } from '@testing-library/react-hooks'
-import JSONresponse from 'utils/__tests__/fixtures/user.json'
+import fetchMock from 'jest-fetch-mock'
+import { mocked } from 'jest-mock'
+
 import { getErrorMessage } from 'shared/services/api/api'
 import { getAuthHeaders } from 'shared/services/auth/auth'
-import { mocked } from 'jest-mock'
+import JSONresponse from 'utils/__tests__/fixtures/user.json'
 
 import type { FetchError } from '../useFetch'
 import useFetch from '../useFetch'

--- a/src/hooks/__tests__/useFetchAll.test.ts
+++ b/src/hooks/__tests__/useFetchAll.test.ts
@@ -1,11 +1,12 @@
+import { renderHook, act } from '@testing-library/react-hooks'
 import fetchMock from 'jest-fetch-mock'
 import { mocked } from 'jest-mock'
-import { renderHook, act } from '@testing-library/react-hooks'
-import JSONresponse from 'utils/__tests__/fixtures/user.json'
 
+import type { FetchError } from 'hooks/useFetch'
 import { getErrorMessage } from 'shared/services/api/api'
 import { getAuthHeaders } from 'shared/services/auth/auth'
-import type { FetchError } from 'hooks/useFetch'
+import JSONresponse from 'utils/__tests__/fixtures/user.json'
+
 import useFetchAll from '../useFetchAll'
 
 jest.mock('shared/services/auth/auth')

--- a/src/hooks/api/__tests__/useGetReportOpen.test.ts
+++ b/src/hooks/api/__tests__/useGetReportOpen.test.ts
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2019 - 2021 Gemeente Amsterdam
-import fetchMock from 'jest-fetch-mock'
 import { renderHook, act } from '@testing-library/react-hooks'
+import fetchMock from 'jest-fetch-mock'
 
 import configuration from 'shared/services/configuration/configuration'
+
 import signalsOpenReport from '../../../../internals/mocks/fixtures/report_signals-open.json'
 import useGetReportOpen from '../useGetReportOpen'
 

--- a/src/hooks/api/qa/useGetQuestionnaire.ts
+++ b/src/hooks/api/qa/useGetQuestionnaire.ts
@@ -1,5 +1,6 @@
 import configuration from 'shared/services/configuration/configuration'
 import type { Questionnaire } from 'types/api/qa/questionnaire'
+
 import { useBuildGetter } from '../useBuildGetter'
 
 const useGetQuestionnaire = () =>

--- a/src/hooks/api/qa/useGetSession.ts
+++ b/src/hooks/api/qa/useGetSession.ts
@@ -1,5 +1,6 @@
 import configuration from 'shared/services/configuration/configuration'
 import type { Session } from 'types/api/qa/session'
+
 import { useBuildGetter } from '../useBuildGetter'
 
 const useGetSession = () =>

--- a/src/hooks/api/useBuildGetter.ts
+++ b/src/hooks/api/useBuildGetter.ts
@@ -1,5 +1,7 @@
 import { useMemo } from 'react'
+
 import useFetch from 'hooks/useFetch'
+
 import type { GetHookResponse } from './types'
 
 export const useBuildGetter = <T, U extends Array<unknown> = Array<any>>(

--- a/src/hooks/api/useGetContextGeography.ts
+++ b/src/hooks/api/useGetContextGeography.ts
@@ -1,5 +1,6 @@
 import configuration from 'shared/services/configuration/configuration'
 import type { Geography } from 'types/api/geography'
+
 import { useBuildGetter } from './useBuildGetter'
 
 const useGetIncidentContextGeography = () =>

--- a/src/hooks/api/useGetContextReporter.ts
+++ b/src/hooks/api/useGetContextReporter.ts
@@ -1,5 +1,6 @@
 import configuration from 'shared/services/configuration/configuration'
 import type Reporter from 'types/api/reporter'
+
 import type { QueryParameters } from './types'
 import { useBuildGetter } from './useBuildGetter'
 

--- a/src/hooks/api/useGetIncident.ts
+++ b/src/hooks/api/useGetIncident.ts
@@ -1,5 +1,6 @@
 import configuration from 'shared/services/configuration/configuration'
 import type { Incident } from 'types/api/incident'
+
 import { useBuildGetter } from './useBuildGetter'
 
 const useGetIncident = () =>

--- a/src/hooks/api/useGetPublicIncident.ts
+++ b/src/hooks/api/useGetPublicIncident.ts
@@ -1,5 +1,6 @@
 import configuration from 'shared/services/configuration/configuration'
 import type { PublicIncident } from 'types/api/public-incident'
+
 import { useBuildGetter } from './useBuildGetter'
 
 const useGetPublicIncident = () =>

--- a/src/hooks/api/useGetReportOpen.ts
+++ b/src/hooks/api/useGetReportOpen.ts
@@ -2,6 +2,7 @@
 // Copyright (C) 2019 - 2021 Gemeente Amsterdam
 import configuration from 'shared/services/configuration/configuration'
 import type { Report } from 'types/api/report'
+
 import { useBuildGetter } from './useBuildGetter'
 
 const useGetReportOpen = () =>

--- a/src/hooks/api/useGetReportReopenRequested.ts
+++ b/src/hooks/api/useGetReportReopenRequested.ts
@@ -1,5 +1,6 @@
 import configuration from 'shared/services/configuration/configuration'
 import type { Report } from 'types/api/report'
+
 import { useBuildGetter } from './useBuildGetter'
 
 const useGetReportReopenRequested = () =>

--- a/src/hooks/useDelayedDoubleClick.js
+++ b/src/hooks/useDelayedDoubleClick.js
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2020 - 2021 Gemeente Amsterdam
 import { useCallback, useRef } from 'react'
+
 import useDebounce from './useDebounce'
 
 /**

--- a/src/hooks/useFetch.ts
+++ b/src/hooks/useFetch.ts
@@ -2,8 +2,9 @@
 // Copyright (C) 2021 - 2022 Vereniging van Nederlandse Gemeenten, Gemeente Amsterdam
 import type { Reducer } from 'react'
 import { useCallback, useEffect, useReducer, useMemo } from 'react'
-import { getAuthHeaders } from 'shared/services/auth/auth'
+
 import { getErrorMessage } from 'shared/services/api/api'
+import { getAuthHeaders } from 'shared/services/auth/auth'
 
 type Data = Record<string, unknown>
 export type FetchError = (Response | Error) & {

--- a/src/hooks/useFetchAll.ts
+++ b/src/hooks/useFetchAll.ts
@@ -1,7 +1,9 @@
 import { useEffect, useMemo, useCallback, useReducer } from 'react'
 import type { Reducer } from 'react'
-import { getAuthHeaders } from 'shared/services/auth/auth'
+
 import { getErrorMessage } from 'shared/services/api/api'
+import { getAuthHeaders } from 'shared/services/auth/auth'
+
 import type { FetchError } from './useFetch'
 
 type Data = Record<string, unknown>

--- a/src/hooks/useIsFrontOffice.js
+++ b/src/hooks/useIsFrontOffice.js
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2019 - 2021 Gemeente Amsterdam
 import { useMemo } from 'react'
+
 import { useLocation } from 'react-router-dom'
 
 const useIsFrontOffice = () => {

--- a/src/hooks/useLocationReferrer.js
+++ b/src/hooks/useLocationReferrer.js
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2020 - 2021 Gemeente Amsterdam
 import { useEffect, useState } from 'react'
+
 import { useLocation } from 'react-router-dom'
 
 /**

--- a/src/models/categories/index.test.ts
+++ b/src/models/categories/index.test.ts
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2019 - 2021 Gemeente Amsterdam
+import { mocked } from 'jest-mock'
+
 import injectReducerModel from 'utils/injectReducerModel'
 import injectSagaModel from 'utils/injectSagaModel'
-import { mocked } from 'jest-mock'
 
 import loadModel from '..'
 import reducer from './reducer'

--- a/src/models/categories/index.ts
+++ b/src/models/categories/index.ts
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2019 - 2021 Gemeente Amsterdam
+import type { InjectedStore } from 'types'
 import injectReducerModel from 'utils/injectReducerModel'
 import injectSagaModel from 'utils/injectSagaModel'
-
-import type { InjectedStore } from 'types'
 
 import reducer from './reducer'
 import saga from './saga'

--- a/src/models/categories/reducer.test.ts
+++ b/src/models/categories/reducer.test.ts
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2020 - 2021 Gemeente Amsterdam
 import { fromJS } from 'immutable'
+
 import categoriesJson from 'utils/__tests__/fixtures/categories_private.json'
 
-import type { CategoriesState } from './reducer'
-
-import reducer, { initialState } from './reducer'
 import {
   fetchCategories,
   fetchCategoriesSuccess,
   fetchCategoriesFailed,
 } from './actions'
+import type { CategoriesState } from './reducer'
+import reducer, { initialState } from './reducer'
 
 const catCount = 9
 

--- a/src/models/categories/reducer.ts
+++ b/src/models/categories/reducer.ts
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2020 - 2021 Gemeente Amsterdam
 import { fromJS } from 'immutable'
-
 import type { Map as ImmutableMap } from 'immutable'
 import type { AnyAction, Reducer } from 'redux'
+
 import type CategoriesType from 'types/api/categories'
+
 import type {
   CategoryActions,
   FetchCategoriesSuccessAction,
   FetchCategoriesFailedAction,
 } from './actions'
-
 import {
   FETCH_CATEGORIES_FAILED,
   FETCH_CATEGORIES_SUCCESS,

--- a/src/models/categories/saga.test.ts
+++ b/src/models/categories/saga.test.ts
@@ -1,17 +1,17 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2020 - 2021 Gemeente Amsterdam
 import * as Sentry from '@sentry/browser'
-import { authCall, getErrorMessage } from 'shared/services/api/api'
 import { testSaga } from 'redux-saga-test-plan'
 
 import * as actions from 'containers/App/actions'
-import categoriesJson from 'utils/__tests__/fixtures/categories_private.json'
-import CONFIGURATION from 'shared/services/configuration/configuration'
 import { VARIANT_ERROR, TYPE_LOCAL } from 'containers/Notification/constants'
+import { authCall, getErrorMessage } from 'shared/services/api/api'
+import CONFIGURATION from 'shared/services/configuration/configuration'
+import categoriesJson from 'utils/__tests__/fixtures/categories_private.json'
 
 import { fetchCategoriesSuccess, fetchCategoriesFailed } from './actions'
-import watchCategoriesSaga, { fetchCategories } from './saga'
 import { FETCH_CATEGORIES } from './constants'
+import watchCategoriesSaga, { fetchCategories } from './saga'
 
 jest.mock('@sentry/browser')
 

--- a/src/models/categories/saga.ts
+++ b/src/models/categories/saga.ts
@@ -1,17 +1,16 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2019 - 2021 Gemeente Amsterdam
-import { call, put, takeLatest } from 'redux-saga/effects'
 import * as Sentry from '@sentry/browser'
+import { call, put, takeLatest } from 'redux-saga/effects'
 
-import CONFIGURATION from 'shared/services/configuration/configuration'
-import { authCall, getErrorMessage } from 'shared/services/api/api'
 import { showGlobalNotification } from 'containers/App/actions'
 import { VARIANT_ERROR, TYPE_LOCAL } from 'containers/Notification/constants'
-
+import { authCall, getErrorMessage } from 'shared/services/api/api'
+import CONFIGURATION from 'shared/services/configuration/configuration'
 import type Categories from 'types/api/categories'
 
-import { FETCH_CATEGORIES } from './constants'
 import { fetchCategoriesSuccess, fetchCategoriesFailed } from './actions'
+import { FETCH_CATEGORIES } from './constants'
 
 export function* fetchCategories() {
   const requestURL = CONFIGURATION.CATEGORIES_PRIVATE_ENDPOINT

--- a/src/models/categories/selectors.test.ts
+++ b/src/models/categories/selectors.test.ts
@@ -1,18 +1,18 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2020 - 2021 Gemeente Amsterdam
 import { fromJS } from 'immutable'
+
+import { initialState as initialAppState } from 'containers/App/reducer'
+import type CategoriesType from 'types/api/categories'
 import {
   mainCategories as mainCategoriesFixture,
   subCategories as subCategoriesFixture,
 } from 'utils/__tests__/fixtures'
 import categoriesJson from 'utils/__tests__/fixtures/categories_private.json'
-import { initialState as initialAppState } from 'containers/App/reducer'
 
-import type CategoriesType from 'types/api/categories'
 import type { CategoriesState } from './reducer'
-import type { ExtendedCategory, SubCategoryOption } from './selectors'
-
 import { initialState } from './reducer'
+import type { ExtendedCategory, SubCategoryOption } from './selectors'
 import {
   filterForMain,
   filterForSub,

--- a/src/models/categories/selectors.ts
+++ b/src/models/categories/selectors.ts
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2020 - 2021 Gemeente Amsterda
+import type { List as ImmutableList, Map as ImmutableMap } from 'immutable'
 import { createSelector } from 'reselect'
+
 import { getDaysString } from 'shared/services/date-utils'
 import { reCategory } from 'shared/services/resolveClassification'
-
-import type { List as ImmutableList, Map as ImmutableMap } from 'immutable'
 import type { ApplicationRootState } from 'types'
-import type { Category } from 'types/category'
 import type SubCategory from 'types/api/sub-category'
+import type { Category } from 'types/category'
 
 import { initialState } from './reducer'
 


### PR DESCRIPTION
Ticket: none

To get rid of all import warnings (due to the new ESLint configuration) I ran the auto re-order for imports in the following folders:
/containers
/hooks
/models

There are more PR's to come. 
