### PR TITLE
[SIG-4784]: zoom to incident on click

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
         "lodash": "^4.17.21",
         "proj4": "^2.7.2",
         "react": "^17.0.2",
-        "react-albus": "^2.0.0",
         "react-datepicker": "^3.6.0",
         "react-dom": "^17.0.2",
         "react-helmet": "^6.1.0",
@@ -75,7 +74,6 @@
         "@types/lodash": "^4.14.168",
         "@types/node": "^16.9.0",
         "@types/react": "^17.0.39",
-        "@types/react-albus": "^2.0.8",
         "@types/react-datepicker": "^3.1.8",
         "@types/react-dom": "^17.0.11",
         "@types/react-helmet": "^6.1.5",
@@ -3732,16 +3730,6 @@
         "@types/prop-types": "*",
         "@types/scheduler": "*",
         "csstype": "^3.0.2"
-      }
-    },
-    "node_modules/@types/react-albus": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@types/react-albus/-/react-albus-2.0.8.tgz",
-      "integrity": "sha512-1+r5A3LMVLHogH/mfOt3fddeHR8rg/UwZ8XuFL56y9yZPwomW8EGaLUAlaUkAsjEUWuCxwh1pjrSCxJnMWbtSw==",
-      "dev": true,
-      "dependencies": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*"
       }
     },
     "node_modules/@types/react-datepicker": {
@@ -15885,24 +15873,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-albus": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/react-albus/-/react-albus-2.0.0.tgz",
-      "integrity": "sha512-+gmvDfs75nFgHOHEPm/nA6DJFwzFm4AgFJD6L/zbjK80jHRasstyphYnPI/RHp4MuI7dBPTpvS9MvE90wBrv8A==",
-      "dependencies": {
-        "history": "^4.6.0",
-        "hoist-non-react-statics": "^2.3.1",
-        "prop-types": "^15.5.8"
-      },
-      "peerDependencies": {
-        "react": "^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/react-albus/node_modules/hoist-non-react-statics": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-      "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
-    },
     "node_modules/react-datepicker": {
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-3.8.0.tgz",
@@ -22456,16 +22426,6 @@
         "@types/prop-types": "*",
         "@types/scheduler": "*",
         "csstype": "^3.0.2"
-      }
-    },
-    "@types/react-albus": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@types/react-albus/-/react-albus-2.0.8.tgz",
-      "integrity": "sha512-1+r5A3LMVLHogH/mfOt3fddeHR8rg/UwZ8XuFL56y9yZPwomW8EGaLUAlaUkAsjEUWuCxwh1pjrSCxJnMWbtSw==",
-      "dev": true,
-      "requires": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*"
       }
     },
     "@types/react-datepicker": {
@@ -31613,23 +31573,6 @@
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
-      }
-    },
-    "react-albus": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/react-albus/-/react-albus-2.0.0.tgz",
-      "integrity": "sha512-+gmvDfs75nFgHOHEPm/nA6DJFwzFm4AgFJD6L/zbjK80jHRasstyphYnPI/RHp4MuI7dBPTpvS9MvE90wBrv8A==",
-      "requires": {
-        "history": "^4.6.0",
-        "hoist-non-react-statics": "^2.3.1",
-        "prop-types": "^15.5.8"
-      },
-      "dependencies": {
-        "hoist-non-react-statics": {
-          "version": "2.5.5",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz",
-          "integrity": "sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw=="
-        }
       }
     },
     "react-datepicker": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -211,6 +211,7 @@
         "@amsterdam/asc-assets": "^0.35.0",
         "classnames": "^2.3.1",
         "deepmerge": "^4.2.2",
+        "objectFitPolyfill": ">=2.3.0",
         "polished": "^4.1.3",
         "react-uid": "^2.3.1"
       },
@@ -252,6 +253,8 @@
       "dev": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.8",
+        "@nicolo-ribaudo/chokidar-2": "2.1.8-no-fsevents.3",
+        "chokidar": "^3.4.0",
         "commander": "^4.0.1",
         "convert-source-map": "^1.1.0",
         "fs-readdir-recursive": "^1.1.0",
@@ -5836,6 +5839,7 @@
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
+        "fsevents": "~2.3.2",
         "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -6297,8 +6301,10 @@
       "resolved": "https://registry.npmjs.org/connected-react-router/-/connected-react-router-6.9.2.tgz",
       "integrity": "sha512-bE8kNBiZv9Mivp7pYn9JvLH5ItTjLl45kk1/Vha0rmAK9I/ETb5JPJrAm0h2KCG9qLfv7vqU3Jo4UUDo0oJnQg==",
       "dependencies": {
+        "immutable": "^3.8.1 || ^4.0.0",
         "lodash.isequalwith": "^4.4.0",
-        "prop-types": "^15.7.2"
+        "prop-types": "^15.7.2",
+        "seamless-immutable": "^7.1.3"
       },
       "optionalDependencies": {
         "immutable": "^3.8.1 || ^4.0.0",
@@ -7692,7 +7698,8 @@
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -10426,6 +10433,7 @@
         "minimist": "^1.2.5",
         "neo-async": "^2.6.0",
         "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4",
         "wordwrap": "^1.0.0"
       },
       "bin": {
@@ -12178,6 +12186,7 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
+        "fsevents": "^2.3.2",
         "graceful-fs": "^4.2.9",
         "jest-regex-util": "^27.5.1",
         "jest-serializer": "^27.5.1",
@@ -12738,6 +12747,7 @@
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
       "dependencies": {
+        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {

--- a/src/components/MarkerCluster/MarkerCluster.test.tsx
+++ b/src/components/MarkerCluster/MarkerCluster.test.tsx
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C)  - 2021 Gemeente Amsterdam
-// eslint-disable-next-line import/no-duplicates
-import type L from 'leaflet'
-// eslint-disable-next-line import/no-duplicates
-import type { MapOptions } from 'leaflet'
-import { render } from '@testing-library/react'
+// Copyright (C) 2021 - 2022 Gemeente Amsterdam
 
 import { Map } from '@amsterdam/react-maps'
+import { render } from '@testing-library/react'
+import type L from 'leaflet'
+import type { MapOptions } from 'leaflet'
+
 import MAP_OPTIONS from 'shared/services/configuration/map-options'
-import MarkerCluster from '..'
+
+import MarkerCluster from './MarkerCluster'
 
 const options = {
   ...MAP_OPTIONS,

--- a/src/components/MarkerCluster/MarkerCluster.tsx
+++ b/src/components/MarkerCluster/MarkerCluster.tsx
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C)  - 2021 Gemeente Amsterdam
-import * as L from 'leaflet'
+// Copyright (C) 2021 - 2022 Gemeente Amsterdam
 import type { Dispatch, FunctionComponent, SetStateAction } from 'react'
+
 import { createLeafletComponent } from '@amsterdam/react-maps'
+import * as L from 'leaflet'
 import 'leaflet.markercluster/dist/MarkerCluster.Default.css'
 import './style.css'
 
@@ -16,12 +17,14 @@ interface MarkerClusterProps {
   setInstance: Dispatch<SetStateAction<L.GeoJSON | undefined>>
   clusterOptions?: L.MarkerClusterGroupOptions
   getIsSelectedCluster?: (cluster: L.MarkerCluster) => boolean
+  spiderfySelectedCluster?: boolean
 }
 
 const MarkerCluster: FunctionComponent<MarkerClusterProps> = ({
   clusterOptions,
   setInstance,
   getIsSelectedCluster,
+  spiderfySelectedCluster = true,
 }) => {
   const options: L.MarkerClusterGroupOptions = {
     showCoverageOnHover: false,
@@ -38,7 +41,7 @@ const MarkerCluster: FunctionComponent<MarkerClusterProps> = ({
         cluster.on({
           add: () => {
             // When selecting a marker in a cluster, re-render the cluster in spiderfied state
-            if (isSelectedCluster) {
+            if (isSelectedCluster && spiderfySelectedCluster) {
               ;(cluster as any)?.spiderfy()
             }
           },

--- a/src/signals/IncidentMap/components/AddressLocation/AddressLocation.tsx
+++ b/src/signals/IncidentMap/components/AddressLocation/AddressLocation.tsx
@@ -30,7 +30,7 @@ export const AddressLocation = ({ setCoordinates, address }: Props) => {
       <Heading as="h4">Zoom naar adres</Heading>
       <StyledPDOKAutoSuggest
         data-testid="searchAddressBar"
-        placeholder={'Zoek naar adres'}
+        placeholder={'Adres'}
         onSelect={onAddressSelect}
         value={addressValue}
         onClear={() => setCoordinates(undefined)}

--- a/src/signals/IncidentMap/components/AddressLocation/AddressLocation.tsx
+++ b/src/signals/IncidentMap/components/AddressLocation/AddressLocation.tsx
@@ -5,19 +5,23 @@ import { useCallback } from 'react'
 import { Heading } from '@amsterdam/asc-ui'
 import type { LatLngLiteral } from 'leaflet'
 
-import { formatAddress } from 'shared/services/format-address'
 import type { PdokResponse } from 'shared/services/map-location'
-import type { Address } from 'types/address'
 
-import { StyledPDOKAutoSuggest, Wrapper } from './styled'
+import {
+  StyledPDOKAutoSuggest,
+  AddressLocationWrapper as Wrapper,
+} from './styled'
 export interface Props {
-  address?: Address
+  address?: string
   setCoordinates: (coordinates?: LatLngLiteral) => void
+  setShowAddressPanel: (value: boolean) => void
 }
 
-export const AddressLocation = ({ setCoordinates, address }: Props) => {
-  const addressValue = address ? formatAddress(address) : ''
-
+export const AddressLocation = ({
+  setCoordinates,
+  address,
+  setShowAddressPanel,
+}: Props) => {
   const onAddressSelect = useCallback(
     (option: PdokResponse) => {
       setCoordinates(option.data.location)
@@ -32,8 +36,11 @@ export const AddressLocation = ({ setCoordinates, address }: Props) => {
         data-testid="searchAddressBar"
         placeholder="Adres"
         onSelect={onAddressSelect}
-        value={addressValue}
+        value={address}
         onClear={() => setCoordinates(undefined)}
+        onFocus={() => {
+          setShowAddressPanel(true)
+        }}
       />
     </Wrapper>
   )

--- a/src/signals/IncidentMap/components/AddressLocation/AddressLocation.tsx
+++ b/src/signals/IncidentMap/components/AddressLocation/AddressLocation.tsx
@@ -30,7 +30,7 @@ export const AddressLocation = ({ setCoordinates, address }: Props) => {
       <Heading as="h4">Zoom naar adres</Heading>
       <StyledPDOKAutoSuggest
         data-testid="searchAddressBar"
-        placeholder={'Adres'}
+        placeholder="Adres"
         onSelect={onAddressSelect}
         value={addressValue}
         onClear={() => setCoordinates(undefined)}

--- a/src/signals/IncidentMap/components/AddressLocation/AddressLocation.tsx
+++ b/src/signals/IncidentMap/components/AddressLocation/AddressLocation.tsx
@@ -11,7 +11,7 @@ import type { Address } from 'types/address'
 
 import { StyledPDOKAutoSuggest, Wrapper } from './styled'
 export interface Props {
-  setCoordinates: (coordinates: LatLngLiteral) => void
+  setCoordinates: (coordinates?: LatLngLiteral) => void
   address?: Address
   setAddress: (address?: Address) => void
 }
@@ -34,6 +34,7 @@ export const AddressLocation = ({ setCoordinates, address }: Props) => {
         placeholder={'Zoek naar adres'}
         onSelect={onAddressSelect}
         value={addressValue}
+        onClear={() => setCoordinates(undefined)}
       />
     </Wrapper>
   )

--- a/src/signals/IncidentMap/components/AddressLocation/AddressLocation.tsx
+++ b/src/signals/IncidentMap/components/AddressLocation/AddressLocation.tsx
@@ -11,9 +11,8 @@ import type { Address } from 'types/address'
 
 import { StyledPDOKAutoSuggest, Wrapper } from './styled'
 export interface Props {
-  setCoordinates: (coordinates?: LatLngLiteral) => void
   address?: Address
-  setAddress: (address?: Address) => void
+  setCoordinates: (coordinates?: LatLngLiteral) => void
 }
 
 export const AddressLocation = ({ setCoordinates, address }: Props) => {

--- a/src/signals/IncidentMap/components/AddressLocation/AddressLocation.tsx
+++ b/src/signals/IncidentMap/components/AddressLocation/AddressLocation.tsx
@@ -14,13 +14,13 @@ import {
 export interface Props {
   address?: string
   setCoordinates: (coordinates?: LatLngLiteral) => void
-  setShowAddressPanel: (value: boolean) => void
+  setShowAddressSearchMobile: (value: boolean) => void
 }
 
 export const AddressLocation = ({
   setCoordinates,
   address,
-  setShowAddressPanel,
+  setShowAddressSearchMobile,
 }: Props) => {
   const onAddressSelect = useCallback(
     (option: PdokResponse) => {
@@ -39,7 +39,7 @@ export const AddressLocation = ({
         value={address}
         onClear={() => setCoordinates(undefined)}
         onFocus={() => {
-          setShowAddressPanel(true)
+          setShowAddressSearchMobile(true)
         }}
       />
     </Wrapper>

--- a/src/signals/IncidentMap/components/AddressLocation/AddressSearchMobile.test.tsx
+++ b/src/signals/IncidentMap/components/AddressLocation/AddressSearchMobile.test.tsx
@@ -69,7 +69,7 @@ jest.mock(
 
 const defaultProps: Props = {
   setCoordinates: jest.fn(),
-  setShowAddressPanel: jest.fn(),
+  setShowAddressSearchMobile: jest.fn(),
 }
 
 describe('AddresLocation', () => {
@@ -115,6 +115,6 @@ describe('AddresLocation', () => {
 
     userEvent.click(button)
 
-    expect(defaultProps.setShowAddressPanel).toHaveBeenCalledWith(false)
+    expect(defaultProps.setShowAddressSearchMobile).toHaveBeenCalledWith(false)
   })
 })

--- a/src/signals/IncidentMap/components/AddressLocation/AddressSearchMobile.test.tsx
+++ b/src/signals/IncidentMap/components/AddressLocation/AddressSearchMobile.test.tsx
@@ -78,7 +78,6 @@ describe('AddresLocation', () => {
 
     userEvent.click(screen.getByText('selectItem'))
 
-    //the mocked PDOKAutoSuggest triggers automatically onSelect/onAddressSelect, no userEvents are necessary
     expect(defaultProps.setCoordinates).toHaveBeenCalledWith(
       mockPDOKResponse.data.location
     )

--- a/src/signals/IncidentMap/components/AddressLocation/AddressSearchMobile.test.tsx
+++ b/src/signals/IncidentMap/components/AddressLocation/AddressSearchMobile.test.tsx
@@ -8,8 +8,8 @@ import userEvent from '@testing-library/user-event'
 import type { PDOKAutoSuggestProps } from 'components/PDOKAutoSuggest'
 import type { PdokResponse } from 'shared/services/map-location'
 
-import type { Props } from './AddressLocation'
-import { AddressLocation } from './AddressLocation'
+import type { Props } from './AddressSearchMobile'
+import { AddressSearchMobile } from './AddressSearchMobile'
 
 const mockAddress = {
   postcode: '1000 AA',
@@ -73,8 +73,8 @@ const defaultProps: Props = {
 }
 
 describe('AddresLocation', () => {
-  it('tests whether the onAddressSelect actually sets the coordinates', async () => {
-    render(<AddressLocation {...defaultProps} />)
+  it('should set coordinates', async () => {
+    render(<AddressSearchMobile {...defaultProps} />)
 
     userEvent.click(screen.getByText('selectItem'))
 
@@ -89,7 +89,7 @@ describe('AddresLocation', () => {
       ...defaultProps,
       address: 'Warmoesstraat 178, 1012JK Amsterdam',
     }
-    render(<AddressLocation {...props} />)
+    render(<AddressSearchMobile {...props} />)
 
     const input = screen.getByText('Warmoesstraat 178, 1012JK Amsterdam')
 
@@ -97,7 +97,7 @@ describe('AddresLocation', () => {
   })
 
   it('should reset the coordinates on reset button', () => {
-    render(<AddressLocation {...defaultProps} />)
+    render(<AddressSearchMobile {...defaultProps} />)
 
     const resetButton = screen.getByRole('button', { name: 'Clear input' })
 
@@ -106,5 +106,15 @@ describe('AddresLocation', () => {
     const input = screen.getByRole('textbox')
 
     expect(input).toHaveValue('')
+  })
+
+  it('should close overlay on back button', () => {
+    render(<AddressSearchMobile {...defaultProps} />)
+
+    const button = screen.getByRole('button', { name: 'Terug' })
+
+    userEvent.click(button)
+
+    expect(defaultProps.setShowAddressPanel).toHaveBeenCalledWith(false)
   })
 })

--- a/src/signals/IncidentMap/components/AddressLocation/AddressSearchMobile.tsx
+++ b/src/signals/IncidentMap/components/AddressLocation/AddressSearchMobile.tsx
@@ -38,11 +38,11 @@ export const AddressSearchMobile = ({
 
   return (
     <Wrapper>
-      <AddressSearch id="AddressSearchMobile">
+      <AddressSearch id="addressSearchMobile">
         <header>
           <Button
             aria-label="Terug"
-            aria-controls="AddressSearchMobile"
+            aria-controls="addressSearchMobile"
             icon={<ChevronLeft />}
             iconSize={16}
             onClick={() => setShowAddressSearchMobile(false)}
@@ -57,7 +57,7 @@ export const AddressSearchMobile = ({
             showInlineList={false}
             value={address}
             placeholder="Zoom naar adres"
-            autoFocus={true}
+            autoFocus
           />
         </header>
 

--- a/src/signals/IncidentMap/components/AddressLocation/AddressSearchMobile.tsx
+++ b/src/signals/IncidentMap/components/AddressLocation/AddressSearchMobile.tsx
@@ -18,27 +18,23 @@ import {
 export interface Props {
   address?: string
   setCoordinates: (coordinates?: LatLngLiteral) => void
-  setShowAddressPanel: (value: boolean) => void
+  setShowAddressSearchMobile: (value: boolean) => void
 }
 
 export const AddressSearchMobile = ({
   address,
   setCoordinates,
-  setShowAddressPanel,
+  setShowAddressSearchMobile,
 }: Props) => {
   const [optionsList, setOptionsList] = useState(null)
 
   const onAddressSelect = useCallback(
     (option: PdokResponse) => {
       setCoordinates(option.data.location)
-      setShowAddressPanel(false)
+      setShowAddressSearchMobile(false)
     },
-    [setCoordinates, setShowAddressPanel]
+    [setCoordinates, setShowAddressSearchMobile]
   )
-
-  const closeOverlay = useCallback(() => {
-    setShowAddressPanel(false)
-  }, [setShowAddressPanel])
 
   return (
     <Wrapper>
@@ -49,7 +45,7 @@ export const AddressSearchMobile = ({
             aria-controls="AddressSearchMobile"
             icon={<ChevronLeft />}
             iconSize={16}
-            onClick={closeOverlay}
+            onClick={() => setShowAddressSearchMobile(false)}
             size={24}
             title="Terug"
             variant="blank"

--- a/src/signals/IncidentMap/components/AddressLocation/AddressSearchMobile.tsx
+++ b/src/signals/IncidentMap/components/AddressLocation/AddressSearchMobile.tsx
@@ -15,7 +15,7 @@ import {
   OptionsList,
 } from './styled'
 
-interface Props {
+export interface Props {
   address?: string
   setCoordinates: (coordinates?: LatLngLiteral) => void
   setShowAddressPanel: (value: boolean) => void
@@ -36,7 +36,7 @@ export const AddressSearchMobile = ({
     [setCoordinates, setShowAddressPanel]
   )
 
-  const closeAddressPanel = useCallback(() => {
+  const closeOverlay = useCallback(() => {
     setShowAddressPanel(false)
   }, [setShowAddressPanel])
 
@@ -49,7 +49,7 @@ export const AddressSearchMobile = ({
             aria-controls="AddressSearchMobile"
             icon={<ChevronLeft />}
             iconSize={16}
-            onClick={closeAddressPanel}
+            onClick={closeOverlay}
             size={24}
             title="Terug"
             variant="blank"

--- a/src/signals/IncidentMap/components/AddressLocation/AddressSearchMobile.tsx
+++ b/src/signals/IncidentMap/components/AddressLocation/AddressSearchMobile.tsx
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (C) 2022 Gemeente Amsterdam
+import { useCallback, useState } from 'react'
+
+import { ChevronLeft } from '@amsterdam/asc-assets'
+import { Button } from '@amsterdam/asc-ui'
+import type { LatLngLiteral } from 'leaflet'
+
+import type { PdokResponse } from 'shared/services/map-location'
+
+import {
+  AddressSearchWrapper as Wrapper,
+  StyledPDOKAutoSuggest,
+  AddressSearch,
+  OptionsList,
+} from './styled'
+
+interface Props {
+  address?: string
+  setCoordinates: (coordinates?: LatLngLiteral) => void
+  setShowAddressPanel: (value: boolean) => void
+}
+
+export const AddressSearchMobile = ({
+  address,
+  setCoordinates,
+  setShowAddressPanel,
+}: Props) => {
+  const [optionsList, setOptionsList] = useState(null)
+
+  const onAddressSelect = useCallback(
+    (option: PdokResponse) => {
+      setCoordinates(option.data.location)
+      setShowAddressPanel(false)
+    },
+    [setCoordinates, setShowAddressPanel]
+  )
+
+  const closeAddressPanel = useCallback(() => {
+    setShowAddressPanel(false)
+  }, [setShowAddressPanel])
+
+  return (
+    <Wrapper>
+      <AddressSearch id="AddressSearchMobile">
+        <header>
+          <Button
+            aria-label="Terug"
+            aria-controls="AddressSearchMobile"
+            icon={<ChevronLeft />}
+            iconSize={16}
+            onClick={closeAddressPanel}
+            size={24}
+            title="Terug"
+            variant="blank"
+          />
+          <StyledPDOKAutoSuggest
+            onClear={() => setCoordinates(undefined)}
+            onData={setOptionsList}
+            onSelect={onAddressSelect}
+            showInlineList={false}
+            value={address}
+            placeholder="Zoom naar adres"
+            autoFocus={true}
+          />
+        </header>
+
+        {optionsList && (
+          <OptionsList data-testid="optionsList">{optionsList}</OptionsList>
+        )}
+      </AddressSearch>
+    </Wrapper>
+  )
+}

--- a/src/signals/IncidentMap/components/AddressLocation/AdressLocation.test.tsx
+++ b/src/signals/IncidentMap/components/AddressLocation/AdressLocation.test.tsx
@@ -69,7 +69,7 @@ jest.mock(
 
 const defaultProps: Props = {
   setCoordinates: jest.fn(),
-  setShowAddressPanel: jest.fn(),
+  setShowAddressSearchMobile: jest.fn(),
 }
 
 describe('AddresLocation', () => {
@@ -78,7 +78,6 @@ describe('AddresLocation', () => {
 
     userEvent.click(screen.getByText('selectItem'))
 
-    //the mocked PDOKAutoSuggest triggers automatically onSelect/onAddressSelect, no userEvents are necessary
     expect(defaultProps.setCoordinates).toHaveBeenCalledWith(
       mockPDOKResponse.data.location
     )

--- a/src/signals/IncidentMap/components/AddressLocation/AdressLocation.test.tsx
+++ b/src/signals/IncidentMap/components/AddressLocation/AdressLocation.test.tsx
@@ -1,61 +1,117 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2022 Gemeente Amsterdam
 
-import { render, screen } from '@testing-library/react'
+import type { ReactPropTypes } from 'react'
 
-import { formatAddress } from 'shared/services/format-address'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import type { PDOKAutoSuggestProps } from 'components/PDOKAutoSuggest'
+import type { PdokResponse } from 'shared/services/map-location'
 
 import type { Props } from './AddressLocation'
 import { AddressLocation } from './AddressLocation'
 
-const coords = {
-  lat: 52.3731081,
-  lng: 4.8932945,
-}
-
-const mockPdokAddress = {
-  huisnummer: '178',
-  openbare_ruimte: 'Warmoesstraat',
-  postcode: '1012JK',
+const mockAddress = {
+  postcode: '1000 AA',
+  huisnummer: '100',
   woonplaats: 'Amsterdam',
+  openbare_ruimte: 'West',
 }
 
-const mockPdokResponse = {
-  id: 1,
-  value: 'mockValue',
+const mockList = (props: ReactPropTypes) => (
+  <ul className="suggestList" {...props}>
+    <li>Suggestion #1</li>
+    <li>Suggestion #2</li>
+  </ul>
+)
+
+const mockPDOKResponse: PdokResponse = {
+  id: 'foo',
+  value: 'Zork',
   data: {
-    location: coords,
-    address: mockPdokAddress,
+    location: {
+      lat: 12.282,
+      lng: 3.141,
+    },
+    address: mockAddress,
   },
 }
 
-jest.mock('./styled', () => ({
-  ...jest.requireActual('./styled'),
-  StyledPDOKAutoSuggest: ({ onSelect, value, ...rest }: any) => {
-    onSelect(mockPdokResponse)
-    return <div {...rest}>{value}</div>
-  },
-}))
+jest.mock(
+  'components/PDOKAutoSuggest/PDOKAutoSuggest',
+  () =>
+    ({
+      className,
+      onSelect,
+      value,
+      onClear,
+      onFocus,
+      onData,
+    }: PDOKAutoSuggestProps) =>
+      (
+        <span data-testid="pdokAutoSuggest" className={className}>
+          <button data-testid="autoSuggestClear" onClick={onClear}>
+            Clear input
+          </button>
+          <button onClick={() => onSelect(mockPDOKResponse)}>selectItem</button>
+          <button
+            data-testid="getDataMockButton"
+            type="button"
+            onClick={() => {
+              onData && onData(mockList)
+            }}
+          />
+          <input data-testid="autoSuggestInput" type="text" onFocus={onFocus} />
+          <span>{value}</span>
+        </span>
+      )
+)
 
 const defaultProps: Props = {
   setCoordinates: jest.fn(),
-  address: mockPdokAddress,
-  setAddress: jest.fn(),
 }
 
 describe('AddresLocation', () => {
   it('tests whether the onAddressSelect actually sets the coordinates', async () => {
     render(<AddressLocation {...defaultProps} />)
 
+    userEvent.click(screen.getByText('selectItem'))
+
     //the mocked PDOKAutoSuggest triggers automatically onSelect/onAddressSelect, no userEvents are necessary
-    expect(defaultProps.setCoordinates).toHaveBeenCalledWith(coords)
+    expect(defaultProps.setCoordinates).toHaveBeenCalledWith(
+      mockPDOKResponse.data.location
+    )
   })
 
   it('shows the address in the searchbar', () => {
+    const mockPdokAddress = {
+      huisnummer: '178',
+      openbare_ruimte: 'Warmoesstraat',
+      postcode: '1012JK',
+      woonplaats: 'Amsterdam',
+    }
+
+    const props = {
+      ...defaultProps,
+      address: mockPdokAddress,
+    }
+    render(<AddressLocation {...props} />)
+
+    const input = screen.getByText('Warmoesstraat 178, 1012JK Amsterdam')
+
+    expect(input).toBeInTheDocument()
+  })
+
+  it('should reset the coordinates on reset button', () => {
     render(<AddressLocation {...defaultProps} />)
 
-    expect(screen.getByTestId('searchAddressBar').innerHTML).toEqual(
-      formatAddress(mockPdokAddress)
-    )
+    const resetButton = screen.getByRole('button', { name: 'Clear input' })
+
+    userEvent.click(resetButton)
+
+    const input = screen.getByRole('textbox')
+
+    expect(input).toHaveValue('')
   })
 })

--- a/src/signals/IncidentMap/components/AddressLocation/index.ts
+++ b/src/signals/IncidentMap/components/AddressLocation/index.ts
@@ -1,4 +1,2 @@
-// SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2022 Gemeente Amsterdam
-
 export { AddressLocation } from './AddressLocation'
+export { AddressSearchMobile } from './AddressSearchMobile'

--- a/src/signals/IncidentMap/components/AddressLocation/styled.ts
+++ b/src/signals/IncidentMap/components/AddressLocation/styled.ts
@@ -1,17 +1,101 @@
-import { breakpoint, themeSpacing } from '@amsterdam/asc-ui'
-import styled from 'styled-components'
+import { breakpoint, themeSpacing, themeColor } from '@amsterdam/asc-ui'
+import styled, { keyframes } from 'styled-components'
 
 import PDOKAutoSuggest from 'components/PDOKAutoSuggest'
+
+/**
+ * AddressLocation
+ * */
 
 export const StyledPDOKAutoSuggest = styled(PDOKAutoSuggest)`
   width: 100%;
 `
 
-export const Wrapper = styled.div`
+export const AddressLocationWrapper = styled.div`
   width: 100%;
   margin: ${themeSpacing(5, 0)};
 
   @media screen and ${breakpoint('max-width', 'tabletM')} {
     margin-top: ${themeSpacing(0)};
+  }
+`
+
+const slideUp = keyframes`
+  from {
+    transform: translate3d(0, 100%, 0);
+  }
+
+  to {
+    transform: translate3d(0, 0, 0);
+  }
+`
+
+/**
+ * AddressSearchMobile
+ * */
+
+export const AddressSearchWrapper = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 100%;
+  width: 100%;
+  display: flex;
+  background-color: white;
+  z-index: 100;
+`
+
+export const AddressSearch = styled.article`
+  background-color: white;
+  position: fixed;
+  width: 100vw;
+  height: 100%;
+  z-index: 2;
+  left: 0;
+  top: 0;
+  animation: ${slideUp} 0.3s cubic-bezier(0.4, 0, 0.2, 1) translate3d(0, 50%, 0);
+
+  @media only screen and ${breakpoint('max-width', 'tabletM')} {
+    transform: translate3d(0, 0, 0);
+  }
+
+  header {
+    border-bottom: 5px solid rgba(0, 0, 0, 0.1);
+    padding: ${themeSpacing(4)};
+    display: flex;
+    align-items: center;
+
+    > * {
+      margin: 0;
+    }
+
+    > button {
+      border: 0;
+      margin-right: ${themeSpacing(4)};
+    }
+  }
+
+  .instruction {
+    color: ${themeColor('tint', 'level4')};
+    font-size: 18px;
+    margin-top: ${themeSpacing(6)};
+    text-align: center;
+  }
+`
+export const OptionsList = styled.div`
+  ul {
+    border: 0;
+    margin: ${themeSpacing(2, 0)};
+
+    li {
+      line-height: 22px;
+      padding: ${themeSpacing(2, 4)};
+    }
+  }
+
+  .chrevronIcon {
+    display: none;
   }
 `

--- a/src/signals/IncidentMap/components/AddressLocation/styled.ts
+++ b/src/signals/IncidentMap/components/AddressLocation/styled.ts
@@ -1,7 +1,7 @@
 import { breakpoint, themeSpacing } from '@amsterdam/asc-ui'
 import styled from 'styled-components'
 
-import PDOKAutoSuggest from 'components/PDOKAutoSuggest/PDOKAutoSuggest'
+import PDOKAutoSuggest from 'components/PDOKAutoSuggest'
 
 export const StyledPDOKAutoSuggest = styled(PDOKAutoSuggest)`
   width: 100%;

--- a/src/signals/IncidentMap/components/AddressLocation/styled.ts
+++ b/src/signals/IncidentMap/components/AddressLocation/styled.ts
@@ -1,4 +1,4 @@
-import { breakpoint, themeSpacing, themeColor } from '@amsterdam/asc-ui'
+import { breakpoint, themeSpacing } from '@amsterdam/asc-ui'
 import styled, { keyframes } from 'styled-components'
 
 import PDOKAutoSuggest from 'components/PDOKAutoSuggest'
@@ -20,16 +20,6 @@ export const AddressLocationWrapper = styled.div`
   }
 `
 
-const slideUp = keyframes`
-  from {
-    transform: translate3d(0, 100%, 0);
-  }
-
-  to {
-    transform: translate3d(0, 0, 0);
-  }
-`
-
 /**
  * AddressSearchMobile
  * */
@@ -45,6 +35,16 @@ export const AddressSearchWrapper = styled.div`
   display: flex;
   background-color: white;
   z-index: 100;
+`
+
+const slideUp = keyframes`
+  from {
+    transform: translate3d(0, 100%, 0);
+  }
+
+  to {
+    transform: translate3d(0, 0, 0);
+  }
 `
 
 export const AddressSearch = styled.article`
@@ -76,14 +76,8 @@ export const AddressSearch = styled.article`
       margin-right: ${themeSpacing(4)};
     }
   }
-
-  .instruction {
-    color: ${themeColor('tint', 'level4')};
-    font-size: 18px;
-    margin-top: ${themeSpacing(6)};
-    text-align: center;
-  }
 `
+
 export const OptionsList = styled.div`
   ul {
     border: 0;

--- a/src/signals/IncidentMap/components/DrawerOverlay/styled.ts
+++ b/src/signals/IncidentMap/components/DrawerOverlay/styled.ts
@@ -181,6 +181,7 @@ export const CloseButton = styled(Button)`
   min-width: inherit;
   // Needs z-index else content blocks the onClick
   z-index: 1;
+  background-color: transparent;
 
   > span {
     margin-right: 0;

--- a/src/signals/IncidentMap/components/DrawerOverlay/styled.ts
+++ b/src/signals/IncidentMap/components/DrawerOverlay/styled.ts
@@ -65,6 +65,7 @@ export const DrawerHandleMiniDesktop = styled.div`
   box-sizing: content-box;
   border-left: none;
   transition: background-color 0.1s ease-in-out;
+
   &:before {
     content: '';
     box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.1);
@@ -82,9 +83,7 @@ export const DrawerHandleDesktop = styled(Button)`
   height: 100%;
   position: relative;
   margin-right: ${themeSpacing(5)};
-  @media print {
-    display: none;
-  }
+
   & > ${styles.IconStyle} {
     opacity: 0;
   }
@@ -127,10 +126,7 @@ export const DrawerContainer = styled.div<{ animate: boolean } & ModeProp>`
   right: 0;
   left: 0;
   will-change: transform;
-  @media print {
-    position: relative;
-    width: 100%;
-  }
+
   ${({ $mode }) =>
     isDesktop($mode) &&
     css`
@@ -160,20 +156,23 @@ export const Drawer = styled.div<ModeProp>`
 
 export const DrawerContent = styled.div`
   display: flex;
+  background-color: ${themeColor('tint', 'level1')};
   flex-direction: column;
   flex-grow: 1;
-  min-height: 0;
-  position: relative;
-  background-color: ${themeColor('tint', 'level1')};
   max-width: 100%;
+  min-height: 0;
   overflow-y: auto;
+  position: relative;
 
   @media screen and ${breakpoint('min-width', 'tabletM')} {
     width: ${MENU_WIDTH}px;
   }
 `
 
-// Detail Panel
+/**
+ * Detail Panel
+ * */
+
 export const CloseButton = styled(Button)`
   position: absolute;
   top: 14px;
@@ -190,16 +189,15 @@ export const CloseButton = styled(Button)`
 
 export const DetailsWrapper = styled.section`
   position: absolute;
-  padding: 20px;
-  top: 0;
-  right: 0;
+  background-color: ${themeColor('tint', 'level1')};
   bottom: 0;
   left: 0;
-  width: calc(${MENU_WIDTH}px - 16px);
   max-width: 100%;
+  padding: 20px;
+  right: 0;
+  top: 0;
+  width: calc(${MENU_WIDTH}px - 16px);
   z-index: 2;
-
-  background-color: ${themeColor('tint', 'level1')};
 
   @media screen and ${breakpoint('max-width', 'tabletM')} {
     width: 100vh;
@@ -216,7 +214,6 @@ export const StyledList = styled.dl`
     color: ${themeColor('tint', 'level5')};
     margin-bottom: ${themeSpacing(1)};
     margin-top: ${themeSpacing(5)};
-
     position: relative;
     font-weight: 400;
 

--- a/src/signals/IncidentMap/components/Header/styled.tsx
+++ b/src/signals/IncidentMap/components/Header/styled.tsx
@@ -6,12 +6,12 @@ import styled from 'styled-components'
 import { HEADER_HEIGHT_DESKTOP, HEADER_HEIGHT_MOBILE } from './constants'
 
 export const HeaderWrapper = styled.div`
-  position: relative;
+  position: absolute;
+  top: 0;
   display: flex;
   justify-content: space-between;
   height: ${themeSpacing(HEADER_HEIGHT_DESKTOP)};
   width: 100%;
-  padding: 0 ${themeSpacing(4)};
   background-color: ${themeColor('tint', 'level1')};
   box-shadow: ${themeSpacing(0, 0, 0, 1)} rgba(0, 0, 0, 0.1);
   // z-index relative to map
@@ -19,7 +19,6 @@ export const HeaderWrapper = styled.div`
 
   @media screen and ${breakpoint('max-width', 'tabletM')} {
     height: ${themeSpacing(HEADER_HEIGHT_MOBILE)};
-    padding: ${themeSpacing(0, 0, 0, 4)};
   }
 `
 
@@ -27,6 +26,7 @@ export const Title = styled.div`
   display: flex;
   align-items: center;
   height: 100%;
+  margin-left: ${themeSpacing(4)};
 
   img {
     height: 100%;

--- a/src/signals/IncidentMap/components/IncidentLayer/IncidentLayer.tsx
+++ b/src/signals/IncidentMap/components/IncidentLayer/IncidentLayer.tsx
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: MPL-2.0 */
 /* Copyright (C) 2022 Gemeente Amsterdam */
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 import type { FeatureCollection, Point } from 'geojson'
 import L from 'leaflet'
@@ -105,16 +105,19 @@ export const IncidentLayer = ({
     selectedMarkerRef,
   ])
 
-  const getIsSelectedCluster = (cluster: L.MarkerCluster) => {
-    const markers = cluster.getAllChildMarkers()
+  const getIsSelectedCluster = useCallback(
+    (cluster: L.MarkerCluster) => {
+      const markers = cluster.getAllChildMarkers()
 
-    // Matching on created_at since incidents do not have ID's
-    return markers.some(
-      (marker) =>
-        marker.feature?.properties.created_at ===
-        selectedMarkerRef.current?.feature?.properties.created_at
-    )
-  }
+      // Matching on created_at since incidents do not have ID's
+      return markers.some(
+        (marker) =>
+          marker.feature?.properties.created_at ===
+          selectedMarkerRef.current?.feature?.properties.created_at
+      )
+    },
+    [selectedMarkerRef]
+  )
 
   return (
     <MarkerCluster

--- a/src/signals/IncidentMap/components/IncidentLayer/IncidentLayer.tsx
+++ b/src/signals/IncidentMap/components/IncidentLayer/IncidentLayer.tsx
@@ -13,7 +13,7 @@ import {
 import type { Bbox } from 'signals/incident/components/form/MapSelectors/hooks/useBoundingBox'
 import useBoundingBox from 'signals/incident/components/form/MapSelectors/hooks/useBoundingBox'
 
-import type { Incident } from '../../types'
+import type { Incident, Properties } from '../../types'
 
 const clusterLayerOptions = {
   zoomToBoundsOnClick: true,
@@ -25,7 +25,7 @@ interface Props {
   incidents?: Incident[]
   passBbox(bbox: Bbox): void
   resetSelectedMarker: () => void
-  selectedMarkerRef: React.MutableRefObject<L.Marker | undefined>
+  selectedMarkerRef: React.MutableRefObject<L.Marker<Properties> | undefined>
 }
 
 /* istanbul ignore next */
@@ -59,7 +59,7 @@ export const IncidentLayer = ({
 
     const layer = L.geoJSON(fc, {
       onEachFeature: (feature: Incident, layer: L.Layer) => {
-        layer.on('click', (e: { target: L.Marker<Incident> }) => {
+        layer.on('click', (e: { target: L.Marker<Properties> }) => {
           if (selectedMarkerRef.current !== e.target) {
             resetSelectedMarker()
           }
@@ -73,18 +73,17 @@ export const IncidentLayer = ({
       pointToLayer: (incident: Incident, latlng) => {
         let marker = L.marker(latlng, {
           icon: dynamicIcon(incident.properties?.icon),
-          alt: incident.properties?.category.name,
+          alt: incident.properties.category.name,
           keyboard: false,
         })
         // Matching on created_at since incidents do not have an ID
         if (
-          selectedMarkerRef.current &&
-          selectedMarkerRef.current.feature?.properties.created_at ===
-            incident.properties.created_at
+          selectedMarkerRef.current?.feature?.properties.created_at ===
+          incident.properties.created_at
         ) {
           marker = L.marker(latlng, {
             icon: selectedMarkerIcon,
-            alt: incident.properties?.category.name,
+            alt: incident.properties.category.name,
             keyboard: false,
           })
           selectedMarkerRef.current = marker
@@ -124,6 +123,7 @@ export const IncidentLayer = ({
       clusterOptions={clusterLayerOptions}
       setInstance={setLayerInstance}
       getIsSelectedCluster={getIsSelectedCluster}
+      spiderfySelectedCluster={false}
     />
   )
 }

--- a/src/signals/IncidentMap/components/IncidentMap/IncidentMap.tsx
+++ b/src/signals/IncidentMap/components/IncidentMap/IncidentMap.tsx
@@ -6,7 +6,6 @@ import { ViewerContainer } from '@amsterdam/arm-core'
 import type { FeatureCollection } from 'geojson'
 import type { Map as MapType, LatLngLiteral } from 'leaflet'
 
-import { DEFAULT_ZOOM } from 'components/AreaMap/AreaMap'
 import { useFetch } from 'hooks'
 import type { Map as MapType, LatLngLiteral } from 'leaflet'
 import configuration from 'shared/services/configuration/configuration'
@@ -29,6 +28,7 @@ import { IncidentLayer } from '../IncidentLayer'
 import { getFilteredIncidents } from '../utils'
 import { Pin } from './Pin'
 import { Wrapper, StyledMap, StyledParagraph } from './styled'
+import { getZoom } from './utils'
 
 export const IncidentMap = () => {
   const [bbox, setBbox] = useState<Bbox | undefined>()
@@ -69,17 +69,11 @@ export const IncidentMap = () => {
       const sanitaizedCoords = featureToCoordinates(incident.geometry)
       // When marker is underneath the drawerOverlay, move the map slightly up
       if (map && isMobile(mode) && sanitaizedCoords.lat < map.getCenter().lat) {
-        const currentZoom = map.getZoom()
         const coords = {
           lat: sanitaizedCoords.lat - 0.0003,
           lng: sanitaizedCoords.lng,
         }
-        const zoom =
-          currentZoom > DEFAULT_ZOOM
-            ? DEFAULT_ZOOM
-            : currentZoom < 12
-            ? 12
-            : currentZoom
+        const zoom = getZoom(map)
 
         map.flyTo(coords, zoom)
       }

--- a/src/signals/IncidentMap/components/IncidentMap/IncidentMap.tsx
+++ b/src/signals/IncidentMap/components/IncidentMap/IncidentMap.tsx
@@ -7,7 +7,6 @@ import type { FeatureCollection } from 'geojson'
 import type { Map as MapType, LatLngLiteral } from 'leaflet'
 
 import { useFetch } from 'hooks'
-import type { Map as MapType, LatLngLiteral } from 'leaflet'
 import configuration from 'shared/services/configuration/configuration'
 import { dynamicIcon } from 'shared/services/configuration/map-markers'
 import MAP_OPTIONS from 'shared/services/configuration/map-options'

--- a/src/signals/IncidentMap/components/IncidentMap/IncidentMap.tsx
+++ b/src/signals/IncidentMap/components/IncidentMap/IncidentMap.tsx
@@ -191,11 +191,7 @@ export const IncidentMap = () => {
             het werk zijn. Vanwege privacy staat een klein deel van de meldingen
             niet op de kaart.
           </StyledParagraph>
-          <AddressLocation
-            setCoordinates={setCoordinates}
-            address={address}
-            setAddress={setAddress}
-          />
+          <AddressLocation setCoordinates={setCoordinates} address={address} />
           <FilterPanel
             filters={filters}
             setFilters={setFilters}

--- a/src/signals/IncidentMap/components/IncidentMap/IncidentMap.tsx
+++ b/src/signals/IncidentMap/components/IncidentMap/IncidentMap.tsx
@@ -41,7 +41,7 @@ export const IncidentMap = () => {
 
   const [drawerState, setDrawerState] = useState<DrawerState>(DrawerState.Open)
   const [selectedIncident, setSelectedIncident] = useState<Incident>()
-  const selectedMarkerRef = useRef<L.Marker>()
+  const selectedMarkerRef = useRef<L.Marker<Properties>>()
 
   const [filters, setFilters] = useState<Filter[]>([])
   const [filteredIncidents, setFilteredIncidents] = useState<Incident[]>()

--- a/src/signals/IncidentMap/components/IncidentMap/IncidentMap.tsx
+++ b/src/signals/IncidentMap/components/IncidentMap/IncidentMap.tsx
@@ -4,11 +4,15 @@ import { useCallback, useEffect, useState, useRef } from 'react'
 
 import { ViewerContainer } from '@amsterdam/arm-core'
 import type { FeatureCollection } from 'geojson'
+import type { Map as MapType, LatLngLiteral } from 'leaflet'
+
+import { DEFAULT_ZOOM } from 'components/AreaMap/AreaMap'
 import { useFetch } from 'hooks'
 import type { Map as MapType, LatLngLiteral } from 'leaflet'
 import configuration from 'shared/services/configuration/configuration'
 import { dynamicIcon } from 'shared/services/configuration/map-markers'
 import MAP_OPTIONS from 'shared/services/configuration/map-options'
+import { featureToCoordinates } from 'shared/services/map-location'
 import reverseGeocoderService from 'shared/services/reverse-geocoder'
 import { MapMessage } from 'signals/incident/components/form/MapSelectors/components/MapMessage'
 import type { Bbox } from 'signals/incident/components/form/MapSelectors/hooks/useBoundingBox'
@@ -18,6 +22,7 @@ import type { PointLatLng } from '../../types'
 import type { Filter, Properties, Incident } from '../../types'
 import { AddressLocation } from '../AddressLocation'
 import { DrawerOverlay, DrawerState } from '../DrawerOverlay'
+import { isMobile, useDeviceMode } from '../DrawerOverlay/utils'
 import { FilterPanel } from '../FilterPanel'
 import { GPSLocation } from '../GPSLocation'
 import { IncidentLayer } from '../IncidentLayer'
@@ -27,6 +32,7 @@ import { Wrapper, StyledMap, StyledParagraph } from './styled'
 
 export const IncidentMap = () => {
   const [bbox, setBbox] = useState<Bbox | undefined>()
+  const [map, setMap] = useState<MapType>()
   const [mapMessage, setMapMessage] = useState<JSX.Element | string>('')
   const [coordinates, setCoordinates] = useState<LatLngLiteral>()
   const [address, setAddress] = useState<Address>()
@@ -39,10 +45,15 @@ export const IncidentMap = () => {
 
   const [filters, setFilters] = useState<Filter[]>([])
   const [filteredIncidents, setFilteredIncidents] = useState<Incident[]>()
-  const [map, setMap] = useState<MapType>()
+
+  const mode = useDeviceMode()
 
   const { get, data, error, isSuccess } =
     useFetch<FeatureCollection<PointLatLng, Properties>>()
+
+  const closeDrawerOverlay = useCallback(() => {
+    setDrawerState(DrawerState.Closed)
+  }, [])
 
   const setNotification = useCallback(
     (message: JSX.Element | string) => {
@@ -53,13 +64,34 @@ export const IncidentMap = () => {
   )
 
   /* istanbul ignore next */
-  const handleIncidentSelect = useCallback((incident: Incident) => {
-    setSelectedIncident(incident)
-    setDrawerState(DrawerState.Open)
-  }, [])
+  const handleIncidentSelect = useCallback(
+    (incident: Incident) => {
+      const sanitaizedCoords = featureToCoordinates(incident.geometry)
+      // When marker is underneath the drawerOverlay, move the map slightly up
+      if (map && isMobile(mode) && sanitaizedCoords.lat < map.getCenter().lat) {
+        const currentZoom = map.getZoom()
+        const coords = {
+          lat: sanitaizedCoords.lat - 0.0003,
+          lng: sanitaizedCoords.lng,
+        }
+        const zoom =
+          currentZoom > DEFAULT_ZOOM
+            ? DEFAULT_ZOOM
+            : currentZoom < 12
+            ? 12
+            : currentZoom
+
+        map.flyTo(coords, zoom)
+      }
+
+      setSelectedIncident(incident)
+      setDrawerState(DrawerState.Open)
+    },
+    [map, mode]
+  )
 
   /* istanbul ignore next */
-  const resetMarkerIcon = useCallback(() => {
+  const resetSelectedMarker = useCallback(() => {
     if (selectedMarkerRef?.current) {
       selectedMarkerRef.current.setIcon(
         dynamicIcon(selectedMarkerRef.current.feature?.properties.icon)
@@ -80,13 +112,13 @@ export const IncidentMap = () => {
         `${configuration.GEOGRAPHY_PUBLIC_ENDPOINT}?${searchParams.toString()}`
       )
     }
-  }, [get, bbox])
+  }, [bbox, get])
 
   useEffect(() => {
     map?.on({
-      click: resetMarkerIcon,
+      click: resetSelectedMarker,
     })
-  }, [resetMarkerIcon, map])
+  }, [resetSelectedMarker, map])
 
   useEffect(() => {
     if (data?.features) {
@@ -102,10 +134,10 @@ export const IncidentMap = () => {
   }, [error, isSuccess, setNotification])
 
   useEffect(() => {
-    coordinates && reverseGeocoderService(coordinates)
-    .then((response) => {
-      setAddress(response?.data?.address)
-    })
+    coordinates &&
+      reverseGeocoderService(coordinates).then((response) => {
+        setAddress(response?.data?.address)
+      })
   }, [coordinates])
 
   return (
@@ -127,11 +159,18 @@ export const IncidentMap = () => {
           handleIncidentSelect={handleIncidentSelect}
           passBbox={setBbox}
           incidents={filteredIncidents}
-          resetMarkerIcon={resetMarkerIcon}
+          resetSelectedMarker={resetSelectedMarker}
           selectedMarkerRef={selectedMarkerRef}
         />
 
-        {map && coordinates && <Pin map={map} coordinates={coordinates} />}
+        {map && coordinates && (
+          <Pin
+            map={map}
+            coordinates={coordinates}
+            mode={mode}
+            closeOverlay={closeDrawerOverlay}
+          />
+        )}
 
         {map && (
           <GPSLocation
@@ -144,7 +183,7 @@ export const IncidentMap = () => {
         <DrawerOverlay
           onStateChange={setDrawerState}
           state={drawerState}
-          onCloseDetailPanel={resetMarkerIcon}
+          onCloseDetailPanel={resetSelectedMarker}
           incident={selectedIncident}
         >
           <StyledParagraph>

--- a/src/signals/IncidentMap/components/IncidentMap/IncidentMap.tsx
+++ b/src/signals/IncidentMap/components/IncidentMap/IncidentMap.tsx
@@ -38,7 +38,7 @@ export const IncidentMap = () => {
   const [address, setAddress] = useState<string>()
 
   const [showMessage, setShowMessage] = useState<boolean>(false)
-  const [showAddressPanel, setShowAddressPanel] = useState(false)
+  const [showAddressSearchMobile, setShowAddressSearchMobile] = useState(false)
 
   const [drawerState, setDrawerState] = useState<DrawerState>(DrawerState.Open)
   const [selectedIncident, setSelectedIncident] = useState<Incident>()
@@ -195,7 +195,7 @@ export const IncidentMap = () => {
           <AddressLocation
             setCoordinates={setCoordinates}
             address={address}
-            setShowAddressPanel={setShowAddressPanel}
+            setShowAddressSearchMobile={setShowAddressSearchMobile}
           />
           <FilterPanel
             filters={filters}
@@ -204,11 +204,11 @@ export const IncidentMap = () => {
           />
         </DrawerOverlay>
 
-        {isMobile(mode) && showAddressPanel && (
+        {isMobile(mode) && showAddressSearchMobile && (
           <AddressSearchMobile
             address={address}
             setCoordinates={setCoordinates}
-            setShowAddressPanel={setShowAddressPanel}
+            setShowAddressSearchMobile={setShowAddressSearchMobile}
           />
         )}
 

--- a/src/signals/IncidentMap/components/IncidentMap/Pin.test.tsx
+++ b/src/signals/IncidentMap/components/IncidentMap/Pin.test.tsx
@@ -5,6 +5,7 @@ import { render, screen } from '@testing-library/react'
 import type { Map } from 'leaflet'
 
 import { DEFAULT_ZOOM } from '../../../../components/AreaMap/AreaMap'
+import { DeviceMode } from '../DrawerOverlay/types'
 import type { Props } from './Pin'
 import { Pin } from './Pin'
 
@@ -29,21 +30,34 @@ const coords = {
 const defaultProps: Props = {
   map: mockMap,
   coordinates: coords,
+  mode: DeviceMode.Desktop,
+  closeOverlay: jest.fn(),
 }
 
 describe('Pin', () => {
-  it('renders a pin', () => {
+  it('should renders a pin', () => {
     render(<Pin {...defaultProps} />)
 
     expect(screen.getByTestId('incidentPinMarker')).toBeInTheDocument()
   })
 
-  it('flies to the location', () => {
+  it('should fly to the location', () => {
     render(<Pin {...defaultProps} />)
 
     expect(defaultProps.map.flyTo).toHaveBeenCalledWith(
       { lat: coords.lat, lng: coords.lng },
       DEFAULT_ZOOM
     )
+    expect(defaultProps.closeOverlay).not.toHaveBeenCalled()
+  })
+
+  it('should close drawerOverlay when on mobile', () => {
+    const props = {
+      ...defaultProps,
+      mode: DeviceMode.Mobile,
+    }
+    render(<Pin {...props} />)
+
+    expect(defaultProps.closeOverlay).toHaveBeenCalled()
   })
 })

--- a/src/signals/IncidentMap/components/IncidentMap/Pin.tsx
+++ b/src/signals/IncidentMap/components/IncidentMap/Pin.tsx
@@ -35,6 +35,7 @@ export const Pin = ({ map, coordinates, mode, closeOverlay }: Props) => {
       options={{
         icon: markerIcon,
         keyboard: false,
+        zIndexOffset: 999,
       }}
     />
   )

--- a/src/signals/IncidentMap/components/IncidentMap/Pin.tsx
+++ b/src/signals/IncidentMap/components/IncidentMap/Pin.tsx
@@ -9,15 +9,23 @@ import type { LatLngLiteral, Map } from 'leaflet'
 import { DEFAULT_ZOOM } from 'components/AreaMap/AreaMap'
 import { markerIcon } from 'shared/services/configuration/map-markers'
 
+import type { DeviceMode } from '../DrawerOverlay/types'
+import { isMobile } from '../DrawerOverlay/utils'
+
 export interface Props {
   map: Map
   coordinates: LatLngLiteral
+  mode: DeviceMode
+  closeOverlay: () => void
 }
 
-export const Pin = ({ map, coordinates }: Props) => {
+export const Pin = ({ map, coordinates, mode, closeOverlay }: Props) => {
   useEffect(() => {
+    if (isMobile(mode)) {
+      closeOverlay()
+    }
     map.flyTo(coordinates, DEFAULT_ZOOM)
-  }, [map, coordinates])
+  }, [closeOverlay, coordinates, map, mode])
 
   return (
     <Marker

--- a/src/signals/IncidentMap/components/IncidentMap/utils.test.ts
+++ b/src/signals/IncidentMap/components/IncidentMap/utils.test.ts
@@ -1,17 +1,25 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (C) 2022 Gemeente Amsterdam
 import type { Map } from 'leaflet'
 
+import { DEFAULT_ZOOM } from '../utils'
 import { getZoom } from './utils'
 
 describe('utils', () => {
   describe('getZoom', () => {
     it('should return the correct value', () => {
+      /**
+       * The map can be zoomed in to max 16 and zoomed out to max 8.
+       * The default zoom is set to 14.
+       */
+
       const mapMockZoomOut = {
-        getZoom: jest.fn(() => 18),
+        getZoom: jest.fn(() => 16),
       } as unknown as Map
 
       const result = getZoom(mapMockZoomOut)
 
-      expect(result).toEqual(14)
+      expect(result).toEqual(DEFAULT_ZOOM)
 
       const mapMockZoomIn = {
         getZoom: jest.fn(() => 10),
@@ -21,7 +29,7 @@ describe('utils', () => {
       expect(secondResult).toEqual(12)
 
       const mapMockZoomNull = {
-        getZoom: jest.fn(() => 14),
+        getZoom: jest.fn(() => DEFAULT_ZOOM),
       } as unknown as Map
 
       const thirdResult = getZoom(mapMockZoomNull)

--- a/src/signals/IncidentMap/components/IncidentMap/utils.test.ts
+++ b/src/signals/IncidentMap/components/IncidentMap/utils.test.ts
@@ -1,0 +1,31 @@
+import type { Map } from 'leaflet'
+
+import { getZoom } from './utils'
+
+describe('utils', () => {
+  describe('getZoom', () => {
+    it('should return the correct value', () => {
+      const mapMockZoomOut = {
+        getZoom: jest.fn(() => 18),
+      } as unknown as Map
+
+      const result = getZoom(mapMockZoomOut)
+
+      expect(result).toEqual(14)
+
+      const mapMockZoomIn = {
+        getZoom: jest.fn(() => 10),
+      } as unknown as Map
+
+      const secondResult = getZoom(mapMockZoomIn)
+      expect(secondResult).toEqual(12)
+
+      const mapMockZoomNull = {
+        getZoom: jest.fn(() => 14),
+      } as unknown as Map
+
+      const thirdResult = getZoom(mapMockZoomNull)
+      expect(thirdResult).toEqual(14)
+    })
+  })
+})

--- a/src/signals/IncidentMap/components/IncidentMap/utils.ts
+++ b/src/signals/IncidentMap/components/IncidentMap/utils.ts
@@ -1,16 +1,19 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (C) 2022 Gemeente Amsterdam
 import type { Map } from 'leaflet'
 
 import { DEFAULT_ZOOM } from '../utils'
 
 /**
- * To get a good user experience on mobile when using flyTo you want to zoom out to the default zoom when
+ * To get a good user experience on mobile when using flyTo you want to zoom out to a set MAX_ZOOM when
  * the zoom exceeds the default zoom, and zoom to a set MIN_ZOOM when zoom it too small.
  */
 export const getZoom = (map: Map) => {
   const currentZoom = map.getZoom()
   const MIN_ZOOM = 12
+  const MAX_ZOOM = DEFAULT_ZOOM
 
-  const zoomOut = currentZoom > DEFAULT_ZOOM
+  const zoomOut = currentZoom > MAX_ZOOM
   const zoomIn = currentZoom < MIN_ZOOM
 
   return zoomOut ? DEFAULT_ZOOM : zoomIn ? MIN_ZOOM : currentZoom

--- a/src/signals/IncidentMap/components/IncidentMap/utils.ts
+++ b/src/signals/IncidentMap/components/IncidentMap/utils.ts
@@ -1,0 +1,17 @@
+import type { Map } from 'leaflet'
+
+import { DEFAULT_ZOOM } from '../utils'
+
+/**
+ * To get a good user experience on mobile when using flyTo you want to zoom out to the default zoom when
+ * the zoom exceeds the default zoom, and zoom to a set MIN_ZOOM when zoom it too small.
+ */
+export const getZoom = (map: Map) => {
+  const currentZoom = map.getZoom()
+  const MIN_ZOOM = 12
+
+  const zoomOut = currentZoom > DEFAULT_ZOOM
+  const zoomIn = currentZoom < MIN_ZOOM
+
+  return zoomOut ? DEFAULT_ZOOM : zoomIn ? MIN_ZOOM : currentZoom
+}

--- a/src/signals/IncidentMap/components/IncidentMap/utils.ts
+++ b/src/signals/IncidentMap/components/IncidentMap/utils.ts
@@ -13,8 +13,8 @@ export const getZoom = (map: Map) => {
   const MIN_ZOOM = 12
   const MAX_ZOOM = DEFAULT_ZOOM
 
-  const zoomOut = currentZoom > MAX_ZOOM
-  const zoomIn = currentZoom < MIN_ZOOM
+  const aboveMaxZoom = currentZoom > MAX_ZOOM
+  const BelowMinZoom = currentZoom < MIN_ZOOM
 
-  return zoomOut ? DEFAULT_ZOOM : zoomIn ? MIN_ZOOM : currentZoom
+  return aboveMaxZoom ? DEFAULT_ZOOM : BelowMinZoom ? MIN_ZOOM : currentZoom
 }

--- a/src/signals/IncidentMap/components/utils/constants.ts
+++ b/src/signals/IncidentMap/components/utils/constants.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_ZOOM = 14

--- a/src/signals/IncidentMap/components/utils/index.ts
+++ b/src/signals/IncidentMap/components/utils/index.ts
@@ -1,2 +1,3 @@
 export { updateFilterCategory } from './update-filter-category'
 export { getFilteredIncidents } from './get-filtered-incidents'
+export * from './constants'

--- a/src/signals/IncidentMap/containers/styled.ts
+++ b/src/signals/IncidentMap/containers/styled.ts
@@ -1,13 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2022 Gemeente Amsterdam
-
 import styled from 'styled-components'
 
 export const Wrapper = styled.div`
-  position: absolute;
+  position: fixed;
   width: 100%;
   height: 100%;
-  min-height: 100vh;
-  min-height: -webkit-fill-available;
-  display: flex;
 `


### PR DESCRIPTION
Ticket: [SIG-4784](https://datapunt.atlassian.net/browse/SIG-4784)

## Context
This PR upgrades the user experience mainly while on mobile.
- When the user selects a marker that is underneath the drawerOverlay we want to move the map slightly up so it is in view. 
- We want to close the drawerOverlay when GPS location is used on mobile.
- When using address input, there should be an overlay
- In general, there should be no weird behaviour while on mobile

## Changes
- Add fly to on IncidentSelect
- pointToLayer: filter so that selected icon stays in place
- add small points to latitude to move the map up when on mobile
- When on clear it removes the pin from the map
- Added a AddressSearchMobile, which is an overlay that pops up when the user uses the address input on mobile
- Changes some css

## Signalen

Before opening a pull request, please ensure:

- [x] Double-check your branch is based on `develop` and targets `develop`
- [x] Pull request has tests (we are going for 100% coverage!)
- [x] Code is well-commented, linted and follows project conventions
- [x] Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
