### PR TITLE
[fix-4911]: change max width and padding top when authenticated at my incidents overview page.

### DIFF
--- a/src/containers/App/index.tsx
+++ b/src/containers/App/index.tsx
@@ -23,6 +23,7 @@ import IncidentReplyContainer from 'signals/incident/containers/IncidentReplyCon
 import styled from 'styled-components'
 
 import useDefaultHeader from '../../hooks/useDefaultHeader'
+import useTallHeader from '../../hooks/useTallHeader'
 import { getSources } from './actions'
 import AppContext from './context'
 import { makeSelectLoading, makeSelectSources } from './selectors'
@@ -67,7 +68,10 @@ export const AppContainer = () => {
   const history = useHistory()
   const location = useLocationReferrer() as { referrer: string }
   const isFrontOffice = useIsFrontOffice()
-  const headerIsTall = isFrontOffice && !getIsAuthenticated()
+  const tallHeaderByDefault = useTallHeader()
+  const headerIsTall =
+    (isFrontOffice && !getIsAuthenticated()) || tallHeaderByDefault
+
   const contextValue = useMemo(() => ({ loading, sources }), [loading, sources])
 
   useEffect(() => {

--- a/src/hooks/useIsFrontOffice.js
+++ b/src/hooks/useIsFrontOffice.js
@@ -11,6 +11,7 @@ const useIsFrontOffice = () => {
     () =>
       !location.pathname.startsWith('/manage') &&
       !location.pathname.startsWith('/instellingen'),
+    !location.pathname.startsWith('/mijn-meldingen'),
     [location.pathname]
   )
 }

--- a/src/hooks/useIsFrontOffice.js
+++ b/src/hooks/useIsFrontOffice.js
@@ -11,7 +11,6 @@ const useIsFrontOffice = () => {
     () =>
       !location.pathname.startsWith('/manage') &&
       !location.pathname.startsWith('/instellingen'),
-    !location.pathname.startsWith('/mijn-meldingen'),
     [location.pathname]
   )
 }

--- a/src/signals/my-incidents/pages/Detail.tsx
+++ b/src/signals/my-incidents/pages/Detail.tsx
@@ -14,7 +14,7 @@ import { Map } from '../components/Map'
 import { routes } from '../definitions'
 import type { HistoryInstance } from '../types'
 import type { MyIncidentDetail } from '../types'
-import { ContentWrapper, Wrapper, StyledRow } from './styled'
+import { ContentWrapper, StyledRow } from './styled'
 
 export const Detail = () => {
   const { get, data, error } = useFetch<MyIncidentDetail>()
@@ -59,26 +59,24 @@ export const Detail = () => {
 
   return (
     <StyledRow>
-      <Wrapper>
-        <Helmet
-          defaultTitle={configuration.language.siteTitle}
-          titleTemplate={`${configuration.language.siteTitle} - %s`}
-        >
-          <title>{`Meldingsnummer: ${data._display}`}</title>
-        </Helmet>
-        {showMap ? (
-          <Map close={() => setShowMap(false)} location={data.location} />
-        ) : (
-          <ContentWrapper>
-            <IncidentsDetailComponent
-              incidentsDetail={data}
-              token={token}
-              setShowMap={setShowMap}
-            />
-            <History incident={data} fetchResponse={fetchResponseHistory} />
-          </ContentWrapper>
-        )}
-      </Wrapper>
+      <Helmet
+        defaultTitle={configuration.language.siteTitle}
+        titleTemplate={`${configuration.language.siteTitle} - %s`}
+      >
+        <title>{`Meldingsnummer: ${data._display}`}</title>
+      </Helmet>
+      {showMap ? (
+        <Map close={() => setShowMap(false)} location={data.location} />
+      ) : (
+        <ContentWrapper>
+          <IncidentsDetailComponent
+            incidentsDetail={data}
+            token={token}
+            setShowMap={setShowMap}
+          />
+          <History incident={data} fetchResponse={fetchResponseHistory} />
+        </ContentWrapper>
+      )}
     </StyledRow>
   )
 }

--- a/src/signals/my-incidents/pages/styled.ts
+++ b/src/signals/my-incidents/pages/styled.ts
@@ -12,9 +12,8 @@ import {
 import styled from 'styled-components'
 
 export const StyledRow = styled(Row)`
-  @media ${breakpoint('max-width', 'tabletS')} {
-    padding: 0 ${themeSpacing(4)};
-  }
+  max-width: 960px;
+  padding: 0 ${themeSpacing(4)};
 `
 
 export const StyledHeading = styled(Heading)`


### PR DESCRIPTION
## changes
Change useIsFrontOffice.js hook. Front office shouldnt be active on mijn-meldingen. Set 960 as default max-width @ overview. Remove unnecessary wrapper at mijn meldingen detail page.
Ticket: [SIG-4911](https://datapunt.atlassian.net/browse/SIG-4911)

## for testing
go to mijn-meldingen, get token en go to overview. Then you'll see a change in margin of the StyledRow component. This has to do with the themeprovider 
```
  if (!getIsAuthenticated()) {
    config.maxGridWidth = 960
```

## Signalen

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
