### PR TITLE
[feat-4904]: Save dashboard filter

### DIFF
--- a/src/signals/incident-management/containers/Dashboard/Dashboard.tsx
+++ b/src/signals/incident-management/containers/Dashboard/Dashboard.tsx
@@ -2,11 +2,14 @@
 // Copyright (C) 2023 Gemeente Amsterdam
 import { useCallback, useEffect, useState } from 'react'
 
+import { Link } from 'react-router-dom'
+
 import GlobalError from 'components/GlobalError'
 
 import { AreaChart } from './components'
 import { Filter } from './components/Filter'
 import { StyledRow } from './styled'
+import { INCIDENTS_URL } from '../../routes'
 
 const Dashboard = () => {
   const [error] = useState<boolean>(false)
@@ -25,10 +28,13 @@ const Dashboard = () => {
       setNotification('Er kan geen data worden geladen. Vernieuw de pagina.')
     }
   }, [error, setNotification])
+
   return (
     <StyledRow data-testid="menu">
       <Filter />
-      <AreaChart />
+      <Link to={{ pathname: INCIDENTS_URL, state: { useBacklink: true } }}>
+        <AreaChart />
+      </Link>
       {errorMessage && showMessage && <GlobalError>{errorMessage}</GlobalError>}
     </StyledRow>
   )

--- a/src/signals/incident-management/containers/Dashboard/components/Filter/Filter.test.tsx
+++ b/src/signals/incident-management/containers/Dashboard/components/Filter/Filter.test.tsx
@@ -8,6 +8,8 @@ import * as reactRouterDom from 'react-router-dom'
 import departmentsFixture from 'utils/__tests__/fixtures/departments.json'
 
 import { Filter } from './Filter'
+import { withAppContext } from '../../../../../../test/utils'
+import history from '../../../../../../utils/history'
 import IncidentManagementContext from '../../../../context'
 
 const mockCallback = jest.fn()
@@ -363,7 +365,7 @@ describe('FilterComponent', () => {
     ).toHaveFocus()
   })
 
-  it('should use defaultValues from incident contexts dashboardFilter and to save dashboardFilter', () => {
+  it('should use defaultValues from incident contexts dashboardFilter', () => {
     const mockSetDashboardFilter = jest.fn()
     render(
       <IncidentManagementContext.Provider
@@ -383,16 +385,6 @@ describe('FilterComponent', () => {
         name: 'Normaal',
       })
     ).toBeInTheDocument()
-
-    expect(mockSetDashboardFilter).toBeCalledTimes(1)
-
-    expect(mockSetDashboardFilter).toBeCalledWith({
-      category: { display: '', value: '' },
-      department: { display: 'Actie Service Centrum', value: 'ASC' },
-      district: { display: '', value: '' },
-      priority: { display: 'Normaal', value: 'normal' },
-      punctuality: { display: '', value: '' },
-    })
   })
 
   it('should not use defaultValues from incident contexts dashboardFilter', () => {
@@ -407,16 +399,18 @@ describe('FilterComponent', () => {
 
     const mockSetDashboardFilter = jest.fn()
     render(
-      <IncidentManagementContext.Provider
-        value={{
-          setDashboardFilter: mockSetDashboardFilter,
-          dashboardFilter: {
-            priority: { value: 'normal', display: 'Normaal' },
-          },
-        }}
-      >
-        <Filter callback={mockCallback} />
-      </IncidentManagementContext.Provider>
+      withAppContext(
+        <IncidentManagementContext.Provider
+          value={{
+            setDashboardFilter: mockSetDashboardFilter,
+            dashboardFilter: {
+              priority: { value: 'normal', display: 'Normaal' },
+            },
+          }}
+        >
+          <Filter callback={mockCallback} />
+        </IncidentManagementContext.Provider>
+      )
     )
 
     expect(
@@ -425,6 +419,29 @@ describe('FilterComponent', () => {
       })
     ).not.toBeInTheDocument()
 
-    expect(mockSetDashboardFilter).toBeCalledTimes(1)
+    act(() => {
+      history.push({
+        pathname: '/manage/incidents',
+        state: {
+          useBacklink: true,
+        },
+      })
+    })
+
+    expect(mockSetDashboardFilter).toHaveBeenLastCalledWith({
+      category: { display: '', value: '' },
+      department: { display: 'Actie Service Centrum', value: 'ASC' },
+      district: { display: '', value: '' },
+      priority: { display: '', value: '' },
+      punctuality: { display: '', value: '' },
+    })
+
+    act(() => {
+      history.push({
+        pathname: '/manage/incidents',
+      })
+    })
+
+    expect(mockSetDashboardFilter.mock.calls[1]).toEqual([{}])
   })
 })

--- a/src/signals/incident-management/containers/Dashboard/components/Filter/Filter.tsx
+++ b/src/signals/incident-management/containers/Dashboard/components/Filter/Filter.tsx
@@ -87,7 +87,7 @@ export const Filter = ({ callback }: Props) => {
 
   useEffect(() => {
     handleCallback()
-  }, [handleCallback, location])
+  }, [handleCallback])
 
   /**
    * This make sure dashboard filters value get cleared
@@ -95,13 +95,19 @@ export const Filter = ({ callback }: Props) => {
    * except when entering the dashboard.
    */
   useEffect(() => {
-    history.listen((location: { pathname: string; state?: any }) => {
-      if (location.pathname === INCIDENTS_URL && location.state?.useBacklink) {
-        setDashboardFilter(getValues())
-      } else if (location.pathname !== DASHBOARD_URL) {
-        setDashboardFilter({})
+    const unlisten = history.listen(
+      (location: { pathname: string; state?: any }) => {
+        if (
+          location.pathname === INCIDENTS_URL &&
+          location.state?.useBacklink
+        ) {
+          setDashboardFilter(getValues())
+        } else if (location.pathname !== DASHBOARD_URL) {
+          setDashboardFilter({})
+        }
       }
-    })
+    )
+    return () => unlisten()
   }, [getValues, setDashboardFilter])
 
   useEffect(() => {

--- a/src/signals/incident-management/containers/Dashboard/components/Filter/Filter.tsx
+++ b/src/signals/incident-management/containers/Dashboard/components/Filter/Filter.tsx
@@ -1,11 +1,18 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2023 Gemeente Amsterdam
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useContext, useEffect, useRef, useState } from 'react'
 
 import { useClickOutside } from '@amsterdam/asc-ui'
 import { useForm, FormProvider } from 'react-hook-form'
 
+import useLocationReferrer from 'hooks/useLocationReferrer'
 import { generateParams } from 'shared/services/api/api'
+import IncidentManagementContext from 'signals/incident-management/context'
+import {
+  DASHBOARD_URL,
+  INCIDENTS_URL,
+} from 'signals/incident-management/routes'
+import history from 'utils/history'
 
 import SelectList from './SelectList'
 import { FilterBar } from './styled'
@@ -17,11 +24,24 @@ type Props = {
 
 export const Filter = ({ callback }: Props) => {
   const [filterActiveName, setFilterActiveName] = useState('')
+  const { dashboardFilter, setDashboardFilter } = useContext(
+    IncidentManagementContext
+  )
+
+  const location = useLocationReferrer() as { referrer: string }
 
   const methods = useForm<{ [key: string]: Option }>({
     defaultValues: Object.fromEntries(
       ['department', 'category', 'priority', 'punctuality', 'district'].map(
-        (name) => [name, { value: '', display: '' }]
+        (name) => [
+          name,
+          (location?.referrer === INCIDENTS_URL &&
+            dashboardFilter &&
+            dashboardFilter[name]) || {
+            display: '',
+            value: '',
+          },
+        ]
       )
     ),
   })
@@ -43,22 +63,46 @@ export const Filter = ({ callback }: Props) => {
     )
 
     const params = generateParams(selectedFilters)
-    params && callback && callback(generateParams(selectedFilters))
+
+    if (callback) {
+      callback(params)
+    }
   }, [callback, getValues])
 
-  // on change form, call handleCallback as a service to the parent component
   useEffect(() => {
     const subscription = watch((_, { name, type }) => {
-      if (name === 'department' && type === 'change') {
-        resetField('category')
+      if (type === 'change') {
+        handleCallback()
+
+        if (name === 'department') {
+          resetField('category')
+        }
       }
-      handleCallback()
     })
 
     return () => {
       subscription.unsubscribe()
     }
   }, [getValues, handleCallback, resetField, watch])
+
+  useEffect(() => {
+    handleCallback()
+  }, [handleCallback, location])
+
+  /**
+   * This make sure dashboard filters value get cleared
+   * when moving to another page without a backlink state property,
+   * except when entering the dashboard.
+   */
+  useEffect(() => {
+    history.listen((location: { pathname: string; state?: any }) => {
+      if (location.pathname === INCIDENTS_URL && location.state?.useBacklink) {
+        setDashboardFilter(getValues())
+      } else if (location.pathname !== DASHBOARD_URL) {
+        setDashboardFilter({})
+      }
+    })
+  }, [getValues, setDashboardFilter])
 
   useEffect(() => {
     refFilterContainer.current?.scrollIntoView({

--- a/src/signals/incident-management/containers/Dashboard/components/Filter/Filter.tsx
+++ b/src/signals/incident-management/containers/Dashboard/components/Filter/Filter.tsx
@@ -14,6 +14,7 @@ import {
 } from 'signals/incident-management/routes'
 import history from 'utils/history'
 
+import { filterNames } from './constants'
 import SelectList from './SelectList'
 import { FilterBar } from './styled'
 import type { Option } from './types'
@@ -32,17 +33,15 @@ export const Filter = ({ callback }: Props) => {
 
   const methods = useForm<{ [key: string]: Option }>({
     defaultValues: Object.fromEntries(
-      ['department', 'category', 'priority', 'punctuality', 'district'].map(
-        (name) => [
-          name,
-          (location?.referrer === INCIDENTS_URL &&
-            dashboardFilter &&
-            dashboardFilter[name]) || {
-            display: '',
-            value: '',
-          },
-        ]
-      )
+      filterNames.map((name) => [
+        name,
+        (location?.referrer === INCIDENTS_URL &&
+          dashboardFilter &&
+          dashboardFilter[name]) || {
+          display: '',
+          value: '',
+        },
+      ])
     ),
   })
 

--- a/src/signals/incident-management/containers/Dashboard/components/Filter/SelectList.tsx
+++ b/src/signals/incident-management/containers/Dashboard/components/Filter/SelectList.tsx
@@ -70,10 +70,6 @@ const SelectList = ({ filterActiveName, setFilterActiveName }: Props) => {
 
   const prevSelectTarget = useRef<HTMLElement>()
 
-  if (!selectedDepartment.value) {
-    return null
-  }
-
   return (
     <SelectContainer ref={selectContainerRef}>
       {filters?.map((filter: Filter) => {

--- a/src/signals/incident-management/containers/Dashboard/components/Filter/SelectList.tsx
+++ b/src/signals/incident-management/containers/Dashboard/components/Filter/SelectList.tsx
@@ -7,6 +7,7 @@ import { ChevronDown } from '@amsterdam/asc-assets'
 import { isNumber } from 'lodash'
 import { useFormContext } from 'react-hook-form'
 
+import { filterNames } from './constants'
 import OptionsList from './OptionsList'
 import {
   InvisibleButton,
@@ -68,6 +69,13 @@ const SelectList = ({ filterActiveName, setFilterActiveName }: Props) => {
     (filter: Filter) => filter.name === filterActiveName
   )
 
+  const resetWithDefaultValues = () => {
+    const defaultValues = Object.fromEntries(
+      filterNames.map((name) => [name, { display: '', value: '' }])
+    )
+    reset(defaultValues)
+  }
+
   const prevSelectTarget = useRef<HTMLElement>()
 
   return (
@@ -113,12 +121,12 @@ const SelectList = ({ filterActiveName, setFilterActiveName }: Props) => {
         tabIndex={0}
         onClick={() => {
           onChangeEvent('')
-          reset()
+          resetWithDefaultValues()
         }}
         onKeyDown={(e) => {
           if (['Enter', 'Space'].includes(e.code)) {
             onChangeEvent('')
-            reset()
+            resetWithDefaultValues()
           }
         }}
       >

--- a/src/signals/incident-management/containers/Dashboard/components/Filter/constants.ts
+++ b/src/signals/incident-management/containers/Dashboard/components/Filter/constants.ts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (C) 2023 Gemeente Amsterdam
+export const filterNames = [
+  'department',
+  'category',
+  'priority',
+  'punctuality',
+  'district',
+]

--- a/src/signals/incident-management/containers/IncidentOverviewPage/components/List/index.test.tsx
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/components/List/index.test.tsx
@@ -39,7 +39,9 @@ jest.mock('shared/services/configuration/configuration')
 
 const withContext = (Component: JSX.Element) =>
   withAppContext(
-    <IncidentManagementContext.Provider value={{ districts }}>
+    <IncidentManagementContext.Provider
+      value={{ districts, setDashboardFilter: jest.fn() }}
+    >
       {Component}
     </IncidentManagementContext.Provider>
   )

--- a/src/signals/incident-management/containers/IncidentOverviewPage/index.js
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/index.js
@@ -50,8 +50,9 @@ import {
   NoResults,
   StyledButton,
   StyledPagination,
+  StyledBackLink,
 } from './styled'
-import { MAP_URL } from '../../routes'
+import { DASHBOARD_URL, MAP_URL } from '../../routes'
 import FilterTagList from '../FilterTagList/FilterTagList'
 
 let lastActiveElement = null
@@ -163,6 +164,15 @@ export const IncidentOverviewPageContainerComponent = ({
       data-testid="incident-management-overview-page"
     >
       <Row>
+        {location.state?.useBacklink && (
+          <StyledBackLink
+            to={{
+              pathname: DASHBOARD_URL,
+            }}
+          >
+            Terug naar dashboard
+          </StyledBackLink>
+        )}
         <TitleRow>
           <PageHeader />
           <ButtonWrapper>

--- a/src/signals/incident-management/containers/IncidentOverviewPage/index.test.js
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/index.test.js
@@ -4,6 +4,7 @@ import { fireEvent, render, act, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17'
 import Enzyme, { mount } from 'enzyme'
+import * as reactRouterDom from 'react-router-dom'
 import { disablePageScroll, enablePageScroll } from 'scroll-lock'
 
 import * as constants from 'signals/incident-management/constants'
@@ -56,6 +57,11 @@ const generateIncidents = (number = 100) =>
     id: index + 1,
   }))
 
+jest.mock('react-router-dom', () => ({
+  __esModule: true,
+  ...jest.requireActual('react-router-dom'),
+}))
+
 describe('signals/incident-management/containers/IncidentOverviewPage', () => {
   let props
 
@@ -75,6 +81,32 @@ describe('signals/incident-management/containers/IncidentOverviewPage', () => {
       pageChangedAction: jest.fn(),
       clearFiltersAction: jest.fn(),
     }
+  })
+
+  it('should render a backlink to dashboard', () => {
+    jest.spyOn(reactRouterDom, 'useLocation').mockImplementationOnce(() => ({
+      state: {
+        useBacklink: true,
+      },
+    }))
+
+    render(
+      withAppContext(<IncidentOverviewPageContainerComponent {...props} />)
+    )
+
+    expect(screen.getByText('Terug naar dashboard')).toBeTruthy()
+  })
+
+  it('should not render a backlink to dashboard', () => {
+    jest.spyOn(reactRouterDom, 'useLocation').mockImplementationOnce(() => ({
+      state: null,
+    }))
+
+    render(
+      withAppContext(<IncidentOverviewPageContainerComponent {...props} />)
+    )
+
+    expect(screen.queryByText('Terug naar dashboard')).toBe(null)
   })
 
   it('should render modal buttons', () => {

--- a/src/signals/incident-management/containers/IncidentOverviewPage/styled.tsx
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/styled.tsx
@@ -10,6 +10,7 @@ import {
 } from '@amsterdam/asc-ui'
 import styled from 'styled-components'
 
+import BackLink from 'components/BackLink'
 import Button from 'components/Button'
 import Paragraph from 'components/Paragraph'
 
@@ -81,10 +82,8 @@ export const NavWrapper = styled(Column).attrs({
   margin-bottom: ${themeSpacing(5)};
 `
 
-export const PageTitle = styled.div`
-  display: flex;
-  justify-content: space-between;
-  margin-bottom: ${themeSpacing(2)};
+export const StyledBackLink = styled(BackLink)`
+  margin-top: ${themeSpacing(6)};
 `
 
 export const PageHeaderItem = styled.div`

--- a/src/signals/incident-management/context.ts
+++ b/src/signals/incident-management/context.ts
@@ -1,13 +1,20 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2020 - 2021 Vereniging van Nederlandse Gemeenten, Gemeente Amsterdam
+import type { Dispatch } from 'react'
 import { createContext } from 'react'
 
+import type { Option } from './containers/Dashboard/components/Filter/types'
 import type { Definition } from './definitions/types'
 
-const initialContext = { districts: undefined }
+const initialContext = {
+  districts: undefined,
+  setDashboardFilter: () => {},
+}
 
-const IncidentManagementContext = createContext<{ districts?: Definition[] }>(
-  initialContext
-)
+const IncidentManagementContext = createContext<{
+  setDashboardFilter: Dispatch<{ [key: string]: Option }>
+  dashboardFilter?: { [key: string]: Option }
+  districts?: Definition[]
+}>(initialContext)
 
 export default IncidentManagementContext

--- a/src/signals/incident-management/index.js
+++ b/src/signals/incident-management/index.js
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2018 - 2023 Gemeente Amsterdam
-import { useEffect, lazy, Suspense, useMemo } from 'react'
+import { useEffect, lazy, Suspense, useMemo, useState } from 'react'
 
 import { useSelector, useDispatch } from 'react-redux'
 import { Route, Switch } from 'react-router-dom'
@@ -45,14 +45,20 @@ const IncidentSplitContainer = lazy(() =>
 const ReporterContainer = lazy(() => import('./containers/ReporterContainer'))
 const AreaContainer = lazy(() => import('./containers/AreaContainer'))
 const SignalingContainer = lazy(() => import('./containers/Signaling'))
-const DashboardContainer = lazy(() => import('./containers/Dashboard/Dashboard'))
+const DashboardContainer = lazy(() =>
+  import('./containers/Dashboard/Dashboard')
+)
 
 const IncidentManagement = () => {
   const location = useLocationReferrer()
   const districts = useSelector(makeSelectDistricts)
   const searchQuery = useSelector(makeSelectSearchQuery)
   const dispatch = useDispatch()
-  const contextValue = useMemo(() => ({ districts }), [districts])
+  const [dashboardFilter, setDashboardFilter] = useState(null)
+  const contextValue = useMemo(
+    () => ({ districts, dashboardFilter, setDashboardFilter }),
+    [dashboardFilter, districts]
+  )
 
   useEffect(() => {
     // prevent continuing (and performing unncessary API calls)

--- a/src/signals/incident/components/StepWizard/components/Wizard.tsx
+++ b/src/signals/incident/components/StepWizard/components/Wizard.tsx
@@ -151,7 +151,7 @@ const Wizard = (props: Props) => {
 
   const initialOnNext = useRef(false)
 
-  // listen for history changes and set set using pathToStep
+  // listen for history changes and set step using pathToStep
   useEffect(() => {
     const unlisten = history.listen(({ pathname }: any) => {
       setStep(pathToStep(pathname))


### PR DESCRIPTION
Save dashboard filter object by updating incident management context.

Ticket: [SIG-4904](https://gemeente-amsterdam.atlassian.net/browse/SIG-4904)

## for testers
When going to overview by clicking a graph (for example areagraph) the filters should be remembered
and a backlink state property be given to the router. That way we can go back to the same dash board filters from the overview page with the backlink (component), or previous button in your browser.
However when moving to a page (incl overview without backlink property), it loses the filters.

**nb**
The click action is currently covering the whole areagraph element. 
 
## Signalen

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)


[SIG-4904]: https://datapunt.atlassian.net/browse/SIG-4904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ