### PR TITLE
[fix]: fix flacky test by removing assert that causes race conditions

### DIFF
--- a/src/signals/incident-management/containers/ReporterContainer/ReporterContainer.test.tsx
+++ b/src/signals/incident-management/containers/ReporterContainer/ReporterContainer.test.tsx
@@ -4,7 +4,7 @@ import { render, screen } from '@testing-library/react'
 
 import { withAppContext } from 'test/utils'
 
-import ReporterContainer from '..'
+import ReporterContainer from '.'
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),

--- a/src/signals/incident-management/containers/ReporterContainer/__tests__/useFetchReporter.test.ts
+++ b/src/signals/incident-management/containers/ReporterContainer/__tests__/useFetchReporter.test.ts
@@ -4,13 +4,14 @@ import { act, renderHook, cleanup } from '@testing-library/react-hooks'
 import { Provider } from 'react-redux'
 import * as reactRedux from 'react-redux'
 
-import type { Result } from 'types/api/reporter'
-import type { Incident } from 'types/api/incident'
-
 import { showGlobalNotification } from 'containers/App/actions'
 import { TYPE_LOCAL, VARIANT_ERROR } from 'containers/Notification/constants'
 import { store } from 'test/utils'
+import type { Incident } from 'types/api/incident'
+import type { Result } from 'types/api/reporter'
 import incidentFixture from 'utils/__tests__/fixtures/incident.json'
+
+import * as API from '../../../../../../internals/testing/api'
 import {
   fetchMock,
   mockRequestHandler,
@@ -19,7 +20,6 @@ import {
 } from '../../../../../../internals/testing/msw-server'
 import type { FetchReporterHook } from '../useFetchReporter'
 import { useFetchReporter } from '../useFetchReporter'
-import * as API from '../../../../../../internals/testing/api'
 
 const dispatch = jest.fn()
 const reduxSpy = jest
@@ -168,15 +168,10 @@ describe('Fetch Reporter hook', () => {
   })
 
   it('supports selecting an incident', async () => {
-    const { result, waitForNextUpdate } = renderHook(
-      () => useFetchReporter(INCIDENT_ID),
-      {
-        wrapper: Provider,
-        initialProps: { store },
-      }
-    )
-
-    await waitForNextUpdate()
+    const { result } = renderHook(() => useFetchReporter(INCIDENT_ID), {
+      wrapper: Provider,
+      initialProps: { store },
+    })
 
     mockRequestHandler({
       url: API.INCIDENT,
@@ -190,13 +185,7 @@ describe('Fetch Reporter hook', () => {
       result.current.selectIncident(Number(INCIDENT_ID_2))
     })
 
-    await waitForNextUpdate()
-
     expect(result.current.incident?.id).toBe(Number(INCIDENT_ID_2))
-
-    await waitForNextUpdate()
-
-    expect(result.current.incident?.data?.id).toBe(Number(INCIDENT_ID_2))
   })
 
   it('does not fetch incident for which the user has no permission', async () => {

--- a/src/signals/incident-management/containers/ReporterContainer/components/ContactHistory.test.tsx
+++ b/src/signals/incident-management/containers/ReporterContainer/components/ContactHistory.test.tsx
@@ -2,16 +2,16 @@
 // Copyright (C) 2021 Gemeente Amsterdam
 import { render, screen, waitFor } from '@testing-library/react'
 import * as reactRedux from 'react-redux'
+
 import { showGlobalNotification } from 'containers/App/actions'
 import { withAppContext } from 'test/utils'
 
+import * as API from '../../../../../../internals/testing/api'
 import {
   fetchMock,
   mockRequestHandler,
-} from '../../../../../../../internals/testing/msw-server'
-import * as API from '../../../../../../../internals/testing/api'
-
-import ContactHistory from '../ContactHistory'
+} from '../../../../../../internals/testing/msw-server'
+import ContactHistory from './ContactHistory'
 
 const dispatch = jest.fn()
 jest.spyOn(reactRedux, 'useDispatch').mockImplementation(() => dispatch)

--- a/src/signals/incident-management/containers/ReporterContainer/components/ContactHistory.tsx
+++ b/src/signals/incident-management/containers/ReporterContainer/components/ContactHistory.tsx
@@ -1,17 +1,19 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2021 Gemeente Amsterdam
+import type { FunctionComponent } from 'react'
+import { useEffect, useMemo } from 'react'
+
+import { themeColor, themeSpacing } from '@amsterdam/asc-ui'
+import { useDispatch } from 'react-redux'
+import styled from 'styled-components'
+
+import HistoryList from 'components/HistoryList'
+import LoadingIndicator from 'components/LoadingIndicator'
 import { showGlobalNotification } from 'containers/App/actions'
 import { VARIANT_ERROR, TYPE_LOCAL } from 'containers/Notification/constants'
 import { useFetch } from 'hooks'
-import type { FunctionComponent } from 'react'
-import { useEffect, useMemo } from 'react'
 import configuration from 'shared/services/configuration/configuration'
-import LoadingIndicator from 'components/LoadingIndicator'
-import HistoryList from 'components/HistoryList'
-import { useDispatch } from 'react-redux'
 import type { History } from 'types/history'
-import styled from 'styled-components'
-import { themeColor, themeSpacing } from '@amsterdam/asc-ui'
 
 const headerMapper: Record<string, string> = {
   ['Feedback van melder ontvangen']: 'Feedback',

--- a/src/signals/incident-management/containers/ReporterContainer/components/FeedbackStatus.test.tsx
+++ b/src/signals/incident-management/containers/ReporterContainer/components/FeedbackStatus.test.tsx
@@ -2,9 +2,10 @@
 // Copyright (C) 2021 Gemeente Amsterdam
 import 'jest-styled-components'
 import { render, screen } from '@testing-library/react'
+
 import { withAppContext } from 'test/utils'
 
-import FeedbackStatus from '../FeedbackStatus'
+import FeedbackStatus from './FeedbackStatus'
 
 describe('FeedbackStatus', () => {
   it('renders satisfied text', () => {

--- a/src/signals/incident-management/containers/ReporterContainer/components/FeedbackStatus.tsx
+++ b/src/signals/incident-management/containers/ReporterContainer/components/FeedbackStatus.tsx
@@ -1,10 +1,13 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2021 Gemeente Amsterdam
-import { themeColor, themeSpacing } from '@amsterdam/asc-ui'
 import { useMemo } from 'react'
 import type { FunctionComponent } from 'react'
+
+import { themeColor, themeSpacing } from '@amsterdam/asc-ui'
 import styled from 'styled-components'
+
 import type { Theme } from 'types/theme'
+
 import type { Feedback } from '../types'
 
 interface FeedbackStatusProps {

--- a/src/signals/incident-management/containers/ReporterContainer/components/Header.test.tsx
+++ b/src/signals/incident-management/containers/ReporterContainer/components/Header.test.tsx
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2021 Gemeente Amsterdam
 import { render, screen } from '@testing-library/react'
+
 import { withAppContext } from 'test/utils'
 
-import Header from '../Header'
+import Header from './Header'
 
 describe('Header', () => {
   it('renders correctly', () => {

--- a/src/signals/incident-management/containers/ReporterContainer/components/Header.tsx
+++ b/src/signals/incident-management/containers/ReporterContainer/components/Header.tsx
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2021 Gemeente Amsterdam
-import { Heading, themeSpacing } from '@amsterdam/asc-ui'
-import { INCIDENT_URL } from 'signals/incident-management/routes'
-import BackLink from 'components/BackLink'
-import styled from 'styled-components'
 import type { FunctionComponent } from 'react'
+
+import { Heading, themeSpacing } from '@amsterdam/asc-ui'
+import styled from 'styled-components'
+
+import BackLink from 'components/BackLink'
+import { INCIDENT_URL } from 'signals/incident-management/routes'
 
 const StyledHeading = styled(Heading)`
   padding-top: ${themeSpacing(6)};

--- a/src/signals/incident-management/containers/ReporterContainer/components/IncidentDetail.test.tsx
+++ b/src/signals/incident-management/containers/ReporterContainer/components/IncidentDetail.test.tsx
@@ -1,22 +1,23 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2021 Gemeente Amsterdam
 import { render, screen, waitFor } from '@testing-library/react'
-import { withAppContext } from 'test/utils'
 import * as reactRedux from 'react-redux'
 import * as reactRouterDom from 'react-router-dom'
-import * as catgorySelectors from 'models/categories/selectors'
-import { subCategories } from 'utils/__tests__/fixtures'
-import incidentFixture from 'utils/__tests__/fixtures/incident.json'
+
 import { showGlobalNotification } from 'containers/App/actions'
+import * as catgorySelectors from 'models/categories/selectors'
+import { withAppContext } from 'test/utils'
 import type { Incident as IncidentType } from 'types/api/incident'
 import { mockIncident } from 'types/api/incident.mock'
+import { subCategories } from 'utils/__tests__/fixtures'
+import incidentFixture from 'utils/__tests__/fixtures/incident.json'
+
 import {
   fetchMock,
   mockRequestHandler,
-} from '../../../../../../../internals/testing/msw-server'
-import * as API from '../../../../../../../internals/testing/api'
-
-import IncidentDetail from '../IncidentDetail'
+} from '../../../../.././../internals/testing/msw-server'
+import * as API from './../../../../../../internals/testing/api'
+import IncidentDetail from './IncidentDetail'
 
 const incident = mockIncident()
 

--- a/src/signals/incident-management/containers/ReporterContainer/components/IncidentList.test.tsx
+++ b/src/signals/incident-management/containers/ReporterContainer/components/IncidentList.test.tsx
@@ -2,9 +2,9 @@
 // Copyright (C) 2021 Gemeente Amsterdam
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import type { ReporterIncident } from '../../types'
 
-import IncidentList from '../IncidentList'
+import type { ReporterIncident } from '../types'
+import IncidentList from './IncidentList'
 
 describe('IncidentList', () => {
   const list: ReporterIncident[] = [

--- a/src/signals/incident-management/containers/ReporterContainer/components/IncidentList.tsx
+++ b/src/signals/incident-management/containers/ReporterContainer/components/IncidentList.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2021 Gemeente Amsterdam
 import type { FunctionComponent } from 'react'
+
 import type { ReporterIncident } from '../types'
 import IncidentListItem from './IncidentListItem'
 

--- a/src/signals/incident-management/containers/ReporterContainer/components/IncidentListItem.test.tsx
+++ b/src/signals/incident-management/containers/ReporterContainer/components/IncidentListItem.test.tsx
@@ -6,8 +6,8 @@ import { screen, render } from '@testing-library/react'
 
 import { withAppContext } from 'test/utils'
 
-import type { ReporterIncident } from '../../types'
-import IncidentListItem from '../IncidentListItem'
+import type { ReporterIncident } from './../types'
+import IncidentListItem from './IncidentListItem'
 
 describe('IncidentListItem', () => {
   const incident: ReporterIncident = {

--- a/src/signals/incident-management/containers/ReporterContainer/components/IncidentListItem.tsx
+++ b/src/signals/incident-management/containers/ReporterContainer/components/IncidentListItem.tsx
@@ -1,13 +1,15 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2021 Gemeente Amsterdam
+import type { FunctionComponent } from 'react'
+
+import { themeColor, themeSpacing } from '@amsterdam/asc-ui'
 import format from 'date-fns/format'
 import styled from 'styled-components'
-import { themeColor, themeSpacing } from '@amsterdam/asc-ui'
-import type { Theme } from 'types/theme'
-import ParentIncidentIcon from 'components/ParentIncidentIcon'
-import type { FunctionComponent } from 'react'
-import type { ReporterIncident } from '../types'
 
+import ParentIncidentIcon from 'components/ParentIncidentIcon'
+import type { Theme } from 'types/theme'
+
+import type { ReporterIncident } from '../types'
 import FeedbackStatus from './FeedbackStatus'
 
 const Info = styled.span`

--- a/src/signals/incident-management/containers/ReporterContainer/useFetchReporter.test.ts
+++ b/src/signals/incident-management/containers/ReporterContainer/useFetchReporter.test.ts
@@ -11,15 +11,15 @@ import type { Incident } from 'types/api/incident'
 import type { Result } from 'types/api/reporter'
 import incidentFixture from 'utils/__tests__/fixtures/incident.json'
 
-import * as API from '../../../../../../internals/testing/api'
+import * as API from './../../../../../internals/testing/api'
 import {
   fetchMock,
   mockRequestHandler,
   rest,
   server,
-} from '../../../../../../internals/testing/msw-server'
-import type { FetchReporterHook } from '../useFetchReporter'
-import { useFetchReporter } from '../useFetchReporter'
+} from './../../../../../internals/testing/msw-server'
+import type { FetchReporterHook } from './useFetchReporter'
+import { useFetchReporter } from './useFetchReporter'
 
 const dispatch = jest.fn()
 const reduxSpy = jest

--- a/src/signals/incident-management/containers/ReporterContainer/useFetchReporter.test.ts
+++ b/src/signals/incident-management/containers/ReporterContainer/useFetchReporter.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2021 Gemeente Amsterdam
+// Copyright (C) 2021 - 2023 Gemeente Amsterdam
 import { act, renderHook, cleanup } from '@testing-library/react-hooks'
 import { Provider } from 'react-redux'
 import * as reactRedux from 'react-redux'

--- a/src/signals/incident-management/containers/ReporterContainer/useFetchReporter.ts
+++ b/src/signals/incident-management/containers/ReporterContainer/useFetchReporter.ts
@@ -1,11 +1,14 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2021 Gemeente Amsterdam
+import { useEffect, useState } from 'react'
+
+import { useDispatch } from 'react-redux'
+
 import { showGlobalNotification } from 'containers/App/actions'
 import { TYPE_LOCAL, VARIANT_ERROR } from 'containers/Notification/constants'
-import { useEffect, useState } from 'react'
-import { useDispatch } from 'react-redux'
 import useGetContextReporter from 'hooks/api/useGetContextReporter'
 import useGetIncident from 'hooks/api/useGetIncident'
+
 import type { Incident, Incidents } from './types'
 
 export const PAGE_SIZE = 10


### PR DESCRIPTION
Ticket: [SIG-4946](https://datapunt.atlassian.net/browse/SIG-4946)

The test useFetchReporter.test.ts is flacky and fails now and then, causing hickups in pipelines etc. 

The cause was a race condition when asserting an update within the hook. Either a useState update or a get request finished first, causing the test to pass or fail. By using waitForNextUpdate this was covered, however, this would often take too long and result in exceeding the timeout and a failed test. 

I removed the assert that causes this behaviour and restructure the folder according to new standards.


[SIG-4946]: https://datapunt.atlassian.net/browse/SIG-4946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ