### PR TITLE
[feat-4984] alert subcategorie klok

### DIFF
--- a/src/signals/incident/definitions/wizard-step-2-vulaan/straatverlichting-klokken.test.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/straatverlichting-klokken.test.ts
@@ -11,6 +11,7 @@ describe('definition straatverlichting-klokken', () => {
       'extra_straatverlichting',
       'extra_straatverlichting_gevaar',
       'extra_klok_nummer',
+      'extra_klok_alert',
       'extra_klok',
       'extra_klok_gevaar',
       'extra_klok_probleem',

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/straatverlichting-klokken.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/straatverlichting-klokken.ts
@@ -201,6 +201,7 @@ const straatverlichtingKlokken = {
     },
     render: QuestionFieldType.RadioInput,
   },
+
   extra_straatverlichting_gevaar: {
     meta: {
       ifAllOf: {
@@ -291,8 +292,19 @@ const straatverlichtingKlokken = {
     },
     render: QuestionFieldType.ClockSelect,
     options: {
-      validators: [validateObjectLocation('klok')],
+      validators: [validateObjectLocation('klok'), 'required'],
     },
+  },
+
+  extra_klok_alert: {
+    meta: {
+      ifAllOf: {
+        subcategory: 'klok',
+      },
+      type: 'alert',
+      value: `De gemeente repareert alleen klokken met het logo van de gemeente Amsterdam: de 3 Andreaskruizen. Wij repareren geen kapotte klokken van bedrijven, winkels en het GVB. Deze klokken kunt u laten repareren door de winkel, het bedrijf of het GVB.`,
+    },
+    render: QuestionFieldType.PlainText,
   },
 
   extra_klok: {
@@ -319,6 +331,7 @@ const straatverlichtingKlokken = {
     },
     render: QuestionFieldType.RadioInput,
   },
+
   extra_klok_gevaar: {
     meta: {
       ifAllOf: {
@@ -337,6 +350,7 @@ const straatverlichtingKlokken = {
     },
     render: QuestionFieldType.PlainText,
   },
+
   extra_klok_probleem: {
     meta: {
       label: 'Wat is het probleem?',
@@ -368,6 +382,7 @@ const straatverlichtingKlokken = {
     },
     render: QuestionFieldType.RadioInput,
   },
+
   extra_klok_toelichting_overig: {
     meta: {
       ifAllOf: {


### PR DESCRIPTION
Ticket: [SIG-4984](https://gemeente-amsterdam.atlassian.net/browse/SIG-4984)

- Adds an alert when an incident falls in the "klok" category
- Removed the (is niet verplicht) at the location, since a location/klok is mandatory.

Nice visual: 

<img width="1031" alt="Screenshot 2023-02-08 at 13 34 24" src="https://user-images.githubusercontent.com/46756331/217531721-9f000dff-07c5-41a2-893b-1906f0ee8357.png">
