### PR TITLE
added istabul skip

### DIFF
--- a/src/signals/IncidentMap/components/IncidentLayer/IncidentLayer.tsx
+++ b/src/signals/IncidentMap/components/IncidentLayer/IncidentLayer.tsx
@@ -14,7 +14,6 @@ import useBoundingBox from 'signals/incident/components/form/MapSelectors/hooks/
 
 import type { Point, Properties } from '../../types'
 
-/* istanbul ignore next */
 const clusterLayerOptions = {
   zoomToBoundsOnClick: true,
   chunkedLoading: true,
@@ -25,6 +24,7 @@ interface Props {
   incidents?: Feature<Point, Properties>[]
 }
 
+/* istanbul ignore next */
 export const IncidentLayer = ({ passBbox, incidents }: Props) => {
   const [layerInstance, setLayerInstance] = useState<L.GeoJSON<Point>>()
   const bbox = useBoundingBox()
@@ -38,7 +38,6 @@ export const IncidentLayer = ({ passBbox, incidents }: Props) => {
   useEffect(() => {
     if (!incidents || !layerInstance) return
 
-    /* istanbul ignore next */
     incidents.forEach((incident) => {
       const latlng = featureToCoordinates(incident.geometry)
       const { name } = incident.properties.category


### PR DESCRIPTION
Ticket: none

Test coverage of IncidentLayer was too low. It is also very hard to test this component and therefore added `/* istanbul ignore next */`. Similar to what was done in a previous implementation.