### PR TITLE
Make text field required when transitioning from heropenen to afgehandeld as this is enforced in the backend as well

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/utils.ts
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/utils.ts
@@ -49,13 +49,20 @@ export const textIsRequired = ({
       StatusCode.Heropend,
       StatusCode.ReactieGevraagd,
     ].includes(toStatus)
-  } else {
-    return emailSentWhenStatusChangedTo({
-      fromStatus,
-      toStatus,
-      isSplitIncident,
-    })
   }
+
+  if (
+    fromStatus === StatusCode.VerzoekTotHeropenen &&
+    toStatus === StatusCode.Afgehandeld
+  ) {
+    return true
+  }
+
+  return emailSentWhenStatusChangedTo({
+    fromStatus,
+    toStatus,
+    isSplitIncident,
+  })
 }
 
 type Warning = {


### PR DESCRIPTION
The backend already enforces this, so this fixes this in the frontend as well. This gives the user a more friendly message.