### PR TITLE
[fix]: Hide 'Extern' button when incident is closed

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/components/DetailHeader/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/DetailHeader/index.js
@@ -9,7 +9,10 @@ import styled from 'styled-components'
 import BackLink from 'components/BackLink'
 import Button from 'components/Button'
 import configuration from 'shared/services/configuration/configuration'
-import { isStatusEnd } from 'signals/incident-management/definitions/statusList'
+import {
+  isStatusEnd,
+  isStatusClosed,
+} from 'signals/incident-management/definitions/statusList'
 import {
   MAP_URL,
   INCIDENT_URL,
@@ -77,9 +80,15 @@ const DetailHeader = () => {
     return true
   }, [incident])
 
-  const canThor = ['m', 'i', 'b', 'h', 'send failed', 'reopened'].includes(
-    incident.status?.state
-  )
+  const forwardToExternalIsAllowed = !isStatusClosed(incident.status?.state)
+  const thorIsAllowed = [
+    'm',
+    'i',
+    'b',
+    'h',
+    'send failed',
+    'reopened',
+  ].includes(incident.status?.state)
   const downloadLink = incident?._links?.['sia:pdf']?.href
 
   const referrer = location.referrer?.startsWith(MAP_URL)
@@ -133,7 +142,7 @@ const DetailHeader = () => {
             </Button>
           )}
 
-          {canThor && configuration.featureFlags.showThorButton && (
+          {thorIsAllowed && configuration.featureFlags.showThorButton && (
             <Button
               type="button"
               variant="application"
@@ -144,17 +153,18 @@ const DetailHeader = () => {
             </Button>
           )}
 
-          {configuration.featureFlags.enableForwardIncidentToExternal && (
-            <Button
-              type="button"
-              variant="application"
-              onClick={() => toggleExternal()}
-              data-testid="detail-header-button-external"
-              title="Doorzetten naar extern"
-            >
-              Extern
-            </Button>
-          )}
+          {forwardToExternalIsAllowed &&
+            configuration.featureFlags.enableForwardIncidentToExternal && (
+              <Button
+                type="button"
+                variant="application"
+                onClick={() => toggleExternal()}
+                data-testid="detail-header-button-external"
+                title="Doorzetten naar extern"
+              >
+                Extern
+              </Button>
+            )}
 
           <DownloadButton
             label="PDF"

--- a/src/signals/incident-management/containers/IncidentDetail/components/DetailHeader/index.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/DetailHeader/index.test.js
@@ -231,6 +231,30 @@ describe('signals/incident-management/containers/IncidentDetail/components/Detai
     })
   })
 
+  it('should render no Extern button when status is "o" or "a"', () => {
+    const { rerender } = render(
+      renderWithContext({
+        ...incidentFixture,
+        status: { ...incidentFixture.status, state: 'o' },
+      })
+    )
+
+    expect(
+      screen.queryByTestId('detail-header-button-external')
+    ).not.toBeInTheDocument()
+
+    rerender(
+      renderWithContext({
+        ...incidentFixture,
+        status: { ...incidentFixture.status, state: 'a' },
+      })
+    )
+
+    expect(
+      screen.queryByTestId('detail-header-button-external')
+    ).not.toBeInTheDocument()
+  })
+
   it('should toggle external when Extern button is clicked', () => {
     render(renderWithContext())
 

--- a/src/signals/incident-management/containers/IncidentDetail/components/ForwardToExternal/styled.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/ForwardToExternal/styled.tsx
@@ -46,6 +46,7 @@ export const ImageWrapper = styled.div`
 `
 
 export const Image = styled.img`
-  width: 80px;
+  max-width: 80px;
+  max-height: 80px;
   object-fit: cover;
 `


### PR DESCRIPTION
## Signalen

### Context

When an incident has been closed (_Afgehandeld_ or _Gennuleerd_), it should not be possible to forward it to an external party. In this case, the "Extern" button should simply not be rendered.


### Note

Besides the issue described above, this PR provides a minor styling fix in the forward to external form: images in portrait orientation were stretched vertically. 