### PR TITLE
[fix-5005]:re-add send email notification

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.test.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.test.tsx
@@ -24,10 +24,7 @@ import { withAppContext } from 'test/utils'
 import type { Incident } from 'types/api/incident'
 import incidentJSON from 'utils/__tests__/fixtures/incident.json'
 
-import StatusForm from '..'
-import { PATCH_TYPE_STATUS } from '../../../constants'
-import IncidentDetailContext from '../../../context'
-import type { IncidentChild } from '../../../types'
+import StatusForm from '.'
 import {
   MELDING_CHECKBOX_DESCRIPTION,
   DEELMELDING_EXPLANATION,
@@ -35,8 +32,10 @@ import {
   DEELMELDINGEN_STILL_OPEN_CONTENT,
   DEFAULT_TEXT_LABEL,
   DEFAULT_TEXT_MAX_LENGTH,
-  NO_EMAIL_IS_SENT,
-} from '../constants'
+} from './constants'
+import { PATCH_TYPE_STATUS } from '../../constants'
+import IncidentDetailContext from '../../context'
+import type { IncidentChild } from '../../types'
 
 const incidentFixture = incidentJSON as unknown as Incident
 const defaultTexts = [
@@ -222,9 +221,8 @@ describe('signals/incident-management/containers/IncidentDetail/components/Statu
       StatusCode.Afgehandeld,
     ])
 
-    expect(checkbox).not.toBeInTheDocument()
-    expect(screen.queryByText('(niet verplicht)')).not.toBeInTheDocument()
-    expect(screen.getByText(NO_EMAIL_IS_SENT)).toBeInTheDocument()
+    expect(checkbox).toBeChecked()
+    expect(checkbox).toBeDisabled()
   })
 
   it('requires a text value when the checkbox is selected', async () => {

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.tsx
@@ -60,7 +60,6 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
 
   const [modalStandardTextIsOpen, setModalStandardTextIsOpen] = useState(false)
   const [modalEmailPreviewIsOpen, setModalEmailPreviewIsOpen] = useState(false)
-  const [emailIsNotSent, setEmailIsNotSend] = useState(false)
   const [state, dispatch] = useReducer<
     Reducer<State, StatusFormActions>,
     { incident: Incident; childIncidents: IncidentChild[] }
@@ -221,11 +220,6 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
   }, [])
 
   const onStatusChange = useCallback((event) => {
-    setEmailIsNotSend(
-      event.target.value === StatusCode.Afgehandeld &&
-        state.status.key === StatusCode.VerzoekTotHeropenen
-    )
-
     const selectedStatus = changeStatusOptionList.find(
       (status) => event.target.value === status.key
     )
@@ -324,7 +318,7 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
               {constants.DEELMELDING_EXPLANATION}
             </Alert>
           ))}
-        {!state.flags.isSplitIncident && !emailIsNotSent && (
+        {!state.flags.isSplitIncident && (
           <div>
             {state.flags.hasEmail ? (
               incident?.reporter?.allows_contact ? (
@@ -354,11 +348,6 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
             )}
           </div>
         )}
-        {emailIsNotSent && (
-          <div data-testid="no-emaiI-is-sent-warning">
-            {constants.NO_EMAIL_IS_SENT}
-          </div>
-        )}
       </StyledSection>
       <StyledSection>
         <AddNoteWrapper>
@@ -373,9 +362,7 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
                     ? state.text.label
                     : 'Toelichting'}
                 </strong>
-                {!state.text.required && !emailIsNotSent && (
-                  <span>&nbsp;(niet verplicht)</span>
-                )}
+                {!state.text.required && <span>&nbsp;(niet verplicht)</span>}
               </>
             }
           />

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/constants.ts
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/constants.ts
@@ -14,7 +14,6 @@ export const DEELMELDINGEN_STILL_OPEN_CONTENT = `Als je de hoofdmelding nu afhan
   Handel de hoofdmelding pas af als alle deelmeldingen zijn opgelost of als de deelmeldingen niet meer nodig zijn.`
 export const NO_REPORTER_EMAIL = `De melder heeft geen e-mailadres opgegeven, er wordt geen bericht verstuurd.`
 export const NO_CONTACT_ALLOWED = `Er wordt geen bericht verstuurd.`
-export const NO_EMAIL_IS_SENT = 'Er wordt geen bericht verstuurd.'
 
 export const DEFAULT_TEXT_MAX_LENGTH = 3000
 export const DEFAULT_TEXT_LABEL = 'Bericht aan melder'

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/utils.ts
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/utils.ts
@@ -12,7 +12,6 @@ import * as constants from './constants'
 
 export const emailSentWhenStatusChangedTo = ({
   toStatus,
-  fromStatus,
   isSplitIncident,
 }: {
   toStatus: StatusCode
@@ -20,13 +19,6 @@ export const emailSentWhenStatusChangedTo = ({
   isSplitIncident: boolean
 }): boolean => {
   if (isSplitIncident) return false
-
-  if (
-    fromStatus === StatusCode.VerzoekTotHeropenen &&
-    toStatus === StatusCode.Afgehandeld
-  ) {
-    return false
-  }
 
   return Boolean(
     changeStatusOptionList.find(


### PR DESCRIPTION
Ticket: [SIG-5005](https://gemeente-amsterdam.atlassian.net/browse/SIG-5005)

When an incident had a "verzoek tot heropenen" request and in the backoffice someone set the status to "Afgehandeld", it a says "no email was send". However, an email is send. This PR removes the logic that causes this behaviour. See screenshot for result.

![Screenshot 2023-02-06 at 14 29 42](https://user-images.githubusercontent.com/46756331/216984640-142e9b29-b345-47e1-80db-4b8cd372d47c.png)
