### PR TITLE
[fix-4981]: removed Dashboardlink from login page

### DIFF
--- a/app.amsterdam.json
+++ b/app.amsterdam.json
@@ -17,7 +17,8 @@
     "reporterMailHandledNegativeContactEnabled": true,
     "showThorButton": true,
     "showVulaanControls": true,
-    "useProjectenSignalType": false
+    "useProjectenSignalType": false,
+    "showDashboard": true
   },
   "head": {
     "androidIcon": "/icon_192x192.png",

--- a/src/components/SiteHeader/index.js
+++ b/src/components/SiteHeader/index.js
@@ -211,7 +211,7 @@ const MenuItems = ({ onLogOut, showItems, onLinkClick }) => {
         </StyledMenuButton>
       </MenuItem>
 
-      {configuration.featureFlags.showDashboard ? (
+      {isAuthenticated && configuration.featureFlags.showDashboard ? (
         <MenuItem element="span">
           <StyledMenuButton
             onClick={onLinkClick}


### PR DESCRIPTION
In the backoffice, on the page where one can enter credentials, the menu item dashboard was visible. This should not be visible when a user is not logged in. Now it is only visisble if user is authenticated. 
Test need not be added, because there is already a test for rendering when not authenticated. 

Ticket: [SIG-4981](https://gemeente-amsterdam.atlassian.net/browse/SIG-4981)

## Signalen

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
