### PR TITLE
Show main categories that don't have a subfilter checkbox list in Fil…

### DIFF
--- a/src/signals/IncidentMap/components/IncidentMap/IncidentMap.tsx
+++ b/src/signals/IncidentMap/components/IncidentMap/IncidentMap.tsx
@@ -25,7 +25,7 @@ import { isMobile, useDeviceMode } from '../DrawerOverlay/utils'
 import { FilterPanel } from '../FilterPanel'
 import { GPSLocation } from '../GPSLocation'
 import { IncidentLayer } from '../IncidentLayer'
-import { getFilteredIncidents, computeIncidentsCountPerFilter } from '../utils'
+import { getFilteredIncidents, countIncidentsPerFilter } from '../utils'
 import { Pin } from './Pin'
 import { Wrapper, StyledMap, StyledParagraph } from './styled'
 import { getZoom } from './utils'
@@ -120,10 +120,7 @@ export const IncidentMap = () => {
 
     const filteredIncidents = getFilteredIncidents(filters, incidents)
     setFilteredIncidents(filteredIncidents)
-    const filterFromIncidents = computeIncidentsCountPerFilter(
-      filters,
-      incidents
-    )
+    const filterFromIncidents = countIncidentsPerFilter(filters, incidents)
     if (!isEqual(filterFromIncidents, filters)) setFilters(filterFromIncidents)
   }, [data, filters])
 

--- a/src/signals/IncidentMap/components/utils/count-incidents-per-filter.test.ts
+++ b/src/signals/IncidentMap/components/utils/count-incidents-per-filter.test.ts
@@ -2,7 +2,7 @@
 // Copyright (C) 2022 Gemeente Amsterdam
 import { mockFiltersShort } from '../__test__/mock-filters'
 import { mockIncidentsShort } from '../__test__/mock-incidents'
-import { computeIncidentsCountPerFilter } from './count-incidents-per-filter'
+import { countIncidentsPerFilter } from './count-incidents-per-filter'
 
 describe('computeincidentsCountPerFilter', () => {
   afterEach(() => {
@@ -19,7 +19,7 @@ describe('computeincidentsCountPerFilter', () => {
         incidentsCount: 0,
       },
     ]
-    const result = computeIncidentsCountPerFilter(
+    const result = countIncidentsPerFilter(
       mockFiltersOneItem,
       mockIncidentsShort
     )
@@ -28,10 +28,7 @@ describe('computeincidentsCountPerFilter', () => {
   })
 
   it("should add 1 to incidentsCount of mainCategoryFilter foreach of it's subCategories", () => {
-    const result = computeIncidentsCountPerFilter(
-      mockFiltersShort,
-      mockIncidentsShort
-    )
+    const result = countIncidentsPerFilter(mockFiltersShort, mockIncidentsShort)
 
     expect(result[0].incidentsCount).toBe(3)
   })

--- a/src/signals/IncidentMap/components/utils/count-incidents-per-filter.ts
+++ b/src/signals/IncidentMap/components/utils/count-incidents-per-filter.ts
@@ -3,7 +3,7 @@
 
 import type { Filter, Incident } from '../../types'
 
-export const computeIncidentsCountPerFilter = (
+export const countIncidentsPerFilter = (
   filters: Filter[],
   incidents: Incident[]
 ): Filter[] => {

--- a/src/signals/IncidentMap/components/utils/get-filtered-incidents.test.ts
+++ b/src/signals/IncidentMap/components/utils/get-filtered-incidents.test.ts
@@ -11,13 +11,13 @@ describe('getFilteredIncidents', () => {
   it('should return only active filters', () => {
     const result = getFilteredIncidents(mockFiltersShort, mockIncidentsShort)
 
-    expect(result.length).toEqual(3)
+    expect(result.length).toEqual(4)
   })
   it('should return only active filters with the first without icon', () => {
     const filters = mockFiltersShort.map(removeIcons)
     const result = getFilteredIncidents(filters, mockIncidentsShort)
 
-    expect(result.length).toEqual(3)
+    expect(result.length).toEqual(4)
   })
 })
 

--- a/src/signals/IncidentMap/components/utils/get-filtered-incidents.ts
+++ b/src/signals/IncidentMap/components/utils/get-filtered-incidents.ts
@@ -26,8 +26,15 @@ export const getFilteredIncidents = (
 
   const activeSlugs = activeFilters.map((filter) => filter.slug)
 
+  /**
+   * Because count-incidents-per-filter only shows subcategories for two
+   * main categories, we need to look for the parent slug to get all the markers.
+   */
   const activeIncidents = incidents.filter((incident) => {
-    return activeSlugs.includes(incident.properties.category.slug)
+    return (
+      activeSlugs.includes(incident.properties.category.slug) ||
+      activeSlugs.includes(incident.properties.category.parent.slug)
+    )
   })
 
   const listedIcons = getListOfIcons(activeFilters)

--- a/src/signals/IncidentMap/components/utils/index.ts
+++ b/src/signals/IncidentMap/components/utils/index.ts
@@ -1,4 +1,4 @@
 export { updateFilterCategory } from './update-filter-category'
 export { getFilteredIncidents } from './get-filtered-incidents'
-export { computeIncidentsCountPerFilter } from './count-incidents-per-filter'
+export { countIncidentsPerFilter } from './count-incidents-per-filter'
 export * from './constants'


### PR DESCRIPTION
…terPanel but still need to be visible in IncidentMap.tsx.

Ticket: [SIG-4910](https://datapunt.atlassian.net/browse/SIG-4910)

## what changed
At the meldingenkaart, we only show subcategory filters in filterpanel for two main categories, the rest we ignore. This pr also shows markers for incidents markers thats only have an active main category.


## Signalen

Before opening a pull request, please ensure:

- [x] Double-check your branch is based on `main` and targets `main`
- [x] Pull request has tests (we are going for 100% coverage!)
- [x] Code is well-commented, linted and follows project conventions
- [x] Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
