### PR TITLE
By default set reporterMailHandledNegativeContactEnabled to false

### DIFF
--- a/app.base.json
+++ b/app.base.json
@@ -16,7 +16,7 @@
     "fetchDistrictsFromBackend": false,
     "fetchQuestionsFromBackend": false,
     "mapFilter24Hours": false,
-    "reporterMailHandledNegativeContactEnabled": true,
+    "reporterMailHandledNegativeContactEnabled": false,
     "showThorButton": false,
     "showVulaanControls": false,
     "useProjectenSignalType": false

--- a/src/signals/incident/containers/KtoContainer/index.test.js
+++ b/src/signals/incident/containers/KtoContainer/index.test.js
@@ -122,7 +122,7 @@ describe('signals/incident/containers/KtoContainer', () => {
     configuration.featureFlags.reporterMailHandledNegativeContactEnabled = false
     configuration.featureFlags.enableMultipleKtoQuestions = true
 
-    const successHeaderText = 'Bedankt voor uw reactie'
+    const successHeaderText = 'Bedankt voor uw feedback!'
     const { container, findByTestId, queryByText, getByText, rerender } =
       render(withAppContext(<KTOContainer />))
 


### PR DESCRIPTION
To make upgrading the Signalen frontend non-breaking, `reporterMailHandledNegativeContactEnabled` should by default set to false. This results in the original behavior of Signalen.

Municipalities can opt-in to this new functionality by enabling the feature flag.