### PR TITLE
Bugfix 4810/filtering sub categories in filterpanel

### DIFF
--- a/src/signals/IncidentMap/components/FilterPanel/FilterCategory.tsx
+++ b/src/signals/IncidentMap/components/FilterPanel/FilterCategory.tsx
@@ -19,6 +19,7 @@ export const FilterCategory = ({
 }: Props) => (
   <CategoryItem htmlFor={text}>
     <Checkbox
+      style={{ padding: '0px' }}
       data-testid={text}
       id={text}
       checked={selected}

--- a/src/signals/IncidentMap/components/FilterPanel/FilterCategory.tsx
+++ b/src/signals/IncidentMap/components/FilterPanel/FilterCategory.tsx
@@ -19,7 +19,6 @@ export const FilterCategory = ({
 }: Props) => (
   <CategoryItem htmlFor={text}>
     <Checkbox
-      style={{ padding: '0px' }}
       data-testid={text}
       id={text}
       checked={selected}

--- a/src/signals/IncidentMap/components/FilterPanel/FilterCategoryWithSub.tsx
+++ b/src/signals/IncidentMap/components/FilterPanel/FilterCategoryWithSub.tsx
@@ -10,6 +10,7 @@ import {
   WrapperFilterCategoryWithIcon,
   InvisibleButton,
   SubSection,
+  Underlined,
 } from './styled'
 
 export interface Props {
@@ -24,17 +25,16 @@ export const FilterCategoryWithSub = ({ onToggleCategory, filter }: Props) => {
   if (!subCategories) return null
   return (
     <Fragment key={`section-${name}`}>
-      <div style={{ border: '1px solid red' }}>
-        <WrapperFilterCategoryWithIcon>
-          <FilterCategory
-            onToggleCategory={() => {
-              onToggleCategory(filter, !filterActive)
-            }}
-            selected={filterActive}
-            text={name}
-            icon={icon}
-          />
-        </WrapperFilterCategoryWithIcon>
+      <WrapperFilterCategoryWithIcon>
+        <FilterCategory
+          onToggleCategory={() => {
+            onToggleCategory(filter, !filterActive)
+          }}
+          selected={filterActive}
+          text={name}
+          icon={icon}
+        />
+
         <InvisibleButton
           title={`Toon ${showSubsection ? 'minder' : 'meer'} filter opties`}
           aria-expanded={showSubsection}
@@ -43,7 +43,7 @@ export const FilterCategoryWithSub = ({ onToggleCategory, filter }: Props) => {
         >
           <ChevronDown width={20} height={20} />
         </InvisibleButton>
-      </div>
+      </WrapperFilterCategoryWithIcon>
 
       <SubSection visible={showSubsection} lines={subCategories.length}>
         {subCategories
@@ -51,15 +51,17 @@ export const FilterCategoryWithSub = ({ onToggleCategory, filter }: Props) => {
           .map((subCategory) => {
             const { name, filterActive, icon } = subCategory
             return (
-              <FilterCategory
-                onToggleCategory={() => {
-                  onToggleCategory(subCategory, !filterActive)
-                }}
-                selected={filterActive}
-                text={name}
-                key={name}
-                icon={icon}
-              />
+              <Underlined>
+                <FilterCategory
+                  onToggleCategory={() => {
+                    onToggleCategory(subCategory, !filterActive)
+                  }}
+                  selected={filterActive}
+                  text={name}
+                  key={name}
+                  icon={icon}
+                />
+              </Underlined>
             )
           })}
       </SubSection>

--- a/src/signals/IncidentMap/components/FilterPanel/FilterCategoryWithSub.tsx
+++ b/src/signals/IncidentMap/components/FilterPanel/FilterCategoryWithSub.tsx
@@ -24,15 +24,17 @@ export const FilterCategoryWithSub = ({ onToggleCategory, filter }: Props) => {
   if (!subCategories) return null
   return (
     <Fragment key={`section-${name}`}>
-      <WrapperFilterCategoryWithIcon>
-        <FilterCategory
-          onToggleCategory={() => {
-            onToggleCategory(filter, !filterActive)
-          }}
-          selected={filterActive}
-          text={name}
-          icon={icon}
-        />
+      <div style={{ border: '1px solid red' }}>
+        <WrapperFilterCategoryWithIcon>
+          <FilterCategory
+            onToggleCategory={() => {
+              onToggleCategory(filter, !filterActive)
+            }}
+            selected={filterActive}
+            text={name}
+            icon={icon}
+          />
+        </WrapperFilterCategoryWithIcon>
         <InvisibleButton
           title={`Toon ${showSubsection ? 'minder' : 'meer'} filter opties`}
           aria-expanded={showSubsection}
@@ -41,7 +43,7 @@ export const FilterCategoryWithSub = ({ onToggleCategory, filter }: Props) => {
         >
           <ChevronDown width={20} height={20} />
         </InvisibleButton>
-      </WrapperFilterCategoryWithIcon>
+      </div>
 
       <SubSection visible={showSubsection} lines={subCategories.length}>
         {subCategories

--- a/src/signals/IncidentMap/components/FilterPanel/FilterCategoryWithSub.tsx
+++ b/src/signals/IncidentMap/components/FilterPanel/FilterCategoryWithSub.tsx
@@ -44,14 +44,14 @@ export const FilterCategoryWithSub = ({ onToggleCategory, filter }: Props) => {
           <ChevronDown width={20} height={20} />
         </InvisibleButton>
       </WrapperFilterCategoryWithIcon>
-
+      <Underlined />
       <SubSection visible={showSubsection} lines={subCategories.length}>
         {subCategories
           .filter((subCategory) => subCategory.incidentsCount)
           .map((subCategory) => {
             const { name, filterActive, icon } = subCategory
             return (
-              <Underlined>
+              <>
                 <FilterCategory
                   onToggleCategory={() => {
                     onToggleCategory(subCategory, !filterActive)
@@ -61,7 +61,8 @@ export const FilterCategoryWithSub = ({ onToggleCategory, filter }: Props) => {
                   key={name}
                   icon={icon}
                 />
-              </Underlined>
+                <Underlined />
+              </>
             )
           })}
       </SubSection>

--- a/src/signals/IncidentMap/components/FilterPanel/FilterPanel.tsx
+++ b/src/signals/IncidentMap/components/FilterPanel/FilterPanel.tsx
@@ -94,7 +94,6 @@ export const FilterPanel = ({ filters, setFilters, setMapMessage }: Props) => {
             </>
           )
         })}
-      <Underlined />
     </>
   )
 }

--- a/src/signals/IncidentMap/components/FilterPanel/FilterPanel.tsx
+++ b/src/signals/IncidentMap/components/FilterPanel/FilterPanel.tsx
@@ -13,7 +13,7 @@ import { updateFilterCategory } from '../utils'
 import { getCombinedFilters } from '../utils/get-combined-filters'
 import { FilterCategory } from './FilterCategory'
 import { FilterCategoryWithSub } from './FilterCategoryWithSub'
-import { Underlined, Wrapper } from './styled'
+import { Underlined } from './styled'
 import { getFilterCategoriesWithIcons } from './utils'
 
 export interface Props {
@@ -67,33 +67,34 @@ export const FilterPanel = ({ filters, setFilters, setMapMessage }: Props) => {
   return (
     <>
       <Heading as="h4">Filter op onderwerp</Heading>
-      <Wrapper>
-        {filters
-          .filter((filter: Filter) => filter.incidentsCount)
-          .map((filter: Filter) => {
-            const { name, filterActive, _display, icon, subCategories } = filter
+      <Underlined />
+      {filters
+        .filter((filter: Filter) => filter.incidentsCount)
+        .map((filter: Filter) => {
+          const { name, filterActive, _display, icon, subCategories } = filter
 
-            return subCategories ? (
-              <FilterCategoryWithSub
+          return subCategories ? (
+            <FilterCategoryWithSub
+              key={name}
+              filter={filter}
+              onToggleCategory={toggleFilter}
+            />
+          ) : (
+            <>
+              <FilterCategory
                 key={name}
-                filter={filter}
-                onToggleCategory={toggleFilter}
+                onToggleCategory={() => {
+                  toggleFilter(filter, !filterActive)
+                }}
+                selected={filterActive}
+                text={_display || name}
+                icon={icon}
               />
-            ) : (
-              <Underlined>
-                <FilterCategory
-                  key={name}
-                  onToggleCategory={() => {
-                    toggleFilter(filter, !filterActive)
-                  }}
-                  selected={filterActive}
-                  text={_display || name}
-                  icon={icon}
-                />
-              </Underlined>
-            )
-          })}
-      </Wrapper>
+              <Underlined />
+            </>
+          )
+        })}
+      <Underlined />
     </>
   )
 }

--- a/src/signals/IncidentMap/components/FilterPanel/FilterPanel.tsx
+++ b/src/signals/IncidentMap/components/FilterPanel/FilterPanel.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect } from 'react'
 
 import { Heading } from '@amsterdam/asc-ui'
+
 import { useFetch } from 'hooks'
 import configuration from 'shared/services/configuration/configuration'
 import type Categories from 'types/api/categories'
@@ -12,7 +13,7 @@ import { updateFilterCategory } from '../utils'
 import { getCombinedFilters } from '../utils/get-combined-filters'
 import { FilterCategory } from './FilterCategory'
 import { FilterCategoryWithSub } from './FilterCategoryWithSub'
-import { Wrapper } from './styled'
+import { Underlined, Wrapper } from './styled'
 import { getFilterCategoriesWithIcons } from './utils'
 
 export interface Props {
@@ -79,15 +80,17 @@ export const FilterPanel = ({ filters, setFilters, setMapMessage }: Props) => {
                 onToggleCategory={toggleFilter}
               />
             ) : (
-              <FilterCategory
-                key={name}
-                onToggleCategory={() => {
-                  toggleFilter(filter, !filterActive)
-                }}
-                selected={filterActive}
-                text={_display || name}
-                icon={icon}
-              />
+              <Underlined>
+                <FilterCategory
+                  key={name}
+                  onToggleCategory={() => {
+                    toggleFilter(filter, !filterActive)
+                  }}
+                  selected={filterActive}
+                  text={_display || name}
+                  icon={icon}
+                />
+              </Underlined>
             )
           })}
       </Wrapper>

--- a/src/signals/IncidentMap/components/FilterPanel/styled.ts
+++ b/src/signals/IncidentMap/components/FilterPanel/styled.ts
@@ -15,6 +15,8 @@ export const StyledLabel = styled(Label)`
 
 export const StyledImg = styled.img`
   padding-right: ${themeSpacing(2)};
+  padding: ${themeSpacing(2, 0)};
+  padding-right: 6px;
   max-height: ${themeSpacing(8)};
 `
 export const Wrapper = styled.div`
@@ -75,6 +77,11 @@ export const WrapperFilterCategoryWithIcon = styled.div`
 
   display: flex;
   align-items: center;
+  border-top: 1px solid ${themeColor('tint', 'level3')};
+  border-bottom: 1px solid ${themeColor('tint', 'level3')};
+  &:first-child {
+    border: none;
+  }
 `
 
 export const InvisibleButton = styled.button<{ toggle: boolean }>`
@@ -103,4 +110,6 @@ export const CategoryItemText = styled.span`
 export const CategoryItem = styled.label`
   display: flex;
   align-items: center;
+  border-bottom: 1px solid ${themeColor('tint', 'level3')};
+  margin-left: -6px;
 `

--- a/src/signals/IncidentMap/components/FilterPanel/styled.ts
+++ b/src/signals/IncidentMap/components/FilterPanel/styled.ts
@@ -14,14 +14,10 @@ export const StyledLabel = styled(Label)`
 `
 
 export const StyledImg = styled.img`
-  padding-right: ${themeSpacing(2)};
-  padding: ${themeSpacing(2, 0)};
-  padding-right: 6px;
   max-height: ${themeSpacing(8)};
+  margin: 0 8px 0 2px;
 `
-export const Wrapper = styled.div`
-  border-top: 1px solid ${themeColor('tint', 'level3')};
-`
+
 export const StyledButton = styled(Button)`
   position: absolute;
   top: ${themeSpacing(5)};
@@ -77,7 +73,6 @@ export const WrapperFilterCategoryWithIcon = styled.div`
 
   display: flex;
   align-items: center;
-  border-bottom: 1px solid ${themeColor('tint', 'level3')};
 `
 
 export const InvisibleButton = styled.button<{ toggle: boolean }>`
@@ -106,7 +101,7 @@ export const CategoryItemText = styled.span`
 export const CategoryItem = styled.label`
   display: flex;
   align-items: center;
-  margin-left: -6px;
+  margin: 8px 0 8px -6px;
 `
 
 export const Underlined = styled.div`

--- a/src/signals/IncidentMap/components/FilterPanel/styled.ts
+++ b/src/signals/IncidentMap/components/FilterPanel/styled.ts
@@ -77,11 +77,7 @@ export const WrapperFilterCategoryWithIcon = styled.div`
 
   display: flex;
   align-items: center;
-  border-top: 1px solid ${themeColor('tint', 'level3')};
   border-bottom: 1px solid ${themeColor('tint', 'level3')};
-  &:first-child {
-    border: none;
-  }
 `
 
 export const InvisibleButton = styled.button<{ toggle: boolean }>`
@@ -110,6 +106,9 @@ export const CategoryItemText = styled.span`
 export const CategoryItem = styled.label`
   display: flex;
   align-items: center;
-  border-bottom: 1px solid ${themeColor('tint', 'level3')};
   margin-left: -6px;
+`
+
+export const Underlined = styled.div`
+  border-bottom: 1px solid ${themeColor('tint', 'level3')};
 `


### PR DESCRIPTION
Ticket: [SIG-4810](https://datapunt.atlassian.net/browse/SIG-4810)

Last feedback from Linda. There was a double line at the end of the filters. It is now a single line.

## Signalen

Before opening a pull request, please ensure:

- [x] Double-check your branch is based on `main` and targets `main`
- [x] Pull request has tests (we are going for 100% coverage!)
- [x] Code is well-commented, linted and follows project conventions
- [x] Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
