### PR TITLE
[fix-4987]: Incidentmap logo alignement

### DIFF
--- a/src/signals/IncidentMap/components/Header/styled.tsx
+++ b/src/signals/IncidentMap/components/Header/styled.tsx
@@ -31,9 +31,10 @@ export const Title = styled.div`
   img,
   a {
     display: block;
-    width: auto;
-    height: 100%;
-    max-height: ${themeSpacing(HEADER_HEIGHT_MOBILE - 5)};
+    width: 100%;
+    height: auto;
+    max-height: ${themeSpacing(HEADER_HEIGHT_MOBILE - 2.5)};
+    max-width: 112px;
 
     @media screen and (${breakpoint('min-width', 'tabletM')}) {
       max-height: ${themeSpacing(HEADER_HEIGHT_DESKTOP - 5)};

--- a/src/signals/IncidentMap/components/Header/styled.tsx
+++ b/src/signals/IncidentMap/components/Header/styled.tsx
@@ -34,10 +34,10 @@ export const Title = styled.div`
     width: 100%;
     height: auto;
     max-height: ${themeSpacing(HEADER_HEIGHT_MOBILE - 2.5)};
-    max-width: 112px;
 
     @media screen and (${breakpoint('min-width', 'tabletM')}) {
       max-height: ${themeSpacing(HEADER_HEIGHT_DESKTOP - 5)};
+      max-width: unset;
     }
   }
 `


### PR DESCRIPTION
Ticket: [SIG-4987](https://gemeente-amsterdam.atlassian.net/browse/SIG-4987)

Implements last feedback on the logo alignment of the IncidentMap. Setting a max-width will not push the burger menu away on mobile. 

<img width="433" alt="Screenshot 2023-02-08 at 12 03 51" src="https://user-images.githubusercontent.com/46756331/217513123-0004c4d2-46aa-4f4e-aff5-84e864311bcc.png">
<img width="429" alt="Screenshot 2023-02-08 at 12 03 58" src="https://user-images.githubusercontent.com/46756331/217513138-0df6801c-9a4f-4e9f-9c50-83707b1c3fdf.png">
<img width="528" alt="Screenshot 2023-02-08 at 12 05 17" src="https://user-images.githubusercontent.com/46756331/217513167-f52ce59e-2567-4a9b-8084-95016b8e8546.png">
