### PR TITLE
Change the apiBaseUrl to the new one

### DIFF
--- a/app.amsterdam.json
+++ b/app.amsterdam.json
@@ -1,5 +1,5 @@
 {
-  "apiBaseUrl": "https://acc.api.data.amsterdam.nl",
+  "apiBaseUrl": "https://acc.api.meldingen.amsterdam.nl",
   "areaTypeCodeForDistrict": "stadsdeel",
   "featureFlags": {
     "assignSignalToDepartment": false,


### PR DESCRIPTION
Ticket: none

We need to talk to a different api endpoint since the migration to Azure. 
