### PR TITLE
Add test for IncidentForms' handleSubmit validation of source and description.

### DIFF
--- a/src/signals/incident/components/IncidentForm/index.test.js
+++ b/src/signals/incident/components/IncidentForm/index.test.js
@@ -412,13 +412,19 @@ describe('<IncidentForm />', () => {
   })
 
   describe('handleSubmit', () => {
-    it('should trigger description and source validation', () => {
+    it('should trigger description and source validation', async () => {
       const fieldConfig = {
         controls: {
-          ...requiredFieldConfig.controls,
+          $field_0: {
+            isStatic: false,
+            render: IncidentNavigation,
+          },
           description: {
             meta: {
               label: 'description',
+            },
+            options: {
+              validators: ['required'],
             },
             render: FormComponents.TextInput,
           },
@@ -426,12 +432,13 @@ describe('<IncidentForm />', () => {
             meta: {
               label: 'source',
             },
-            render: FormComponents.HiddenInput,
+            options: {
+              validators: ['required'],
+            },
+            render: FormComponents.TextInput,
           },
         },
       }
-
-      const triggerSpy = jest.fn().mockImplementation(() => true)
 
       const props = {
         ...defaultProps,
@@ -440,23 +447,31 @@ describe('<IncidentForm />', () => {
           loadingData: true,
         },
         fieldConfig,
-        reactHookFormProps: {
-          trigger: triggerSpy,
-          formState: {
-            errors: {
-              phone: {},
-            },
-          },
-        },
       }
 
       renderIncidentForm(props)
 
-      act(() => {
+      await waitFor(() => {
+        userEvent.type(screen.getByLabelText('description'), 'afval')
+      })
+
+      await waitFor(() => {
         userEvent.click(screen.getByText(mockForm.nextButtonLabel))
       })
 
-      expect(triggerSpy).toBeCalledWith(['description', 'source'])
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        'Dit is een verplicht veld'
+      )
+
+      await waitFor(() => {
+        userEvent.type(screen.getByLabelText('source'), 'afvalpunt')
+      })
+
+      await waitFor(() => {
+        userEvent.click(screen.getByText(mockForm.nextButtonLabel))
+      })
+
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument()
     })
   })
 })

--- a/src/signals/incident/components/IncidentForm/index.test.js
+++ b/src/signals/incident/components/IncidentForm/index.test.js
@@ -467,10 +467,6 @@ describe('<IncidentForm />', () => {
         userEvent.type(screen.getByLabelText('source'), 'afvalpunt')
       })
 
-      await waitFor(() => {
-        userEvent.click(screen.getByText(mockForm.nextButtonLabel))
-      })
-
       expect(screen.queryByRole('alert')).not.toBeInTheDocument()
     })
   })

--- a/src/signals/incident/components/IncidentForm/index.test.js
+++ b/src/signals/incident/components/IncidentForm/index.test.js
@@ -410,4 +410,53 @@ describe('<IncidentForm />', () => {
       })
     })
   })
+
+  describe('handleSubmit', () => {
+    it('should trigger description and source validation', () => {
+      const fieldConfig = {
+        controls: {
+          ...requiredFieldConfig.controls,
+          description: {
+            meta: {
+              label: 'description',
+            },
+            render: FormComponents.TextInput,
+          },
+          source: {
+            meta: {
+              label: 'source',
+            },
+            render: FormComponents.HiddenInput,
+          },
+        },
+      }
+
+      const triggerSpy = jest.fn().mockImplementation(() => true)
+
+      const props = {
+        ...defaultProps,
+        incidentContainer: {
+          ...defaultProps.incidentContainer,
+          loadingData: true,
+        },
+        fieldConfig,
+        reactHookFormProps: {
+          trigger: triggerSpy,
+          formState: {
+            errors: {
+              phone: {},
+            },
+          },
+        },
+      }
+
+      renderIncidentForm(props)
+
+      act(() => {
+        userEvent.click(screen.getByText(mockForm.nextButtonLabel))
+      })
+
+      expect(triggerSpy).toBeCalledWith(['description', 'source'])
+    })
+  })
 })


### PR DESCRIPTION
## context 
This test assures that a source and description is given before the next step method is called. This test suite makes use of a nextSpy instead of really going to the next page. We could rewrite the suite to really go to a next step for a more realistic scenario. This will take some time however.

## Signalen

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
