### PR TITLE
Add ability to deploy review apps

### DIFF
--- a/.github/review/values.yml
+++ b/.github/review/values.yml
@@ -1,0 +1,7 @@
+ingress:
+  enabled: true
+  annotations:
+    kubernetes.io/ingress.class: azure/application-gateway
+    appgw.ingress.kubernetes.io/appgw-ssl-certificate: test-meldingen-amsterdam-delta10-cloud
+    appgw.ingress.kubernetes.io/ssl-redirect: "true"
+  tls: []

--- a/.github/workflows/review_cleanup.yml
+++ b/.github/workflows/review_cleanup.yml
@@ -1,0 +1,41 @@
+name: Cleanup review environment
+
+on:
+  pull_request:
+    types: [ "closed", "unlabeled" ]
+
+env:
+  AZURE_CONTAINER_REGISTRY: "siaweuacrt4eij7yb42xum25r62"
+  CONTAINER_NAME: "frontend"
+  RESOURCE_GROUP: "sia-t-rg"
+  CLUSTER_NAME: "sia-weu-aks-t"
+  CHART_PATH: "chart"
+
+jobs:
+  uninstall:
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    if: ${{ contains( github.event.pull_request.labels.*.name, 'review') }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Azure login
+        uses: azure/login@v1.4.6
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Get K8s context
+        uses: azure/aks-set-context@v3
+        with:
+          resource-group: ${{ env.RESOURCE_GROUP }}
+          cluster-name: ${{ env.CLUSTER_NAME }}
+          admin: 'true'
+
+      - name: Delete namespace
+        run: |
+          kubectl delete namespace frontend-${{ github.event.pull_request.number }}

--- a/.github/workflows/review_deploy.yml
+++ b/.github/workflows/review_deploy.yml
@@ -37,6 +37,8 @@ jobs:
       actions: read
       contents: read
       id-token: write
+      issues: write
+      pull-requests: write
     runs-on: ubuntu-latest
     if: ${{ contains( github.event.pull_request.labels.*.name, 'review') }}
     needs: [ buildImage ]

--- a/.github/workflows/review_deploy.yml
+++ b/.github/workflows/review_deploy.yml
@@ -1,0 +1,88 @@
+name: Deploy review environment
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  AZURE_CONTAINER_REGISTRY: "siaweuacrt4eij7yb42xum25r62"
+  CONTAINER_NAME: "frontend"
+  RESOURCE_GROUP: "sia-t-rg"
+  CLUSTER_NAME: "sia-weu-aks-t"
+  CHART_PATH: "chart"
+
+jobs:
+  buildImage:
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    if: ${{ contains( github.event.pull_request.labels.*.name, 'review') }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Azure login
+        uses: azure/login@v1.4.6
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Build and push image to ACR
+        run: |
+          az acr build --image ${{ env.AZURE_CONTAINER_REGISTRY }}.azurecr.io/${{ env.CONTAINER_NAME }}:${{ github.sha }} --registry ${{ env.AZURE_CONTAINER_REGISTRY }} -g ${{ env.RESOURCE_GROUP }} .
+
+  deploy:
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    if: ${{ contains( github.event.pull_request.labels.*.name, 'review') }}
+    needs: [ buildImage ]
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Azure login
+        uses: azure/login@v1.4.6
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Get K8s context
+        uses: azure/aks-set-context@v3
+        with:
+          resource-group: ${{ env.RESOURCE_GROUP }}
+          cluster-name: ${{ env.CLUSTER_NAME }}
+          admin: 'true'
+
+      - name: Helm add repository
+        run: |
+          helm repo add signalen https://signalen.github.io/helm-charts/ && helm repo update
+
+      - name: Helm upgrade (or install)
+        run: |
+          helm upgrade signalen-frontend signalen/frontend \
+            --install \
+            --version 4.4.2 \
+            --namespace frontend-${{ github.event.pull_request.number }} \
+            --create-namespace \
+            --values .github/review/values.yml \
+            --set ingress.hosts[0].host=frontend-${{ github.event.pull_request.number }}.test.meldingen.amsterdam.delta10.cloud \
+            --set ingress.hosts[0].paths[0].path=/ \
+            --set ingress.hosts[0].paths[0].pathType=ImplementationSpecific \
+            --set image.repository=${{ env.AZURE_CONTAINER_REGISTRY }}.azurecr.io/${{ env.CONTAINER_NAME }} \
+            --set image.tag=${{ github.sha }}
+
+  publish:
+    runs-on: ubuntu-latest
+    if: ${{ contains( github.event.pull_request.labels.*.name, 'review') }}
+    needs: [ deploy ]
+    environment:
+      name: review-${{ github.event.pull_request.number }}
+      url: https://frontend-${{ github.event.pull_request.number }}.test.meldingen.amsterdam.delta10.cloud
+    steps:
+      - name: Echo review URL
+        run: |
+          echo "Review environment available on https://frontend-${{ github.event.pull_request.number }}.test.meldingen.amsterdam.delta10.cloud"

--- a/.github/workflows/review_deploy.yml
+++ b/.github/workflows/review_deploy.yml
@@ -75,14 +75,9 @@ jobs:
             --set image.repository=${{ env.AZURE_CONTAINER_REGISTRY }}.azurecr.io/${{ env.CONTAINER_NAME }} \
             --set image.tag=${{ github.sha }}
 
-  publish:
-    runs-on: ubuntu-latest
-    if: ${{ contains( github.event.pull_request.labels.*.name, 'review') }}
-    needs: [ deploy ]
-    environment:
-      name: review-${{ github.event.pull_request.number }}
-      url: https://frontend-${{ github.event.pull_request.number }}.test.meldingen.amsterdam.delta10.cloud
-    steps:
-      - name: Echo review URL
-        run: |
-          echo "Review environment available on https://frontend-${{ github.event.pull_request.number }}.test.meldingen.amsterdam.delta10.cloud"
+      - name: Comment review link to PR
+        uses: thollander/actions-comment-pull-request@v1
+        with:
+          message: |
+            Deployed review environment to https://frontend-${{ github.event.pull_request.number }}.test.meldingen.amsterdam.delta10.cloud 🚀
+          comment_includes: 'Deployed review environment to'

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,7 @@ RUN apt-get update && apt-get install -y \
 RUN git config --global url."https://".insteadOf git://
 RUN git config --global url."https://github.com/".insteadOf git@github.com:
 
-COPY .gitignore \
-  .gitattributes \
-  .eslintrc.js \
+COPY .eslintrc.js \
   .prettierrc \
   custom.d.ts \
   tsconfig.json \


### PR DESCRIPTION
This PR adds the ability to deploy review apps for open pull requests. Pull requests need to be labeled with the label "review" in order to deploy.

Example deployment: https://github.com/delta10/signalen-frontend/pull/1

## Todo

- [ ] Release new version of frontend and new Helm chart version (due to #2282)
