### PR TITLE
Add ability to forward incident to an external party 

### DIFF
--- a/app.base.json
+++ b/app.base.json
@@ -19,7 +19,8 @@
     "reporterMailHandledNegativeContactEnabled": false,
     "showThorButton": false,
     "showVulaanControls": false,
-    "useProjectenSignalType": false
+    "useProjectenSignalType": false,
+    "enableForwardIncidentToExternal": false
   },
   "head": {
     "androidIcon": "/icon_192x192.png",

--- a/internals/schemas/app.schema.json
+++ b/internals/schemas/app.schema.json
@@ -134,6 +134,10 @@
         "reporterMailHandledNegativeContactEnabled": {
           "description": "When true, will show a feedback text based on the satisfaction value yes or no.",
           "type": "boolean"
+        },
+        "enableForwardIncidentToExternal": {
+          "description": "Enables forwarding the handling of an incident to an external organization.",
+          "type": "boolean"
         }
       },
       "required": [

--- a/src/signals/incident-management/containers/IncidentDetail/IncidentDetail.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/IncidentDetail.test.js
@@ -47,6 +47,9 @@ jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
 }))
 
+let scrollIntoViewMock = jest.fn()
+window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock
+
 jest.mock('shared/services/configuration/configuration')
 jest.mock('hooks/useEventEmitter')
 
@@ -208,6 +211,23 @@ describe('signals/incident-management/containers/IncidentDetail', () => {
     userEvent.click(screen.getByTestId('statusFormCancelButton'))
 
     expect(screen.queryByTestId('statusForm')).not.toBeInTheDocument()
+  })
+
+  it('renders forward to external form', async () => {
+    configuration.featureFlags.enableForwardIncidentToExternal = true
+    render(withAppContext(<IncidentDetail />))
+
+    await screen.findByTestId('incidentDetail')
+
+    expect(screen.queryByTestId('forwardToExternal')).not.toBeInTheDocument()
+
+    userEvent.click(screen.getByRole('button', { name: 'Extern' }))
+
+    expect(screen.getByTestId('forwardToExternal')).toBeInTheDocument()
+
+    userEvent.click(screen.getByTestId('formCancelButton'))
+
+    expect(screen.queryByTestId('forwardToExternal')).not.toBeInTheDocument()
   })
 
   it('renders attachment viewer', async () => {

--- a/src/signals/incident-management/containers/IncidentDetail/IncidentDetail.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/IncidentDetail.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2018 - 2022 Gemeente Amsterdam
+// Copyright (C) 2018 - 2022 Gemeente Amsterdam, Vereniging van Nederlandse Gemeenten
 import { useReducer, useEffect, useCallback, useState } from 'react'
 
 import { themeSpacing, Row, Column } from '@amsterdam/asc-ui'
@@ -24,12 +24,14 @@ import AttachmentViewer from './components/AttachmentViewer'
 import ChildIncidents from './components/ChildIncidents'
 import Detail from './components/Detail'
 import DetailHeader from './components/DetailHeader'
+import ForwardToExternal from './components/ForwardToExternal'
 import LocationForm from './components/LocationForm'
 import LocationPreview from './components/LocationPreview'
 import MetaList from './components/MetaList'
 import {
   CLOSE_ALL,
   EDIT,
+  EXTERNAL,
   PATCH_START,
   PATCH_SUCCESS,
   PREVIEW,
@@ -298,6 +300,10 @@ const IncidentDetail = () => {
     dispatch({ type: EDIT, payload: { edit: section, ...payload } })
   }, [])
 
+  const toggleExternalDispatch = useCallback(() => {
+    dispatch({ type: EXTERNAL, payload: {} })
+  }, [])
+
   const addAttachment = useCallback(
     (files) => {
       if (incident) {
@@ -368,6 +374,8 @@ const IncidentDetail = () => {
         preview: previewDispatch,
         edit: editDispatch,
         close: closeDispatch,
+        attachments: state?.attachments,
+        toggleExternal: toggleExternalDispatch,
       }}
     >
       <Row data-testid="incidentDetail">
@@ -409,10 +417,14 @@ const IncidentDetail = () => {
           span={{ small: 4, medium: 4, big: 4, large: 5, xLarge: 5 }}
           push={{ small: 0, medium: 0, big: 0, large: 0, xLarge: 0 }}
         >
-          <MetaList
-            defaultTexts={state.defaultTexts}
-            childIncidents={state.children?.results}
-          />
+          {state.external ? (
+            <ForwardToExternal onClose={toggleExternalDispatch} />
+          ) : (
+            <MetaList
+              defaultTexts={state.defaultTexts}
+              childIncidents={state.children?.results}
+            />
+          )}
         </DetailContainer>
 
         {((!showAttachmentViewer && state.preview) || state.edit) && (

--- a/src/signals/incident-management/containers/IncidentDetail/actions.ts
+++ b/src/signals/incident-management/containers/IncidentDetail/actions.ts
@@ -26,6 +26,7 @@ import type {
   EDIT,
   SET_CHILD_INCIDENTS,
   SET_CONTEXT,
+  EXTERNAL,
 } from './constants'
 
 export type ResetAction = Action<typeof RESET, void>
@@ -61,6 +62,7 @@ export type PatchStartAction = Action<typeof PATCH_START, string>
 export type PatchSuccessAction = Action<typeof PATCH_SUCCESS, string>
 export type PreviewAction = Action<typeof PREVIEW, Partial<State>>
 export type EditAction = Action<typeof EDIT, Partial<State>>
+export type ExternalAction = Action<typeof EXTERNAL, Partial<State>>
 
 export type IncidentDetailAction =
   | ResetAction
@@ -78,3 +80,4 @@ export type IncidentDetailAction =
   | PatchSuccessAction
   | PreviewAction
   | EditAction
+  | ExternalAction

--- a/src/signals/incident-management/containers/IncidentDetail/components/Attachments/styles.ts
+++ b/src/signals/incident-management/containers/IncidentDetail/components/Attachments/styles.ts
@@ -18,6 +18,7 @@ export const Wrapper = styled.section`
 
 export const StyledButtonWrapper = styled.div`
   display: flex;
+  flex-wrap: wrap;
   margin-top: ${themeSpacing(8)};
   gap: ${themeSpacing(2)};
 `

--- a/src/signals/incident-management/containers/IncidentDetail/components/DetailHeader/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/DetailHeader/index.js
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2019 - 2021 Gemeente Amsterdam
+// Copyright (C) 2019 - 2022 Gemeente Amsterdam, Vereniging van Nederlandse Gemeenten
 import { useCallback, useContext, useMemo } from 'react'
 import styled from 'styled-components'
 import { Link, useLocation } from 'react-router-dom'
@@ -20,25 +20,9 @@ import IncidentDetailContext from '../../context'
 import DownloadButton from './components/DownloadButton'
 
 const Header = styled.header`
-  display: grid;
   padding: ${themeSpacing(2, 0)};
   border-bottom: 2px solid ${themeColor('tint', 'level3')};
   width: 100%;
-
-  @media (min-width: ${({ theme }) => theme.layouts.medium.max}px) {
-    column-gap: ${({ theme }) => theme.layouts.medium.gutter}px;
-    grid-template-columns: 7fr 4fr;
-  }
-
-  @media (min-width: ${({ theme }) => theme.layouts.large.min}px) {
-    column-gap: ${({ theme }) => theme.layouts.large.gutter}px;
-    grid-template-columns: 7fr 1fr 4fr;
-  }
-`
-
-const BackLinkContainer = styled.div`
-  grid-column-start: 1;
-  grid-column-end: 4;
 `
 
 const StyledBackLink = styled(BackLink)`
@@ -46,18 +30,17 @@ const StyledBackLink = styled(BackLink)`
 `
 
 const ButtonContainer = styled.div`
-  grid-column-start: 3;
   display: flex;
-  justify-content: flex-end;
+  flex-wrap: wrap;
   align-items: center;
-
-  & > * {
-    margin-left: ${themeSpacing(2)};
-  }
+  gap: ${themeSpacing(2)};
 `
 
 const HeadingContainer = styled.div`
   display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: ${themeSpacing(1)};
 
   && > * {
     margin: 0;
@@ -79,7 +62,7 @@ const StyledHeading = styled(Heading)`
 `
 
 const DetailHeader = () => {
-  const { incident, update } = useContext(IncidentDetailContext)
+  const { incident, update, toggleExternal } = useContext(IncidentDetailContext)
   const location = useLocation()
 
   const showSplitButton = useMemo(() => {
@@ -128,48 +111,58 @@ const DetailHeader = () => {
 
   return (
     <Header className="detail-header">
-      <BackLinkContainer>
-        <StyledBackLink to={referrer}>Terug naar overzicht</StyledBackLink>
-      </BackLinkContainer>
+      <StyledBackLink to={referrer}>Terug naar overzicht</StyledBackLink>
 
       <HeadingContainer>
         <StyledHeading data-testid="detail-header-title">
           {headingText}&nbsp;
           <span>{incident.id}</span>
         </StyledHeading>
+
+        <ButtonContainer>
+          {showSplitButton && (
+            <Button
+              type="button"
+              variant="application"
+              forwardedAs={Link}
+              to={`${INCIDENT_URL}/${incident.id}/split`}
+              data-testid="detail-header-button-split"
+            >
+              Delen
+            </Button>
+          )}
+
+          {canThor && configuration.featureFlags.showThorButton && (
+            <Button
+              type="button"
+              variant="application"
+              onClick={patchIncident}
+              data-testid="detail-header-button-thor"
+            >
+              THOR
+            </Button>
+          )}
+
+          {configuration.featureFlags.enableForwardIncidentToExternal && (
+            <Button
+              type="button"
+              variant="application"
+              onClick={() => toggleExternal()}
+              data-testid="detail-header-button-external"
+              title="Doorzetten naar extern"
+            >
+              Extern
+            </Button>
+          )}
+
+          <DownloadButton
+            label="PDF"
+            url={downloadLink}
+            filename={`${configuration.language.shortTitle}-${incident.id}.pdf`}
+            data-testid="detail-header-button-download"
+          />
+        </ButtonContainer>
       </HeadingContainer>
-
-      <ButtonContainer>
-        {showSplitButton && (
-          <Button
-            type="button"
-            variant="application"
-            forwardedAs={Link}
-            to={`${INCIDENT_URL}/${incident.id}/split`}
-            data-testid="detail-header-button-split"
-          >
-            Delen
-          </Button>
-        )}
-
-        {canThor && configuration.featureFlags.showThorButton && (
-          <Button
-            type="button"
-            variant="application"
-            onClick={patchIncident}
-            data-testid="detail-header-button-thor"
-          >
-            THOR
-          </Button>
-        )}
-
-        <DownloadButton
-          label="PDF"
-          url={downloadLink}
-          filename={`${configuration.language.shortTitle}-${incident.id}.pdf`}
-          data-testid="detail-header-button-download"
-        />
-      </ButtonContainer>
     </Header>
   )
 }

--- a/src/signals/incident-management/containers/IncidentDetail/components/EmailPreview/EmailPreview.test.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/EmailPreview/EmailPreview.test.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2022 Gemeente Amsterdam
+// Copyright (C) 2022 Gemeente Amsterdam, Vereniging van Nederlandse Gemeenten
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { withAppContext } from 'test/utils'
@@ -16,6 +16,8 @@ describe('StatusForm EmailPreview component', () => {
     render(
       withAppContext(
         <EmailPreview
+          isLoading={false}
+          title="Controleer bericht aan melder"
           onUpdate={onUpdate}
           emailBody={emailBody}
           onClose={onClose}
@@ -38,6 +40,8 @@ describe('StatusForm EmailPreview component', () => {
     render(
       withAppContext(
         <EmailPreview
+          isLoading={false}
+          title="Foo"
           onUpdate={onUpdate}
           emailBody={emailBody}
           onClose={onClose}
@@ -47,5 +51,21 @@ describe('StatusForm EmailPreview component', () => {
 
     userEvent.click(screen.getByText('Wijzig'))
     expect(onClose).toHaveBeenCalled()
+  })
+
+  it('renders the loading incidator', () => {
+    render(
+      withAppContext(
+        <EmailPreview
+          isLoading
+          title="Foo"
+          onUpdate={onUpdate}
+          emailBody={emailBody}
+          onClose={onClose}
+        />
+      )
+    )
+
+    expect(screen.getByTestId('loadingIndicator')).toBeInTheDocument()
   })
 })

--- a/src/signals/incident-management/containers/IncidentDetail/components/EmailPreview/EmailPreview.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/EmailPreview/EmailPreview.tsx
@@ -1,20 +1,15 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2022 Gemeente Amsterdam
+// Copyright (C) 2022 Gemeente Amsterdam, Vereniging van Nederlandse Gemeenten
 import type { FC } from 'react'
-import styled from 'styled-components'
+
 import { themeSpacing } from '@amsterdam/asc-ui'
+import styled from 'styled-components'
+
 import FormFooter from 'components/FormFooter'
 import { FORM_FOOTER_HEIGHT } from 'components/FormFooter/FormFooter'
-import ModalHeader from '../ModalHeader/ModalHeader'
+import LoadingIndicator from 'components/LoadingIndicator'
 
-const ModalContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-  * {
-    box-sizing: border-box;
-  }
-`
+import ModalDialog from '../ModalDialog/ModalDialog'
 
 const StyledFormFooter = styled(FormFooter)`
   .formFooterRow {
@@ -30,9 +25,11 @@ const StyledIframe = styled.iframe`
 `
 
 interface EmailPreviewProps {
-  emailBody: string
+  emailBody?: string
   onClose: () => void
   onUpdate: () => void
+  title: string
+  isLoading: boolean
 }
 
 const styling = `
@@ -53,20 +50,33 @@ const EmailPreview: FC<EmailPreviewProps> = ({
   emailBody,
   onUpdate,
   onClose,
+  title,
+  isLoading,
 }) => {
-  const styledHtml = emailBody.replace('</head>', `${fontSrc}${styling}</head>`)
+  const styledHtml = emailBody?.replace(
+    '</head>',
+    `${fontSrc}${styling}</head>`
+  )
 
   return (
-    <ModalContainer>
-      <ModalHeader title="Controleer bericht aan melder" onClose={onClose} />
-      <StyledIframe data-testid="emailBodyIframe" srcDoc={styledHtml} />
-      <StyledFormFooter
-        cancelBtnLabel="Wijzig"
-        onCancel={onClose}
-        submitBtnLabel="Verstuur"
-        onSubmitForm={onUpdate}
-      />
-    </ModalContainer>
+    <ModalDialog
+      data-testid="emailPreviewModal"
+      title={title}
+      onClose={onClose}
+    >
+      {isLoading && <LoadingIndicator />}
+      {emailBody && (
+        <>
+          <StyledIframe data-testid="emailBodyIframe" srcDoc={styledHtml} />
+          <StyledFormFooter
+            cancelBtnLabel="Wijzig"
+            onCancel={onClose}
+            submitBtnLabel="Verstuur"
+            onSubmitForm={onUpdate}
+          />
+        </>
+      )}
+    </ModalDialog>
   )
 }
 

--- a/src/signals/incident-management/containers/IncidentDetail/components/EmailPreview/EmailPreview.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/EmailPreview/EmailPreview.tsx
@@ -1,7 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2022 Gemeente Amsterdam, Vereniging van Nederlandse Gemeenten
-import type { FC } from 'react'
-
 import { themeSpacing } from '@amsterdam/asc-ui'
 import styled from 'styled-components'
 
@@ -46,13 +44,13 @@ const styling = `
 const fontSrc =
   '<link rel="stylesheet" href="https://static.amsterdam.nl/fonts/fonts.css"/>'
 
-const EmailPreview: FC<EmailPreviewProps> = ({
+const EmailPreview = ({
   emailBody,
   onUpdate,
   onClose,
   title,
   isLoading,
-}) => {
+}: EmailPreviewProps) => {
   const styledHtml = emailBody?.replace(
     '</head>',
     `${fontSrc}${styling}</head>`

--- a/src/signals/incident-management/containers/IncidentDetail/components/EmailPreview/EmailPreview.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/EmailPreview/EmailPreview.tsx
@@ -23,11 +23,11 @@ const StyledIframe = styled.iframe`
 `
 
 interface EmailPreviewProps {
-  emailBody?: string
   onClose: () => void
   onUpdate: () => void
   title: string
   isLoading: boolean
+  emailBody?: string
 }
 
 const styling = `

--- a/src/signals/incident-management/containers/IncidentDetail/components/ForwardToExternal/ForwardToExternal.test.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/ForwardToExternal/ForwardToExternal.test.tsx
@@ -91,7 +91,7 @@ describe('ForwardToExternal', () => {
 
         await waitFor(() => {
           expect(screen.queryByRole('alert')).toHaveTextContent(
-            'Dit is geen geldig e-mail adres'
+            'Dit is geen geldig e-mail adres.'
           )
         })
       })

--- a/src/signals/incident-management/containers/IncidentDetail/components/ForwardToExternal/ForwardToExternal.test.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/ForwardToExternal/ForwardToExternal.test.tsx
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (C) 2022 Vereniging van Nederlandse Gemeenten
+import { act, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import fetchMock from 'jest-fetch-mock'
+
+import * as actions from 'containers/App/actions'
+import configuration from 'shared/services/configuration/configuration'
+import { DOORGEZET_NAAR_EXTERN } from 'signals/incident-management/definitions/statusList'
+import { StatusCode } from 'signals/incident-management/definitions/types'
+import { withAppContext } from 'test/utils'
+import type { Incident } from 'types/api/incident'
+import incidentFixture from 'utils/__tests__/fixtures/incident.json'
+
+import attachmentsFixture from '../../../../../../../internals/mocks/fixtures/attachments.json'
+import { PATCH_TYPE_STATUS } from '../../constants'
+import IncidentDetailContext from '../../context'
+import ForwardToExternal, { MAX_MESSAGE_LENGTH } from './ForwardToExternal'
+
+const scrollIntoViewMock = jest.fn()
+window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock
+jest.spyOn(actions, 'showGlobalNotification')
+
+const EMAIL_URL = `${configuration.INCIDENTS_ENDPOINT}${incidentFixture.id}/email/preview`
+const components = {
+  title: () =>
+    screen.getByRole('heading', {
+      name: /doorzetten naar externe partij/i,
+    }),
+  emailInput: () =>
+    screen.getByRole('textbox', { name: /e-mail behandelaar/i }),
+  messageInput: () =>
+    screen.getByRole('textbox', { name: /toelichting behandelaar/i }),
+  formSubmit: () => screen.getByTestId('formSubmitButton'),
+  formCancel: () => screen.getByRole('button', { name: /annuleer/i }),
+  attachment: () =>
+    screen.getByRole('img', { name: attachmentsFixture.results[0]._display }),
+  emailPreview: () => screen.getByText('Controleer bericht aan behandelaar'),
+  emailPreviewSubmitButton: () => screen.getByTestId('submitBtn'),
+}
+
+describe('ForwardToExternal', () => {
+  it('renders the component', () => {
+    render(
+      withAppContext(
+        <IncidentDetailContext.Provider
+          value={{
+            update: jest.fn(),
+            attachments: attachmentsFixture,
+          }}
+        >
+          <ForwardToExternal onClose={jest.fn()} />
+        </IncidentDetailContext.Provider>
+      )
+    )
+
+    expect(components.title()).toBeInTheDocument()
+    expect(components.emailInput()).toBeInTheDocument()
+    expect(components.messageInput()).toBeInTheDocument()
+    expect(components.attachment()).toBeInTheDocument()
+    expect(components.formSubmit()).toBeInTheDocument()
+    expect(components.formCancel()).toBeInTheDocument()
+    expect(scrollIntoViewMock).toHaveBeenCalled()
+  })
+
+  describe('form', () => {
+    describe('validation', () => {
+      it('validates required fields', async () => {
+        render(withAppContext(<ForwardToExternal onClose={() => {}} />))
+
+        userEvent.click(components.formSubmit())
+
+        await waitFor(() => {
+          const alerts = screen.getAllByRole('alert')
+
+          expect(alerts).toHaveLength(2)
+          alerts.forEach((alert) =>
+            expect(alert).toHaveTextContent(
+              'Dit veld is verplicht voor het doorzetten naar een externe partij.'
+            )
+          )
+        })
+      })
+
+      it('validates e-mail address format', async () => {
+        render(withAppContext(<ForwardToExternal onClose={() => {}} />))
+
+        userEvent.type(components.emailInput(), 'invalid: not an e-mail')
+        userEvent.type(components.messageInput(), 'valid message')
+        userEvent.click(components.formSubmit())
+
+        await waitFor(() => {
+          expect(screen.queryByRole('alert')).toHaveTextContent(
+            'Dit is geen geldig e-mail adres'
+          )
+        })
+      })
+
+      it('validates message length', async () => {
+        render(withAppContext(<ForwardToExternal onClose={() => {}} />))
+
+        userEvent.type(components.emailInput(), 'foo@example.com')
+        userEvent.type(
+          components.messageInput(),
+          'x'.repeat(MAX_MESSAGE_LENGTH + 1)
+        )
+        userEvent.click(components.formSubmit())
+
+        await waitFor(() => {
+          expect(screen.queryByRole('alert')).toHaveTextContent(
+            `Je hebt meer dan de maximale ${MAX_MESSAGE_LENGTH} tekens ingevoerd.`
+          )
+        })
+      })
+    })
+
+    it('handles cancel', () => {
+      const mockClose = jest.fn()
+      const { unmount } = render(
+        withAppContext(<ForwardToExternal onClose={mockClose} />)
+      )
+
+      userEvent.click(components.formCancel())
+
+      expect(mockClose).toHaveBeenCalled()
+      unmount()
+    })
+
+    describe('email preview', () => {
+      const email = 'foo@example.com'
+      const message = 'Some message'
+      const updateSpy = jest.fn()
+      const closeSpy = jest.fn()
+      const renderAndSubmitForm = () => {
+        render(
+          withAppContext(
+            <IncidentDetailContext.Provider
+              value={{
+                update: updateSpy,
+                incident: incidentFixture as unknown as Incident,
+              }}
+            >
+              <ForwardToExternal onClose={closeSpy} />
+            </IncidentDetailContext.Provider>
+          )
+        )
+
+        userEvent.type(components.emailInput(), email)
+        userEvent.type(components.messageInput(), message)
+        act(() => {
+          userEvent.click(components.formSubmit())
+        })
+      }
+
+      it('renders email preview', async () => {
+        renderAndSubmitForm()
+
+        await waitFor(() => {
+          expect(fetchMock).toHaveBeenCalledWith(
+            EMAIL_URL,
+            expect.objectContaining({
+              method: 'POST',
+              body: JSON.stringify({
+                status: StatusCode.DoorgezetNaarExtern,
+                text: message,
+                email_override: email,
+              }),
+            })
+          )
+          expect(components.emailPreview()).toBeInTheDocument()
+        })
+      })
+
+      it('shows an error notification when no email preview is available', async () => {
+        fetchMock.mockResponse('Error!', { status: 404 })
+        renderAndSubmitForm()
+
+        await waitFor(() => {
+          expect(actions.showGlobalNotification).toHaveBeenCalledWith(
+            expect.objectContaining({
+              title:
+                'Er is geen email template beschikbaar voor de gegeven statustransitie',
+            })
+          )
+        })
+      })
+
+      it('updates status on submit', async () => {
+        const htmlString =
+          '<!DOCTYPE html><html lang="nl"><head><meta charset="UTF-8"><title>Uw melding SIA-1</title></head><body><p>Geachte melder,</p><p>Op 9 februari 2022 om 13.00 uur hebt u een melding gedaan bij de gemeente. In deze e-mail leest u de stand van zaken van uw melding.</p><p><strong>U liet ons het volgende weten</strong><br />Just some text<br /> Some text on the next line</p><p><strong>Stand van zaken</strong><br />Wij pakken dit z.s.m. op</p><p><strong>Gegevens van uw melding</strong><br />Nummer: SIA-1<br />Gemeld op: 9 februari 2022, 13.00 uur<br />Plaats: Amstel 1, 1011 PN Amsterdam</p><p><strong>Meer weten?</strong><br />Voor vragen over uw melding in Amsterdam kunt u bellen met telefoonnummer 14 020, maandag tot en met vrijdag van 08.00 tot 18.00 uur. Voor Weesp kunt u bellen met 0294 491 391, maandag tot en met vrijdag van 08.30 tot 17.00 uur. Geef dan ook het nummer van uw melding door: SIA-1.</p><p>Met vriendelijke groet,</p><p>Gemeente Amsterdam</p></body></html>'
+        const mockResponse = JSON.stringify({
+          subject: 'melding 123',
+          html: htmlString,
+        })
+        fetchMock.mockResponseOnce(mockResponse, { status: 200 })
+        renderAndSubmitForm()
+        await waitFor(() => {
+          expect(components.emailPreviewSubmitButton()).toBeInTheDocument()
+        })
+
+        userEvent.click(components.emailPreviewSubmitButton())
+
+        expect(updateSpy).toHaveBeenCalledWith({
+          type: PATCH_TYPE_STATUS,
+          patch: {
+            status: {
+              state: DOORGEZET_NAAR_EXTERN.key,
+              text: message,
+              send_email: true,
+              email_override: email,
+            },
+          },
+        })
+        expect(closeSpy).toHaveBeenCalled()
+      })
+    })
+  })
+})

--- a/src/signals/incident-management/containers/IncidentDetail/components/ForwardToExternal/ForwardToExternal.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/ForwardToExternal/ForwardToExternal.tsx
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (C) 2022 Vereniging van Nederlandse Gemeenten
+import type { FunctionComponent } from 'react'
+import { useRef, useContext, useCallback, useState, useEffect } from 'react'
+
+import { Label } from '@amsterdam/asc-ui'
+import { yupResolver } from '@hookform/resolvers/yup'
+import { useForm } from 'react-hook-form'
+import { useDispatch } from 'react-redux'
+import * as yup from 'yup'
+
+import { ErrorWrapper } from 'components/ErrorMessage'
+import Input from 'components/Input'
+import TextArea from 'components/TextArea'
+import { showGlobalNotification } from 'containers/App/actions'
+import { TYPE_LOCAL, VARIANT_ERROR } from 'containers/Notification/constants'
+import { useFetch } from 'hooks'
+import configuration from 'shared/services/configuration/configuration'
+import { DOORGEZET_NAAR_EXTERN } from 'signals/incident-management/definitions/statusList'
+
+import { PATCH_TYPE_STATUS } from '../../constants'
+import IncidentDetailContext from '../../context'
+import type { EmailTemplate } from '../../types'
+import EmailPreview from '../EmailPreview/EmailPreview'
+import {
+  Form,
+  Image,
+  ImageWrapper,
+  StyledButton,
+  StyledErrorMessage,
+  StyledH2,
+  StyledParagraph,
+  StyledSection,
+} from './styled'
+
+export const MAX_MESSAGE_LENGTH = 3000
+const schema = yup.object({
+  email: yup
+    .string()
+    .email('Dit is geen geldig e-mail adres')
+    .required(
+      'Dit veld is verplicht voor het doorzetten naar een externe partij.'
+    ),
+  message: yup
+    .string()
+    .max(
+      MAX_MESSAGE_LENGTH,
+      `Je hebt meer dan de maximale ${MAX_MESSAGE_LENGTH} tekens ingevoerd.`
+    )
+    .required(
+      'Dit veld is verplicht voor het doorzetten naar een externe partij.'
+    ),
+})
+
+type Form = {
+  email: string
+  message: string
+}
+
+type ForwardToExternalProps = {
+  onClose: () => void
+}
+
+const ForwardToExternal: FunctionComponent<ForwardToExternalProps> = ({
+  onClose,
+}) => {
+  const { incident, update, attachments } = useContext(IncidentDetailContext)
+  const storeDispatch = useDispatch()
+  const formRef = useRef<HTMLFormElement>(null)
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    getValues,
+  } = useForm<Form>({
+    resolver: yupResolver(schema),
+  })
+
+  const [modalEmailPreviewIsOpen, setModalEmailPreviewIsOpen] = useState(false)
+
+  const {
+    post: getEmailTemplate,
+    data: emailTemplate,
+    error: emailTemplateError,
+    isLoading: isLoadingEmailTemplate,
+  } = useFetch<EmailTemplate>()
+
+  const closeEmailPreview = useCallback(() => {
+    setModalEmailPreviewIsOpen(false)
+  }, [setModalEmailPreviewIsOpen])
+
+  const handleUpdateStatus = useCallback(() => {
+    update({
+      type: PATCH_TYPE_STATUS,
+      patch: {
+        status: {
+          state: DOORGEZET_NAAR_EXTERN.key,
+          text: getValues('message'),
+          send_email: true,
+          email_override: getValues('email'),
+        },
+      },
+    })
+
+    closeEmailPreview()
+    onClose()
+  }, [closeEmailPreview, getValues, onClose, update])
+
+  const handleGetEmailTemplate = useCallback(async () => {
+    getEmailTemplate(
+      `${configuration.INCIDENTS_ENDPOINT}${incident?.id}/email/preview`,
+      {
+        status: DOORGEZET_NAAR_EXTERN.key,
+        text: getValues('message'),
+        email_override: getValues('email'),
+      }
+    )
+    setModalEmailPreviewIsOpen(true)
+  }, [getEmailTemplate, getValues, incident?.id])
+
+  // ensure component is in view
+  useEffect(() => {
+    if (formRef.current) {
+      formRef.current.scrollIntoView({ behavior: 'smooth', block: 'nearest' })
+    }
+  }, [formRef])
+
+  useEffect(() => {
+    if (emailTemplateError) {
+      storeDispatch(
+        showGlobalNotification({
+          title:
+            'Er is geen email template beschikbaar voor de gegeven statustransitie',
+          variant: VARIANT_ERROR,
+          type: TYPE_LOCAL,
+        })
+      )
+    }
+  }, [emailTemplateError, storeDispatch])
+
+  return (
+    <Form
+      ref={formRef}
+      onSubmit={handleSubmit(handleGetEmailTemplate)}
+      data-testid="forwardToExternal"
+    >
+      <StyledH2 forwardedAs="h2">Doorzetten naar externe partij</StyledH2>
+
+      <StyledSection>
+        <ErrorWrapper invalid={Boolean(errors.email?.message)}>
+          <Label
+            htmlFor="externalEmail"
+            label={<strong>E-mail behandelaar</strong>}
+          />
+
+          {errors.email?.message && (
+            <StyledErrorMessage message={errors.email?.message} />
+          )}
+
+          <Input
+            id="externalEmail"
+            {...register('email')}
+            placeholder="E-mailadres"
+          />
+        </ErrorWrapper>
+      </StyledSection>
+
+      <StyledSection>
+        <ErrorWrapper invalid={Boolean(errors.message?.message)}>
+          <Label
+            htmlFor="externalEmailMessage"
+            label={<strong>Toelichting behandelaar</strong>}
+          />
+
+          {errors.message?.message && (
+            <StyledErrorMessage message={errors.message?.message} />
+          )}
+
+          <TextArea
+            id="externalEmailMessage"
+            maxContentLength={MAX_MESSAGE_LENGTH}
+            rows={12}
+            {...register('message')}
+          />
+        </ErrorWrapper>
+      </StyledSection>
+
+      {attachments && attachments?.count > 0 && (
+        <StyledSection>
+          <StyledParagraph strong>Foto&apos;s</StyledParagraph>
+          <ImageWrapper>
+            {attachments.results.map((attachment) => (
+              <Image
+                key={attachment.location}
+                src={attachment.location}
+                alt={attachment._display}
+              />
+            ))}
+          </ImageWrapper>
+        </StyledSection>
+      )}
+
+      <div>
+        <StyledButton
+          data-testid="formSubmitButton"
+          type="submit"
+          variant="secondary"
+        >
+          Verstuur
+        </StyledButton>
+
+        <StyledButton
+          data-testid="formCancelButton"
+          variant="tertiary"
+          onClick={onClose}
+        >
+          Annuleer
+        </StyledButton>
+      </div>
+
+      {modalEmailPreviewIsOpen && (
+        <EmailPreview
+          isLoading={isLoadingEmailTemplate}
+          title="Controleer bericht aan behandelaar"
+          emailBody={emailTemplate?.html}
+          onClose={closeEmailPreview}
+          onUpdate={handleUpdateStatus}
+        />
+      )}
+    </Form>
+  )
+}
+
+export default ForwardToExternal

--- a/src/signals/incident-management/containers/IncidentDetail/components/ForwardToExternal/ForwardToExternal.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/ForwardToExternal/ForwardToExternal.tsx
@@ -182,7 +182,7 @@ const ForwardToExternal = ({ onClose }: ForwardToExternalProps) => {
         </ErrorWrapper>
       </StyledSection>
 
-      {attachments?.count && (
+      {attachments?.count ? (
         <StyledSection>
           <StyledParagraph strong>Foto&apos;s</StyledParagraph>
           <ImageWrapper>
@@ -195,7 +195,7 @@ const ForwardToExternal = ({ onClose }: ForwardToExternalProps) => {
             ))}
           </ImageWrapper>
         </StyledSection>
-      )}
+      ) : null}
 
       <div>
         <StyledButton

--- a/src/signals/incident-management/containers/IncidentDetail/components/ForwardToExternal/ForwardToExternal.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/ForwardToExternal/ForwardToExternal.tsx
@@ -36,7 +36,7 @@ export const MAX_MESSAGE_LENGTH = 3000
 const schema = yup.object({
   email: yup
     .string()
-    .email('Dit is geen geldig e-mail adres')
+    .email('Dit is geen geldig e-mail adres.')
     .required(
       'Dit veld is verplicht voor het doorzetten naar een externe partij.'
     ),
@@ -182,7 +182,7 @@ const ForwardToExternal = ({ onClose }: ForwardToExternalProps) => {
         </ErrorWrapper>
       </StyledSection>
 
-      {attachments && attachments.count > 0 && (
+      {attachments?.count && (
         <StyledSection>
           <StyledParagraph strong>Foto&apos;s</StyledParagraph>
           <ImageWrapper>

--- a/src/signals/incident-management/containers/IncidentDetail/components/ForwardToExternal/ForwardToExternal.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/ForwardToExternal/ForwardToExternal.tsx
@@ -182,7 +182,7 @@ const ForwardToExternal = ({ onClose }: ForwardToExternalProps) => {
         </ErrorWrapper>
       </StyledSection>
 
-      {attachments && attachments?.count > 0 && (
+      {attachments && attachments.count > 0 && (
         <StyledSection>
           <StyledParagraph strong>Foto&apos;s</StyledParagraph>
           <ImageWrapper>

--- a/src/signals/incident-management/containers/IncidentDetail/components/ForwardToExternal/ForwardToExternal.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/ForwardToExternal/ForwardToExternal.tsx
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2022 Vereniging van Nederlandse Gemeenten
-import type { FunctionComponent } from 'react'
 import { useRef, useContext, useCallback, useState, useEffect } from 'react'
 
 import { Label } from '@amsterdam/asc-ui'
@@ -61,9 +60,7 @@ type ForwardToExternalProps = {
   onClose: () => void
 }
 
-const ForwardToExternal: FunctionComponent<ForwardToExternalProps> = ({
-  onClose,
-}) => {
+const ForwardToExternal = ({ onClose }: ForwardToExternalProps) => {
   const { incident, update, attachments } = useContext(IncidentDetailContext)
   const storeDispatch = useDispatch()
   const formRef = useRef<HTMLFormElement>(null)

--- a/src/signals/incident-management/containers/IncidentDetail/components/ForwardToExternal/index.ts
+++ b/src/signals/incident-management/containers/IncidentDetail/components/ForwardToExternal/index.ts
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (C) 2022 Vereniging van Nederlandse Gemeenten
+export { default } from './ForwardToExternal'

--- a/src/signals/incident-management/containers/IncidentDetail/components/ForwardToExternal/styled.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/ForwardToExternal/styled.tsx
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (C) 2022 Vereniging van Nederlandse Gemeenten
+import { Heading, themeColor, themeSpacing } from '@amsterdam/asc-ui'
+import styled from 'styled-components'
+
+import Button from 'components/Button'
+import ErrorMessage from 'components/ErrorMessage'
+import Paragraph from 'components/Paragraph'
+
+export const Form = styled.form`
+  position: relative;
+  padding: ${themeSpacing(5, 5, 6, 5)};
+  margin: ${themeSpacing(6)} 0;
+  background-color: ${themeColor('tint', 'level2')};
+
+  @media (min-width: ${({ theme }) => theme.layouts.big.max}px) {
+    margin-left: ${themeSpacing(23)};
+  }
+`
+
+export const StyledButton = styled(Button)`
+  margin-right: ${themeSpacing(2)};
+`
+
+export const StyledH2 = styled(Heading)`
+  margin-bottom: ${themeSpacing(4)};
+  margin-top: ${themeSpacing(0)};
+`
+
+export const StyledSection = styled.section`
+  margin-bottom: ${themeSpacing(6)};
+`
+
+export const StyledErrorMessage = styled(ErrorMessage)`
+  margin-bottom: ${themeSpacing(2)};
+`
+
+export const StyledParagraph = styled(Paragraph)`
+  margin-bottom: ${themeSpacing(2)};
+`
+
+export const ImageWrapper = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: ${themeSpacing(2)};
+`
+
+export const Image = styled.img`
+  width: 80px;
+  object-fit: cover;
+`

--- a/src/signals/incident-management/containers/IncidentDetail/components/ModalDialog/ModalDialog.test.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/ModalDialog/ModalDialog.test.tsx
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (C) 2022 Vereniging van Nederlandse Gemeenten
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { withAppContext } from 'test/utils'
+
+import ModalDialog from './ModalDialog'
+
+const title = 'foo'
+const content = 'bar'
+const mockClose = jest.fn()
+const renderModal = () => {
+  render(
+    withAppContext(
+      <ModalDialog onClose={mockClose} title={title}>
+        {content}
+      </ModalDialog>
+    )
+  )
+}
+
+describe('ModalDialog', () => {
+  beforeEach(() => {
+    mockClose.mockClear()
+  })
+
+  it('renders correctly', () => {
+    renderModal()
+
+    expect(screen.getByRole('heading', { name: title })).toBeInTheDocument()
+    expect(screen.getByText(content)).toBeInTheDocument()
+  })
+
+  it('handles clicking the close button', () => {
+    renderModal()
+
+    userEvent.click(screen.getByRole('button', { description: 'Sluiten' }))
+
+    expect(mockClose).toHaveBeenCalled()
+  })
+
+  it('handles pressing the escape button', () => {
+    renderModal()
+
+    expect(mockClose).not.toHaveBeenCalled()
+    userEvent.keyboard('{escape}')
+
+    expect(mockClose).toHaveBeenCalled()
+  })
+})

--- a/src/signals/incident-management/containers/IncidentDetail/components/ModalDialog/ModalDialog.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/ModalDialog/ModalDialog.tsx
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (C) 2022 Vereniging van Nederlandse Gemeenten
+import type { FunctionComponent } from 'react'
+
+import { Modal } from '@amsterdam/asc-ui'
+import styled from 'styled-components'
+
+import ModalHeader from './components/ModalHeader/ModalHeader'
+
+const StyledModal = styled(Modal)`
+  overflow: hidden;
+  height: 75%;
+`
+
+const ModalContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  * {
+    box-sizing: border-box;
+  }
+`
+
+interface ModalDialogProps {
+  onClose: () => void
+  title: string
+}
+
+const ModalDialog: FunctionComponent<ModalDialogProps> = ({
+  onClose,
+  title,
+  children,
+}) => (
+  <StyledModal open onClose={onClose}>
+    <ModalHeader title={title} onClose={onClose} />
+    <ModalContent>{children}</ModalContent>
+  </StyledModal>
+)
+
+export default ModalDialog

--- a/src/signals/incident-management/containers/IncidentDetail/components/ModalDialog/ModalDialog.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/ModalDialog/ModalDialog.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2022 Vereniging van Nederlandse Gemeenten
-import type { FunctionComponent } from 'react'
+import type { ReactNode } from 'react'
 
 import { Modal } from '@amsterdam/asc-ui'
 import styled from 'styled-components'
@@ -24,13 +24,10 @@ const ModalContent = styled.div`
 interface ModalDialogProps {
   onClose: () => void
   title: string
+  children: ReactNode
 }
 
-const ModalDialog: FunctionComponent<ModalDialogProps> = ({
-  onClose,
-  title,
-  children,
-}) => (
+const ModalDialog = ({ onClose, title, children }: ModalDialogProps) => (
   <StyledModal open onClose={onClose}>
     <ModalHeader title={title} onClose={onClose} />
     <ModalContent>{children}</ModalContent>

--- a/src/signals/incident-management/containers/IncidentDetail/components/ModalDialog/components/ModalHeader/ModalHeader.test.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/ModalDialog/components/ModalHeader/ModalHeader.test.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2022 Gemeente Amsterdam, Vereniging van Nederlandse Gemeenten
+// Copyright (C) 2022 Gemeente Amsterdam
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { withAppContext } from 'test/utils'

--- a/src/signals/incident-management/containers/IncidentDetail/components/ModalDialog/components/ModalHeader/ModalHeader.test.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/ModalDialog/components/ModalHeader/ModalHeader.test.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2022 Gemeente Amsterdam
+// Copyright (C) 2022 Gemeente Amsterdam, Vereniging van Nederlandse Gemeenten
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { withAppContext } from 'test/utils'

--- a/src/signals/incident-management/containers/IncidentDetail/components/ModalDialog/components/ModalHeader/ModalHeader.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/ModalDialog/components/ModalHeader/ModalHeader.tsx
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2022 Gemeente Amsterdam
+// Copyright (C) 2022 Gemeente Amsterdam, Vereniging van Nederlandse Gemeenten
 import type { FC } from 'react'
-import styled from 'styled-components'
-import { Button, Heading, themeColor, themeSpacing } from '@amsterdam/asc-ui'
+
 import { Close } from '@amsterdam/asc-assets'
+import { Button, Heading, themeColor, themeSpacing } from '@amsterdam/asc-ui'
+import styled from 'styled-components'
 
 export const Header = styled.div`
   align-items: center;
@@ -30,11 +31,12 @@ const ModalHeader: FC<ModalHeaderProps> = ({ title, onClose }) => (
     </StyledHeading>
     {onClose && (
       <Button
+        square
         variant="blank"
         onClick={onClose}
         icon={<Close />}
         iconSize={20}
-        size={20}
+        size={32}
         title="Sluiten"
       />
     )}

--- a/src/signals/incident-management/containers/IncidentDetail/components/ModalDialog/index.ts
+++ b/src/signals/incident-management/containers/IncidentDetail/components/ModalDialog/index.ts
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (C) 2022 Vereniging van Nederlandse Gemeenten
+export { default } from './ModalDialog'

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/DefaultTexts/DefaultTexts.test.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/DefaultTexts/DefaultTexts.test.tsx
@@ -7,6 +7,7 @@ import { StatusCode } from 'signals/incident-management/definitions/types'
 import type { DefaultText as DefaultTextType } from 'types/api/default-text'
 import type { DefaulTextsProps } from './DefaultTexts'
 
+import { withAppContext } from 'test/utils'
 import DefaultTexts from '.'
 
 describe('<DefaultTexts />', () => {
@@ -15,6 +16,7 @@ describe('<DefaultTexts />', () => {
   beforeEach(() => {
     props = {
       status: StatusCode.Afgehandeld,
+      onClose: jest.fn(),
       defaultTexts: [
         {
           state: StatusCode.Afgehandeld,
@@ -42,7 +44,9 @@ describe('<DefaultTexts />', () => {
   })
 
   it('should render correctly', () => {
-    const { queryAllByTestId } = render(<DefaultTexts {...props} />)
+    const { queryAllByTestId } = render(
+      withAppContext(<DefaultTexts {...props} />)
+    )
 
     expect(screen.getByTestId('modalTitle')).toHaveTextContent(
       /^Standaardtekst$/
@@ -71,7 +75,7 @@ describe('<DefaultTexts />', () => {
 
   it('should not render when wrong status is used', () => {
     const { queryAllByTestId } = render(
-      <DefaultTexts {...props} status={StatusCode.Ingepland} />
+      withAppContext(<DefaultTexts {...props} status={StatusCode.Ingepland} />)
     )
 
     expect(queryAllByTestId('defaultTextsItemText')).toHaveLength(0)
@@ -81,7 +85,7 @@ describe('<DefaultTexts />', () => {
     const defaultTexts: Array<DefaultTextType> = []
 
     const { queryAllByTestId } = render(
-      <DefaultTexts {...props} defaultTexts={defaultTexts} />
+      withAppContext(<DefaultTexts {...props} defaultTexts={defaultTexts} />)
     )
 
     expect(queryAllByTestId('defaultTextsItemText')).toHaveLength(0)
@@ -92,7 +96,7 @@ describe('<DefaultTexts />', () => {
     defaultTexts[0].templates = []
 
     const { getByText } = render(
-      <DefaultTexts {...props} defaultTexts={defaultTexts} />
+      withAppContext(<DefaultTexts {...props} defaultTexts={defaultTexts} />)
     )
 
     expect(
@@ -103,7 +107,9 @@ describe('<DefaultTexts />', () => {
   })
 
   it('should call the callback function when button clicked', () => {
-    const { queryAllByTestId } = render(<DefaultTexts {...props} />)
+    const { queryAllByTestId } = render(
+      withAppContext(<DefaultTexts {...props} />)
+    )
     fireEvent.click(queryAllByTestId('defaultTextsItemButton')[0])
 
     expect(props.onHandleUseDefaultText).toHaveBeenCalledTimes(1)

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/DefaultTexts/DefaultTexts.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/DefaultTexts/DefaultTexts.tsx
@@ -4,19 +4,13 @@ import type { FC, SyntheticEvent } from 'react'
 import type { DefaultText as DefaultTextType } from 'types/api/default-text'
 import type { StatusCode } from 'signals/incident-management/definitions/types'
 
-import ModalHeader from '../ModalHeader/ModalHeader'
-import {
-  StyledDefaultText,
-  StyledTitle,
-  StyledLink,
-  Container,
-  Wrapper,
-} from './styled'
+import ModalDialog from '../../../ModalDialog'
+import { StyledDefaultText, StyledTitle, StyledLink, Wrapper } from './styled'
 
 export type DefaulTextsProps = {
   defaultTexts: Array<DefaultTextType>
   status: StatusCode
-  onClose?: () => void
+  onClose: () => void
   onHandleUseDefaultText: (
     event: SyntheticEvent<HTMLAnchorElement>,
     text: string
@@ -34,8 +28,7 @@ const DefaultTexts: FC<DefaulTextsProps> = ({
     defaultTexts.find((text) => text.state === status)
 
   return (
-    <Container>
-      <ModalHeader title="Standaardtekst" onClose={onClose} />
+    <ModalDialog title="Standaardtekst" onClose={onClose}>
       <Wrapper data-scroll-lock-scrollable>
         {(!allText || allText.templates.length === 0) && (
           <StyledDefaultText key={`empty_${status}`} empty>
@@ -64,7 +57,7 @@ const DefaultTexts: FC<DefaulTextsProps> = ({
             </StyledDefaultText>
           ))}
       </Wrapper>
-    </Container>
+    </ModalDialog>
   )
 }
 

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/DefaultTexts/styled.ts
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/DefaultTexts/styled.ts
@@ -24,12 +24,6 @@ export const StyledTitle = styled.div`
   margin-bottom: ${themeSpacing(1)};
 `
 
-export const Container = styled.div`
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-`
-
 export const Wrapper = styled.div`
   padding: ${themeSpacing(5, 4)};
   overflow: auto;

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/reducer.test.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/reducer.test.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2020 - 2022 Gemeente Amsterdam, Verenigin van Nederlandse Gemeenten
+// Copyright (C) 2020 - 2022 Gemeente Amsterdam
 import statusList, {
   changeStatusOptionList,
   GEMELD,

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/reducer.test.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/reducer.test.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2020 - 2022 Gemeente Amsterdam
+// Copyright (C) 2020 - 2022 Gemeente Amsterdam, Verenigin van Nederlandse Gemeenten
 import statusList, {
   changeStatusOptionList,
   GEMELD,

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/reducer.ts
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/reducer.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2020 - 2021 Gemeente Amsterdam
+// Copyright (C) 2020 - 2021 Gemeente Amsterdam, Vereniging van Nederlandse Gemeenten
 import type { AlertLevel } from '@amsterdam/asc-ui'
 import statusList, {
   isStatusClosed,

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/reducer.ts
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/reducer.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2020 - 2021 Gemeente Amsterdam, Vereniging van Nederlandse Gemeenten
+// Copyright (C) 2020 - 2021 Gemeente Amsterdam
 import type { AlertLevel } from '@amsterdam/asc-ui'
 import statusList, {
   isStatusClosed,

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/styled.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/styled.tsx
@@ -6,7 +6,6 @@ import {
   Checkbox,
   Heading,
   Label,
-  Modal,
   Row,
   themeColor,
   themeSpacing,
@@ -60,6 +59,7 @@ export const StandardTextsButton = styled(Button)<{
       css`
         color: ${themeColor('tint', 'level5')};
       `}
+  }
 `
 
 export const StyledAlert = styled(Alert)<{ level?: AlertLevel }>`
@@ -97,11 +97,6 @@ export const StyledCheckbox = styled(Checkbox)<{ disabled: boolean }>`
     css`
       opacity: 0.3;
     `}
-`
-
-export const StyledModal = styled(Modal)`
-  overflow: hidden;
-  height: 75%;
 `
 
 export const StyledParagraph = styled.p`

--- a/src/signals/incident-management/containers/IncidentDetail/constants.ts
+++ b/src/signals/incident-management/containers/IncidentDetail/constants.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2020 - 2022 Gemeente Amsterdam
+// Copyright (C) 2020 - 2022 Gemeente Amsterdam, Vereniging van Nederlandse Gemeenten
 export const PATCH_TYPE_LOCATION = 'location'
 export const PATCH_TYPE_NOTES = 'notes'
 export const PATCH_TYPE_PRIORITY = 'priority'
@@ -36,3 +36,5 @@ export const PATCH_SUCCESS =
 export const PREVIEW =
   'sia/incidentManagement/containers/IncidentDetail/PREVIEW'
 export const EDIT = 'sia/incidentManagement/containers/IncidentDetail/EDIT'
+export const EXTERNAL =
+  'sia/incidentManagement/containers/IncidentDetail/EXTERNAL'

--- a/src/signals/incident-management/containers/IncidentDetail/reducer.test.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/reducer.test.tsx
@@ -7,6 +7,7 @@ import { StatusCode } from '../../definitions/types'
 import {
   CLOSE_ALL,
   EDIT,
+  EXTERNAL,
   PATCH_START,
   PATCH_SUCCESS,
   PREVIEW,
@@ -235,6 +236,20 @@ describe('signals/incident-management/containers/IncidentDetail/reducer', () => 
       edit: undefined,
       external: false,
       ...payload,
+    })
+  })
+
+  it('should handle EXTERNAL', () => {
+    const mockState = {
+      ...state,
+      edit: 'foo',
+      preview: 'bar',
+    }
+    expect(reducer(mockState, { type: EXTERNAL })).toEqual({
+      ...mockState,
+      edit: undefined,
+      external: !mockState.external,
+      preview: undefined,
     })
   })
 

--- a/src/signals/incident-management/containers/IncidentDetail/reducer.test.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/reducer.test.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2020 - 2022 Gemeente Amsterdam
+// Copyright (C) 2020 - 2022 Gemeente Amsterdam, Vereniging van Nederlandse Gemeenten
 import type { DefaultTexts } from 'types/api/default-text'
 import incidentFixture from 'utils/__tests__/fixtures/incident.json'
 import type { Incident } from 'types/api/incident'
@@ -233,6 +233,7 @@ describe('signals/incident-management/containers/IncidentDetail/reducer', () => 
     expect(reducer(state, { type: PREVIEW, payload })).toEqual({
       ...state,
       edit: undefined,
+      external: false,
       ...payload,
     })
   })

--- a/src/signals/incident-management/containers/IncidentDetail/reducer.ts
+++ b/src/signals/incident-management/containers/IncidentDetail/reducer.ts
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2020 - 2022 Gemeente Amsterdam
+// Copyright (C) 2020 - 2022 Gemeente Amsterdam, Vereniging van Nederlandse Gemeenten
 import type { Reducer } from 'react'
 import {
   CLOSE_ALL,
   EDIT,
+  EXTERNAL,
   PATCH_START,
   PATCH_SUCCESS,
   PREVIEW,
@@ -86,6 +87,7 @@ const reducer: Reducer<State, Action> = (state, action) => {
       return {
         ...state,
         edit: undefined,
+        external: false,
         ...action.payload,
         preview: action.payload?.preview,
       }
@@ -100,6 +102,14 @@ const reducer: Reducer<State, Action> = (state, action) => {
 
     case RESET:
       return { ...initialState, incident: state.incident }
+
+    case EXTERNAL:
+      return {
+        ...state,
+        edit: undefined,
+        external: !state.external,
+        preview: undefined,
+      }
 
     default:
       return state

--- a/src/signals/incident-management/containers/IncidentDetail/types.ts
+++ b/src/signals/incident-management/containers/IncidentDetail/types.ts
@@ -11,6 +11,8 @@ export interface Context {
   preview?: (section: string, payload?: Partial<State>) => void
   edit?: (section: string, payload?: Partial<State>) => void
   close?: () => void
+  toggleExternal?: () => void
+  attachments?: Result<Attachment>
 }
 
 export interface State {
@@ -27,6 +29,7 @@ export interface State {
   patching?: string
   edit?: string
   preview?: string
+  external?: boolean
 }
 
 export interface IncidentChild {

--- a/src/signals/incident-management/definitions/statusList.ts
+++ b/src/signals/incident-management/definitions/statusList.ts
@@ -132,6 +132,13 @@ export const VERZOEK_TOT_AFHANDELING = {
   topic: 'topic2',
 }
 
+export const DOORGEZET_NAAR_EXTERN = {
+  key: StatusCode.DoorgezetNaarExtern,
+  value: 'Doorgezet naar extern',
+  email_sent_when_set: true,
+  shows_remaining_sla_days: true,
+}
+
 export const AFGEHANDELD_EXTERN = {
   key: StatusCode.AfgehandeldExtern,
   value: 'Extern: afgehandeld',
@@ -157,6 +164,7 @@ const statusList: Status[] = [
   VERZENDEN_MISLUKT,
   VERZOEK_TOT_AFHANDELING,
   AFGEHANDELD_EXTERN,
+  DOORGEZET_NAAR_EXTERN,
 ]
 
 export default statusList

--- a/src/signals/incident-management/definitions/types.ts
+++ b/src/signals/incident-management/definitions/types.ts
@@ -21,6 +21,7 @@ export enum StatusCode {
   Verzonden = 'sent',
   VerzendenMislukt = 'send failed',
   VerzoekTotAfhandeling = 'closure requested',
+  DoorgezetNaarExtern = 'forward to external',
   AfgehandeldExtern = 'done external',
 }
 


### PR DESCRIPTION
Part of https://github.com/Signalen/product-steering/issues/286. 

## Signalen

### Context

This PR adds a new form to forward incidents to an external party, for them to pick up the issue. 

When the feature flag is turned on, users are able to press the "Extern" button in the incident detail page. A form is displayed for e-mail, a text field and the images (if available) that will be visible to the external party. When submitted, an e-mail template is shown which can be confirmed. On confirmation, the incident status is changed (Doorgezet naar extern) and the e-mail is sent to the external party. 

The second part of the flow (reply from the external party) will be submitted in a separate PR. 

### Changes

- Adds `enableForwardIncidentToExternal` feature flag
- Adds `ForwardToExternal` form
- Create ModalDialog component used by EmailPreview and DefaultTexts
- Adds `DOORGEZET_NAAR_EXTERN` status
- Wrap buttons on incident detail page to prevent horizontal scroll bar on mobile

## Design

InVision designs can be found [here](https://projects.invisionapp.com/share/RF131I9Q6DVM#/screens/470029477)

## Testing this branch

- Set `enableForwardIncidentToExternal` to `true` in your json config (e.g. `app.json`)
- Run the backend using the [appropriate branch](https://github.com/Signalen/backend/tree/product-steering/261-prototype), as seen in PR #https://github.com/Amsterdam/signals/pull/1106. 
- In the [Django admin](http://localhost:8000/signals/admin/email_integrations/emailtemplate/), add the below email template for the key `Send mail signal forwarded to external`. This example corresponds to the design but any municipality can choose their own template. 

```
Geachte behandelaar,

Er is een melding binnengekomen bij de Gemeente. Kunnen jullie hier naar kijken en ons laten weten of jullie deze kunnen afhandelen?

**Wat kan u doen?**\
U kan de melding gelijk inzien en oppakken. Als de melding is verwerkt ontvangen wij graag een bericht.\
[Bekijk de actie]({{ reaction_url }})

Nummer: {{ formatted_signal_id }}

Met vriendelijke groet,

{{ ORGANIZATION_NAME }}
```