### PR TITLE
[bugfix-4867] Resize filter icons and set default icons

### DIFF
--- a/src/shared/services/configuration/map-markers.ts
+++ b/src/shared/services/configuration/map-markers.ts
@@ -52,10 +52,10 @@ export const currentIncidentIcon = L.icon({
   iconAnchor: [48, 48],
 })
 
-const defaultIncidentIcon = '/assets/images/icon-incident-marker.svg'
+export const defaultIcon = '/assets/images/icon-incident-marker.svg'
 export const dynamicIcon = (iconUrl?: string) =>
   L.icon({
-    iconUrl: iconUrl ?? defaultIncidentIcon,
+    iconUrl: iconUrl ?? defaultIcon,
     iconSize: [40, 40],
     iconAnchor: [20, 39],
     className: 'map-marker-incident',

--- a/src/signals/IncidentMap/components/FilterPanel/FilterCategory.tsx
+++ b/src/signals/IncidentMap/components/FilterPanel/FilterCategory.tsx
@@ -24,10 +24,7 @@ export const FilterCategory = ({
       checked={selected}
       onChange={onToggleCategory}
     />
-    <StyledImg
-      alt="icon"
-      src={icon || 'assets/images/icon-incident-marker.svg'}
-    />
+    <StyledImg alt="icon" src={icon} />
     <CategoryItemText>{text}</CategoryItemText>
   </CategoryItem>
 )

--- a/src/signals/IncidentMap/components/FilterPanel/styled.ts
+++ b/src/signals/IncidentMap/components/FilterPanel/styled.ts
@@ -15,6 +15,7 @@ export const StyledLabel = styled(Label)`
 
 export const StyledImg = styled.img`
   padding-right: ${themeSpacing(2)};
+  max-height: ${themeSpacing(8)};
 `
 export const Wrapper = styled.div`
   border-top: 1px solid ${themeColor('tint', 'level3')};

--- a/src/signals/IncidentMap/components/FilterPanel/utils.test.ts
+++ b/src/signals/IncidentMap/components/FilterPanel/utils.test.ts
@@ -19,12 +19,12 @@ describe('getFilterCategoriesWithIcon', () => {
     expect(results.find((filter) => filter.slug === 'afval')).toBeTruthy()
   })
 
-  it('should return filters with icon if available', () => {
+  it('should return filters with icon', () => {
     const results = getFilterCategoriesWithIcons(mockData)
 
-    expect(
-      results.find((filter) => filter.slug === 'overig')?.icon
-    ).toBeUndefined()
+    expect(results.find((filter) => filter.slug === 'overig')?.icon).toEqual(
+      '/assets/images/icon-incident-marker.svg'
+    )
 
     expect(
       results.find((filter) => filter.slug === 'overlast-bedrijven-en-horeca')

--- a/src/signals/IncidentMap/components/FilterPanel/utils.ts
+++ b/src/signals/IncidentMap/components/FilterPanel/utils.ts
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: MPL-2.0 */
 /* Copyright (C) 2022 Gemeente Amsterdam */
+import { defaultIcon } from 'shared/services/configuration/map-markers'
 import type { Category } from 'types/category'
 
 import type { Filter, SubCategory } from '../../types'
@@ -15,7 +16,7 @@ export const getFilterCategoriesWithIcons = (
       const categoriesWithIcons: Filter = {
         _display,
         filterActive: true,
-        icon: _links['sia:icon']?.href,
+        icon: _links['sia:icon']?.href ?? defaultIcon,
         name,
         slug,
         incidentsCount: 0,
@@ -43,7 +44,7 @@ const getSubCategories = (
       return {
         _display,
         filterActive: true,
-        icon: _links['sia:icon']?.href,
+        icon: _links['sia:icon']?.href ?? defaultIcon,
         name,
         slug,
         incidentsCount: 0,

--- a/src/signals/IncidentMap/components/IncidentLayer/IncidentLayer.tsx
+++ b/src/signals/IncidentMap/components/IncidentLayer/IncidentLayer.tsx
@@ -3,9 +3,10 @@
 import type { MutableRefObject } from 'react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
-import MarkerCluster from 'components/MarkerCluster'
 import type { FeatureCollection, Point } from 'geojson'
 import L from 'leaflet'
+
+import MarkerCluster from 'components/MarkerCluster'
 import {
   dynamicIcon,
   selectedMarkerIcon,

--- a/src/signals/IncidentMap/components/utils/get-filtered-incidents.ts
+++ b/src/signals/IncidentMap/components/utils/get-filtered-incidents.ts
@@ -51,7 +51,7 @@ export const getFilteredIncidents = (
 
 interface Icon {
   slug: string
-  icon: string
+  icon?: string
 }
 
 const getListOfIcons = (filters: Filter[]) => {
@@ -66,7 +66,7 @@ const getListOfIcons = (filters: Filter[]) => {
   return allFilters.map(createIcon)
 }
 
-const createIcon = (category: Filter): Partial<Icon> => ({
+const createIcon = (category: Filter): Icon => ({
   slug: category.slug,
   icon: category.icon,
 })


### PR DESCRIPTION
Ticket: [SIG-4867](https://datapunt.atlassian.net/browse/SIG-4867)

- The default icon in the filterpanel of the incidentMap was too big. Resizing it to follow the other icons. 
- Meanwhile, set default icon where filters are created. 