### PR TITLE
[fix-4930]: changed text

### DIFF
--- a/src/signals/incident/containers/KtoContainer/components/KtoForm/index.js
+++ b/src/signals/incident/containers/KtoContainer/components/KtoForm/index.js
@@ -164,7 +164,7 @@ const KtoForm = ({
               meta={{
                 label: ` Waarom bent u ${!isSatisfied ? 'on' : ''}tevreden?`,
                 name: 'input',
-                subtitle: 'U kunt meer keuzes maken.',
+                subtitle: 'Kies één van de onderstaande antwoorden',
               }}
               hasError={(errorType) => errors['text_list']?.type === errorType}
               getError={(errorType) => errors['text_list']?.type === errorType}


### PR DESCRIPTION
Ticket: [SIG-4930](https://datapunt.atlassian.net/browse/SIG-4930)

The text in the KTO form said you could choose multiple answers while this is not the case. Changed the text to "Kies één van de onderstaande antwoorden".