### PR TITLE
[fix-4938]: Validate source when creating incident.

### DIFF
--- a/src/signals/incident/components/IncidentForm/index.tsx
+++ b/src/signals/incident/components/IncidentForm/index.tsx
@@ -153,7 +153,7 @@ const IncidentForm = forwardRef<any, any>(
         if (next) {
           if (
             prevState.current.loading &&
-            (await reactHookFormProps.trigger('description'))
+            (await reactHookFormProps.trigger(['description', 'source']))
           ) {
             next()
             setStepsCompletedCount(index + 1)


### PR DESCRIPTION
Ticket: [SIG-4938](https://datapunt.atlassian.net/browse/SIG-4938)

## for testers
Currently, you can set a category, press next without blurring the textfield, and while your subcategory request is pending, go to the next step. In this pr the source field is also validated before going to the next step.

## Signalen

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)


[SIG-4938]: https://datapunt.atlassian.net/browse/SIG-4938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SIG-4938]: https://datapunt.atlassian.net/browse/SIG-4938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ