### PR TITLE
Add ability to send e-mail notification on user or department assignment

### DIFF
--- a/src/signals/settings/users/Detail/components/UserForm/__tests__/UserForm.test.js
+++ b/src/signals/settings/users/Detail/components/UserForm/__tests__/UserForm.test.js
@@ -5,6 +5,7 @@ import Adapter from '@wojtekmaj/enzyme-adapter-react-17'
 import Enzyme, { mount } from 'enzyme'
 import * as modelSelectors from 'models/departments/selectors'
 import * as rolesSelectors from 'models/roles/selectors'
+import configuration from 'shared/services/configuration/configuration'
 import { withAppContext } from 'test/utils'
 import { departments } from 'utils/__tests__/fixtures'
 import inputCheckboxRolesSelectorJson from 'utils/__tests__/fixtures/inputCheckboxRolesSelector.json'
@@ -12,6 +13,8 @@ import inputCheckboxRolesSelectorJson from 'utils/__tests__/fixtures/inputCheckb
 import UserForm from '..'
 
 Enzyme.configure({ adapter: new Adapter() })
+
+jest.mock('shared/services/configuration/configuration')
 
 jest.mock('models/departments/selectors', () => ({
   __esModule: true,
@@ -285,4 +288,28 @@ describe('signals/settings/users/containers/Detail/components/UserForm', () => {
 
     expect(checkbox.checked).toBe(true)
   })
+})
+
+it('should not show notification checkboxes when feature is disabled', async () => {
+  const { container } = render(withAppContext(<UserForm />))
+  expect(
+    container.querySelector('[name="notifications"]')
+  ).not.toBeInTheDocument()
+})
+
+it('should show notification checkboxes when feature is enabled', async () => {
+  configuration.featureFlags.assignSignalToDepartment = true
+  configuration.featureFlags.assignSignalToEmployee = true
+
+  const { getByLabelText } = render(withAppContext(<UserForm />))
+
+  const assignSignalToDepartment = getByLabelText(
+    'Stuur mij een e-mail als een melding aan mij is toegewezen'
+  )
+  expect(assignSignalToDepartment.checked).toBe(false)
+
+  const assignSignalToEmployeeCheckbox = getByLabelText(
+    'Stuur mij een e-mail als een melding aan mij is toegewezen'
+  )
+  expect(assignSignalToEmployeeCheckbox.checked).toBe(false)
 })

--- a/src/signals/settings/users/Detail/components/UserForm/index.js
+++ b/src/signals/settings/users/Detail/components/UserForm/index.js
@@ -19,6 +19,7 @@ import PropTypes from 'prop-types'
 import { useSelector } from 'react-redux'
 import { userType, historyType } from 'shared/types'
 import styled from 'styled-components'
+import configuration from 'shared/services/configuration/configuration'
 
 const Form = styled.form`
   width: 100%;
@@ -48,18 +49,6 @@ const StyledFormFooter = styled(FormFooter)`
 const statusOptions = [
   { key: 'true', value: 'Actief' },
   { key: 'false', value: 'Niet actief' },
-]
-
-const notificationOptions = [
-  {
-    key: 'notification_on_department_assignment',
-    value:
-      'Stuur mij een e-mail als een melding aan mijn afdeling is gekoppeld',
-  },
-  {
-    key: 'notification_on_user_assignment',
-    value: 'Stuur mij een e-mail als een melding aan mij is toegewezen',
-  },
 ]
 
 const StyledHistory = styled(History)`
@@ -92,6 +81,26 @@ const UserForm = ({ data, history, onCancel, onSubmit, readOnly }) => {
     data?.roles
       ?.map((role) => inputRoles.find(({ name }) => name === role.name))
       .filter(Boolean) || []
+
+  const notificationOptions = [
+    ...(configuration.featureFlags.assignSignalToDepartment
+      ? [
+          {
+            key: 'notification_on_department_assignment',
+            value:
+              'Stuur mij een e-mail als een melding aan mijn afdeling is gekoppeld',
+          },
+        ]
+      : []),
+    ...(configuration.featureFlags.assignSignalToEmployee
+      ? [
+          {
+            key: 'notification_on_user_assignment',
+            value: 'Stuur mij een e-mail als een melding aan mij is toegewezen',
+          },
+        ]
+      : []),
+  ]
 
   const userNotifications =
     notificationOptions.filter(
@@ -217,19 +226,22 @@ const UserForm = ({ data, history, onCancel, onSubmit, readOnly }) => {
               />
             </FieldGroup>
 
-            <FieldGroup>
-              <Label as="span">Notificatie</Label>
-              <CheckboxList
-                defaultValue={state.notifications}
-                disabled={readOnly}
-                groupName="notifications"
-                name="notifications"
-                options={notificationOptions}
-                onChange={(field, value) => {
-                  onChange(field, value)
-                }}
-              />
-            </FieldGroup>
+            {(configuration.featureFlags.assignSignalToDepartment ||
+              configuration.featureFlags.assignSignalToEmployee) && (
+              <FieldGroup>
+                <Label as="span">Notificatie</Label>
+                <CheckboxList
+                  defaultValue={state.notifications}
+                  disabled={readOnly}
+                  groupName="notifications"
+                  name="notifications"
+                  options={notificationOptions}
+                  onChange={(field, value) => {
+                    onChange(field, value)
+                  }}
+                />
+              </FieldGroup>
+            )}
 
             <FieldGroup>
               <Label as="span">Status</Label>

--- a/src/signals/settings/users/Detail/components/UserForm/index.js
+++ b/src/signals/settings/users/Detail/components/UserForm/index.js
@@ -50,6 +50,18 @@ const statusOptions = [
   { key: 'false', value: 'Niet actief' },
 ]
 
+const notificationOptions = [
+  {
+    key: 'notification_on_assigment_to_department',
+    value:
+      'Stuur mij een e-mail als een melding aan mijn afdeling is gekoppeld',
+  },
+  {
+    key: 'notification_on_assigment_to_user',
+    value: 'Stuur mij een e-mail als een melding aan mij is toegewezen',
+  },
+]
+
 const StyledHistory = styled(History)`
   h2 {
     font-size: 16px;
@@ -81,6 +93,11 @@ const UserForm = ({ data, history, onCancel, onSubmit, readOnly }) => {
       ?.map((role) => inputRoles.find(({ name }) => name === role.name))
       .filter(Boolean) || []
 
+  const userNotifications =
+    notificationOptions.filter(
+      (notificationOption) => data?.profile?.[notificationOption.key]
+    ) || []
+
   const [state, dispatch] = useReducer(reducer, {
     username: data.username || '',
     first_name: data.first_name || '',
@@ -92,6 +109,7 @@ const UserForm = ({ data, history, onCancel, onSubmit, readOnly }) => {
         : `${data.is_active}`,
     departments: userDepartments,
     roles: userRoles,
+    notifications: userNotifications,
   })
 
   const onChangeEvent = useCallback(
@@ -117,6 +135,12 @@ const UserForm = ({ data, history, onCancel, onSubmit, readOnly }) => {
     form.is_active = state.is_active === 'true'
     form.profile.note = state.note
     form.profile.departments = state.departments.map(({ value }) => value)
+
+    const enabledNotifications = state.notifications.map(({ key }) => key)
+    form.profile.notification_on_assigment_to_department =
+      enabledNotifications.includes('notification_on_assigment_to_department')
+    form.profile.notification_on_assigment_to_user =
+      enabledNotifications.includes('notification_on_assigment_to_user')
 
     form.roles = state.roles.map(({ name: stateRoleName }) =>
       roles.find(({ name: dataRoleName }) => dataRoleName === stateRoleName)
@@ -190,6 +214,20 @@ const UserForm = ({ data, history, onCancel, onSubmit, readOnly }) => {
                 onChange={onChangeEvent}
                 type="text"
                 value={state.last_name}
+              />
+            </FieldGroup>
+
+            <FieldGroup>
+              <Label as="span">Notificatie</Label>
+              <CheckboxList
+                defaultValue={state.notifications}
+                disabled={readOnly}
+                groupName="notifications"
+                name="notifications"
+                options={notificationOptions}
+                onChange={(field, value) => {
+                  onChange(field, value)
+                }}
               />
             </FieldGroup>
 

--- a/src/signals/settings/users/Detail/components/UserForm/index.js
+++ b/src/signals/settings/users/Detail/components/UserForm/index.js
@@ -52,12 +52,12 @@ const statusOptions = [
 
 const notificationOptions = [
   {
-    key: 'notification_on_assigment_to_department',
+    key: 'notification_on_department_assignment',
     value:
       'Stuur mij een e-mail als een melding aan mijn afdeling is gekoppeld',
   },
   {
-    key: 'notification_on_assigment_to_user',
+    key: 'notification_on_user_assignment',
     value: 'Stuur mij een e-mail als een melding aan mij is toegewezen',
   },
 ]
@@ -137,10 +137,10 @@ const UserForm = ({ data, history, onCancel, onSubmit, readOnly }) => {
     form.profile.departments = state.departments.map(({ value }) => value)
 
     const enabledNotifications = state.notifications.map(({ key }) => key)
-    form.profile.notification_on_assigment_to_department =
-      enabledNotifications.includes('notification_on_assigment_to_department')
-    form.profile.notification_on_assigment_to_user =
-      enabledNotifications.includes('notification_on_assigment_to_user')
+    form.profile.notification_on_department_assignment =
+      enabledNotifications.includes('notification_on_department_assignment')
+    form.profile.notification_on_user_assignment =
+      enabledNotifications.includes('notification_on_user_assignment')
 
     form.roles = state.roles.map(({ name: stateRoleName }) =>
       roles.find(({ name: dataRoleName }) => dataRoleName === stateRoleName)

--- a/src/utils/__tests__/fixtures/user.json
+++ b/src/utils/__tests__/fixtures/user.json
@@ -359,6 +359,8 @@
       "FB"
     ],
     "created_at": "2019-10-24T10:25:48.874301+02:00",
-    "updated_at": "2019-10-24T10:25:48.874315+02:00"
+    "updated_at": "2019-10-24T10:25:48.874315+02:00",
+    "notification_on_department_assignment": false,
+    "notification_on_user_assignment": false
   }
 }


### PR DESCRIPTION
Add the ability to configure an e-mail notification for a user on user or department assignment.

Closes https://github.com/Signalen/product-steering/issues/82
Depends on https://github.com/Amsterdam/signals/pull/1057