### PR TITLE
[fix-4956]: remove old notifications from incidents form.

### DIFF
--- a/src/signals/incident/components/IncidentForm/index.test.js
+++ b/src/signals/incident/components/IncidentForm/index.test.js
@@ -136,6 +136,10 @@ describe('<IncidentForm />', () => {
         },
       }
       renderIncidentForm(props)
+
+      expect(defaultProps.removeQuestionData).toBeCalledWith([
+        'extra_removed_question',
+      ])
     })
 
     it('renders updated form values', async () => {


### PR DESCRIPTION
Ticket: [SIG-4956](https://datapunt.atlassian.net/browse/SIG-4956)

**Acc**
- notifications from a subcategory in wizard step 2 should hide when main category isn't selected anymore.
- in the endstep there shouldn't be a mention of the selected sub category



## Signalen

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)


[SIG-4956]: https://datapunt.atlassian.net/browse/SIG-4956?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ