### PR TITLE
[feat 4902]: Time notation changed from hh:mm to hh.mm. 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4533,8 +4533,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
       "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -4550,9 +4548,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/ajv-keywords": {
       "version": "3.5.2",
@@ -23076,14 +23072,15 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "dev": true,
-      "requires": {},
+      "requires": {
+        "ajv": "^8.0.0"
+      },
       "dependencies": {
         "ajv": {
-          "version": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
           "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
           "dev": true,
-          "optional": true,
-          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -23095,9 +23092,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
           "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-          "dev": true,
-          "optional": true,
-          "peer": true
+          "dev": true
         }
       }
     },

--- a/src/components/HistoryList/HistoryList.test.tsx
+++ b/src/components/HistoryList/HistoryList.test.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2020 - 2021 Gemeente Amsterdam
 import { render, screen } from '@testing-library/react'
+
 import { withAppContext } from 'test/utils'
 import history from 'utils/__tests__/fixtures/history.json'
 
@@ -12,7 +13,7 @@ describe('<ChildIncidentHistory />', () => {
 
     expect(screen.getByRole('list')).toBeInTheDocument()
     expect(screen.getAllByRole('listitem')).toHaveLength(4)
-    expect(screen.getByText('25-03-2020 om 14:07')).toBeInTheDocument()
+    expect(screen.getByText('25-03-2020 om 14.07')).toBeInTheDocument()
     expect(screen.getByText(history[0].who)).toBeInTheDocument()
     expect(screen.getByText(history[0].action)).toBeInTheDocument()
   })

--- a/src/components/OverviewMap/DetailPanel/__tests__/DetailPanel.test.tsx
+++ b/src/components/OverviewMap/DetailPanel/__tests__/DetailPanel.test.tsx
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2020 - 2021 Gemeente Amsterdam
+// Copyright (C) 2020 - 2022 Gemeente Amsterdam
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+
 import { getIsAuthenticated } from 'shared/services/auth/auth'
 import { statusList } from 'signals/incident-management/definitions'
 import { withAppContext } from 'test/utils'
@@ -63,7 +64,7 @@ describe('signals/incident-management/containes/IncidentOverviewPage/components/
       withAppContext(<DetailPanel incident={incident} onClose={() => {}} />)
     )
     expect(screen.getByText(/gemeld op/i)).toBeInTheDocument()
-    expect(screen.getByText(/04-03-2020 05:06/i)).toBeInTheDocument()
+    expect(screen.getByText(/04-03-2020 05.06/i)).toBeInTheDocument()
     expect(screen.getByText(/status/i)).toBeInTheDocument()
     expect(
       screen.getByText(new RegExp(statusList[1].value, 'i'))
@@ -88,7 +89,7 @@ describe('signals/incident-management/containes/IncidentOverviewPage/components/
       withAppContext(<DetailPanel incident={incident} onClose={() => {}} />)
     )
     expect(screen.getByText(/gemeld op/i)).toBeInTheDocument()
-    expect(screen.getByText(/04-03-2020 05:06/i)).toBeInTheDocument()
+    expect(screen.getByText(/04-03-2020 05.06/i)).toBeInTheDocument()
     expect(screen.getByText(/status/i)).toBeInTheDocument()
     expect(
       screen.getByText(new RegExp(statusList[1].value, 'i'))

--- a/src/shared/services/string-parser/index.js
+++ b/src/shared/services/string-parser/index.js
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2020 - 2021 Gemeente Amsterdam
-import { dateToString } from 'shared/services/date-utils'
+// Copyright (C) 2020 - 2022 Gemeente Amsterdam
 import format from 'date-fns/format'
+
+import { dateToString } from 'shared/services/date-utils'
 
 export const string2date = (value) => {
   if (!value) return ''
@@ -20,7 +21,7 @@ export const string2time = (value) => {
 
   try {
     const date = new Date(value)
-    return format(date, 'HH:mm', date)
+    return format(date, 'HH.mm', date)
   } catch {
     return `[${value}]`
   }

--- a/src/shared/services/string-parser/index.test.js
+++ b/src/shared/services/string-parser/index.test.js
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2018 - 2021 Gemeente Amsterdam
+// Copyright (C) 2018 - 2022 Gemeente Amsterdam
 import { string2date, string2time } from '.'
 
 describe('The string parser service', () => {
@@ -12,7 +12,7 @@ describe('The string parser service', () => {
   it('should return the correct time value', () => {
     expect(string2time(null)).toEqual('')
     expect(string2time('32-02-1970T00:00:00')).toEqual('[32-02-1970T00:00:00]')
-    expect(string2time('1970-07-21T11:55:00')).toEqual('11:55')
-    expect(string2time('1970-07-21T08:05:00')).toEqual('08:05')
+    expect(string2time('1970-07-21T11:55:00')).toEqual('11.55')
+    expect(string2time('1970-07-21T08:05:00')).toEqual('08.05')
   })
 })

--- a/src/signals/incident-management/containers/AreaContainer/components/IncidentDetail/__tests__/IncidentDetail.test.tsx
+++ b/src/signals/incident-management/containers/AreaContainer/components/IncidentDetail/__tests__/IncidentDetail.test.tsx
@@ -1,6 +1,10 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (C) 2021 - 2022 Gemeente Amsterdam
 import { render, screen } from '@testing-library/react'
-import { mockIncident } from 'types/api/incident.mock'
+
 import { withAppContext } from 'test/utils'
+import { mockIncident } from 'types/api/incident.mock'
+
 import IncidentDetail from '../'
 
 describe('IncidentDetail', () => {
@@ -47,7 +51,7 @@ describe('IncidentDetail', () => {
       '124 Conch St., Bikini Bottom'
     )
     expect(screen.getByTestId('date').textContent?.trim()).toEqual(
-      '01-01-1970 01:00'
+      '01-01-1970 01.00'
     )
     expect(screen.getByTestId('status').textContent?.trim()).toEqual('Gemeld')
     expect(screen.getByTestId('departments').textContent?.trim()).toEqual(

--- a/src/signals/incident-management/containers/IncidentOverviewPage/components/List/index.test.tsx
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/components/List/index.test.tsx
@@ -1,27 +1,27 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2018 - 2021 Gemeente Amsterdam
+// Copyright (C) 2018 - 2022 Gemeente Amsterdam
 import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import * as reactRouterDom from 'react-router-dom'
+
 import configuration from 'shared/services/configuration/configuration'
+import { formatAddress } from 'shared/services/format-address'
 import {
   priorityList,
   statusList,
   stadsdeelList,
 } from 'signals/incident-management/definitions'
+import { StatusCode } from 'signals/incident-management/definitions/types'
+import { INCIDENT_URL } from 'signals/incident-management/routes'
 import { withAppContext } from 'test/utils'
 import 'jest-styled-components'
-import * as reactRouterDom from 'react-router-dom'
-
+import type { IncidentList, IncidentListItem } from 'types/api/incident-list'
 import districts from 'utils/__tests__/fixtures/districts.json'
 import incidents from 'utils/__tests__/fixtures/incidents.json'
 import users from 'utils/__tests__/fixtures/users.json'
 
-import type { IncidentList, IncidentListItem } from 'types/api/incident-list'
-import { StatusCode } from 'signals/incident-management/definitions/types'
-import { formatAddress } from 'shared/services/format-address'
-import { INCIDENT_URL } from 'signals/incident-management/routes'
-import IncidentManagementContext from '../../../../context'
 import List, { getDaysOpen } from '.'
+import IncidentManagementContext from '../../../../context'
 
 jest.mock('react-router-dom', () => ({
   __esModule: true,
@@ -92,7 +92,7 @@ describe('List', () => {
         '',
         `${INCIDENT_1.id}`,
         '-',
-        '03-12-2018 10:41',
+        '03-12-2018 10.41',
         INCIDENT_1.category.sub,
         INCIDENT_1.status.state_display,
         'Centrum',
@@ -103,7 +103,7 @@ describe('List', () => {
         '',
         `${INCIDENT_2.id}`,
         `${getDaysOpen(INCIDENT_2 as unknown as IncidentListItem)}`,
-        '29-11-2018 23:03',
+        '29-11-2018 23.03',
         INCIDENT_2.category.sub,
         INCIDENT_2.status.state_display,
         'Zuid',
@@ -125,7 +125,7 @@ describe('List', () => {
   })
 
   it('should handle invalid dates correctly', () => {
-    const VALID_DATE = '29-11-2018 23:03'
+    const VALID_DATE = '29-11-2018 23.03'
     const FALLBACK_DATE = '-'
 
     const incident = incidents[1] as unknown as IncidentListItem

--- a/src/signals/incident/containers/IncidentReplyContainer/IncidentReplyContainer.tsx
+++ b/src/signals/incident/containers/IncidentReplyContainer/IncidentReplyContainer.tsx
@@ -159,11 +159,7 @@ const IncidentReplyContainer = () => {
   }, [session, getQuestionnaire, getIncident])
 
   const formattedDate = useMemo(
-    () =>
-      (incident ? formatDate(new Date(incident.created_at)) : '').replace(
-        ':',
-        '.'
-      ),
+    () => (incident ? formatDate(new Date(incident.created_at)) : ''),
     [incident]
   )
 

--- a/src/signals/incident/containers/IncidentReplyContainer/IncidentReplyContainer.tsx
+++ b/src/signals/incident/containers/IncidentReplyContainer/IncidentReplyContainer.tsx
@@ -1,29 +1,29 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2021 Gemeente Amsterdam
+// Copyright (C) 2021-2022 Gemeente Amsterdam
 import { useEffect, useCallback, useMemo, useState } from 'react'
-import { useParams } from 'react-router-dom'
+
 import { Column, Row } from '@amsterdam/asc-ui'
 import { useDispatch } from 'react-redux'
+import { useParams } from 'react-router-dom'
 
 import LoadingIndicator from 'components/LoadingIndicator'
 import Paragraph from 'components/Paragraph'
-import { TYPE_LOCAL, VARIANT_ERROR } from 'containers/Notification/constants'
 import { showGlobalNotification } from 'containers/App/actions'
-import configuration from 'shared/services/configuration/configuration'
-import type { FetchError } from 'hooks/useFetch'
-import useFetch from 'hooks/useFetch'
+import { TYPE_LOCAL, VARIANT_ERROR } from 'containers/Notification/constants'
 import useGetQuestionnaire from 'hooks/api/qa/useGetQuestionnaire'
 import useGetSession from 'hooks/api/qa/useGetSession'
-import useGetPublicIncident from 'hooks/api/useGetPublicIncident'
-import { FieldType } from 'types/api/qa/question'
-import { filesUpload } from 'shared/services/files-upload/files-upload'
-
 import { usePostAnswer } from 'hooks/api/qa/usePostAnswer'
+import useGetPublicIncident from 'hooks/api/useGetPublicIncident'
+import useFetch from 'hooks/useFetch'
+import type { FetchError } from 'hooks/useFetch'
+import configuration from 'shared/services/configuration/configuration'
+import { filesUpload } from 'shared/services/files-upload/files-upload'
+import { FieldType } from 'types/api/qa/question'
+
 import Notice from './components/Notice/Notice'
 import QuestionnaireComponent from './components/Questionnaire'
-
-import { Content, StyledHeading, StyledSubHeading, Wrapper } from './styled'
 import * as constants from './constants'
+import { Content, StyledHeading, StyledSubHeading, Wrapper } from './styled'
 import type { FormAnswer } from './types'
 import { formatDate } from './utils'
 
@@ -159,7 +159,11 @@ const IncidentReplyContainer = () => {
   }, [session, getQuestionnaire, getIncident])
 
   const formattedDate = useMemo(
-    () => (incident ? formatDate(new Date(incident.created_at)) : ''),
+    () =>
+      (incident ? formatDate(new Date(incident.created_at)) : '').replace(
+        ':',
+        '.'
+      ),
     [incident]
   )
 

--- a/src/signals/incident/containers/IncidentReplyContainer/__tests__/IncidentReplyContainer.test.tsx
+++ b/src/signals/incident/containers/IncidentReplyContainer/__tests__/IncidentReplyContainer.test.tsx
@@ -1,20 +1,20 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2021 Gemeente Amsterdam
-import * as reactRouterDom from 'react-router-dom'
-import * as actions from 'containers/App/actions'
+// Copyright (C) 2021-2022 Gemeente Amsterdam
 import { render, waitFor, screen, act } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { withAppContext } from 'test/utils'
 import { mocked } from 'jest-mock'
+import * as reactRouterDom from 'react-router-dom'
 
-import * as constants from '../constants'
-import * as API from '../../../../../../internals/testing/api'
+import * as actions from 'containers/App/actions'
+import { withAppContext } from 'test/utils'
+
 import IncidentReplyContainer from '..'
-
+import * as API from '../../../../../../internals/testing/api'
 import {
   fetchMock,
   mockRequestHandler,
 } from '../../../../../../internals/testing/msw-server'
+import * as constants from '../constants'
 
 fetchMock.disableMocks()
 
@@ -48,7 +48,7 @@ describe('IncidentReplyContainer', () => {
         screen.getByRole('heading', { name: 'Aanvullende informatie' })
         screen.getByRole('heading', { name: 'Uw melding' })
         screen.getByText('Nummer: SIA-1234')
-        screen.getByText('Gemeld op: 26 juli 2021, 17:43 uur')
+        screen.getByText('Gemeld op: 26 juli 2021, 17.43 uur')
         screen.getByRole('textbox', { name: 'Wat voor kleur heeft de auto?' })
         screen.getByLabelText(/Foto's toevoegen/)
         screen.getByRole('button', { name: 'Verstuur' })

--- a/src/signals/incident/containers/IncidentReplyContainer/__tests__/utils.test.ts
+++ b/src/signals/incident/containers/IncidentReplyContainer/__tests__/utils.test.ts
@@ -6,7 +6,7 @@ describe('utils', () => {
   describe('formatDate', () => {
     it('should format a date correctly', () => {
       expect(formatDate(new Date(1627639862532))).toEqual(
-        '30 juli 2021, 12:11 uur'
+        '30 juli 2021, 12.11 uur'
       )
     })
   })

--- a/src/signals/incident/containers/IncidentReplyContainer/utils.ts
+++ b/src/signals/incident/containers/IncidentReplyContainer/utils.ts
@@ -5,7 +5,7 @@ import nl from 'date-fns/locale/nl'
 
 export const formatDate = (
   date: Date,
-  formatAs = "dd MMMM yyyy, HH:mm 'uur'"
+  formatAs = "dd MMMM yyyy, HH.mm 'uur'"
 ): string =>
   format(date, formatAs, {
     locale: nl,


### PR DESCRIPTION
Ticket: [SIG-4902](https://datapunt.atlassian.net/browse/SIG-4902)

**Context**
In the backoffice there are two time notifications in the meldingpage styled as hh:mm. This needs to be hh.mm

**Changes** 
1. formatDate in IncidentReplyContainer, the : has been replaced with a .
2. string2time the : has been changed to .

## Signalen

Before opening a pull request, please ensure:

- [ ] Double-check your branch is based on `main` and targets `main`
- [ ] Pull request has tests (we are going for 100% coverage!)
- [ ] Code is well-commented, linted and follows project conventions
- [ ] Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
