### PR TITLE
[chore]: reset app.base.json optionsIncidentMap config

### DIFF
--- a/app.base.json
+++ b/app.base.json
@@ -95,7 +95,7 @@
       "zoom": 7
     },
     "optionsIncidentMap": {
-      "hasSubfiltersEnabled": ["afval", "wegen-verkeer-straatmeubilair"]
+      "hasSubfiltersEnabled": ["main-category-slug"]
     },
     "tiles": {
       "args": [
@@ -138,3 +138,4 @@
     }
   }
 }
+

--- a/internals/schemas/app.schema.json
+++ b/internals/schemas/app.schema.json
@@ -384,7 +384,7 @@
           "$ref": "#/definitions/OptionsBackOffice"
         },
         "optionsIncidentMap": {
-          "$ref": "#/definitions/optionsIncidentMap"
+          "$ref": "#/definitions/OptionsIncidentMap"
         },
         "tiles": {
           "$ref": "#/definitions/Tiles"
@@ -535,7 +535,7 @@
       "required": [],
       "title": "OptionsBackOffice"
     },
-    "optionsIncidentMap": {
+    "OptionsIncidentMap": {
       "type": "object",
       "additionalProperties": false,
       "description": "Array with slugs of main categories that will show subfilters based on the connected subcategories. Note: main category 'overig', cannot have subcategory filters since it has the same slug as one of his subcategories.",
@@ -636,3 +636,4 @@
     }
   }
 }
+

--- a/src/signals/IncidentMap/components/FilterPanel/utils.test.ts
+++ b/src/signals/IncidentMap/components/FilterPanel/utils.test.ts
@@ -8,6 +8,12 @@ import { showSubCategoryFilter } from './utils'
 jest.mock('shared/services/configuration/configuration')
 
 describe('getFilterCategoriesWithIcon', () => {
+  beforeEach(() => {
+    configuration.map.optionsIncidentMap.hasSubfiltersEnabled = [
+      'afval',
+      'wegen-verkeer-straatmeubilair',
+    ]
+  })
   const mockData =
     fetchCategoriesResponse.results as unknown as Categories['results']
 

--- a/src/signals/IncidentMap/components/utils/get-filtered-incidents.test.ts
+++ b/src/signals/IncidentMap/components/utils/get-filtered-incidents.test.ts
@@ -1,8 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2022 - 2023 Gemeente Amsterdam
+import configuration from 'shared/services/configuration/configuration'
+
 import { mockFiltersShort } from '../__test__/mock-filters'
 import { mockIncidentsWithoutIcon } from '../__test__/mock-incidents-without-icon'
 import { getFilteredIncidents } from './get-filtered-incidents'
+
+jest.mock('shared/services/configuration/configuration')
 
 const mockFiltersAllActive = mockFiltersShort.map((filter) => {
   if (filter.subCategories) {
@@ -25,6 +29,13 @@ const mockFiltersAllActive = mockFiltersShort.map((filter) => {
 })
 
 describe('getFilteredIncidents', () => {
+  beforeEach(() => {
+    configuration.map.optionsIncidentMap.hasSubfiltersEnabled = [
+      'afval',
+      'wegen-verkeer-straatmeubilair',
+    ]
+  })
+
   it('should return only active incidents', () => {
     const result = getFilteredIncidents(
       mockFiltersShort,

--- a/src/signals/incident-management/containers/ReporterContainer/useFetchReporter.test.ts
+++ b/src/signals/incident-management/containers/ReporterContainer/useFetchReporter.test.ts
@@ -6,6 +6,7 @@ import * as reactRedux from 'react-redux'
 
 import { showGlobalNotification } from 'containers/App/actions'
 import { TYPE_LOCAL, VARIANT_ERROR } from 'containers/Notification/constants'
+import configuration from 'shared/services/configuration/configuration'
 import { store } from 'test/utils'
 import type { Incident } from 'types/api/incident'
 import type { Result } from 'types/api/reporter'
@@ -29,6 +30,7 @@ const reduxSpy = jest
 fetchMock.disableMocks()
 
 jest.mock('react-router-dom')
+jest.mock('shared/services/configuration/configuration')
 
 const INCIDENT_ID = '4440'
 const INCIDENT_ID_2 = '4441'
@@ -54,6 +56,12 @@ const REPORTER_MOCK: Result = {
 }
 
 describe('Fetch Reporter hook', () => {
+  beforeEach(() => {
+    configuration.map.optionsIncidentMap.hasSubfiltersEnabled = [
+      'afval',
+      'wegen-verkeer-straatmeubilair',
+    ]
+  })
   afterEach(cleanup)
   afterAll(() => {
     reduxSpy.mockRestore()


### PR DESCRIPTION
Ticket: none

I added some main categories to the hasSubfiltersEnabled in app.base.json. But this file is the base config for all municipalities. The default should be that no mainFilters have subfilters, so adjusted the file.