### PR TITLE
[feature 4891] set font to Amsterdam Sans

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -13,7 +13,6 @@ const MIN_BUTTON_WIDTH = 90
 const Button = styled(AscButton)`
   min-width: ${MIN_BUTTON_WIDTH}px;
   justify-content: center;
-  font-family: Amsterdam Sans;
 
   svg path {
     fill: inherit;

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -13,7 +13,7 @@ const MIN_BUTTON_WIDTH = 90
 const Button = styled(AscButton)`
   min-width: ${MIN_BUTTON_WIDTH}px;
   justify-content: center;
-  font-family: Avenir Next;
+  font-family: Amsterdam Sans;
 
   svg path {
     fill: inherit;

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -21,7 +21,6 @@ const Hint = styled.span`
 const StyledInput = styled(AscInput)<{ showError: boolean }>`
   padding: 10px; /* needed to style the textboxes as according to the design system */
   box-shadow: initial;
-  font-family: Amsterdam Sans;
 
   &[disabled] {
     border: 1px solid ${themeColor('tint', 'level4')};

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -21,7 +21,7 @@ const Hint = styled.span`
 const StyledInput = styled(AscInput)<{ showError: boolean }>`
   padding: 10px; /* needed to style the textboxes as according to the design system */
   box-shadow: initial;
-  font-family: Avenir Next;
+  font-family: Amsterdam Sans;
 
   &[disabled] {
     border: 1px solid ${themeColor('tint', 'level4')};

--- a/src/components/MarkerCluster/style.css
+++ b/src/components/MarkerCluster/style.css
@@ -31,7 +31,6 @@
 }
 
 .marker-cluster.large span {
-  font-family: Amsterdam Sans;
   font-size: 16px;
   font-weight: 500;
   line-height: 48px;

--- a/src/components/MarkerCluster/style.css
+++ b/src/components/MarkerCluster/style.css
@@ -31,7 +31,7 @@
 }
 
 .marker-cluster.large span {
-  font-family: Avenir Next;
+  font-family: Amsterdam Sans;
   font-size: 16px;
   font-weight: 500;
   line-height: 48px;

--- a/src/global.css
+++ b/src/global.css
@@ -50,7 +50,7 @@ html {
 
 body {
   font-family: Amsterdam Sans, sans-serif;
-  font-weight: 400 ;
+  font-weight: 400;
   font-size: 1rem;
   line-height: 1.375;
   overflow-y: scroll;

--- a/src/global.css
+++ b/src/global.css
@@ -49,7 +49,7 @@ html {
 }
 
 body {
-  font: 400 1rem/1.375 Avenir Next;
+  font: 400 1rem/1.375 "Amsterdam Sans";
   overflow-y: scroll;
   background-color: #e5e5e5;
 }

--- a/src/global.css
+++ b/src/global.css
@@ -49,7 +49,10 @@ html {
 }
 
 body {
-  font: 400 1rem/1.375 "Amsterdam Sans";
+  font-family: Amsterdam Sans, sans-serif;
+  font-weight: 400 ;
+  font-size: 1rem;
+  line-height: 1.375;
   overflow-y: scroll;
   background-color: #e5e5e5;
 }

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/EmailPreview/EmailPreview.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/EmailPreview/EmailPreview.tsx
@@ -38,7 +38,7 @@ interface EmailPreviewProps {
 const styling = `
 <style>
   *{
-    font-family:"Amsterdam Sans";
+    font-family: Amsterdam Sans, sans-serif;
     line-height: 22px;
     overflow-wrap: break-word;
     word-break: break-all;

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/EmailPreview/EmailPreview.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/EmailPreview/EmailPreview.tsx
@@ -38,7 +38,7 @@ interface EmailPreviewProps {
 const styling = `
 <style>
   *{
-    font-family:"Avenir Next";
+    font-family:"Amsterdam Sans";
     line-height: 22px;
     overflow-wrap: break-word;
     word-break: break-all;

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/styled.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/styled.tsx
@@ -50,7 +50,6 @@ export const StandardTextsButton = styled(Button)<{
   }
   div {
     font-weight: normal;
-    font-family: 'Amsterdam Sans';
     text-align: left;
     width: 100%;
     height: 100%;

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/styled.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/styled.tsx
@@ -50,7 +50,7 @@ export const StandardTextsButton = styled(Button)<{
   }
   div {
     font-weight: normal;
-    font-family: 'Avenir Next';
+    font-family: 'Amsterdam Sans';
     text-align: left;
     width: 100%;
     height: 100%;


### PR DESCRIPTION
**Context**
Per 15th of December the old font Avenir Next is no longer paid for. To prevent fines font in Sia needs het font to change to Amsterdam Sans.

**Tested by comparing local to acceptation environment** 
- happy flow voor civillians
- happy flow, filters and Signaleringen in back office
- kto-proces, not happy with result
- mijn-meldingen
- meldingenkaart

Ticket: [SIG-4891](https://datapunt.atlassian.net/browse/SIG-4891)

## Signalen

Before opening a pull request, please ensure:

- [ ] Double-check your branch is based on `main` and targets `main`
- [ ] Pull request has tests (we are going for 100% coverage!)
- [ ] Code is well-commented, linted and follows project conventions
- [ ] Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
