### PR TITLE
[feat]: handle tooManyRequest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4533,6 +4533,8 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
       "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -4548,7 +4550,9 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/ajv-keywords": {
       "version": "3.5.2",
@@ -23072,15 +23076,14 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "dev": true,
-      "requires": {
-        "ajv": "^8.0.0"
-      },
+      "requires": {},
       "dependencies": {
         "ajv": {
-          "version": "8.11.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+          "version": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
           "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
           "dev": true,
+          "optional": true,
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -23092,7 +23095,9 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
           "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-          "dev": true
+          "dev": true,
+          "optional": true,
+          "peer": true
         }
       }
     },

--- a/src/signals/my-incidents/hooks/usePostEmail.test.ts
+++ b/src/signals/my-incidents/hooks/usePostEmail.test.ts
@@ -1,25 +1,64 @@
 import { act, renderHook } from '@testing-library/react-hooks'
-import fetchMock from 'jest-fetch-mock'
 
+import useFetch from 'hooks/useFetch'
+import type { FetchError } from 'hooks/useFetch'
 import configuration from 'shared/services/configuration/configuration'
 
 import { usePostEmail } from './usePostEmail'
 
+jest.mock('hooks/useFetch')
+
+export const del = jest.fn()
+export const get = jest.fn()
+export const patch = jest.fn()
+export const post = jest.fn()
+export const put = jest.fn()
+
+export const useFetchResponse = {
+  del,
+  get,
+  patch,
+  post,
+  put,
+  data: undefined,
+  isLoading: false,
+  error: false,
+  isSuccess: false,
+}
 const URL = `${configuration.MY_SIGNALS_LOGIN_URL}`
 
 describe('usePostEmail', () => {
-  it('should post email', async () => {
+  it('should post email', () => {
+    jest.mocked(useFetch).mockImplementation(() => useFetchResponse)
     const { result } = renderHook(usePostEmail)
 
     const [postEmail] = result.current
 
-    expect(fetchMock).not.toHaveBeenCalled()
+    expect(post).not.toHaveBeenCalled()
 
-    await act(() => postEmail('test@email.com'))
+    act(() => postEmail('test@email.com'))
 
-    expect(fetchMock).toHaveBeenCalledWith(
-      URL,
-      expect.objectContaining({ method: 'POST' })
+    expect(post).toHaveBeenCalledWith(URL, { email: 'test@email.com' })
+  })
+
+  it('should set error message when too many requests', () => {
+    const error = { status: 429, message: 'Too many requests' } as FetchError
+    const response = {
+      ...useFetchResponse,
+      error,
+    }
+    jest.mocked(useFetch).mockImplementation(() => response)
+
+    const { result } = renderHook(usePostEmail)
+
+    const [postEmail] = result.current
+
+    act(() => postEmail('test@email.com'))
+
+    const [, { errorMessage }] = result.current
+
+    expect(errorMessage).toEqual(
+      `U hebt te vaak gevraagd om de e-mail opnieuw te versturen. Over 20 minuten kunt u het opnieuw proberen.`
     )
   })
 })

--- a/src/signals/my-incidents/hooks/usePostEmail.ts
+++ b/src/signals/my-incidents/hooks/usePostEmail.ts
@@ -13,7 +13,7 @@ export const usePostEmail = (): [
 ] => {
   const { post, error } = useFetch<null>()
   const postError = error as Response | undefined
-  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [errorMessage, setErrorMessage] = useState<string>('')
 
   const endpoint = `${configuration.MY_SIGNALS_LOGIN_URL}`
 
@@ -34,7 +34,7 @@ export const usePostEmail = (): [
         `U hebt te vaak gevraagd om de e-mail opnieuw te versturen. Over 20 minuten kunt u het opnieuw proberen.`
       )
     } else {
-      setErrorMessage(null)
+      setErrorMessage('')
     }
   }, [postError])
 

--- a/src/signals/my-incidents/hooks/usePostEmail.ts
+++ b/src/signals/my-incidents/hooks/usePostEmail.ts
@@ -5,8 +5,6 @@ import { useCallback, useEffect, useState } from 'react'
 import useFetch from 'hooks/useFetch'
 import configuration from 'shared/services/configuration/configuration'
 
-import { isFetchError, isResponseError } from '../types'
-
 type PostEmail = (email: string) => Promise<void>
 
 export const usePostEmail = (): [
@@ -14,6 +12,7 @@ export const usePostEmail = (): [
   { errorMessage: string | null }
 ] => {
   const { post, error } = useFetch<null>()
+  const postError = error as Response | undefined
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
   const endpoint = `${configuration.MY_SIGNALS_LOGIN_URL}`
@@ -30,19 +29,14 @@ export const usePostEmail = (): [
   )
 
   useEffect(() => {
-    if (
-      error &&
-      isFetchError(error) &&
-      isResponseError(error) &&
-      error.status === 429
-    ) {
+    if (postError?.status === 429) {
       setErrorMessage(
         `U hebt te vaak gevraagd om de e-mail opnieuw te versturen. Over 20 minuten kunt u het opnieuw proberen.`
       )
     } else {
       setErrorMessage(null)
     }
-  }, [error])
+  }, [postError])
 
   return [postEmail, { errorMessage }]
 }

--- a/src/signals/my-incidents/hooks/usePostEmail.ts
+++ b/src/signals/my-incidents/hooks/usePostEmail.ts
@@ -1,23 +1,25 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2022 Gemeente Amsterdam
-import { useCallback } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 
 import useFetch from 'hooks/useFetch'
-import type { FetchResponse } from 'hooks/useFetch'
 import configuration from 'shared/services/configuration/configuration'
+
+import { isFetchError, isResponseError } from '../types'
 
 type PostEmail = (email: string) => Promise<void>
 
 export const usePostEmail = (): [
   PostEmail,
-  Omit<FetchResponse<null>, 'post'>
+  { errorMessage: string | null }
 ] => {
-  const { post, ...rest } = useFetch<null>()
+  const { post, error } = useFetch<null>()
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
 
   const endpoint = `${configuration.MY_SIGNALS_LOGIN_URL}`
 
   const postEmail = useCallback(
-    (email) => {
+    (email: string) => {
       const payload = {
         email,
       }
@@ -27,5 +29,20 @@ export const usePostEmail = (): [
     [endpoint, post]
   )
 
-  return [postEmail, rest]
+  useEffect(() => {
+    if (
+      error &&
+      isFetchError(error) &&
+      isResponseError(error) &&
+      error.status === 429
+    ) {
+      setErrorMessage(
+        `U hebt te vaak gevraagd om de e-mail opnieuw te versturen. Over 20 minuten kunt u het opnieuw proberen.`
+      )
+    } else {
+      setErrorMessage(null)
+    }
+  }, [error])
+
+  return [postEmail, { errorMessage }]
 }

--- a/src/signals/my-incidents/pages/Confirmation.test.tsx
+++ b/src/signals/my-incidents/pages/Confirmation.test.tsx
@@ -9,12 +9,14 @@ import { providerMock } from '../__test__'
 import { MyIncidentsProvider } from '../context'
 import { Confirmation } from './Confirmation'
 
+let mockResponse = {}
+
 jest.mock('../hooks', () => {
   const actual = jest.requireActual('../hooks')
   return {
     __esModule: true,
     ...actual,
-    usePostEmail: () => [jest.fn(), 'rest'],
+    usePostEmail: () => [jest.fn(), mockResponse],
   }
 })
 
@@ -61,6 +63,25 @@ describe('BasePage', () => {
     expect(
       screen.getByText(
         `Wij hebben opnieuw een e-mail verstuurd naar test@test.nl. Bevestig uw e-mailadres met de link in de e-mail. Het kan zijn dat de e-mail in uw spamfolder staat.`
+      )
+    ).toBeInTheDocument()
+  })
+
+  it('should show error message when too many requests are done', () => {
+    mockResponse = {
+      errorMessage: `U hebt te vaak gevraagd om de e-mail opnieuw te versturen. Over 20 minuten kunt u het opnieuw proberen.`,
+    }
+    render(
+      withAppContext(
+        <MyIncidentsProvider value={providerMock}>
+          <Confirmation />
+        </MyIncidentsProvider>
+      )
+    )
+
+    expect(
+      screen.getByText(
+        `U hebt te vaak gevraagd om de e-mail opnieuw te versturen. Over 20 minuten kunt u het opnieuw proberen.`
       )
     ).toBeInTheDocument()
   })

--- a/src/signals/my-incidents/pages/Confirmation.tsx
+++ b/src/signals/my-incidents/pages/Confirmation.tsx
@@ -14,7 +14,7 @@ import { BasePage } from './BasePage'
 export const Confirmation = () => {
   const { email } = useMyIncidentContext()
   const history = useHistory()
-  const [postEmail] = usePostEmail()
+  const [postEmail, { errorMessage }] = usePostEmail()
 
   const initialPageInfo = {
     documentTitle: 'Bevestig e-mailadres',
@@ -72,6 +72,12 @@ export const Confirmation = () => {
       history.push(routes.requestAccess)
     }
   }, [email, history])
+
+  useEffect(() => {
+    if (errorMessage) {
+      setParagraphs([errorMessage])
+    }
+  }, [errorMessage])
 
   return (
     <BasePage buttons={buttons} pageInfo={pageInfo} paragraphs={paragraphs} />


### PR DESCRIPTION
Ticket: none

This PR add logic that handles the error response when too many requests are fired when a user tries to get an access token. 
