### PR TITLE
[feature 4901]: text change in wizard step 2

### DIFF
--- a/src/signals/incident/definitions/wizard-step-2-vulaan/afval-container.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/afval-container.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2018 - 2021 Gemeente Amsterdam
 import type { IconOptions } from 'leaflet'
+
 import { UNREGISTERED_TYPE } from 'signals/incident/components/form/MapSelectors/constants'
 import { validateObjectLocation } from 'signals/incident/services/custom-validators'
 import { QuestionFieldType } from 'types/question'
@@ -131,7 +132,7 @@ export const controls = {
     },
     render: QuestionFieldType.AssetSelect,
     options: {
-      validators: [validateObjectLocation('container')],
+      validators: [validateObjectLocation('container'), 'required'],
     },
   },
 }

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/straatverlichting-klokken.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/straatverlichting-klokken.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2018 - 2021 Gemeente Amsterdam
 import type { IconOptions } from 'leaflet'
+
 import appConfiguration from 'shared/services/configuration/configuration'
 import { UNREGISTERED_TYPE } from 'signals/incident/components/form/MapSelectors/constants'
 import { QuestionFieldType } from 'types/question'
@@ -140,7 +141,7 @@ const straatverlichtingKlokken = {
     },
     render: QuestionFieldType.StreetlightSelect,
     options: {
-      validators: [validateObjectLocation('lichtpunt')],
+      validators: [validateObjectLocation('lichtpunt'), 'required'],
     },
   },
 


### PR DESCRIPTION
Ticket: [SIG-4901](https://datapunt.atlassian.net/browse/SIG-4901)
**Context**
It is obligatory to choose either the afval-container or the lantaarnpaal on the locatiekaart. The text above the map indicated it was not. That indication has been removed.

**Changes**
To the options.validators of both afvalcontainers and straatverlichting-klokken has been added 'required'



## Signalen

Before opening a pull request, please ensure:

- [ ] Double-check your branch is based on `main` and targets `main`
- [ ] Pull request has tests (we are going for 100% coverage!)
- [ ] Code is well-commented, linted and follows project conventions
- [ ] Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
