### PR TITLE
[fix]: Allow input values with spaces for unregistered map asset

### DIFF
--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.test.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2021 - 2022 Gemeente Amsterdam
+// Copyright (C) 2021 - 2022 Gemeente Amsterdam, Vereniging van Nederlandse Gemeenten
 import type { ReactPropTypes } from 'react'
 
 import { fireEvent, render, screen, within } from '@testing-library/react'
@@ -297,7 +297,7 @@ describe('DetailPanel', () => {
 
     expect(screen.getByText('Nummer van de container')).toBeInTheDocument()
 
-    const unregisteredObjectId = '8976238'
+    const unregisteredObjectId = '897 6238'
 
     userEvent.type(
       screen.getByTestId('unregisteredAssetInput'),

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2021 - 2022 Gemeente Amsterdam
+// Copyright (C) 2021 - 2022 Gemeente Amsterdam, Vereniging van Nederlandse Gemeenten
 import { useCallback, useState, useContext, useRef, useEffect } from 'react'
 import type { KeyboardEvent, ChangeEvent, FC } from 'react'
 
@@ -99,15 +99,16 @@ const DetailPanel: FC<DetailPanelProps> = ({ language = {} }) => {
     }))
 
   const onChange = (event: ChangeEvent<HTMLInputElement>) => {
-    setUnregisteredAssetValue(event.currentTarget.value.trim())
+    setUnregisteredAssetValue(event.currentTarget.value)
   }
 
   const onSetUnregisteredItem = useCallback(() => {
     removeItem()
+    const trimmedUnregisteredAssetValue = `${unregisteredAssetValue}`.trim()
     setItem({
-      id: unregisteredAssetValue,
+      id: trimmedUnregisteredAssetValue,
       type: UNKNOWN_TYPE,
-      label: [unregisteredLabel, unregisteredAssetValue]
+      label: [unregisteredLabel, trimmedUnregisteredAssetValue]
         .filter(Boolean)
         .join(' - '),
     })


### PR DESCRIPTION
## Signalen

### Context

Users should be able to add values with spaces when adding a value for unregistered objects in the incident map.

### Steps to reproduce:

1. Run application against amsterdam acc backend
2. Use "container" as incident description to trigger container asset map on step 2 of the flow
3. Press "De container staat niet op de kaart"
4. In "Nummer van de container", type "123 456"

Expected: "123 456" is accepted
Actual: input is trimmed while typing, thereby preventing spaces from being added
