### PR TITLE
[bugfix]: fix display name on filter panel meldingenkaart

### DIFF
--- a/src/signals/IncidentMap/components/FilterPanel/FilterCategoryWithSub.test.tsx
+++ b/src/signals/IncidentMap/components/FilterPanel/FilterCategoryWithSub.test.tsx
@@ -82,7 +82,7 @@ describe('FilterCategoryWithSub', () => {
     renderFilterCategoryWithSub()
 
     const checkBox = screen.getByRole('checkbox', {
-      name: /mockSubCategory_display1/,
+      name: /mockSubCategoryname1/,
     })
 
     userEvent.click(checkBox)

--- a/src/signals/IncidentMap/components/FilterPanel/FilterCategoryWithSub.tsx
+++ b/src/signals/IncidentMap/components/FilterPanel/FilterCategoryWithSub.tsx
@@ -47,14 +47,14 @@ export const FilterCategoryWithSub = ({ onToggleCategory, filter }: Props) => {
         {subCategories
           .filter((subCategory) => subCategory.incidentsCount)
           .map((subCategory) => {
-            const { name, filterActive, _display, icon } = subCategory
+            const { name, filterActive, icon } = subCategory
             return (
               <FilterCategory
                 onToggleCategory={() => {
                   onToggleCategory(subCategory, !filterActive)
                 }}
                 selected={filterActive}
-                text={_display || name}
+                text={name}
                 key={name}
                 icon={icon}
               />


### PR DESCRIPTION
Ticket: none

The wrong name was displayed in the filter panel.

<img width="2284" alt="Screenshot 2022-11-09 at 12 27 48" src="https://user-images.githubusercontent.com/46756331/200819239-c991d09c-70d7-4236-b448-f2ab85457b75.png">
