### PR TITLE
Refining accessibility van Meldingenkaart

### DIFF
--- a/src/components/MarkerCluster/MarkerCluster.tsx
+++ b/src/components/MarkerCluster/MarkerCluster.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2021 - 2022 Gemeente Amsterdam
 import type { Dispatch, FunctionComponent, SetStateAction } from 'react'
+import { useMemo } from 'react'
 
 import { createLeafletComponent } from '@amsterdam/react-maps'
 import * as L from 'leaflet'
@@ -11,7 +12,6 @@ import 'leaflet.markercluster'
 
 const SELECTED_CLASS_MODIFIER = '--selected'
 const CLUSTER_ICON_SIZE = 40
-const MarkerClusterGroup = createLeafletComponent('markerClusterGroup')
 
 interface MarkerClusterProps {
   setInstance: Dispatch<SetStateAction<L.GeoJSON | undefined>>
@@ -28,19 +28,22 @@ const MarkerCluster: FunctionComponent<MarkerClusterProps> = ({
   spiderfySelectedCluster = true,
   keyboard = true,
 }) => {
+  const MarkerClusterGroup = useMemo(() => {
+    return createLeafletComponent('markerClusterGroup')
+  }, [keyboard])
+
   const options: L.MarkerClusterGroupOptions = {
     showCoverageOnHover: false,
+
     iconCreateFunction: /* istanbul ignore next */ (cluster) => {
       let className = 'marker-cluster'
 
+      cluster.options.keyboard = keyboard
       if (getIsSelectedCluster) {
         const isSelectedCluster = getIsSelectedCluster(cluster)
 
         if (isSelectedCluster) {
           className += ` ${className}${SELECTED_CLASS_MODIFIER}`
-        }
-        if (!keyboard) {
-          cluster.options.keyboard = false
         }
 
         cluster.on({

--- a/src/signals/IncidentMap/components/DrawerOverlay/DetailPanel.test.tsx
+++ b/src/signals/IncidentMap/components/DrawerOverlay/DetailPanel.test.tsx
@@ -38,5 +38,8 @@ describe('DetailPanel', () => {
     expect(screen.getByText('7 september 2022')).toBeInTheDocument()
     expect(screen.getByText(/Damstraat 100/)).toBeInTheDocument()
     expect(screen.getByText(/1000 AA Amsterdam/)).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Detail panel sluiten' })
+    ).toHaveFocus()
   })
 })

--- a/src/signals/IncidentMap/components/DrawerOverlay/DetailPanel.tsx
+++ b/src/signals/IncidentMap/components/DrawerOverlay/DetailPanel.tsx
@@ -1,19 +1,22 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2022 Gemeente Amsterdam
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 import { Close } from '@amsterdam/asc-assets'
 import { Heading } from '@amsterdam/asc-ui'
 import format from 'date-fns/format'
 import nl from 'date-fns/locale/nl'
-
 import { capitalize } from 'shared/services/date-utils'
 import type { PdokAddress } from 'shared/services/map-location'
+import styled from 'styled-components'
 
 import type { Incident } from '../../types'
 import { StyledList } from './styled'
 import { CloseButton, DetailsWrapper } from './styled'
 import { getAddress } from './utils'
+
+// Using this block, we can use ref on DetailsWrapper
+const Block = styled.div``
 
 const defaultAddress: PdokAddress = {
   openbare_ruimte: 'Onbekend',
@@ -30,6 +33,8 @@ export interface Props {
 export const DetailPanel = ({ onClose, incident }: Props) => {
   const [address, setAddress] = useState<PdokAddress>(defaultAddress)
 
+  const detailWrapperRef = useRef<HTMLElement>()
+
   const { properties, geometry } = incident
   const date = new Date(properties.created_at)
 
@@ -41,8 +46,15 @@ export const DetailPanel = ({ onClose, incident }: Props) => {
     getAddress(geometry, setAddress)
   }, [geometry, incident])
 
+  useEffect(() => {
+    const button = detailWrapperRef.current?.querySelector(
+      'button[title="Sluiten"]'
+    ) as HTMLElement
+    button.focus()
+  }, [])
+
   return (
-    <DetailsWrapper>
+    <Block as={DetailsWrapper} ref={detailWrapperRef}>
       <CloseButton
         type="button"
         variant="blank"
@@ -68,6 +80,6 @@ export const DetailPanel = ({ onClose, incident }: Props) => {
           {address.postcode} {address.woonplaats}
         </dd>
       </StyledList>
-    </DetailsWrapper>
+    </Block>
   )
 }

--- a/src/signals/IncidentMap/components/IncidentLayer/IncidentLayer.tsx
+++ b/src/signals/IncidentMap/components/IncidentLayer/IncidentLayer.tsx
@@ -1,12 +1,13 @@
 /* SPDX-License-Identifier: MPL-2.0 */
 /* Copyright (C) 2022 Gemeente Amsterdam */
+
 import type { MutableRefObject } from 'react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
-import type { FeatureCollection, Point } from 'geojson'
-import L from 'leaflet'
-
 import MarkerCluster from 'components/MarkerCluster'
+import type { FeatureCollection, Point } from 'geojson'
+import type { LeafletEvent } from 'leaflet'
+import L from 'leaflet'
 import {
   dynamicIcon,
   selectedMarkerIcon,
@@ -15,6 +16,7 @@ import type { Bbox } from 'signals/incident/components/form/MapSelectors/hooks/u
 import useBoundingBox from 'signals/incident/components/form/MapSelectors/hooks/useBoundingBox'
 
 import type { Incident, Properties } from '../../types'
+import { DEFAULT_ZOOM } from '../utils'
 
 const clusterLayerOptions = {
   zoomToBoundsOnClick: true,
@@ -27,6 +29,8 @@ interface Props {
   passBbox(bbox: Bbox): void
   resetSelectedMarker: () => void
   selectedMarkerRef: MutableRefObject<L.Marker<Properties> | undefined>
+  selectedIncident?: Incident
+  zoomLevel: number
 }
 
 /* istanbul ignore next */
@@ -36,10 +40,14 @@ export const IncidentLayer = ({
   passBbox,
   resetSelectedMarker,
   selectedMarkerRef,
+  selectedIncident,
+  zoomLevel,
 }: Props) => {
   const [layerInstance, setLayerInstance] = useState<L.GeoJSON<Point>>()
   const activeLayer = useRef<L.GeoJSON>()
   const bbox = useBoundingBox()
+
+  const focussedMarkerRef = useRef<HTMLElement | null>(null)
 
   useEffect(() => {
     if (bbox) {
@@ -67,15 +75,25 @@ export const IncidentLayer = ({
 
           e.target.setIcon(selectedMarkerIcon)
           selectedMarkerRef.current = e.target
-
+          focussedMarkerRef.current = e.target.getElement() || null
           handleIncidentSelect(feature)
         })
+
+        layer.on(
+          'keypress',
+          (e: LeafletEvent & { originalEvent: KeyboardEvent }) => {
+            if (['Enter', 'Space'].includes(e.originalEvent.code)) {
+              focussedMarkerRef.current = e.target.getElement()
+              handleIncidentSelect(feature)
+            }
+          }
+        )
       },
       pointToLayer: (incident: Incident, latlng) => {
         let marker = L.marker(latlng, {
           icon: dynamicIcon(incident.properties?.icon),
           alt: incident.properties.category.name,
-          keyboard: false,
+          keyboard: zoomLevel >= DEFAULT_ZOOM,
         })
         // Matching on created_at since incidents do not have an ID
         if (
@@ -85,7 +103,7 @@ export const IncidentLayer = ({
           marker = L.marker(latlng, {
             icon: selectedMarkerIcon,
             alt: incident.properties.category.name,
-            keyboard: false,
+            keyboard: zoomLevel >= DEFAULT_ZOOM,
           })
           selectedMarkerRef.current = marker
         }
@@ -97,13 +115,24 @@ export const IncidentLayer = ({
     layer.addTo(layerInstance)
 
     activeLayer.current = layer
+
+    // We ignore selectedIncident on purpose, otherwise markers are removed from the dom when selecting one.
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
   }, [
     handleIncidentSelect,
     incidents,
     layerInstance,
     resetSelectedMarker,
     selectedMarkerRef,
+    zoomLevel,
   ])
+
+  useEffect(() => {
+    if (!selectedIncident) {
+      focussedMarkerRef.current?.focus()
+    }
+  }, [focussedMarkerRef, selectedIncident])
 
   const getIsSelectedCluster = useCallback(
     (cluster: L.MarkerCluster) => {
@@ -125,7 +154,7 @@ export const IncidentLayer = ({
       setInstance={setLayerInstance}
       getIsSelectedCluster={getIsSelectedCluster}
       spiderfySelectedCluster={false}
-      keyboard={false}
+      keyboard={zoomLevel >= DEFAULT_ZOOM}
     />
   )
 }

--- a/src/signals/IncidentMap/components/IncidentLayer/IncidentLayer.tsx
+++ b/src/signals/IncidentMap/components/IncidentLayer/IncidentLayer.tsx
@@ -115,10 +115,6 @@ export const IncidentLayer = ({
     layer.addTo(layerInstance)
 
     activeLayer.current = layer
-
-    // We ignore selectedIncident on purpose, otherwise markers are removed from the dom when selecting one.
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
   }, [
     handleIncidentSelect,
     incidents,

--- a/src/signals/IncidentMap/components/IncidentMap/IncidentMap.tsx
+++ b/src/signals/IncidentMap/components/IncidentMap/IncidentMap.tsx
@@ -25,7 +25,11 @@ import { isMobile, useDeviceMode } from '../DrawerOverlay/utils'
 import { FilterPanel } from '../FilterPanel'
 import { GPSLocation } from '../GPSLocation'
 import { IncidentLayer } from '../IncidentLayer'
-import { getFilteredIncidents, countIncidentsPerFilter } from '../utils'
+import {
+  getFilteredIncidents,
+  countIncidentsPerFilter,
+  DEFAULT_ZOOM,
+} from '../utils'
 import { Pin } from './Pin'
 import { Wrapper, StyledMap, StyledParagraph } from './styled'
 import { getZoom } from './utils'
@@ -75,7 +79,6 @@ export const IncidentMap = () => {
           lng: sanitizedCoords.lng,
         }
         const zoom = getZoom(map)
-
         map.flyTo(coords, zoom)
       }
 
@@ -143,6 +146,8 @@ export const IncidentMap = () => {
     }
   }, [coordinates])
 
+  const zoomLevel = map?.getZoom() || DEFAULT_ZOOM
+
   return (
     <Wrapper>
       <StyledMap
@@ -158,11 +163,13 @@ export const IncidentMap = () => {
         }}
       >
         <IncidentLayer
+          selectedIncident={selectedIncident}
           handleIncidentSelect={handleIncidentSelect}
           passBbox={setBbox}
           incidents={filteredIncidents}
           resetSelectedMarker={resetSelectedMarker}
           selectedMarkerRef={selectedMarkerRef}
+          zoomLevel={zoomLevel}
         />
 
         {map && coordinates && (


### PR DESCRIPTION
## goal
make the map accessible for visually impaired people.

## changes
- Focus on button when entering DetailPanel.tsx. And go back to marker again when closing DetailPanel.tsx.
- Save last focussed marker on meldingenkaart, before selecting one and opening the detailpanel. When hiding the detailpanel focus on the last selected marker again.

Ticket: [SIG-4871](https://datapunt.atlassian.net/browse/SIG-4871)

## Signalen

Before opening a pull request, please ensure:

- [x] Double-check your branch is based on `main` and targets `main`
- [x] Pull request has tests (we are going for 100% coverage!)
- [x] Code is well-commented, linted and follows project conventions
- [x] Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
