### PR TITLE
[feat-4990]: Add accessibility to dashboard filter

### DIFF
--- a/src/signals/incident-management/containers/Dashboard/components/Filter/Filter.test.tsx
+++ b/src/signals/incident-management/containers/Dashboard/components/Filter/Filter.test.tsx
@@ -29,13 +29,13 @@ describe('FilterComponent', () => {
     render(<Filter callback={mockCallback} />)
 
     expect(
-      screen.queryByRole('listbox', {
+      screen.queryByRole('combobox', {
         name: 'Politie',
       })
     ).not.toBeInTheDocument()
 
     expect(
-      screen.getByRole('listbox', { name: 'Actie Service Centr...' })
+      screen.getByRole('combobox', { name: 'Actie Service Centr...' })
     ).toBeInTheDocument()
   })
 
@@ -48,7 +48,7 @@ describe('FilterComponent', () => {
     )
 
     userEvent.click(
-      screen.getByRole('listbox', {
+      screen.getByRole('combobox', {
         name: 'Actie Service Centr...',
       })
     )
@@ -68,13 +68,13 @@ describe('FilterComponent', () => {
     render(<Filter callback={mockCallback} />)
 
     expect(
-      screen.getByRole('listbox', {
+      screen.getByRole('combobox', {
         name: 'Actie Service Centr...',
       })
     ).toBeInTheDocument()
 
     userEvent.click(
-      screen.getByRole('listbox', {
+      screen.getByRole('combobox', {
         name: 'Categorie',
       })
     )
@@ -84,7 +84,7 @@ describe('FilterComponent', () => {
     ).toBeInTheDocument()
 
     userEvent.click(
-      screen.getByRole('listbox', {
+      screen.getByRole('combobox', {
         name: 'Actie Service Centr...',
       })
     )
@@ -96,11 +96,11 @@ describe('FilterComponent', () => {
     )
 
     expect(
-      screen.queryByRole('listbox', { name: 'Bedrijfsafval' })
+      screen.queryByRole('combobox', { name: 'Bedrijfsafval' })
     ).not.toBeInTheDocument()
 
     expect(
-      screen.queryByRole('listbox', { name: 'Categorie' })
+      screen.queryByRole('combobox', { name: 'Categorie' })
     ).toBeInTheDocument()
   })
 
@@ -108,23 +108,23 @@ describe('FilterComponent', () => {
     render(<Filter callback={mockCallback} />)
 
     expect(
-      screen.getByRole('listbox', {
+      screen.getByRole('combobox', {
         name: 'Actie Service Centr...',
       })
     ).toBeInTheDocument()
 
     screen
-      .getByRole('listbox', {
+      .getByRole('combobox', {
         name: 'Categorie',
       })
       .focus()
 
     act(() => {
       fireEvent.keyDown(
-        screen.getByRole('listbox', {
+        screen.getByRole('combobox', {
           name: 'Categorie',
         }),
-        { code: 'Enter' }
+        { code: 'Space' }
       )
     })
 
@@ -145,12 +145,12 @@ describe('FilterComponent', () => {
         screen.getByRole('option', {
           name: 'Bedrijfsafval',
         }),
-        { code: 'Enter' }
+        { code: 'Space' }
       )
     })
 
     expect(
-      screen.getByRole('listbox', {
+      screen.getByRole('combobox', {
         name: 'Bedrijfsafval',
       })
     ).toBeInTheDocument()
@@ -166,12 +166,12 @@ describe('FilterComponent', () => {
         screen.getByRole('button', {
           name: 'Wis filters',
         }),
-        { code: 'Enter' }
+        { code: 'Space' }
       )
     })
 
     expect(
-      screen.queryByRole('listbox', {
+      screen.queryByRole('combobox', {
         name: 'Bedrijfsafval',
       })
     ).not.toBeInTheDocument()
@@ -181,7 +181,7 @@ describe('FilterComponent', () => {
     render(<Filter callback={mockCallback} />)
 
     userEvent.click(
-      screen.getByRole('listbox', {
+      screen.getByRole('combobox', {
         name: 'Actie Service Centr...',
       })
     )
@@ -195,7 +195,7 @@ describe('FilterComponent', () => {
     expect(mockCallback).toBeCalledWith('department=AEG')
 
     userEvent.click(
-      screen.getByRole('listbox', {
+      screen.getByRole('combobox', {
         name: 'Categorie',
       })
     )
@@ -226,7 +226,7 @@ describe('FilterComponent', () => {
     const { rerender } = render(<Filter callback={mockCallback} />)
 
     expect(
-      screen.queryByRole('listbox', {
+      screen.queryByRole('combobox', {
         name: 'Actie Service Centr...',
       })
     ).not.toBeInTheDocument()
@@ -236,17 +236,17 @@ describe('FilterComponent', () => {
     rerender(<Filter callback={mockCallback} />)
 
     expect(
-      screen.queryByRole('listbox', {
+      screen.queryByRole('combobox', {
         name: 'Actie Service Centr...',
       })
     ).toBeInTheDocument()
   })
 
-  it('should tab over the listboxes back and forth, select an option and return to last focussed listbox again', () => {
+  it('should tab over the comboboxes back and forth, select an option and return to last focussed combobox again', () => {
     render(<Filter callback={mockCallback} />)
 
     screen
-      .queryByRole('listbox', {
+      .queryByRole('combobox', {
         name: 'Actie Service Centr...',
       })
       ?.focus()
@@ -258,17 +258,17 @@ describe('FilterComponent', () => {
     userEvent.tab({ shift: true })
 
     expect(
-      screen.queryByRole('listbox', {
+      screen.queryByRole('combobox', {
         name: 'Categorie',
       })
     ).toHaveFocus()
 
     act(() => {
       fireEvent.keyDown(
-        screen.getByRole('listbox', {
+        screen.getByRole('combobox', {
           name: 'Categorie',
         }),
-        { code: 'Enter' }
+        { code: 'Space' }
       )
     })
 
@@ -278,7 +278,14 @@ describe('FilterComponent', () => {
       })
     ).toHaveFocus()
 
-    userEvent.tab()
+    act(() => {
+      fireEvent.keyDown(
+        screen.getByRole('option', {
+          name: 'Asbest / accu',
+        }),
+        { code: 'ArrowDown' }
+      )
+    })
 
     expect(
       screen.queryByRole('option', {
@@ -291,9 +298,32 @@ describe('FilterComponent', () => {
         screen.getByRole('option', {
           name: 'Auto- / scooter- / bromfiets(wrak)',
         }),
-        { code: 'Enter' }
+        { code: 'Space' }
       )
     })
+  })
+
+  it('should open a dropdown and close it by enter Esc', () => {
+    render(<Filter callback={mockCallback} />)
+
+    act(() => {
+      fireEvent.keyDown(
+        screen.getByRole('combobox', {
+          name: 'Actie Service Centr...',
+        }),
+        { code: 'Space' }
+      )
+    })
+
+    expect(
+      screen.queryByRole('option', { name: 'Afval en Grondstoffen' })
+    ).toBeInTheDocument()
+
+    userEvent.keyboard('{Escape}')
+
+    expect(
+      screen.queryByRole('option', { name: 'Afval en Grondstoffen' })
+    ).not.toBeInTheDocument()
   })
 
   it('should focus on reset button, shift back and forth to end with focus on reset button', () => {

--- a/src/signals/incident-management/containers/Dashboard/components/Filter/Filter.tsx
+++ b/src/signals/incident-management/containers/Dashboard/components/Filter/Filter.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { useClickOutside } from '@amsterdam/asc-ui'
 import { useForm, FormProvider } from 'react-hook-form'
+
 import { generateParams } from 'shared/services/api/api'
 
 import SelectList from './SelectList'

--- a/src/signals/incident-management/containers/Dashboard/components/Filter/Option.tsx
+++ b/src/signals/incident-management/containers/Dashboard/components/Filter/Option.tsx
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (C) 2023 Gemeente Amsterdam
+import type { Dispatch, SetStateAction } from 'react'
+import { useEffect, useRef } from 'react'
+
+import { Controller, useFormContext } from 'react-hook-form'
+
+import { OptionLi } from './styled'
+import type { Filter } from './types'
+import type { Option as OptionType } from './types'
+
+type Props = {
+  activeFilter: Filter
+  setFilterNameActive: (name: string) => void
+  option: OptionType
+  index: number
+  focus: number
+  setFocus: Dispatch<SetStateAction<number>>
+}
+
+export const Option = ({
+  activeFilter,
+  setFocus,
+  setFilterNameActive,
+  option,
+  index,
+  focus,
+}: Props) => {
+  const { control, getValues } = useFormContext()
+
+  const optionRef = useRef<HTMLLIElement | null>(null)
+
+  useEffect(() => {
+    if (focus === index) {
+      optionRef.current?.focus()
+    }
+  }, [focus, index])
+
+  return (
+    <Controller
+      key={`${option}${index}`}
+      name={activeFilter.name}
+      control={control}
+      render={({ field: { onChange, ref } }) => (
+        <OptionLi
+          selected={option.value === getValues(activeFilter.name)?.value}
+          role="option"
+          tabIndex={0}
+          ref={(el) => {
+            ref(el)
+            optionRef.current = el
+          }}
+          onClick={() => {
+            onChange(option)
+            setFilterNameActive('')
+          }}
+          onKeyDown={(e) => {
+            e.preventDefault()
+            setFocus(index)
+
+            if (['Enter', 'Space'].includes(e.code)) {
+              onChange(option)
+              setFilterNameActive('')
+            } else if (e.code === 'Escape') {
+              setFilterNameActive('')
+            }
+          }}
+        >
+          {option.display}
+        </OptionLi>
+      )}
+    />
+  )
+}

--- a/src/signals/incident-management/containers/Dashboard/components/Filter/OptionsList.tsx
+++ b/src/signals/incident-management/containers/Dashboard/components/Filter/OptionsList.tsx
@@ -3,9 +3,11 @@
 import type { Dispatch, SetStateAction } from 'react'
 import { useEffect, useRef } from 'react'
 
-import { Controller, useFormContext } from 'react-hook-form'
+import { useFormContext } from 'react-hook-form'
 
-import { OptionUl, OptionLi } from './styled'
+import { useRoveFocus } from '../../hooks/useRoveFocus'
+import { Option } from './Option'
+import { OptionUl } from './styled'
 import type { Filter } from './types'
 
 type Props = {
@@ -19,47 +21,37 @@ const OptionsList = ({
   activeFilter,
   optionsOffsetLeft,
 }: Props) => {
-  const { control, getValues } = useFormContext()
-
   const optionUlRef = useRef<HTMLUListElement>(null)
 
+  const { currentFocus, setCurrentFocus } = useRoveFocus(
+    activeFilter.options.length
+  )
+
+  const { getValues } = useFormContext()
+
   useEffect(() => {
-    if (activeFilter.name) {
-      optionUlRef.current?.querySelector('li')?.focus()
-    }
-  }, [activeFilter])
+    const index = activeFilter.options.findIndex(
+      (option) => option.value === getValues(activeFilter.name)?.value
+    )
+    index > -1 && setCurrentFocus(index)
+  }, [activeFilter, getValues, setCurrentFocus])
 
   return (
     <OptionUl
+      role="listbox"
       ref={optionUlRef}
       optionsOffsetLeft={optionsOffsetLeft}
       optionsTotal={activeFilter.options.length}
     >
       {activeFilter.options.map((option, index) => (
-        <Controller
-          key={`${option}${index}`}
-          name={activeFilter.name}
-          control={control}
-          render={({ field: { onChange, ref } }) => (
-            <OptionLi
-              selected={option.value === getValues(activeFilter.name)?.value}
-              role="option"
-              tabIndex={0}
-              ref={ref}
-              onClick={() => {
-                onChange(option)
-                setFilterNameActive('')
-              }}
-              onKeyDown={(e) => {
-                if (['Enter', 'Space'].includes(e.code)) {
-                  onChange(option)
-                  setFilterNameActive('')
-                }
-              }}
-            >
-              {option.display}
-            </OptionLi>
-          )}
+        <Option
+          key={index}
+          focus={currentFocus}
+          setFocus={setCurrentFocus}
+          activeFilter={activeFilter}
+          option={option}
+          index={index}
+          setFilterNameActive={setFilterNameActive}
         />
       ))}
     </OptionUl>

--- a/src/signals/incident-management/containers/Dashboard/components/Filter/SelectList.tsx
+++ b/src/signals/incident-management/containers/Dashboard/components/Filter/SelectList.tsx
@@ -30,12 +30,15 @@ const SelectList = ({ filterActiveName, setFilterActiveName }: Props) => {
 
   const filters = useFilters(selectedDepartment)
 
-  // set initial department value
   useEffect(() => {
     if (!selectedDepartment.value && filters[0].options[0]) {
       setValue('department', filters[0].options[0])
     }
-  }, [filters, selectedDepartment, setValue])
+
+    if (prevSelectTarget.current && !filterActiveName) {
+      prevSelectTarget.current?.focus()
+    }
+  }, [filters, selectedDepartment, setValue, filterActiveName])
 
   const truncateFilterName = (filterName: string) =>
     filterName.length > 19 ? filterName.substring(0, 19) + '...' : filterName
@@ -80,16 +83,17 @@ const SelectList = ({ filterActiveName, setFilterActiveName }: Props) => {
         return (
           <Select
             key={filter.name}
-            role="listbox"
+            role="combobox"
+            tabIndex={0}
+            aria-expanded={!!activeFilter?.name}
             aria-label={truncateFilterName(
               getValues(filter.name)?.display || filter.display
             )}
-            tabIndex={0}
             onClick={(e) => {
               onChangeEvent(filter.name, e.currentTarget)
             }}
             onKeyDown={(e) => {
-              if (['Enter', 'Space'].includes(e.code)) {
+              if (['Space', 'ArrowUp', 'ArrowDown'].includes(e.code)) {
                 e.preventDefault()
                 onChangeEvent(filter.name, e.currentTarget)
               }
@@ -109,8 +113,8 @@ const SelectList = ({ filterActiveName, setFilterActiveName }: Props) => {
         )
       })}
       <Select
-        tabIndex={0}
         role={'button'}
+        tabIndex={0}
         onClick={() => {
           onChangeEvent('')
           reset()

--- a/src/signals/incident-management/containers/Dashboard/components/Filter/SelectList.tsx
+++ b/src/signals/incident-management/containers/Dashboard/components/Filter/SelectList.tsx
@@ -7,7 +7,6 @@ import { ChevronDown } from '@amsterdam/asc-assets'
 import { isNumber } from 'lodash'
 import { useFormContext } from 'react-hook-form'
 
-import { useFilters } from '../../hooks/useFilter'
 import OptionsList from './OptionsList'
 import {
   InvisibleButton,
@@ -17,6 +16,7 @@ import {
   SelectContainer,
 } from './styled'
 import type { Filter } from './types'
+import { useFilters } from '../../hooks/useFilter'
 
 type Props = {
   filterActiveName: string
@@ -129,15 +129,15 @@ const SelectList = ({ filterActiveName, setFilterActiveName }: Props) => {
         <RefreshIcon width={16} height={18} />
         Wis filters
       </Select>
-      {activeFilter?.name && isNumber(optionsOffsetLeftRef.current) && (
-        <OptionListDropdown>
+      <OptionListDropdown active={!!activeFilter?.name}>
+        {activeFilter?.name && isNumber(optionsOffsetLeftRef.current) && (
           <OptionsList
             optionsOffsetLeft={optionsOffsetLeftRef.current}
             activeFilter={activeFilter}
             setFilterNameActive={setFilterActiveName}
           />
-        </OptionListDropdown>
-      )}
+        )}
+      </OptionListDropdown>
     </SelectContainer>
   )
 }

--- a/src/signals/incident-management/containers/Dashboard/components/Filter/styled.tsx
+++ b/src/signals/incident-management/containers/Dashboard/components/Filter/styled.tsx
@@ -61,14 +61,22 @@ export const RefreshIcon = styled(Refresh)`
   margin-right: ${themeSpacing(2)};
 `
 
-export const OptionListDropdown = styled.div`
+export const OptionListDropdown = styled.div<{ active: boolean }>`
   position: absolute;
   left: 0;
   right: 0;
-  height: calc(100vh - ${themeSpacing(26.5)});
   top: ${themeSpacing(14)};
   overflow-y: auto;
+  opacity: 0;
   background-color: ${themeColor('tint', 'level2')};
+  transition: opacity 0.25s ease-out;
+  height: calc(100vh - ${themeSpacing(26.5)});
+
+  ${({ active }) =>
+    active &&
+    css`
+      opacity: 100;
+    `}
 `
 
 export const OptionUl = styled.ul<{

--- a/src/signals/incident-management/containers/Dashboard/hooks/useRoveFocus.test.ts
+++ b/src/signals/incident-management/containers/Dashboard/hooks/useRoveFocus.test.ts
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (C) 2023 Gemeente Amsterdam
+import { renderHook } from '@testing-library/react-hooks'
+import userEvent from '@testing-library/user-event'
+import { act } from 'react-test-renderer'
+
+import { useRoveFocus } from './useRoveFocus'
+
+describe('useRoveFocus', () => {
+  it('should set a focus index', () => {
+    const { result } = renderHook(() => useRoveFocus(10))
+
+    act(() => {
+      userEvent.keyboard('{ArrowDown}')
+    })
+
+    expect(result.current.currentFocus).toBe(1)
+
+    act(() => {
+      userEvent.keyboard('{ArrowUp}')
+    })
+    act(() => {
+      userEvent.keyboard('{ArrowUp}')
+    })
+
+    expect(result.current.currentFocus).toBe(9)
+  })
+})

--- a/src/signals/incident-management/containers/Dashboard/hooks/useRoveFocus.test.ts
+++ b/src/signals/incident-management/containers/Dashboard/hooks/useRoveFocus.test.ts
@@ -19,10 +19,23 @@ describe('useRoveFocus', () => {
     act(() => {
       userEvent.keyboard('{ArrowUp}')
     })
+
     act(() => {
       userEvent.keyboard('{ArrowUp}')
     })
 
     expect(result.current.currentFocus).toBe(9)
+
+    act(() => {
+      userEvent.keyboard('{ArrowDown}')
+    })
+
+    expect(result.current.currentFocus).toBe(0)
+
+    act(() => {
+      userEvent.keyboard('a')
+    })
+
+    expect(result.current.currentFocus).toBe(0)
   })
 })

--- a/src/signals/incident-management/containers/Dashboard/hooks/useRoveFocus.ts
+++ b/src/signals/incident-management/containers/Dashboard/hooks/useRoveFocus.ts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (C) 2023 Gemeente Amsterdam
+import { useCallback, useState, useEffect } from 'react'
+
+export function useRoveFocus(size: number) {
+  const [currentFocus, setCurrentFocus] = useState<number>(0)
+
+  const handleKeyDown = useCallback(
+    (e) => {
+      if (e.code === 'ArrowDown') {
+        setCurrentFocus(currentFocus === size - 1 ? 0 : currentFocus + 1)
+      } else if (e.code === 'ArrowUp') {
+        setCurrentFocus(currentFocus === 0 ? size - 1 : currentFocus - 1)
+      }
+    },
+    [size, currentFocus, setCurrentFocus]
+  )
+
+  useEffect(() => {
+    document.addEventListener('keydown', handleKeyDown, false)
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown, false)
+    }
+  }, [handleKeyDown])
+
+  return { currentFocus, setCurrentFocus }
+}


### PR DESCRIPTION
**context**
Add custom accessibility to the dashboard filter.

**testers**
Should add on first render a tabindex on the logo in the header, cause the tabindex gets priority other the normal focusable items like links.

Space and arrow up /down should open a combobox(filter option) and bring you to the first or selected filter option. then navigate with arrows up and down, select option with enter / space, close dropdown with Escape.


Ticket: [SIG-4990](https://gemeente-amsterdam.atlassian.net/browse/SIG-4990)

## Signalen

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
