### PR TITLE
Increase page size to 1000 for the districts endpoint

### DIFF
--- a/src/signals/incident-management/__tests__/saga.test.js
+++ b/src/signals/incident-management/__tests__/saga.test.js
@@ -299,6 +299,7 @@ describe('signals/incident-management/saga', () => {
         .next()
         .call(authCall, CONFIGURATION.AREAS_ENDPOINT, {
           type_code: CONFIGURATION.areaTypeCodeForDistrict,
+          page_size: 1000,
         })
         .next(districts)
         .put(getDistrictsSuccess(districts.results))
@@ -314,6 +315,7 @@ describe('signals/incident-management/saga', () => {
         .next()
         .call(authCall, CONFIGURATION.AREAS_ENDPOINT, {
           type_code: CONFIGURATION.areaTypeCodeForDistrict,
+          page_size: 1000,
         })
         .throw(error)
         .put(getDistrictsFailed(message))

--- a/src/signals/incident-management/saga.js
+++ b/src/signals/incident-management/saga.js
@@ -150,6 +150,7 @@ export function* fetchDistricts() {
   try {
     const result = yield call(authCall, CONFIGURATION.AREAS_ENDPOINT, {
       type_code: CONFIGURATION.areaTypeCodeForDistrict,
+      page_size: 1000,
     })
 
     yield put(getDistrictsSuccess(result.results))


### PR DESCRIPTION
The current limit of districts is not enough for some municipalities. This increases the maximum number of districts to 1000, analog to the categories endpoint.