### PR TITLE
[fix-4934]: fix incidentMap subcategory filter

### DIFF
--- a/src/signals/IncidentMap/components/FilterPanel/utils.ts
+++ b/src/signals/IncidentMap/components/FilterPanel/utils.ts
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: MPL-2.0 */
-/* Copyright (C) 2022 Gemeente Amsterdam */
+/* Copyright (C) 2022 - 2023 Gemeente Amsterdam */
 import { defaultIcon } from 'shared/services/configuration/map-markers'
 import type { Category } from 'types/category'
 

--- a/src/signals/IncidentMap/components/FilterPanel/utils.ts
+++ b/src/signals/IncidentMap/components/FilterPanel/utils.ts
@@ -22,7 +22,7 @@ export const getFilterCategoriesWithIcons = (
         incidentsCount: 0,
       }
 
-      if (sub_categories && showSubCategoryFilter(category)) {
+      if (sub_categories && showSubCategoryFilter(category.slug)) {
         categoriesWithIcons.subCategories = getSubCategories(sub_categories)
       }
 
@@ -30,8 +30,8 @@ export const getFilterCategoriesWithIcons = (
     })
 }
 
-function showSubCategoryFilter(category: Category) {
-  return ['afval', 'wegen-verkeer-straatmeubilair'].includes(category.slug)
+export const showSubCategoryFilter = (slug: Category['slug']) => {
+  return ['afval', 'wegen-verkeer-straatmeubilair'].includes(slug)
 }
 
 const getSubCategories = (

--- a/src/signals/IncidentMap/components/__test__/mock-incidents.ts
+++ b/src/signals/IncidentMap/components/__test__/mock-incidents.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2022 Gemeente Amsterdam
+// Copyright (C) 2022 - 2023 Gemeente Amsterdam
 
 import type { Incident } from '../../types'
 

--- a/src/signals/IncidentMap/components/__test__/mock-incidents.ts
+++ b/src/signals/IncidentMap/components/__test__/mock-incidents.ts
@@ -69,11 +69,11 @@ export const mockIncidentsShort: Incident[] = [
     },
     properties: {
       category: {
-        name: 'Openbaar groen en water',
-        slug: 'openbaar-groen-en-water',
+        name: 'Eikenprocessierups',
+        slug: 'eikenprocessierups',
         parent: {
           name: 'Openbaar groen en water',
-          slug: 'openbaar groen en water',
+          slug: 'openbaar-groen-en-water',
         },
       },
       icon: 'https://ae70d54aca324d0480ca01934240c78f.objectstore.eu/signals/icons/categories/afval/afval.svg?temp_url_sig=6679c552c423eb18ffe55643e5692fb4c348bde4e2bde851f33a7aef8d0474fe&temp_url_expires=1665401494',

--- a/src/signals/IncidentMap/components/utils/get-filtered-incidents.test.ts
+++ b/src/signals/IncidentMap/components/utils/get-filtered-incidents.test.ts
@@ -5,26 +5,9 @@ import { mockIncidentsShort } from '../__test__/mock-incidents'
 import { getFilteredIncidents } from './get-filtered-incidents'
 
 describe('getFilteredIncidents', () => {
-  afterEach(() => {
-    jest.resetAllMocks()
-  })
-  it('should return only active filters', () => {
+  it('should return only active incidents', () => {
     const result = getFilteredIncidents(mockFiltersShort, mockIncidentsShort)
 
-    expect(result.length).toEqual(4)
-  })
-  it('should return only active filters with the first without icon', () => {
-    const filters = mockFiltersShort.map(removeIcons)
-    const result = getFilteredIncidents(filters, mockIncidentsShort)
-
-    expect(result.length).toEqual(4)
+    expect(result.length).toEqual(3)
   })
 })
-
-const removeIcons = (feature: any) => {
-  const f = { ...feature, icon: '' }
-  if (f.subCategories) {
-    f.subCategories = f.subCategories?.map(removeIcons)
-  }
-  return f
-}

--- a/src/signals/IncidentMap/components/utils/get-filtered-incidents.test.ts
+++ b/src/signals/IncidentMap/components/utils/get-filtered-incidents.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2022 Gemeente Amsterdam
+// Copyright (C) 2022 - 2023 Gemeente Amsterdam
 import { mockFiltersShort } from '../__test__/mock-filters'
 import { mockIncidentsShort } from '../__test__/mock-incidents'
 import { getFilteredIncidents } from './get-filtered-incidents'

--- a/src/signals/IncidentMap/components/utils/get-filtered-incidents.ts
+++ b/src/signals/IncidentMap/components/utils/get-filtered-incidents.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2022 Gemeente Amsterdam
-
 import type { Filter, Incident } from '../../types'
+import { showSubCategoryFilter } from '../FilterPanel/utils'
 /*
 When mainCategory is checked, all incidents on the map needs to be shown except for those incidents where the subCategory
 of the maintCategory is unchecked.
@@ -33,7 +33,8 @@ export const getFilteredIncidents = (
   const activeIncidents = incidents.filter((incident) => {
     return (
       activeSlugs.includes(incident.properties.category.slug) ||
-      activeSlugs.includes(incident.properties.category.parent.slug)
+      (!showSubCategoryFilter(incident.properties.category.parent.slug) &&
+        activeSlugs.includes(incident.properties.category.parent.slug))
     )
   })
 

--- a/src/signals/IncidentMap/components/utils/get-filtered-incidents.ts
+++ b/src/signals/IncidentMap/components/utils/get-filtered-incidents.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2022 Gemeente Amsterdam
+// Copyright (C) 2022 -2023 Gemeente Amsterdam
 import type { Filter, Incident } from '../../types'
 import { showSubCategoryFilter } from '../FilterPanel/utils'
 /*

--- a/src/signals/incident/components/IncidentForm/index.tsx
+++ b/src/signals/incident/components/IncidentForm/index.tsx
@@ -232,7 +232,10 @@ const IncidentForm = forwardRef<any, any>(
                           handler={() => ({
                             onChange: (e: BaseSyntheticEvent) => {
                               value.meta && onChange(e.target.value)
-                              if (submitting) {
+                              if (
+                                submitting ||
+                                value.meta.name == 'description'
+                              ) {
                                 reactHookFormProps.trigger(value.meta.name)
                               }
                             },


### PR DESCRIPTION
Ticket: [SIG-4934](https://datapunt.atlassian.net/browse/SIG-4934)

Filtering on subcategory did not work as expected. When selecting/deselecting a subcategory, all incidents of the main category where shown. This was because `activeIncidents` where defined as having an active filter slug on main PR subcategory. While, when a mainCategoryFilter has the option to filter in subcategories as well, an incident can have a deslected subcategory while the main category stays selected. This incident should be treated as deselected, not as selected. 

## Changes
- changes the function that checks whether an incident is active
- adjusted the test. Which had a wrong assertion, therefore passed while faulty. 
