### PR TITLE
[fix-4786]: unset position map controls

### DIFF
--- a/src/components/MapInput/index.js
+++ b/src/components/MapInput/index.js
@@ -41,6 +41,7 @@ const StyledMap = styled(Map)`
 `
 
 const StyledViewerContainer = styled(ViewerContainer)`
+  position: unset;
   & > * {
     width: calc(
       100% - 8px


### PR DESCRIPTION
Ticket: [SIG-4786](https://datapunt.atlassian.net/browse/SIG-4786)

With the update of Amsterdam React Maps some styling was added which caused the address button to flow over the save and cancel button. This PR set the position of the "StyledViewerContainer" to unset, which was the value before the update.