### PR TITLE
Only show contactAllowedText when feature flag reporterMailHandledNegativeContactEnabled is on

### DIFF
--- a/src/signals/incident/containers/KtoContainer/index.js
+++ b/src/signals/incident/containers/KtoContainer/index.js
@@ -177,7 +177,10 @@ export const KtoContainer = () => {
               </StyledHeading>
               <StyledParagraph data-testid="succesSectionBody">
                 {successSections[satisfactionIndication].body}
-                {contactAllowed && contactAllowedText}
+                {configuration.featureFlags
+                  .reporterMailHandledNegativeContactEnabled &&
+                  contactAllowed &&
+                  contactAllowedText}
               </StyledParagraph>
             </header>
           )}


### PR DESCRIPTION
Debugged this together with @tcoenen.

Fixes Signalen/frontend#175 and fixes https://github.com/Signalen/product-steering/issues/283