### PR TITLE
[chore]: update PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,7 @@ Ticket: [SIG-1234](https://datapunt.atlassian.net/browse/SIG-1234)
 
 Before opening a pull request, please ensure:
 
+- [ ] Make sure your PR title follows naming conventions: [feat-1234]: name feature
 - [ ] Double-check your branch is based on `main` and targets `main`
 - [ ] Pull request has tests (we are going for 100% coverage!)
 - [ ] Code is well-commented, linted and follows project conventions

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,10 +4,10 @@ Ticket: [SIG-1234](https://datapunt.atlassian.net/browse/SIG-1234)
 
 Before opening a pull request, please ensure:
 
-- [ ] Make sure your PR title follows naming conventions: [feat-1234]: name feature
-- [ ] Double-check your branch is based on `main` and targets `main`
-- [ ] Pull request has tests (we are going for 100% coverage!)
-- [ ] Code is well-commented, linted and follows project conventions
-- [ ] Committed source code is headed by the correct SPDX license expression
+- Make sure your PR title follows naming conventions: [feat-1234]: name feature
+- Double-check your branch is based on `main` and targets `main`
+- Pull request has tests (we are going for 100% coverage!)
+- Code is well-commented, linted and follows project conventions
+- Committed source code is headed by the correct SPDX license expression
 
 Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)


### PR DESCRIPTION
Ticket: none

Since the PR titles did not follow any convention and therefore the jira ticket number was not visible it was very hard to see which features where in which release. 

- I updated the wiki in the SIA repo in Azure with a naming convention
- I removed the checkboxes to avoid unnecessary work
- I updated the PR Template in this PR to ensure everyone gets a reminder to provide a proper title