### PR TITLE
[fix-4933]: When tabbing and pressing enter over a filter, toggle filter.

### DIFF
--- a/src/signals/IncidentMap/components/FilterPanel/FilterCategory.test.tsx
+++ b/src/signals/IncidentMap/components/FilterPanel/FilterCategory.test.tsx
@@ -16,20 +16,43 @@ const defaultProps: Props = {
 }
 
 describe('FilterCategory', () => {
-  it('checkbox is checked by default', () => {
+  beforeEach(() => {
+    mockOnToggleCategory.mockReset()
+  })
+
+  it('checkbox is checked by default and toggle on click', () => {
     render(<FilterCategory {...defaultProps} />)
+
     expect(screen.getByRole('checkbox', { name: /mockName/ })).toBeChecked()
 
-    const cb = screen.getByRole('checkbox', { name: /mockName/ })
+    const checkBox = screen.getByRole('checkbox', { name: /mockName/ })
 
-    cb.click()
+    checkBox.click()
 
     expect(mockOnToggleCategory).toBeCalledTimes(1)
+  })
 
-    cb.focus()
+  it('should toggle when pressing enter on focus', function () {
+    render(<FilterCategory {...defaultProps} />)
+
+    const checkBox = screen.getByRole('checkbox', { name: /mockName/ })
+
+    checkBox.focus()
 
     userEvent.keyboard('{enter}')
 
-    expect(mockOnToggleCategory).toBeCalledTimes(2)
+    expect(mockOnToggleCategory).toBeCalledTimes(1)
+  })
+
+  it('should toggle when pressing space on focus', function () {
+    render(<FilterCategory {...defaultProps} />)
+
+    const checkBox = screen.getByRole('checkbox', { name: /mockName/ })
+
+    checkBox.focus()
+
+    userEvent.keyboard('{space}')
+
+    expect(mockOnToggleCategory).toBeCalledTimes(1)
   })
 })

--- a/src/signals/IncidentMap/components/FilterPanel/FilterCategory.test.tsx
+++ b/src/signals/IncidentMap/components/FilterPanel/FilterCategory.test.tsx
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: MPL-2.0 */
-/* Copyright (C) 2022 Gemeente Amsterdam */
+/* Copyright (C) 2023 Gemeente Amsterdam */
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 

--- a/src/signals/IncidentMap/components/FilterPanel/FilterCategory.test.tsx
+++ b/src/signals/IncidentMap/components/FilterPanel/FilterCategory.test.tsx
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: MPL-2.0 */
 /* Copyright (C) 2022 Gemeente Amsterdam */
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 
 import type { Props } from './FilterCategory'
 import { FilterCategory } from './FilterCategory'
@@ -18,5 +19,17 @@ describe('FilterCategory', () => {
   it('checkbox is checked by default', () => {
     render(<FilterCategory {...defaultProps} />)
     expect(screen.getByRole('checkbox', { name: /mockName/ })).toBeChecked()
+
+    const cb = screen.getByRole('checkbox', { name: /mockName/ })
+
+    cb.click()
+
+    expect(mockOnToggleCategory).toBeCalledTimes(1)
+
+    cb.focus()
+
+    userEvent.keyboard('{enter}')
+
+    expect(mockOnToggleCategory).toBeCalledTimes(2)
   })
 })

--- a/src/signals/IncidentMap/components/FilterPanel/FilterCategory.tsx
+++ b/src/signals/IncidentMap/components/FilterPanel/FilterCategory.tsx
@@ -23,6 +23,11 @@ export const FilterCategory = ({
       id={text}
       checked={selected}
       onChange={onToggleCategory}
+      onKeyUp={(event) => {
+        if (event.code === 'Enter') {
+          onToggleCategory()
+        }
+      }}
     />
 
     <StyledImg alt={'icon ' + text} src={icon} />

--- a/src/signals/IncidentMap/components/FilterPanel/FilterCategory.tsx
+++ b/src/signals/IncidentMap/components/FilterPanel/FilterCategory.tsx
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: MPL-2.0 */
-/* Copyright (C) 2022 Gemeente Amsterdam */
+/* Copyright (C) 2023 Gemeente Amsterdam */
 import { Checkbox } from '@amsterdam/asc-ui'
 
 import { StyledImg, CategoryItemText, CategoryItem } from './styled'
@@ -22,9 +22,7 @@ export const FilterCategory = ({
       data-testid={text}
       id={text}
       checked={selected}
-      onChange={() => {
-        onToggleCategory()
-      }}
+      onChange={onToggleCategory}
       onKeyDown={(event) => {
         if (['Enter', 'Space'].includes(event.code)) {
           event.preventDefault()

--- a/src/signals/IncidentMap/components/FilterPanel/FilterCategory.tsx
+++ b/src/signals/IncidentMap/components/FilterPanel/FilterCategory.tsx
@@ -22,9 +22,12 @@ export const FilterCategory = ({
       data-testid={text}
       id={text}
       checked={selected}
-      onChange={onToggleCategory}
-      onKeyUp={(event) => {
-        if (event.code === 'Enter') {
+      onChange={() => {
+        onToggleCategory()
+      }}
+      onKeyDown={(event) => {
+        if (['Enter', 'Space'].includes(event.code)) {
+          event.preventDefault()
           onToggleCategory()
         }
       }}

--- a/src/signals/IncidentMap/components/FilterPanel/FilterPanel.test.tsx
+++ b/src/signals/IncidentMap/components/FilterPanel/FilterPanel.test.tsx
@@ -2,7 +2,6 @@
 /* Copyright (C) 2022 Gemeente Amsterdam */
 import { screen, render } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-
 import configuration from 'shared/services/configuration/configuration'
 
 import useFetch from '../../../../hooks/useFetch'
@@ -95,6 +94,29 @@ describe('FilterPanel', () => {
           expect(subCategory.filterActive).toBe(false)
         })
       })
+  })
+
+  it('should set toggle a main category without subcategories', () => {
+    const fetchResponseWithFilters = {
+      ...useFetchResponse,
+      data: fetchCategoriesResponse,
+    }
+
+    jest.mocked(useFetch).mockImplementation(() => fetchResponseWithFilters)
+
+    renderFilterPanel({ filters: mockFiltersLong })
+
+    const testCategory = 'Openbaar groen en water'
+
+    const checkbox = screen.getByTestId(testCategory)
+
+    userEvent.click(checkbox)
+
+    expect(
+      mockSetFilters.mock.calls[1][0].find(
+        (filter: Filter) => filter.name === testCategory
+      ).filterActive
+    ).toBe(false)
   })
 
   it('should not render anything when filters are empty', () => {

--- a/src/signals/IncidentMap/components/FilterPanel/FilterPanel.test.tsx
+++ b/src/signals/IncidentMap/components/FilterPanel/FilterPanel.test.tsx
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: MPL-2.0 */
-/* Copyright (C) 2022 Gemeente Amsterdam */
+/* Copyright (C) 2023 Gemeente Amsterdam */
 import { screen, render } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import configuration from 'shared/services/configuration/configuration'
@@ -30,7 +30,7 @@ const renderFilterPanel = (props: Partial<Props> = {}) =>
   render(<FilterPanel {...defaultProps} {...props} />)
 
 describe('FilterPanel', () => {
-  afterEach(() => {
+  beforeEach(() => {
     jest.resetAllMocks()
   })
 
@@ -109,6 +109,12 @@ describe('FilterPanel', () => {
     const testCategory = 'Openbaar groen en water'
 
     const checkbox = screen.getByTestId(testCategory)
+
+    expect(
+      mockSetFilters.mock.calls[0][0].find(
+        (filter: Filter) => filter.name === testCategory
+      ).filterActive
+    ).toBe(true)
 
     userEvent.click(checkbox)
 

--- a/src/signals/IncidentMap/components/FilterPanel/FilterPanel.tsx
+++ b/src/signals/IncidentMap/components/FilterPanel/FilterPanel.tsx
@@ -3,7 +3,6 @@
 import { Fragment, useCallback, useEffect } from 'react'
 
 import { Heading } from '@amsterdam/asc-ui'
-
 import { useFetch } from 'hooks'
 import configuration from 'shared/services/configuration/configuration'
 import type Categories from 'types/api/categories'
@@ -49,7 +48,6 @@ export const FilterPanel = ({ filters, setFilters, setMapMessage }: Props) => {
   useEffect(() => {
     if (data?.results) {
       const filters: Filter[] = getFilterCategoriesWithIcons(data.results)
-
       setFilters(filters)
     }
   }, [data, setFilters])


### PR DESCRIPTION
Ticket: [SIG-4933](https://datapunt.atlassian.net/browse/SIG-4933)

## changes
currently on meldingenkaart, a user cant focus and keypress 'enter' to toggle this filter. With this pr it can.

## Signalen

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
