### PR TITLE
[refactor-4656]: convert Modal/index.js to Modal.tsx

### DIFF
--- a/src/components/Modal/Modal.test.tsx
+++ b/src/components/Modal/Modal.test.tsx
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2019 - 2021 Gemeente Amsterdam
+// Copyright (C) 2023 Gemeente Amsterdam
 import { render, fireEvent } from '@testing-library/react'
+
 import { withAppContext } from 'test/utils'
 
-import Modal from '..'
+import Modal from './Modal'
 
 describe('components/Modal', () => {
   it('should have a heading', () => {

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2019 - 2022 Gemeente Amsterdam
-import PropTypes from 'prop-types'
-import styled, { css } from 'styled-components'
+// Copyright (C) 2023 Gemeente Amsterdam
+import type { ReactNode } from 'react'
+
+import { Close as CloseIcon } from '@amsterdam/asc-assets'
 import {
   Button,
   Row,
@@ -10,7 +11,8 @@ import {
   Heading,
   themeColor,
 } from '@amsterdam/asc-ui'
-import { Close as CloseIcon } from '@amsterdam/asc-assets'
+import PropTypes from 'prop-types'
+import styled, { css } from 'styled-components'
 
 export const ModalWrapper = styled.div`
   position: fixed;
@@ -62,8 +64,14 @@ const Header = styled.header`
 const StyledColumn = styled(Column)`
   flex-direction: column;
 `
+interface ModalProps {
+  children: ReactNode
+  title: string
+  onClose: () => void
+  isOpen: boolean
+}
 
-const Modal = ({ children, title, onClose, ...rest }) => (
+const Modal = ({ children, title, onClose, ...rest }: ModalProps) => (
   <ModalWrapper>
     <StyledModal data-testid="modal" open backdropOpacity={1} {...rest}>
       <Header>

--- a/src/components/Modal/index.ts
+++ b/src/components/Modal/index.ts
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (C) 2023 Gemeente Amsterdam
+export { default } from './Modal'

--- a/src/signals/settings/users/Overview/__tests__/Overview.test.tsx
+++ b/src/signals/settings/users/Overview/__tests__/Overview.test.tsx
@@ -105,7 +105,7 @@ describe('signals/settings/users/containers/Overview', () => {
       .mockImplementation(() => () => true)
 
     const { rerender, unmount } = render(withAppContext(<UsersOverview />))
-    screen.debug()
+
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     await waitForElementToBeRemoved(screen.queryByTestId('loading-indicator'))
 


### PR DESCRIPTION
**Context**
All files need to convert to typescript

**Changes**
Converted Modal/index.js to Modal.tsx
Added index.ts 
Restructured folder structure so that Modal.test will be next to Modal.tsx and not in a seperate test folder.
Made prop IsOpen  explicit

Ticket: [SIG-4656](https://datapunt.atlassian.net/browse/SIG-4656)
Ticket: [SIG-4941](https://datapunt.atlassian.net/browse/SIG-4941)

## Signalen

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)


[SIG-4656]: https://datapunt.atlassian.net/browse/SIG-4656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SIG-4941]: https://datapunt.atlassian.net/browse/SIG-4941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ