### PR TITLE
[feat-4951]: add subfilters to configuration

### DIFF
--- a/app.amsterdam.json
+++ b/app.amsterdam.json
@@ -90,6 +90,9 @@
       "minZoom": 7,
       "zoom": 7
     },
+    "optionsIncidentMap": {
+      "hasSubfiltersEnabled": ["afval", "wegen-verkeer-straatmeubilair"]
+    },
     "tiles": {
       "args": [
         "https://{s}.data.amsterdam.nl/topo_rd/{z}/{x}/{y}.png"

--- a/app.base.json
+++ b/app.base.json
@@ -94,6 +94,9 @@
       "minZoom": 7,
       "zoom": 7
     },
+    "optionsIncidentMap": {
+      "hasSubfiltersEnabled": ["afval", "wegen-verkeer-straatmeubilair"]
+    },
     "tiles": {
       "args": [
         "https://service.pdok.nl/brt/achtergrondkaart/wmts/v2_0/standaard/EPSG:28992/{z}/{x}/{y}.png"

--- a/internals/schemas/app.schema.json
+++ b/internals/schemas/app.schema.json
@@ -383,6 +383,9 @@
         "optionsBackOffice": {
           "$ref": "#/definitions/OptionsBackOffice"
         },
+        "optionsIncidentMap": {
+          "$ref": "#/definitions/optionsIncidentMap"
+        },
         "tiles": {
           "$ref": "#/definitions/Tiles"
         },
@@ -531,6 +534,21 @@
       },
       "required": [],
       "title": "OptionsBackOffice"
+    },
+    "optionsIncidentMap": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Array with slugs of main categories that will show subfilters based on the connected subcategories",
+      "title": "OptionsIncidentMap",
+      "properties": {
+        "hasSubfiltersEnabled": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 0
+        }
+      }
     },
     "Tiles": {
       "type": "object",

--- a/internals/schemas/app.schema.json
+++ b/internals/schemas/app.schema.json
@@ -538,7 +538,7 @@
     "optionsIncidentMap": {
       "type": "object",
       "additionalProperties": false,
-      "description": "Array with slugs of main categories that will show subfilters based on the connected subcategories",
+      "description": "Array with slugs of main categories that will show subfilters based on the connected subcategories. Note: main category 'overig', cannot have subcategory filters since it has the same slug as one of his subcategories.",
       "title": "OptionsIncidentMap",
       "properties": {
         "hasSubfiltersEnabled": {

--- a/src/signals/IncidentMap/components/AddressLocation/AddressSearchMobile.test.tsx
+++ b/src/signals/IncidentMap/components/AddressLocation/AddressSearchMobile.test.tsx
@@ -87,6 +87,15 @@ describe('AddresLocation', () => {
     )
   })
 
+  it('should show options', async () => {
+    render(<AddressSearchMobile {...defaultProps} />)
+
+    userEvent.click(screen.getByTestId('get-data-mock-button'))
+
+    expect(screen.getByText('Suggestion #1')).toBeInTheDocument()
+    expect(screen.getByText('Suggestion #2')).toBeInTheDocument()
+  })
+
   it('shows the address in the searchbar', () => {
     const props = {
       ...defaultProps,

--- a/src/signals/IncidentMap/components/FilterPanel/FilterPanel.tsx
+++ b/src/signals/IncidentMap/components/FilterPanel/FilterPanel.tsx
@@ -3,6 +3,7 @@
 import { Fragment, useCallback, useEffect } from 'react'
 
 import { Heading } from '@amsterdam/asc-ui'
+
 import { useFetch } from 'hooks'
 import configuration from 'shared/services/configuration/configuration'
 import type Categories from 'types/api/categories'
@@ -31,7 +32,7 @@ export const FilterPanel = ({ filters, setFilters, setMapMessage }: Props) => {
 
       combinedFilters.forEach((categoryFilter) => {
         if (categoryFilter.filterActive !== newFilterActive) {
-          allFilters = updateFilterCategory(categoryFilter.name, allFilters)
+          allFilters = updateFilterCategory(categoryFilter.slug, allFilters)
         }
       })
       setFilters(allFilters)

--- a/src/signals/IncidentMap/components/FilterPanel/utils.test.ts
+++ b/src/signals/IncidentMap/components/FilterPanel/utils.test.ts
@@ -41,6 +41,7 @@ describe('getFilterCategoriesWithIcon', () => {
 
 describe('showSubCategoryFilter', () => {
   it('should return false on default', () => {
+    configuration.map.optionsIncidentMap.hasSubfiltersEnabled = []
     const result = showSubCategoryFilter('afval')
 
     expect(result).toEqual(false)

--- a/src/signals/IncidentMap/components/FilterPanel/utils.test.ts
+++ b/src/signals/IncidentMap/components/FilterPanel/utils.test.ts
@@ -1,7 +1,11 @@
+import configuration from 'shared/services/configuration/configuration'
 import type Categories from 'types/api/categories'
 
 import { fetchCategoriesResponse } from '../__test__'
 import { getFilterCategoriesWithIcons } from './utils'
+import { showSubCategoryFilter } from './utils'
+
+jest.mock('shared/services/configuration/configuration')
 
 describe('getFilterCategoriesWithIcon', () => {
   const mockData =
@@ -32,5 +36,20 @@ describe('getFilterCategoriesWithIcon', () => {
     ).toEqual(
       'https://ae70d54aca324d0480ca01934240c78f.objectstore.eu/signals/icons/categories/overlast-bedrijven-en-horeca/bedrijven.svg?temp_url_sig=44addc6725e4523b2115f0285d9312c35d006533aee756b3b77344b71c75b98d&temp_url_expires=1665401495'
     )
+  })
+})
+
+describe('showSubCategoryFilter', () => {
+  it('should return false on default', () => {
+    const result = showSubCategoryFilter('afval')
+
+    expect(result).toEqual(false)
+  })
+
+  it('should return true when main category has subFilter enabled', () => {
+    configuration.map.optionsIncidentMap.hasSubfiltersEnabled = ['afval']
+    const result = showSubCategoryFilter('afval')
+
+    expect(result).toEqual(true)
   })
 })

--- a/src/signals/IncidentMap/components/FilterPanel/utils.test.ts
+++ b/src/signals/IncidentMap/components/FilterPanel/utils.test.ts
@@ -40,6 +40,13 @@ describe('getFilterCategoriesWithIcon', () => {
 })
 
 describe('showSubCategoryFilter', () => {
+  beforeEach(() => {
+    configuration.map.optionsIncidentMap.hasSubfiltersEnabled = [
+      'afval',
+      'wegen-verkeer-straatmeubilair',
+    ]
+  })
+
   it('should return false on default', () => {
     configuration.map.optionsIncidentMap.hasSubfiltersEnabled = []
     const result = showSubCategoryFilter('afval')
@@ -48,7 +55,6 @@ describe('showSubCategoryFilter', () => {
   })
 
   it('should return true when main category has subFilter enabled', () => {
-    configuration.map.optionsIncidentMap.hasSubfiltersEnabled = ['afval']
     const result = showSubCategoryFilter('afval')
 
     expect(result).toEqual(true)

--- a/src/signals/IncidentMap/components/FilterPanel/utils.ts
+++ b/src/signals/IncidentMap/components/FilterPanel/utils.ts
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: MPL-2.0 */
 /* Copyright (C) 2022 - 2023 Gemeente Amsterdam */
+import configuration from 'shared/services/configuration/configuration'
 import { defaultIcon } from 'shared/services/configuration/map-markers'
 import type { Category } from 'types/category'
 
@@ -31,7 +32,9 @@ export const getFilterCategoriesWithIcons = (
 }
 
 export const showSubCategoryFilter = (slug: Category['slug']) => {
-  return ['afval', 'wegen-verkeer-straatmeubilair'].includes(slug)
+  return configuration.map.optionsIncidentMap.hasSubfiltersEnabled.includes(
+    slug
+  )
 }
 
 const getSubCategories = (

--- a/src/signals/IncidentMap/components/FilterPanel/utils.ts
+++ b/src/signals/IncidentMap/components/FilterPanel/utils.ts
@@ -50,8 +50,5 @@ const getSubCategories = (
     })
 }
 
-export const showSubCategoryFilter = (slug: Category['slug']) => {
-  return configuration.map.optionsIncidentMap.hasSubfiltersEnabled.includes(
-    slug
-  )
-}
+export const showSubCategoryFilter = (slug: Category['slug']) =>
+  configuration.map.optionsIncidentMap.hasSubfiltersEnabled.includes(slug)

--- a/src/signals/IncidentMap/components/FilterPanel/utils.ts
+++ b/src/signals/IncidentMap/components/FilterPanel/utils.ts
@@ -3,6 +3,7 @@
 import configuration from 'shared/services/configuration/configuration'
 import { defaultIcon } from 'shared/services/configuration/map-markers'
 import type { Category } from 'types/category'
+import type { SubCategory as SubCategoryBackend } from 'types/category'
 
 import type { Filter, SubCategory } from '../../types'
 
@@ -31,14 +32,8 @@ export const getFilterCategoriesWithIcons = (
     })
 }
 
-export const showSubCategoryFilter = (slug: Category['slug']) => {
-  return configuration.map.optionsIncidentMap.hasSubfiltersEnabled.includes(
-    slug
-  )
-}
-
 const getSubCategories = (
-  subCategories: Category['sub_categories'] = []
+  subCategories: SubCategoryBackend[]
 ): SubCategory[] => {
   return subCategories
     .filter(({ is_public_accessible }) => is_public_accessible)
@@ -53,4 +48,10 @@ const getSubCategories = (
         incidentsCount: 0,
       }
     })
+}
+
+export const showSubCategoryFilter = (slug: Category['slug']) => {
+  return configuration.map.optionsIncidentMap.hasSubfiltersEnabled.includes(
+    slug
+  )
 }

--- a/src/signals/IncidentMap/components/utils/update-filter-category.test.ts
+++ b/src/signals/IncidentMap/components/utils/update-filter-category.test.ts
@@ -3,17 +3,17 @@ import { updateFilterCategory } from './update-filter-category'
 
 describe('updateFilterCategory', () => {
   it('should set filter inactive', () => {
-    const result = updateFilterCategory('Afval', mockFiltersLong)
+    const result = updateFilterCategory('afval', mockFiltersLong)
 
     expect(result[0].filterActive).toEqual(false)
   })
 
   it('should set filter active', () => {
-    const result = updateFilterCategory('Afval', mockFiltersLong)
+    const result = updateFilterCategory('afval', mockFiltersLong)
 
     expect(result[0].filterActive).toEqual(false)
 
-    const resultSecond = updateFilterCategory('Afval', result)
+    const resultSecond = updateFilterCategory('afval', result)
 
     expect(resultSecond[0].filterActive).toEqual(true)
   })

--- a/src/signals/IncidentMap/components/utils/update-filter-category.ts
+++ b/src/signals/IncidentMap/components/utils/update-filter-category.ts
@@ -1,11 +1,11 @@
 import type { Filter } from '../../types'
 
 export const updateFilterCategory = (
-  categoryName: string,
+  categorySlug: string,
   filters: Filter[]
 ): Filter[] => {
   return filters.map((filter) => {
-    if (filter.name === categoryName) {
+    if (filter.slug === categorySlug) {
       return {
         ...filter,
         filterActive: !filter.filterActive,
@@ -14,7 +14,7 @@ export const updateFilterCategory = (
     if (filter.subCategories) {
       return {
         ...filter,
-        subCategories: updateFilterCategory(categoryName, filter.subCategories),
+        subCategories: updateFilterCategory(categorySlug, filter.subCategories),
       }
     }
     return filter

--- a/src/types/category.ts
+++ b/src/types/category.ts
@@ -41,12 +41,12 @@ export interface Category {
   sub_categories?: SubCategory[]
 }
 
-interface SubCategory {
+export interface SubCategory {
   name: string
   slug: string
-  _display?: string
+  _display: string
   filterActive: boolean
-  is_public_accessible?: boolean
+  is_public_accessible: boolean
   _links: {
     'sia:icon'?: {
       href: string


### PR DESCRIPTION
Ticket: [SIG-4951](https://datapunt.atlassian.net/browse/SIG-4951)

## Context
The values of the maincategories of which the subcatefory filters were enabled was hard coded. Since other municipalities want to have different filters we want to make them configurable.

## Changes
- Added hasSubcategoriesEnabled to the map options in the configuration file
- Adjust tests

## Release notes
- we should add this configuration in the base file in azure config of acceptance and production
- We should set the correct config for Amsterdam in azure config

[SIG-4951]: https://datapunt.atlassian.net/browse/SIG-4951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ