### PR TITLE
chore: cleanup components and small refactor

### DIFF
--- a/src/signals/IncidentMap/components/AddressLocation/AddressLocation.tsx
+++ b/src/signals/IncidentMap/components/AddressLocation/AddressLocation.tsx
@@ -27,16 +27,14 @@ export const AddressLocation = ({ setCoordinates, address }: Props) => {
   )
 
   return (
-    <>
-      <Wrapper className={'testing'}>
-        <Heading as="h4">Zoom naar adres</Heading>
-        <StyledPDOKAutoSuggest
-          data-testid="searchAddressBar"
-          placeholder={'Zoek naar adres'}
-          onSelect={onAddressSelect}
-          value={addressValue}
-        />
-      </Wrapper>
-    </>
+    <Wrapper>
+      <Heading as="h4">Zoom naar adres</Heading>
+      <StyledPDOKAutoSuggest
+        data-testid="searchAddressBar"
+        placeholder={'Zoek naar adres'}
+        onSelect={onAddressSelect}
+        value={addressValue}
+      />
+    </Wrapper>
   )
 }

--- a/src/signals/IncidentMap/components/AddressLocation/styled.ts
+++ b/src/signals/IncidentMap/components/AddressLocation/styled.ts
@@ -1,4 +1,4 @@
-import { breakpoint } from '@amsterdam/asc-ui'
+import { themeSpacing } from '@amsterdam/asc-ui'
 import styled from 'styled-components'
 
 import PDOKAutoSuggest from 'components/PDOKAutoSuggest/PDOKAutoSuggest'
@@ -9,8 +9,5 @@ export const StyledPDOKAutoSuggest = styled(PDOKAutoSuggest)`
 
 export const Wrapper = styled.div`
   width: 100%;
-
-  @media screen and ${breakpoint('max-width', 'tabletM')} {
-    padding: 20px;
-  }
+  margin: ${themeSpacing(5)} 0;
 `

--- a/src/signals/IncidentMap/components/AddressLocation/styled.ts
+++ b/src/signals/IncidentMap/components/AddressLocation/styled.ts
@@ -1,4 +1,4 @@
-import { themeSpacing } from '@amsterdam/asc-ui'
+import { breakpoint, themeSpacing } from '@amsterdam/asc-ui'
 import styled from 'styled-components'
 
 import PDOKAutoSuggest from 'components/PDOKAutoSuggest/PDOKAutoSuggest'
@@ -9,5 +9,9 @@ export const StyledPDOKAutoSuggest = styled(PDOKAutoSuggest)`
 
 export const Wrapper = styled.div`
   width: 100%;
-  margin: ${themeSpacing(5)} 0;
+  margin: ${themeSpacing(5, 0)};
+
+  @media screen and ${breakpoint('max-width', 'tabletM')} {
+    margin-top: ${themeSpacing(0)};
+  }
 `

--- a/src/signals/IncidentMap/components/DrawerOverlay/DrawerOverlay.test.tsx
+++ b/src/signals/IncidentMap/components/DrawerOverlay/DrawerOverlay.test.tsx
@@ -8,21 +8,13 @@ import userEvent from '@testing-library/user-event'
 import { mockIncidents } from '../__test__'
 import { DrawerOverlay } from './DrawerOverlay'
 import type { Props } from './DrawerOverlay'
-import type { ControlledContentProps } from './types'
 import { DrawerState } from './types'
 
-const mockControlledComponent = (props: ControlledContentProps) => (
-  <span {...props}>[Address Search Input]</span>
-)
-
 const defaultProps: PropsWithChildren<Props> = {
-  ControlledContent: mockControlledComponent,
   onCloseDetailPanel: jest.fn(),
   onStateChange: jest.fn(),
   state: DrawerState.Open,
   children: <div>[ChildrenComponent]</div>,
-  setPin: jest.fn(),
-  setAddress: jest.fn(),
 }
 
 const renderComponent = (props?: Partial<Props>) =>
@@ -35,7 +27,6 @@ describe('DrawerOverlay', () => {
     expect(
       screen.getByRole('button', { name: 'Paneel sluiten' })
     ).toBeInTheDocument()
-    expect(screen.getByText('[Address Search Input]')).toBeInTheDocument()
     expect(screen.getByText('[ChildrenComponent]')).toBeInTheDocument()
   })
 

--- a/src/signals/IncidentMap/components/DrawerOverlay/DrawerOverlay.tsx
+++ b/src/signals/IncidentMap/components/DrawerOverlay/DrawerOverlay.tsx
@@ -4,12 +4,8 @@ import type { CSSProperties, FunctionComponent } from 'react'
 import { useCallback } from 'react'
 
 import { Icon } from '@amsterdam/asc-ui'
-import type { LatLngLiteral } from 'leaflet'
-
-import type { Address } from 'types/address'
 
 import type { Incident } from '../../types'
-import { AddressLocation } from '../AddressLocation'
 import { DetailPanel } from './DetailPanel'
 import {
   Drawer,
@@ -22,21 +18,16 @@ import {
   DrawerMapOverlay,
   HandleIcon,
 } from './styled'
-import type { ControlledContentProps } from './types'
 import { DrawerState } from './types'
 import { isMobile, isDesktop, useDeviceMode } from './utils'
 
 const CONTROLS_PADDING = 32
 
 export interface Props {
-  ControlledContent?: React.ComponentType<ControlledContentProps>
   incident?: Incident
   onCloseDetailPanel: () => void
   onStateChange?: (state: DrawerState) => void
   state?: DrawerState
-  setPin: (coordinates: LatLngLiteral) => void
-  address?: Address
-  setAddress: (address?: Address) => void
 }
 
 export const DrawerOverlay: FunctionComponent<Props> = ({
@@ -45,9 +36,6 @@ export const DrawerOverlay: FunctionComponent<Props> = ({
   onCloseDetailPanel,
   onStateChange,
   state = DrawerState.Closed,
-  setPin,
-  address,
-  setAddress,
 }) => {
   const mode = useDeviceMode()
   const DrawerHandle = isMobile(mode) ? DrawerHandleMobile : DrawerHandleDesktop
@@ -104,14 +92,7 @@ export const DrawerOverlay: FunctionComponent<Props> = ({
           )}
 
           <DrawerContent style={drawerContentStyle} data-testid="drawerContent">
-            <DrawerContentWrapper>
-              <AddressLocation
-                setCoordinates={setPin}
-                address={address}
-                setAddress={setAddress}
-              />
-              {children}
-            </DrawerContentWrapper>
+            <DrawerContentWrapper>{children}</DrawerContentWrapper>
           </DrawerContent>
         </Drawer>
       </DrawerContainer>

--- a/src/signals/IncidentMap/components/DrawerOverlay/DrawerOverlay.tsx
+++ b/src/signals/IncidentMap/components/DrawerOverlay/DrawerOverlay.tsx
@@ -12,7 +12,6 @@ import type { Incident } from '../../types'
 import { AddressLocation } from '../AddressLocation'
 import { DetailPanel } from './DetailPanel'
 import {
-  ControlsContainer,
   Drawer,
   DrawerContainer,
   DrawerContent,
@@ -42,7 +41,6 @@ export interface Props {
 
 export const DrawerOverlay: FunctionComponent<Props> = ({
   children,
-  ControlledContent = () => null,
   incident,
   onCloseDetailPanel,
   onStateChange,
@@ -106,15 +104,14 @@ export const DrawerOverlay: FunctionComponent<Props> = ({
           )}
 
           <DrawerContent style={drawerContentStyle} data-testid="drawerContent">
-            <ControlsContainer $mode={mode}>
-              <ControlledContent onClose={drawerClick} />
+            <DrawerContentWrapper>
               <AddressLocation
                 setCoordinates={setPin}
                 address={address}
                 setAddress={setAddress}
               />
-            </ControlsContainer>
-            <DrawerContentWrapper>{children}</DrawerContentWrapper>
+              {children}
+            </DrawerContentWrapper>
           </DrawerContent>
         </Drawer>
       </DrawerContainer>

--- a/src/signals/IncidentMap/components/DrawerOverlay/styled.ts
+++ b/src/signals/IncidentMap/components/DrawerOverlay/styled.ts
@@ -111,7 +111,7 @@ export const DrawerContentWrapper = styled('div')`
   width: 100%;
   height: 100%;
   padding: ${themeSpacing(0, 5, 0, 5)};
-  margin-bottom: 16px;
+  margin-bottom: ${themeSpacing(4)};
   overflow-y: auto;
 `
 

--- a/src/signals/IncidentMap/components/DrawerOverlay/styled.ts
+++ b/src/signals/IncidentMap/components/DrawerOverlay/styled.ts
@@ -110,9 +110,12 @@ export const HandleIcon = styled(ChevronRight)<{ $isOpen: boolean }>`
 export const DrawerContentWrapper = styled('div')`
   width: 100%;
   height: 100%;
-  padding: ${themeSpacing(0, 5, 0, 5)};
-  margin-bottom: ${themeSpacing(4)};
+  padding: ${themeSpacing(5)};
   overflow-y: auto;
+
+  @media screen and ${breakpoint('max-width', 'tabletM')} {
+    padding-top: 0;
+  }
 `
 
 export const DrawerContainer = styled.div<{ animate: boolean } & ModeProp>`

--- a/src/signals/IncidentMap/components/DrawerOverlay/styled.ts
+++ b/src/signals/IncidentMap/components/DrawerOverlay/styled.ts
@@ -111,6 +111,7 @@ export const DrawerContentWrapper = styled('div')`
   width: 100%;
   height: 100%;
   padding: ${themeSpacing(0, 5, 0, 5)};
+  margin-bottom: 16px;
   overflow-y: auto;
 `
 
@@ -162,26 +163,10 @@ export const DrawerContent = styled.div`
   position: relative;
   background-color: ${themeColor('tint', 'level1')};
   max-width: 100%;
+  overflow-y: auto;
 
   @media screen and ${breakpoint('min-width', 'tabletM')} {
     width: ${MENU_WIDTH}px;
-  }
-`
-
-export const ControlsContainer = styled.div<ModeProp>`
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  justify-content: space-between;
-
-  @media print {
-    display: none;
-  }
-
-  @media screen and (min-width: 576px) {
-    padding: ${themeSpacing(4)};
-    min-height: 16px;
-    flex-direction: row;
   }
 `
 

--- a/src/signals/IncidentMap/components/DrawerOverlay/types.ts
+++ b/src/signals/IncidentMap/components/DrawerOverlay/types.ts
@@ -14,7 +14,3 @@ export interface ModeProp {
   // prefixing mode with $ to prevent prop bleeding through to the DOM
   $mode: DeviceMode
 }
-
-export interface ControlledContentProps {
-  onClose: () => void
-}

--- a/src/signals/IncidentMap/components/FilterPanel/FilterPanel.tsx
+++ b/src/signals/IncidentMap/components/FilterPanel/FilterPanel.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2022 Gemeente Amsterdam
-import { useEffect } from 'react'
+import { Fragment, useEffect } from 'react'
 
 import { Checkbox, Paragraph, Heading } from '@amsterdam/asc-ui'
 
@@ -10,12 +10,7 @@ import type Categories from 'types/api/categories'
 
 import type { Filter } from '../../types'
 import { updateFilterCategory } from '../utils'
-import {
-  StyledPanelContent,
-  StyledLabel,
-  CategoryFilter,
-  Wrapper,
-} from './styled'
+import { StyledLabel, CategoryFilter, Wrapper } from './styled'
 
 export interface Props {
   filters: Filter[]
@@ -64,7 +59,7 @@ export const FilterPanel = ({ filters, setFilters, setMapMessage }: Props) => {
   }
 
   return (
-    <StyledPanelContent data-testid="filterCategoryPanel">
+    <Fragment>
       <Paragraph>
         Op deze kaart staan meldingen in de openbare ruimte waarmee we aan het
         werk zijn. Vanwege privacy staat een klein deel van de meldingen niet op
@@ -86,6 +81,6 @@ export const FilterPanel = ({ filters, setFilters, setMapMessage }: Props) => {
           )
         })}
       </Wrapper>
-    </StyledPanelContent>
+    </Fragment>
   )
 }

--- a/src/signals/IncidentMap/components/FilterPanel/FilterPanel.tsx
+++ b/src/signals/IncidentMap/components/FilterPanel/FilterPanel.tsx
@@ -59,7 +59,7 @@ export const FilterPanel = ({ filters, setFilters, setMapMessage }: Props) => {
   }
 
   return (
-    <Fragment>
+    <>
       <Heading as="h4">Filter op onderwerp</Heading>
       <Wrapper>
         {filters.map(({ name, filterActive, _display }) => {
@@ -76,6 +76,6 @@ export const FilterPanel = ({ filters, setFilters, setMapMessage }: Props) => {
           )
         })}
       </Wrapper>
-    </Fragment>
+    </>
   )
 }

--- a/src/signals/IncidentMap/components/FilterPanel/FilterPanel.tsx
+++ b/src/signals/IncidentMap/components/FilterPanel/FilterPanel.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2022 Gemeente Amsterdam
-import { Fragment, useEffect } from 'react'
+import { useEffect } from 'react'
 
 import { Checkbox, Heading } from '@amsterdam/asc-ui'
 

--- a/src/signals/IncidentMap/components/FilterPanel/FilterPanel.tsx
+++ b/src/signals/IncidentMap/components/FilterPanel/FilterPanel.tsx
@@ -2,7 +2,7 @@
 // Copyright (C) 2022 Gemeente Amsterdam
 import { Fragment, useEffect } from 'react'
 
-import { Checkbox, Paragraph, Heading } from '@amsterdam/asc-ui'
+import { Checkbox, Heading } from '@amsterdam/asc-ui'
 
 import { useFetch } from 'hooks'
 import configuration from 'shared/services/configuration/configuration'
@@ -60,11 +60,6 @@ export const FilterPanel = ({ filters, setFilters, setMapMessage }: Props) => {
 
   return (
     <Fragment>
-      <Paragraph>
-        Op deze kaart staan meldingen in de openbare ruimte waarmee we aan het
-        werk zijn. Vanwege privacy staat een klein deel van de meldingen niet op
-        de kaart.
-      </Paragraph>
       <Heading as="h4">Filter op onderwerp</Heading>
       <Wrapper>
         {filters.map(({ name, filterActive, _display }) => {

--- a/src/signals/IncidentMap/components/FilterPanel/styled.ts
+++ b/src/signals/IncidentMap/components/FilterPanel/styled.ts
@@ -10,10 +10,6 @@ import {
 } from '@amsterdam/asc-ui'
 import styled from 'styled-components'
 
-export const StyledPanelContent = styled.div`
-  height: 100%;
-`
-
 export const StyledLabel = styled(Label)`
   font-weight: normal;
 `

--- a/src/signals/IncidentMap/components/IncidentMap/IncidentMap.tsx
+++ b/src/signals/IncidentMap/components/IncidentMap/IncidentMap.tsx
@@ -27,7 +27,7 @@ import { GPSLocation } from '../GPSLocation'
 import { IncidentLayer } from '../IncidentLayer'
 import { getFilteredIncidents } from '../utils'
 import { Pin } from './Pin'
-import { Wrapper, StyledMap } from './styled'
+import { Wrapper, StyledMap, StyledParagraph } from './styled'
 
 export const IncidentMap = () => {
   const [bbox, setBbox] = useState<Bbox | undefined>()
@@ -154,6 +154,11 @@ export const IncidentMap = () => {
           onCloseDetailPanel={handleCloseDetailPanel}
           incident={selectedIncident}
         >
+          <StyledParagraph>
+            Op deze kaart staan meldingen in de openbare ruimte waarmee we aan
+            het werk zijn. Vanwege privacy staat een klein deel van de meldingen
+            niet op de kaart.
+          </StyledParagraph>
           <AddressLocation
             setCoordinates={setCoordinates}
             address={address}

--- a/src/signals/IncidentMap/components/IncidentMap/IncidentMap.tsx
+++ b/src/signals/IncidentMap/components/IncidentMap/IncidentMap.tsx
@@ -20,6 +20,7 @@ import type { Bbox } from 'signals/incident/components/form/MapSelectors/hooks/u
 import type { Address } from 'types/address'
 
 import type { Filter, Point, Properties, Incident } from '../../types'
+import { AddressLocation } from '../AddressLocation'
 import { DrawerOverlay, DrawerState } from '../DrawerOverlay'
 import { FilterPanel } from '../FilterPanel'
 import { GPSLocation } from '../GPSLocation'
@@ -137,6 +138,8 @@ export const IncidentMap = () => {
           resetMarkerIcons={resetMarkerIcons}
         />
 
+        {map && coordinates && <Pin map={map} coordinates={coordinates} />}
+
         {map && (
           <GPSLocation
             setNotification={setNotification}
@@ -150,18 +153,18 @@ export const IncidentMap = () => {
           state={drawerState}
           onCloseDetailPanel={handleCloseDetailPanel}
           incident={selectedIncident}
-          setPin={setCoordinates}
-          address={address}
-          setAddress={setAddress}
         >
+          <AddressLocation
+            setCoordinates={setCoordinates}
+            address={address}
+            setAddress={setAddress}
+          />
           <FilterPanel
             filters={filters}
             setFilters={setFilters}
             setMapMessage={setMapMessage}
           />
         </DrawerOverlay>
-
-        {map && coordinates && <Pin map={map} coordinates={coordinates} />}
 
         {mapMessage && showMessage && (
           <ViewerContainer

--- a/src/signals/IncidentMap/components/IncidentMap/styled.ts
+++ b/src/signals/IncidentMap/components/IncidentMap/styled.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2022 Gemeente Amsterdam
-import { breakpoint, themeSpacing } from '@amsterdam/asc-ui'
+import { breakpoint, themeSpacing, Paragraph } from '@amsterdam/asc-ui'
 import styled from 'styled-components'
 
 import Map from 'components/Map'
@@ -33,4 +33,8 @@ export const StyledMap = styled(Map)`
   height: 100%;
   width: 100%;
   z-index: 0;
+`
+
+export const StyledParagraph = styled(Paragraph)`
+  margin-bottom: ${themeSpacing(5)};
 `


### PR DESCRIPTION
Ticket: none

There was some obsolete code left after the implementation of the `AddressLocation`. This PR deletes that. 

Also, the component sticked to the top since it was not wrapped in the `DrawerContentWrapper` and therefore was not scrollable on mobile. Passing the `AddressLocation` as children of DrawerOverlay now. 