### PR TITLE
[fix-4922]: color-link-is-blue

### DIFF
--- a/src/signals/incident/components/form/PlainText/index.js
+++ b/src/signals/incident/components/form/PlainText/index.js
@@ -69,9 +69,6 @@ const getStyle = (type) => {
     case 'message':
       return css`
         color: ${themeColor('tint', 'level7')};
-        a {
-          color: inherit;
-        }
       `
     default:
       return css`


### PR DESCRIPTION
**Context**
The wish was to have a Markdown link in a plainText component colored blue. It inherited it's color, so that was removed. No other plainText with type message is used in conjunction with a Markdown link.
The line-heigth was addressed in an earlier sprint with Linda and does not need to change.

**Change**
- plainText type message the styling of a has been removed. 

Ticket: [SIG-4922](https://datapunt.atlassian.net/browse/SIG-4922)

## Signalen

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
