### PR TITLE
Do not set max-width on logo, as this breaks aspect ratio's for other municipalities

### DIFF
--- a/src/signals/IncidentMap/components/Header/styled.tsx
+++ b/src/signals/IncidentMap/components/Header/styled.tsx
@@ -30,6 +30,5 @@ export const Title = styled.div`
 
   img {
     height: 100%;
-    max-width: 90px;
   }
 `


### PR DESCRIPTION
Different municipalities have different aspect ratio's of the logo. The fixed max-width breaks aspect ratio's of different logos. Would removing the max-width work for you?

Would be happy to implement other solution directions as well to support different aspect ratio's.