### PR TITLE
Make step by step nav navigatable when creating an incident.

### DIFF
--- a/src/shared/services/configuration/map-markers.ts
+++ b/src/shared/services/configuration/map-markers.ts
@@ -53,6 +53,8 @@ export const currentIncidentIcon = L.icon({
 })
 
 export const defaultIcon = '/assets/images/icon-incident-marker.svg'
+
+/* istanbul ignore next */
 export const dynamicIcon = (iconUrl?: string) =>
   L.icon({
     iconUrl: iconUrl ?? defaultIcon,

--- a/src/shared/services/configuration/map-markers.ts
+++ b/src/shared/services/configuration/map-markers.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2020 - 2021 Gemeente Amsterdam
+// Copyright (C) 2020 - 2022 Gemeente Amsterdam
 /* eslint-disable global-require */
 import L from 'leaflet'
 

--- a/src/signals/incident/components/IncidentForm/index.tsx
+++ b/src/signals/incident/components/IncidentForm/index.tsx
@@ -151,9 +151,7 @@ const IncidentForm = forwardRef<any, any>(
         if (next) {
           if (prevState.current.loading) {
             next()
-            if (stepsCompletedCount < index + 1) {
-              setStepsCompletedCount(index + 1)
-            }
+            setStepsCompletedCount(index + 1)
             return
           }
 

--- a/src/signals/incident/components/IncidentForm/index.tsx
+++ b/src/signals/incident/components/IncidentForm/index.tsx
@@ -1,7 +1,14 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2018 - 2022 Gemeente Amsterdam
 import type { BaseSyntheticEvent, ForwardedRef } from 'react'
-import { useState, useRef, useEffect, useCallback, forwardRef } from 'react'
+import {
+  useState,
+  useRef,
+  useEffect,
+  useCallback,
+  forwardRef,
+  useContext,
+} from 'react'
 
 import { isEmpty, isObject } from 'lodash'
 import isEqual from 'lodash/isEqual'
@@ -9,6 +16,7 @@ import { Controller } from 'react-hook-form'
 
 import formatConditionalForm from '../../services/format-conditional-form'
 import constructYupResolver from '../../services/yup-resolver'
+import { WizardContext } from '../StepWizard'
 import { Form, Fieldset, ProgressContainer } from './styled'
 import { scrollToInvalidElement } from './utils/scroll-to-invalid-element'
 
@@ -24,10 +32,14 @@ const IncidentForm = forwardRef<any, any>(
       removeFromSelection,
       getClassification,
       fieldConfig,
+      index,
     },
     controlsRef: ForwardedRef<any>
   ) => {
     const [submitting, setSubmitting] = useState(false)
+
+    const { steps, stepsCompletedCount, setStepsCompletedCount } =
+      useContext(WizardContext)
 
     const prevState = useRef<{ isMounted: boolean; loading: boolean }>({
       isMounted: true,
@@ -139,6 +151,9 @@ const IncidentForm = forwardRef<any, any>(
         if (next) {
           if (prevState.current.loading) {
             next()
+            if (stepsCompletedCount < index + 1) {
+              setStepsCompletedCount(index + 1)
+            }
             return
           }
 
@@ -146,11 +161,6 @@ const IncidentForm = forwardRef<any, any>(
             setSubmitting(true)
           }
 
-          /**
-           * Trigger the form before before calling handle submit,
-           * to make sure useForm takes the latest yupResolver defined right
-           * above the return jsx statement.
-           */
           const isValid = await reactHookFormProps.trigger()
 
           /**
@@ -161,6 +171,9 @@ const IncidentForm = forwardRef<any, any>(
             setIncident(formAction)
             setSubmitting(false)
             next()
+            if (index < steps.length) {
+              setStepsCompletedCount(index + 1)
+            }
           } else {
             scrollToInvalidElement(
               controls,
@@ -170,7 +183,16 @@ const IncidentForm = forwardRef<any, any>(
           }
         }
       },
-      [controls, reactHookFormProps, setIncident, submitting]
+      [
+        controls,
+        index,
+        reactHookFormProps,
+        setIncident,
+        setStepsCompletedCount,
+        steps.length,
+        stepsCompletedCount,
+        submitting,
+      ]
     )
 
     const parent = {
@@ -191,6 +213,7 @@ const IncidentForm = forwardRef<any, any>(
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     controlsRef.current = constructYupResolver(controls)
+
     return (
       <div data-testid="incidentForm" ref={formRef}>
         <ProgressContainer />

--- a/src/signals/incident/components/IncidentWizard/IncidentWizard.tsx
+++ b/src/signals/incident/components/IncidentWizard/IncidentWizard.tsx
@@ -3,12 +3,7 @@
 import { useContext, useMemo, useRef } from 'react'
 import type { FC } from 'react'
 
-import {
-  StepByStepNav,
-  breakpoint,
-  Paragraph,
-  ascDefaultTheme,
-} from '@amsterdam/asc-ui'
+import { breakpoint, Paragraph, ascDefaultTheme } from '@amsterdam/asc-ui/lib'
 import LoadingIndicator from 'components/LoadingIndicator'
 import AppContext from 'containers/App/context'
 import { FormProvider, useForm } from 'react-hook-form'
@@ -26,6 +21,7 @@ import type { Incident } from 'types/incident'
 
 import IncidentForm from '../IncidentForm'
 import IncidentPreview from '../IncidentPreview'
+import { StepByStepNavClickable } from '../StepByStepNavClickable'
 import { Wizard, Steps, Step } from '../StepWizard'
 import onNext from './services/on-next'
 import {
@@ -64,6 +60,7 @@ const IncidentWizard: FC<IncidentWizardProps> = ({
   // Controls is used here for setting the validations rules used in UseForm resolver.
   const controlsRef = useRef()
   const appContext = useContext(AppContext)
+
   const sources = appContext.sources
 
   const incident = useMemo(
@@ -113,7 +110,6 @@ const IncidentWizard: FC<IncidentWizardProps> = ({
                           previewFactory,
                           sectionLabels,
                         } = wizardDefinition[key as keyof WizardSection]
-
                         const showProgress = index < steps.length
 
                         return previewFactory || form || formFactory ? (
@@ -127,10 +123,11 @@ const IncidentWizard: FC<IncidentWizardProps> = ({
                             </Header>
 
                             <Progress>
-                              <StepByStepNav
+                              <StepByStepNavClickable
                                 steps={steps}
                                 itemType="numeric"
-                                activeItem={index + 1}
+                                activeItem={index}
+                                wizardRoutes={Object.keys(wizardDefinition)}
                                 breakpoint={breakpoint(
                                   'max-width',
                                   'tabletM'
@@ -149,6 +146,7 @@ const IncidentWizard: FC<IncidentWizardProps> = ({
 
                               {(form || formFactory) && (
                                 <IncidentForm
+                                  index={index}
                                   ref={controlsRef}
                                   reactHookFormProps={formMethods}
                                   fieldConfig={

--- a/src/signals/incident/components/StepByStepNavClickable/StepByStepNavClickable.test.tsx
+++ b/src/signals/incident/components/StepByStepNavClickable/StepByStepNavClickable.test.tsx
@@ -1,2 +1,207 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2018 - 2022 Gemeente Amsterdam
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import form from 'react-hook-form'
+
+import WizardContext from '../StepWizard/context/WizardContext'
+import { StepByStepNavClickable } from './StepByStepNavClickable'
+
+const mockPush = jest.fn()
+const mockSetStepsCompletedCount = jest.fn()
+
+const defaultContextProps = {
+  push: mockPush,
+  stepsCompletedCount: 1,
+  setStepsCompletedCount: mockSetStepsCompletedCount,
+  next: jest.fn(),
+  previous: jest.fn(),
+  step: { id: 'someid' },
+  steps: [{ id: 'someid' }],
+}
+
+jest.mock('react-hook-form', () => ({
+  ...jest.requireActual('react-hook-form'),
+}))
+
+describe('StepBySTepNavClickable when form is valid', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('should render properly', function () {
+    const mockTrigger = jest
+      .fn()
+      .mockImplementation(() => Promise.resolve(true))
+
+    jest.spyOn(form, 'useFormContext').mockImplementationOnce(() => ({
+      ...jest.requireActual('react-hook-form').useFormContext,
+      trigger: mockTrigger,
+    }))
+
+    render(
+      <WizardContext.Provider value={{ ...defaultContextProps }}>
+        <StepByStepNavClickable
+          activeItem={0}
+          wizardRoutes={['step1', 'step2']}
+          steps={[{ label: 'step1' }, { label: 'step2' }]}
+        />
+      </WizardContext.Provider>
+    )
+
+    expect(screen.getByText('step1')).toBeInTheDocument()
+    expect(screen.getByText('step2')).toBeInTheDocument()
+  })
+
+  it('should go to the next step with a valid current step and call setStepsCompletedCount', async function () {
+    const mockTrigger = jest
+      .fn()
+      .mockImplementation(() => Promise.resolve(true))
+
+    jest.spyOn(form, 'useFormContext').mockImplementationOnce(() => ({
+      ...jest.requireActual('react-hook-form').useFormContext,
+      trigger: mockTrigger,
+    }))
+
+    render(
+      <WizardContext.Provider
+        value={{
+          push: mockPush,
+          stepsCompletedCount: 1,
+          setStepsCompletedCount: mockSetStepsCompletedCount,
+          next: jest.fn(),
+          previous: jest.fn(),
+          step: { id: 'someid' },
+          steps: [{ id: 'someid' }],
+        }}
+      >
+        <StepByStepNavClickable
+          activeItem={1}
+          wizardRoutes={['step1', 'step2']}
+          steps={[{ label: 'step1' }, { label: 'step2' }]}
+        />
+      </WizardContext.Provider>
+    )
+
+    await waitFor(() => {
+      userEvent.click(screen.getByText('step1'))
+    })
+    expect(mockTrigger).toBeCalled()
+    expect(mockPush).toBeCalledWith('incident/step1')
+    expect(mockSetStepsCompletedCount).not.toHaveBeenCalled()
+  })
+
+  it("should go to the next step with a valid current step, and don't call setStepsCompletedCount", async function () {
+    const mockTrigger = jest
+      .fn()
+      .mockImplementation(() => Promise.resolve(true))
+
+    jest.spyOn(form, 'useFormContext').mockImplementationOnce(() => ({
+      ...jest.requireActual('react-hook-form').useFormContext,
+      trigger: mockTrigger,
+    }))
+
+    render(
+      <WizardContext.Provider
+        value={{
+          push: mockPush,
+          stepsCompletedCount: 1,
+          setStepsCompletedCount: mockSetStepsCompletedCount,
+          next: jest.fn(),
+          previous: jest.fn(),
+          step: { id: 'someid' },
+          steps: [{ id: 'someid' }],
+        }}
+      >
+        <StepByStepNavClickable
+          activeItem={0}
+          wizardRoutes={['step1', 'step2']}
+          steps={[{ label: 'step1' }, { label: 'step2' }]}
+        />
+      </WizardContext.Provider>
+    )
+
+    await waitFor(() => {
+      userEvent.click(screen.getByText('step2'))
+    })
+    expect(mockTrigger).toBeCalled()
+    expect(mockPush).toBeCalledWith('incident/step2')
+    expect(mockSetStepsCompletedCount).not.toHaveBeenCalled()
+  })
+
+  it('should go to the next step with a invalid current step', async function () {
+    const mockTriggerFalse = jest
+      .fn()
+      .mockImplementation(() => Promise.resolve(false))
+
+    jest.spyOn(form, 'useFormContext').mockImplementationOnce(() => ({
+      ...jest.requireActual('react-hook-form').useFormContext,
+      trigger: mockTriggerFalse,
+    }))
+
+    render(
+      <WizardContext.Provider
+        value={{
+          push: mockPush,
+          stepsCompletedCount: 1,
+          setStepsCompletedCount: mockSetStepsCompletedCount,
+          next: jest.fn(),
+          previous: jest.fn(),
+          step: { id: 'someid' },
+          steps: [{ id: 'someid' }],
+        }}
+      >
+        <StepByStepNavClickable
+          activeItem={1}
+          wizardRoutes={['step1', 'step2']}
+          steps={[{ label: 'step1' }, { label: 'step2' }]}
+        />
+      </WizardContext.Provider>
+    )
+
+    await waitFor(() => {
+      userEvent.click(screen.getByText('step1'))
+    })
+    expect(mockTriggerFalse).toBeCalled()
+    expect(mockPush).toBeCalledWith('incident/step1')
+    expect(mockSetStepsCompletedCount).toBeCalledWith(1)
+  })
+
+  it('should not go the next step with an invalid current step', async function () {
+    const mockTriggerFalse = jest
+      .fn()
+      .mockImplementation(() => Promise.resolve(false))
+
+    jest.spyOn(form, 'useFormContext').mockImplementationOnce(() => ({
+      ...jest.requireActual('react-hook-form').useFormContext,
+      trigger: mockTriggerFalse,
+    }))
+
+    render(
+      <WizardContext.Provider
+        value={{
+          push: mockPush,
+          stepsCompletedCount: 1,
+          setStepsCompletedCount: mockSetStepsCompletedCount,
+          next: jest.fn(),
+          previous: jest.fn(),
+          step: { id: 'someid' },
+          steps: [{ id: 'someid' }],
+        }}
+      >
+        <StepByStepNavClickable
+          activeItem={0}
+          wizardRoutes={['step1', 'step2']}
+          steps={[{ label: 'step1' }, { label: 'step2' }]}
+        />
+      </WizardContext.Provider>
+    )
+
+    await waitFor(() => {
+      userEvent.click(screen.getByText('step2'))
+    })
+    expect(mockTriggerFalse).toBeCalled()
+    expect(mockPush).not.toBeCalled()
+    expect(mockSetStepsCompletedCount).toBeCalledWith(0)
+  })
+})

--- a/src/signals/incident/components/StepByStepNavClickable/StepByStepNavClickable.test.tsx
+++ b/src/signals/incident/components/StepByStepNavClickable/StepByStepNavClickable.test.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2018 - 2022 Gemeente Amsterdam
+// Copyright (C) 2022 - 2022 Gemeente Amsterdam
 // eslint-disable-next-line no-restricted-imports
 import React from 'react'
 
@@ -43,7 +43,7 @@ const watchWithDescriptionChange = (cb: any) => {
   return { unsubscribe: jest.fn() }
 }
 
-describe('StepBySTepNavClickable when form is valid', () => {
+describe('StepByStepNavClickable when form is valid', () => {
   beforeEach(() => {
     jest.resetAllMocks()
   })
@@ -193,6 +193,31 @@ describe('StepBySTepNavClickable when form is valid', () => {
     const mockTrigger = jest
       .fn()
       .mockImplementation(() => Promise.resolve(false))
+
+    jest.spyOn(form, 'useFormContext').mockImplementationOnce(() => ({
+      ...jest.requireActual('react-hook-form').useFormContext,
+      trigger: mockTrigger,
+      watch: jest.fn().mockImplementation(watchWithDescriptionChange),
+    }))
+
+    render(
+      <WizardContext.Provider value={{ ...defaultContextProps }}>
+        <StepByStepNavClickable
+          activeItem={0}
+          wizardRoutes={['step1', 'step2']}
+          steps={[{ label: 'step1' }, { label: 'step2' }]}
+        />
+      </WizardContext.Provider>
+    )
+
+    expect(mockPush).not.toBeCalled()
+    expect(mockSetStepsCompletedCount).toBeCalledTimes(1)
+  })
+
+  it('it should trigger setCountStep when there is an error in the formState', async function () {
+    const mockTrigger = jest
+      .fn()
+      .mockImplementation(() => Promise.resolve(false))
     jest
       .spyOn(React, 'useRef')
       .mockReturnValueOnce({ current: 'someErrorField' })
@@ -200,7 +225,7 @@ describe('StepBySTepNavClickable when form is valid', () => {
     jest.spyOn(form, 'useFormContext').mockImplementationOnce(() => ({
       ...jest.requireActual('react-hook-form').useFormContext,
       trigger: mockTrigger,
-      watch: jest.fn().mockImplementation(watchWithDescriptionChange),
+      watch: jest.fn().mockImplementation(watch),
       formState: { errors: { someErrorField: 'error' } },
     }))
 
@@ -215,6 +240,6 @@ describe('StepBySTepNavClickable when form is valid', () => {
     )
 
     expect(mockPush).not.toBeCalled()
-    expect(mockSetStepsCompletedCount).toBeCalledTimes(2)
+    expect(mockSetStepsCompletedCount).toBeCalledTimes(1)
   })
 })

--- a/src/signals/incident/components/StepByStepNavClickable/StepByStepNavClickable.test.tsx
+++ b/src/signals/incident/components/StepByStepNavClickable/StepByStepNavClickable.test.tsx
@@ -64,17 +64,7 @@ describe('StepBySTepNavClickable when form is valid', () => {
     }))
 
     render(
-      <WizardContext.Provider
-        value={{
-          push: mockPush,
-          stepsCompletedCount: 1,
-          setStepsCompletedCount: mockSetStepsCompletedCount,
-          next: jest.fn(),
-          previous: jest.fn(),
-          step: { id: 'someid' },
-          steps: [{ id: 'someid' }],
-        }}
-      >
+      <WizardContext.Provider value={{ ...defaultContextProps }}>
         <StepByStepNavClickable
           activeItem={1}
           wizardRoutes={['step1', 'step2']}
@@ -102,17 +92,7 @@ describe('StepBySTepNavClickable when form is valid', () => {
     }))
 
     render(
-      <WizardContext.Provider
-        value={{
-          push: mockPush,
-          stepsCompletedCount: 1,
-          setStepsCompletedCount: mockSetStepsCompletedCount,
-          next: jest.fn(),
-          previous: jest.fn(),
-          step: { id: 'someid' },
-          steps: [{ id: 'someid' }],
-        }}
-      >
+      <WizardContext.Provider value={{ ...defaultContextProps }}>
         <StepByStepNavClickable
           activeItem={0}
           wizardRoutes={['step1', 'step2']}
@@ -140,17 +120,7 @@ describe('StepBySTepNavClickable when form is valid', () => {
     }))
 
     render(
-      <WizardContext.Provider
-        value={{
-          push: mockPush,
-          stepsCompletedCount: 1,
-          setStepsCompletedCount: mockSetStepsCompletedCount,
-          next: jest.fn(),
-          previous: jest.fn(),
-          step: { id: 'someid' },
-          steps: [{ id: 'someid' }],
-        }}
-      >
+      <WizardContext.Provider value={{ ...defaultContextProps }}>
         <StepByStepNavClickable
           activeItem={1}
           wizardRoutes={['step1', 'step2']}
@@ -178,17 +148,7 @@ describe('StepBySTepNavClickable when form is valid', () => {
     }))
 
     render(
-      <WizardContext.Provider
-        value={{
-          push: mockPush,
-          stepsCompletedCount: 1,
-          setStepsCompletedCount: mockSetStepsCompletedCount,
-          next: jest.fn(),
-          previous: jest.fn(),
-          step: { id: 'someid' },
-          steps: [{ id: 'someid' }],
-        }}
-      >
+      <WizardContext.Provider value={{ ...defaultContextProps }}>
         <StepByStepNavClickable
           activeItem={0}
           wizardRoutes={['step1', 'step2']}

--- a/src/signals/incident/components/StepByStepNavClickable/StepByStepNavClickable.test.tsx
+++ b/src/signals/incident/components/StepByStepNavClickable/StepByStepNavClickable.test.tsx
@@ -1,0 +1,2 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (C) 2018 - 2022 Gemeente Amsterdam

--- a/src/signals/incident/components/StepByStepNavClickable/StepByStepNavClickable.tsx
+++ b/src/signals/incident/components/StepByStepNavClickable/StepByStepNavClickable.tsx
@@ -23,7 +23,6 @@ export function StepByStepNavClickable({
   wizardRoutes,
   ...props
 }: Props & { activeItem: number }) {
-  let realActiveItem = 0
   const { push, stepsCompletedCount, setStepsCompletedCount } =
     useContext(WizardContext)
   const { trigger } = useFormContext()
@@ -68,10 +67,9 @@ export function StepByStepNavClickable({
     ]
   )
 
-  realActiveItem = stepsCompletedCount
   return (
     <StepByStepNavStyle
-      activeItem={realActiveItem}
+      activeItem={stepsCompletedCount}
       aria-label="progress"
       className={className}
       role="group"
@@ -79,7 +77,7 @@ export function StepByStepNavClickable({
     >
       <OrderdedList breakpoint={breakpoint}>
         {props.steps.map(({ label }, index) => {
-          const isActive = index === realActiveItem - 1
+          const isActive = index === stepsCompletedCount - 1
           return (
             <StyledListItem
               stepsCompletedCount={stepsCompletedCount}

--- a/src/signals/incident/components/StepByStepNavClickable/StepByStepNavClickable.tsx
+++ b/src/signals/incident/components/StepByStepNavClickable/StepByStepNavClickable.tsx
@@ -6,13 +6,12 @@ import { useCallback, useContext } from 'react'
 import type { StepByStepNavProps } from '@amsterdam/asc-ui/lib/components/StepByStepNav/StepByStepNavStyle'
 import StepByStepNavStyle, {
   OrderdedList,
-  Label,
   transitionBreakpoint,
 } from '@amsterdam/asc-ui/lib/components/StepByStepNav/StepByStepNavStyle'
 import { useFormContext } from 'react-hook-form'
 
 import { WizardContext } from '../StepWizard'
-import { StyledListItem } from './styled'
+import { StyledLabel, StyledListItem } from './styled'
 
 type Props = StepByStepNavProps &
   HTMLAttributes<HTMLElement> & { wizardRoutes: string[] }
@@ -32,22 +31,25 @@ export function StepByStepNavClickable({
   const onListClickHandler = useCallback(
     async (newIndex) => {
       const isValid = await trigger()
+
       /**
-       * If the new step is lower or equal to stepsCompletedCount
-       * go to that step.
+       * When going to a lower step, check validity of the current one.
+       * When the current step is invalid:
+       * Decrease the stepsCompletedCount by new step index +1 to continue
+       * the form in a valid or possible invalid step (when going back one step).
        */
       if (newIndex < activeItem) {
-        /**
-         * If the current step is not valid and the new step is lower than minus 1,
-         * eg from 3 to 1, set stepsCompletedCount to newIndex
-         */
         if (!isValid) {
           setStepsCompletedCount(newIndex + 1)
         }
         push(`incident/${wizardRoutes[newIndex]}`)
       }
 
-      // For steps higher than activeItem check validity. If its not valid, change the stepsCompletedCount param
+      /**
+       * For steps higher than activeItem check validity. If its not valid,
+       * change stepsCompletedCount to the current one. This is to force the user
+       * to fix the faulty steps first before continuing.
+       */
       if (newIndex > activeItem && newIndex <= stepsCompletedCount) {
         if (isValid) {
           push(`incident/${wizardRoutes[newIndex]}`)
@@ -67,7 +69,6 @@ export function StepByStepNavClickable({
   )
 
   realActiveItem = stepsCompletedCount
-
   return (
     <StepByStepNavStyle
       activeItem={realActiveItem}
@@ -90,9 +91,9 @@ export function StepByStepNavClickable({
               onClick={() => onListClickHandler(index)}
               {...props}
             >
-              <Label itemType={props.itemType} breakpoint={breakpoint}>
+              <StyledLabel itemType={props.itemType} breakpoint={breakpoint}>
                 {label}
-              </Label>
+              </StyledLabel>
             </StyledListItem>
           )
         })}

--- a/src/signals/incident/components/StepByStepNavClickable/StepByStepNavClickable.tsx
+++ b/src/signals/incident/components/StepByStepNavClickable/StepByStepNavClickable.tsx
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (C) 2018 - 2022 Gemeente Amsterdam
+import type { HTMLAttributes } from 'react'
+import { useCallback, useContext } from 'react'
+
+import type { StepByStepNavProps } from '@amsterdam/asc-ui/lib/components/StepByStepNav/StepByStepNavStyle'
+import StepByStepNavStyle, {
+  OrderdedList,
+  Label,
+  transitionBreakpoint,
+} from '@amsterdam/asc-ui/lib/components/StepByStepNav/StepByStepNavStyle'
+import { useFormContext } from 'react-hook-form'
+
+import { WizardContext } from '../StepWizard'
+import { StyledListItem } from './styled'
+
+type Props = StepByStepNavProps &
+  HTMLAttributes<HTMLElement> & { wizardRoutes: string[] }
+
+export function StepByStepNavClickable({
+  activeItem,
+  className,
+  breakpoint,
+  wizardRoutes,
+  ...props
+}: Props & { activeItem: number }) {
+  let realActiveItem = 0
+  const { push, stepsCompletedCount, setStepsCompletedCount } =
+    useContext(WizardContext)
+  const { trigger } = useFormContext()
+
+  const onListClickHandler = useCallback(
+    async (newIndex) => {
+      const isValid = await trigger()
+      /**
+       * If the new step is lower or equal to stepsCompletedCount
+       * go to that step.
+       */
+      if (newIndex < activeItem) {
+        /**
+         * If the current step is not valid and the new step is lower than minus 1,
+         * eg from 3 to 1, set stepsCompletedCount to newIndex
+         */
+        if (!isValid) {
+          setStepsCompletedCount(newIndex + 1)
+        }
+        push(`incident/${wizardRoutes[newIndex]}`)
+      }
+
+      // For steps higher than activeItem check validity. If its not valid, change the stepsCompletedCount param
+      if (newIndex > activeItem && newIndex <= stepsCompletedCount) {
+        if (isValid) {
+          push(`incident/${wizardRoutes[newIndex]}`)
+        } else {
+          setStepsCompletedCount(activeItem)
+        }
+      }
+    },
+    [
+      activeItem,
+      push,
+      setStepsCompletedCount,
+      stepsCompletedCount,
+      trigger,
+      wizardRoutes,
+    ]
+  )
+
+  realActiveItem = stepsCompletedCount
+
+  return (
+    <StepByStepNavStyle
+      activeItem={realActiveItem}
+      aria-label="progress"
+      className={className}
+      role="group"
+      {...props}
+    >
+      <OrderdedList breakpoint={breakpoint}>
+        {props.steps.map(({ label }, index) => {
+          const isActive = index === realActiveItem - 1
+          return (
+            <StyledListItem
+              stepsCompletedCount={stepsCompletedCount}
+              index={index}
+              activeItem={activeItem + 1}
+              aria-current={!stepsCompletedCount && isActive ? 'step' : 'false'}
+              breakpoint={breakpoint}
+              key={label}
+              onClick={() => onListClickHandler(index)}
+              {...props}
+            >
+              <Label itemType={props.itemType} breakpoint={breakpoint}>
+                {label}
+              </Label>
+            </StyledListItem>
+          )
+        })}
+      </OrderdedList>
+    </StepByStepNavStyle>
+  )
+}
+
+StepByStepNavClickable.defaultProps = {
+  activeItem: 1,
+  breakpoint: transitionBreakpoint,
+  className: '',
+  itemType: 'none',
+}
+
+export default StepByStepNavClickable

--- a/src/signals/incident/components/StepByStepNavClickable/StepByStepNavClickable.tsx
+++ b/src/signals/incident/components/StepByStepNavClickable/StepByStepNavClickable.tsx
@@ -14,7 +14,7 @@ import { WizardContext } from '../StepWizard'
 import { StyledLabel, StyledListItem } from './styled'
 
 type Props = StepByStepNavProps &
-  HTMLAttributes<HTMLElement> & { wizardRoutes: string[] }
+  HTMLAttributes<HTMLElement> & { wizardRoutes: string[]; activeItem: number }
 
 export function StepByStepNavClickable({
   activeItem,
@@ -22,7 +22,7 @@ export function StepByStepNavClickable({
   breakpoint,
   wizardRoutes,
   ...props
-}: Props & { activeItem: number }) {
+}: Props) {
   const { push, stepsCompletedCount, setStepsCompletedCount } =
     useContext(WizardContext)
   const { trigger, watch, formState } = useFormContext()
@@ -89,9 +89,10 @@ export function StepByStepNavClickable({
      * when changing the description field, reset stepsCompletedCount.
      */
     const subscription = watch((_, { name, type }) => {
-      prevChangedField.current = name
       if (name === 'description' && type === 'change') {
         setStepsCompletedCount(activeItem)
+      } else {
+        prevChangedField.current = name
       }
     })
     return () => subscription.unsubscribe()

--- a/src/signals/incident/components/StepByStepNavClickable/index.ts
+++ b/src/signals/incident/components/StepByStepNavClickable/index.ts
@@ -1,0 +1,1 @@
+export { StepByStepNavClickable } from './StepByStepNavClickable'

--- a/src/signals/incident/components/StepByStepNavClickable/styled.tsx
+++ b/src/signals/incident/components/StepByStepNavClickable/styled.tsx
@@ -18,6 +18,9 @@ export const StyledListItem = styled(ListItem)<{
       ${StyledLabel}:before {
         background-color: ${themeColor('primary', 'main')};
       }
+      ${StyledLabel}: hover {
+        text-decoration: underline;
+      }
     `}
   `}
 `

--- a/src/signals/incident/components/StepByStepNavClickable/styled.tsx
+++ b/src/signals/incident/components/StepByStepNavClickable/styled.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2018 - 2022 Gemeente Amsterdam
+// Copyright (C) 2022 - 2022 Gemeente Amsterdam
 import { themeColor } from '@amsterdam/asc-ui'
 import {
   ListItem,

--- a/src/signals/incident/components/StepByStepNavClickable/styled.tsx
+++ b/src/signals/incident/components/StepByStepNavClickable/styled.tsx
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (C) 2018 - 2022 Gemeente Amsterdam
+import { themeColor } from '@amsterdam/asc-ui'
+import {
+  ListItem,
+  Label,
+} from '@amsterdam/asc-ui/lib/components/StepByStepNav/StepByStepNavStyle'
+import styled, { css } from 'styled-components'
+
+export const StyledListItem = styled(ListItem)<{
+  index: number
+  stepsCompletedCount: number
+}>`
+  ${({ index, stepsCompletedCount }) => css`
+    cursor: ${index <= stepsCompletedCount ? 'pointer' : ''};
+    ${index <= stepsCompletedCount &&
+    css`
+      ${Label}:before {
+        background-color: ${themeColor('primary', 'main')};
+      }
+    `}
+  `}
+`
+
+export const styledLabel = styled(Label)``

--- a/src/signals/incident/components/StepByStepNavClickable/styled.tsx
+++ b/src/signals/incident/components/StepByStepNavClickable/styled.tsx
@@ -15,11 +15,11 @@ export const StyledListItem = styled(ListItem)<{
     cursor: ${index <= stepsCompletedCount ? 'pointer' : ''};
     ${index <= stepsCompletedCount &&
     css`
-      ${Label}:before {
+      ${StyledLabel}:before {
         background-color: ${themeColor('primary', 'main')};
       }
     `}
   `}
 `
 
-export const styledLabel = styled(Label)``
+export const StyledLabel = styled(Label)``

--- a/src/signals/incident/components/StepWizard/components/Step.tsx
+++ b/src/signals/incident/components/StepWizard/components/Step.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2020 - 2022 Vereniging van Nederlandse Gemeenten, Gemeente Amsterdam
+// Copyright (C) 2022 - 2022 Vereniging van Nederlandse Gemeenten, Gemeente Amsterdam
 export default function Step({
   render,
   id,

--- a/src/signals/incident/components/StepWizard/components/Steps.tsx
+++ b/src/signals/incident/components/StepWizard/components/Steps.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2020 - 2022 Vereniging van Nederlandse Gemeenten, Gemeente Amsterdam
+// Copyright (C) 2022 - 2022 Vereniging van Nederlandse Gemeenten, Gemeente Amsterdam
 import type { FunctionComponent, ReactElement } from 'react'
 import { Children, memo, useContext, useEffect, useMemo } from 'react'
 

--- a/src/signals/incident/components/StepWizard/components/Wizard.tsx
+++ b/src/signals/incident/components/StepWizard/components/Wizard.tsx
@@ -22,6 +22,9 @@ const Wizard = (props: Props) => {
 
   const [steps, setSteps] = useState<WizardApi['steps']>([{ id: '' }])
 
+  const [stepsCompletedCount, setStepsCompletedCount] =
+    useState<WizardApi['stepsCompletedCount']>(0)
+
   const didMount = useRef(false)
 
   const history = useMemo(
@@ -129,8 +132,21 @@ const Wizard = (props: Props) => {
       push,
       replace,
       steps,
+      stepsCompletedCount,
+      setStepsCompletedCount,
     }),
-    [history, init, next, previous, push, replace, set, stepState, steps]
+    [
+      history,
+      init,
+      next,
+      previous,
+      push,
+      replace,
+      set,
+      stepState,
+      steps,
+      stepsCompletedCount,
+    ]
   )
 
   const initialOnNext = useRef(false)

--- a/src/signals/incident/components/StepWizard/components/Wizard.tsx
+++ b/src/signals/incident/components/StepWizard/components/Wizard.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2020 - 2022 Vereniging van Nederlandse Gemeenten, Gemeente Amsterdam
+// Copyright (C) 2022 - 2022 Vereniging van Nederlandse Gemeenten, Gemeente Amsterdam
 import type { ReactNode } from 'react'
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 

--- a/src/signals/incident/components/StepWizard/context/WizardContext.tsx
+++ b/src/signals/incident/components/StepWizard/context/WizardContext.tsx
@@ -1,30 +1,30 @@
 import { createContext } from 'react'
 
-type Step = {id: string}
+type Step = { id: string }
 
 export interface WizardApi {
-  go?: () => void,
-  set?: (step: Step) => void,
-  history?: History,
-  init?: (steps: WizardApi["steps"]) => void,
-  push: (step: string) => void,
-  next: () => void,
-  previous: () => void,
-  replace?: () => void,
-  step: Step,
-  steps: Step[],
+  push: (step: string) => void
+  next: () => void
+  previous: () => void
+  step: Step
+  steps: Step[]
+  setStepsCompletedCount: (step: number) => void
+  stepsCompletedCount: number
+  replace?: () => void
+  set?: (step: Step) => void
+  history?: History
+  init?: (steps: WizardApi['steps']) => void
+  go?: () => void
 }
 
 const WizardContext = createContext<WizardApi>({
-  step: {
-    id: ''
-  },
+  step: { id: '' },
   steps: [{ id: '' }],
-  previous: () => {
-  },
-  next: () => {
-  },
-  push: () => {}
+  stepsCompletedCount: 0,
+  setStepsCompletedCount: () => {},
+  previous: () => {},
+  next: () => {},
+  push: () => {},
 })
 
 export default WizardContext

--- a/src/signals/incident/components/StepWizard/context/WizardContext.tsx
+++ b/src/signals/incident/components/StepWizard/context/WizardContext.tsx
@@ -8,7 +8,9 @@ export interface WizardApi {
   previous: () => void
   step: Step
   steps: Step[]
+  // This method sets the completed steps count
   setStepsCompletedCount: (step: number) => void
+  // The steps that are completed and valid or the step that is active
   stepsCompletedCount: number
   replace?: () => void
   set?: (step: Step) => void

--- a/src/signals/incident/components/StepWizard/context/WizardContext.tsx
+++ b/src/signals/incident/components/StepWizard/context/WizardContext.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (C) 2022 - 2022 Gemeente Amsterdam
 import { createContext } from 'react'
 
 type Step = { id: string }
@@ -8,9 +10,7 @@ export interface WizardApi {
   previous: () => void
   step: Step
   steps: Step[]
-  // This method sets the completed steps count
   setStepsCompletedCount: (step: number) => void
-  // The steps that are completed and valid or the step that is active
   stepsCompletedCount: number
   replace?: () => void
   set?: (step: Step) => void

--- a/src/signals/incident/components/StepWizard/index.test.tsx
+++ b/src/signals/incident/components/StepWizard/index.test.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2020 - 2022 Vereniging van Nederlandse Gemeenten, Gemeente Amsterdam
+// Copyright (C) 2022 - 2022 Vereniging van Nederlandse Gemeenten, Gemeente Amsterdam
 import { useContext } from 'react'
 
 import { render, screen, act } from '@testing-library/react'

--- a/src/signals/incident/services/yup-resolver/index.ts
+++ b/src/signals/incident/services/yup-resolver/index.ts
@@ -6,7 +6,7 @@ import isObject from 'lodash/isObject'
 import * as yup from 'yup'
 import type { AnyObject } from 'yup/es/types'
 
-type Controls = { [s: string]: unknown } | ArrayLike<unknown> | undefined
+type Controls = { [s: string]: unknown } | ArrayLike<unknown>
 
 type Validators = Array<
   ((props: any) => { custom: any }) | string | number | Array<string | number>
@@ -19,61 +19,59 @@ type Validators = Array<
  * their meta values and validation rules.
  */
 export function setupSchema(controls: Controls) {
-  const schema = controls
-    ? Object.fromEntries(
-        Object.entries(controls).reduce(
-          (acc: Array<[string, any]>, [key, control]: [string, any]) => {
-            let validators: Validators = control?.options?.validators
-            validators = Array.isArray(validators) ? validators : [validators]
+  const schema = Object.fromEntries(
+    Object.entries(controls).reduce(
+      (acc: Array<[string, any]>, [key, control]: [string, any]) => {
+        let validators: Validators = control?.options?.validators
+        validators = Array.isArray(validators) ? validators : [validators]
 
-            if (!validators) return acc
+        if (!validators) return acc
 
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
-            const validationField: AnyObject = yup.lazy((value) => {
-              /**
-               * For a predefined set of questions, we add a custom validation.
-               */
-              let field: AnyObject | undefined = addNestedValidation(key, value)
-              if (field) return field
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        const validationField: AnyObject = yup.lazy((value) => {
+          /**
+           * For a predefined set of questions, we add a custom validation.
+           */
+          let field: AnyObject | undefined = addNestedValidation(key, value)
+          if (field) return field
 
-              /**
-               * For most fields, the value type is determined in runtime.
-               */
-              if (Array.isArray(value)) {
-                field = yup.array()
-                if (formatValidators(validators).includes('required')) {
-                  field = yup.array().min(1)
-                }
-              } else if (isObject(value)) {
-                field = yup.object().shape({})
-              } else {
-                if (typeof value === 'string') {
-                  field = yup.string()
-                } else if (typeof value === 'number') {
-                  field = yup.number()
-                } else {
-                  field = yup.mixed()
-                }
-                /**
-                 * After we have the main type of an input field, we add
-                 * validations like: email/phone/function/maxLength
-                 */
-                field = addValidators(validators, field)
-              }
-              field = addRequiredValidation(validators, field)
+          /**
+           * For most fields, the value type is determined in runtime.
+           */
+          if (Array.isArray(value)) {
+            field = yup.array()
+            if (formatValidators(validators).includes('required')) {
+              field = yup.array().min(1)
+            }
+          } else if (isObject(value)) {
+            field = yup.object().shape({})
+          } else {
+            if (typeof value === 'string') {
+              field = yup.string()
+            } else if (typeof value === 'number') {
+              field = yup.number()
+            } else {
+              field = yup.mixed()
+            }
+            /**
+             * After we have the main type of an input field, we add
+             * validations like: email/phone/function/maxLength
+             */
+            field = addValidators(validators, field)
+          }
+          field = addRequiredValidation(validators, field)
 
-              return field
-            })
+          return field
+        })
 
-            acc.push([key, validationField])
+        acc.push([key, validationField])
 
-            return acc
-          },
-          []
-        )
-      )
-    : {}
+        return acc
+      },
+      []
+    )
+  )
 
   return yup.object(schema)
 }

--- a/src/signals/my-incidents/components/Routing/styled.tsx
+++ b/src/signals/my-incidents/components/Routing/styled.tsx
@@ -1,8 +1,0 @@
-// SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2022 Gemeente Amsterdam
-import { themeSpacing } from '@amsterdam/asc-ui'
-import styled from 'styled-components'
-
-export const PageWrapper = styled.div`
-  padding: ${themeSpacing(5)};
-`

--- a/src/signals/my-incidents/pages/Confirmation.test.tsx
+++ b/src/signals/my-incidents/pages/Confirmation.test.tsx
@@ -2,8 +2,7 @@
 // Copyright (C) 2022 Gemeente Amsterdam
 import { screen, render } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-
-import { history, withAppContext } from 'test/utils'
+import { withAppContext } from 'test/utils'
 
 import { providerMock } from '../__test__'
 import { MyIncidentsProvider } from '../context'
@@ -87,19 +86,13 @@ describe('BasePage', () => {
   })
 
   it('should redirect to requestAccess page when email is undefined', () => {
-    const value = {
-      ...providerMock,
-      email: undefined,
-    }
-
-    render(
-      withAppContext(
-        <MyIncidentsProvider value={value}>
-          <Confirmation />
-        </MyIncidentsProvider>
+    try {
+      render(withAppContext(<Confirmation />))
+    } catch (e) {
+      const error = new Error(
+        'Missing MyIncidentsContext provider. You have to wrap the application with the MyIncidentsProvider component.'
       )
-    )
-
-    expect(history.location.pathname).toEqual('/mijn-meldingen/login')
+      expect(e).toEqual(error)
+    }
   })
 })

--- a/src/signals/my-incidents/pages/Detail.test.tsx
+++ b/src/signals/my-incidents/pages/Detail.test.tsx
@@ -4,7 +4,7 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
 import useFetch from '../../../hooks/useFetch'
-import { withAppContext } from '../../../test/utils'
+import { history, withAppContext } from '../../../test/utils'
 import { get, useFetchResponse } from '../../IncidentMap/components/__test__'
 import { providerMock } from '../__test__'
 import { incidentsDetail } from '../__test__/incidents-detail'
@@ -63,5 +63,22 @@ describe('Detail', () => {
     userEvent.click(screen.getByTestId('closeButton'))
 
     expect(screen.getByText('Bekijk op kaart')).toBeInTheDocument()
+  })
+  it('should redirect to the expired page when an error is thrown', () => {
+    const response = {
+      ...useFetchResponse,
+      error: true,
+    }
+    jest.mocked(useFetch).mockImplementation(() => response)
+
+    render(
+      withAppContext(
+        <MyIncidentsProvider value={providerMock}>
+          <Detail />
+        </MyIncidentsProvider>
+      )
+    )
+
+    expect(history.location.pathname).toEqual('/mijn-meldingen/verlopen')
   })
 })


### PR DESCRIPTION
Ticket: [SIG-4725](https://datapunt.atlassian.net/browse/SIG-4725)

## goal
add navigation to stepbystepnav component. To fit it in the current step navigation, a context property called "stepsCompletedCount" , is there to keep track of the first non validated field.

## Signalen

Before opening a pull request, please ensure:

- [x] Double-check your branch is based on `main` and targets `main`
- [x] Pull request has tests (we are going for 100% coverage!)
- [x] Code is well-commented, linted and follows project conventions
- [x] Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
