### PR TITLE
Set "@typescript-eslint/restrict-template-expressions": "error"

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,7 +37,11 @@ module.exports = {
         'prettier/@typescript-eslint',
       ],
       files: ['**/*.ts', '**/*.tsx'],
+      parserOptions: {
+        project: './tsconfig.json',
+      },
       rules: {
+        '@typescript-eslint/restrict-template-expressions': 'error',
         '@typescript-eslint/consistent-type-imports': 'error',
         '@typescript-eslint/explicit-function-return-type': 'off',
         '@typescript-eslint/explicit-member-accessibility': 'off',


### PR DESCRIPTION
## goal

Find problems with your string literals by enforcing this rule.

https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/restrict-template-expressions.md

