### PR TITLE
[feat-5007]: positioning of components on dashboard

### DIFF
--- a/src/signals/incident-management/containers/Dashboard/Dashboard.tsx
+++ b/src/signals/incident-management/containers/Dashboard/Dashboard.tsx
@@ -2,10 +2,8 @@
 // Copyright (C) 2023 Gemeente Amsterdam
 import { useState } from 'react'
 
-import { Row } from '@amsterdam/asc-ui'
-
 import { AreaChart, BarChart, Filter } from './components'
-import { StyledRow } from './styled'
+import { StyledRow, Wrapper } from './styled'
 
 const Dashboard = () => {
   const [queryString, setQueryString] = useState<string>('')
@@ -15,10 +13,10 @@ const Dashboard = () => {
       <StyledRow data-testid="menu">
         <Filter callback={setQueryString} />
       </StyledRow>
-      <Row data-testid="menu">
+      <Wrapper data-testid="menu">
         <BarChart />
         <AreaChart queryString={queryString} />
-      </Row>
+      </Wrapper>
     </>
   )
 }

--- a/src/signals/incident-management/containers/Dashboard/charts/getAreaChartSpec.test.ts
+++ b/src/signals/incident-management/containers/Dashboard/charts/getAreaChartSpec.test.ts
@@ -18,15 +18,17 @@ const mockValues = [
 ]
 
 const maxDomain = 60
+const height = 220
 const mockToday = { year: 2012, month: 1, date: 7, hours: 23, minutes: 0 }
 
 describe('getAreaChartSpec', () => {
   it('should return correct object', () => {
-    const result = getAreaChartSpec(mockValues, maxDomain, mockToday)
+    const result = getAreaChartSpec(mockValues, maxDomain, mockToday, height)
 
     expect(result).toMatchInlineSnapshot(`
       Object {
         "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+        "autosize": "fit",
         "config": Object {
           "style": Object {
             "area": Object {
@@ -247,7 +249,7 @@ describe('getAreaChartSpec', () => {
             ],
           },
         ],
-        "width": 430,
+        "width": "container",
       }
     `)
   })

--- a/src/signals/incident-management/containers/Dashboard/charts/getAreaChartSpec.ts
+++ b/src/signals/incident-management/containers/Dashboard/charts/getAreaChartSpec.ts
@@ -7,11 +7,13 @@ import type { Today, AreaChartValue } from './types'
 export const getAreaChartSpec = (
   values: AreaChartValue[],
   maxDomain: number,
-  today: Today
+  today: Today,
+  height: number
 ): VisualizationSpec => ({
   $schema: 'https://vega.github.io/schema/vega-lite/v5.json',
-  width: 430,
-  height: 220,
+  width: 'container',
+  height: height,
+  autosize: 'fit',
   data: {
     values,
   },

--- a/src/signals/incident-management/containers/Dashboard/components/AreaChart/styled.ts
+++ b/src/signals/incident-management/containers/Dashboard/components/AreaChart/styled.ts
@@ -3,17 +3,21 @@
 import { themeColor, themeSpacing } from '@amsterdam/asc-ui'
 import styled from 'styled-components'
 
-export const AreaChartWrapper = styled.span`
+export const AreaChartWrapper = styled.div`
   position: relative;
+  max-width: 500px;
 `
-
+export const StyledAreaChart = styled.div`
+  width: 100%;
+  min-height: 220px;
+`
 export const ComparisonRateWrapper = styled.span`
   position: absolute;
   display: flex;
   flex-direction: column;
+  right: 45px;
+  bottom: 45px;
   color: ${themeColor('primary')};
-  right: 50px;
-  bottom: 60px;
   font-size: ${themeSpacing(3.5)};
   line-height: ${themeSpacing(4)};
   font-weight: 700;

--- a/src/signals/incident-management/containers/Dashboard/components/BarChart/BarChart.tsx
+++ b/src/signals/incident-management/containers/Dashboard/components/BarChart/BarChart.tsx
@@ -1,23 +1,35 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2023 Gemeente Amsterdam
+import { useState } from 'react'
+
 import vegaEmbed from 'vega-embed'
 
-import { StyledBarChart, Wrapper } from './styled'
+import { BarChartWrapper, StyledBarChart } from './styled'
 import { vegaConfigBarChart } from './vega-config-bar-chart'
 import { ModuleTitle } from '../ModuleTitle'
+import { getMaxRange } from '../../utils/get-max-range'
 
 export const BarChart = () => {
+  const [sizeChart, setSizeChart] = useState(getMaxRange())
   // needs to be function later, when endpoint is available
+  const specs = vegaConfigBarChart(sizeChart)
+
   const nrOfIncidents = 422
-  vegaEmbed('#bar-chart', vegaConfigBarChart, { actions: false })
-  //there should be two spaces between title and amount
+  vegaEmbed('#bar-chart', specs, { actions: false })
+
+  const onResize = () => {
+    setSizeChart(getMaxRange())
+  }
+
+  window.addEventListener('resize', onResize)
+
   return (
-    <Wrapper>
+    <BarChartWrapper>
       <ModuleTitle
         title="Openstaande meldingen tot en met vandaag"
         amount={nrOfIncidents}
       />
-      <StyledBarChart data-testid="bar-chart" id="bar-chart" />
-    </Wrapper>
+      <StyledBarChart id="bar-chart" />
+    </BarChartWrapper>
   )
 }

--- a/src/signals/incident-management/containers/Dashboard/components/BarChart/styled.tsx
+++ b/src/signals/incident-management/containers/Dashboard/components/BarChart/styled.tsx
@@ -3,10 +3,9 @@
 
 import styled from 'styled-components'
 
-export const Wrapper = styled.span`
+export const BarChartWrapper = styled.div`
   position: relative;
 `
-
 export const StyledBarChart = styled.div`
   width: 100%;
 `

--- a/src/signals/incident-management/containers/Dashboard/components/BarChart/vega-config-bar-chart.ts
+++ b/src/signals/incident-management/containers/Dashboard/components/BarChart/vega-config-bar-chart.ts
@@ -2,22 +2,22 @@
 // Copyright (C) 2023 Gemeente Amsterdam
 import type { VisualizationSpec } from 'vega-embed'
 
-export const vegaConfigBarChart: VisualizationSpec = {
+export const vegaConfigBarChart = (maxRange: number): VisualizationSpec => ({
   $schema: 'https://vega.github.io/schema/vega-lite/v5.json',
   description: 'A bar chart showing showing number of incidents per status',
   data: {
     values: [
-      { status: 'Heropend', nrOfIncidentsPerStatus: 0 },
+      { status: 'Heropend', nrOfIncidentsPerStatus: 3909 },
       { status: 'Extern: afgehandeld', nrOfIncidentsPerStatus: 54 },
       { status: 'Ingepland', nrOfIncidentsPerStatus: 75 },
-      { status: 'Verzoek tot heropenen', nrOfIncidentsPerStatus: 22 },
+      { status: 'Verzoek tot heropenen', nrOfIncidentsPerStatus: 200 },
       { status: 'Reactie ontvangen', nrOfIncidentsPerStatus: 560 },
       { status: 'In behandeling', nrOfIncidentsPerStatus: 82 },
-      { status: 'Gesplitst', nrOfIncidentsPerStatus: 32 },
-      { status: 'Reactie gevraagd', nrOfIncidentsPerStatus: 60 },
-      { status: 'Gemeld', nrOfIncidentsPerStatus: 1103 },
+      { status: 'Gesplitst', nrOfIncidentsPerStatus: 3832 },
+      { status: 'Reactie gevraagd', nrOfIncidentsPerStatus: 15 },
+      { status: 'Gemeld', nrOfIncidentsPerStatus: 3903 },
       { status: 'Afwachting van behandeling', nrOfIncidentsPerStatus: 409 },
-      { status: 'Extern: verzoek tot afhandeling', nrOfIncidentsPerStatus: 64 },
+      { status: 'Extern: verzoek tot afhandeling', nrOfIncidentsPerStatus: 0 },
     ],
   },
   transform: [
@@ -26,7 +26,6 @@ export const vegaConfigBarChart: VisualizationSpec = {
       as: 'nrOfIncidentsPerStatusWithMax',
     },
   ],
-  spacing: 5,
   facet: {
     field: 'status',
     type: 'nominal',
@@ -50,7 +49,7 @@ export const vegaConfigBarChart: VisualizationSpec = {
             field: 'nrOfIncidentsPerStatusWithMax',
             title: null,
             axis: null,
-            scale: { rangeMax: 275 },
+            scale: { rangeMax: maxRange },
           },
         },
       },
@@ -59,7 +58,7 @@ export const vegaConfigBarChart: VisualizationSpec = {
           type: 'text',
           align: 'left',
           x: 15,
-          fontSize: 12,
+          fontSize: 14,
           fontWeight: 700,
           font: 'Amsterdam Sans',
         },
@@ -81,7 +80,7 @@ export const vegaConfigBarChart: VisualizationSpec = {
   config: {
     style: {
       cell: { stroke: 'transparent' },
-      bar: { color: '#004699', opacity: 0.6, size: 27 },
+      bar: { color: '#004699', opacity: 0.5, size: 27 },
     },
   },
-}
+})

--- a/src/signals/incident-management/containers/Dashboard/components/styled.ts
+++ b/src/signals/incident-management/containers/Dashboard/components/styled.ts
@@ -20,3 +20,8 @@ export const Subtitle = styled.p`
 export const Amount = styled.span`
   color: ${themeColor('primary')};
 `
+
+export const Description = styled.span`
+  font-size: ${themeSpacing(1.75)};
+  line-height: ${themeSpacing(2)};
+`

--- a/src/signals/incident-management/containers/Dashboard/styled.ts
+++ b/src/signals/incident-management/containers/Dashboard/styled.ts
@@ -1,10 +1,22 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2023 Gemeente Amsterdam
-import { themeColor } from '@amsterdam/asc-ui'
+import { breakpoint, themeColor, themeSpacing } from '@amsterdam/asc-ui'
 import styled from 'styled-components'
 
 export const StyledRow = styled.div`
   width: 100%;
   background-color: ${themeColor('tint', 'level2')};
   margin: 0;
+`
+
+export const Wrapper = styled.div`
+  margin: ${themeSpacing(0, 15)};
+  display: grid;
+  grid-column-gap: 40px;
+  grid-template-columns: 2fr 1fr;
+
+  @media screen and ${breakpoint('max-width', 'laptopM')} {
+    display: flex;
+    flex-direction: column;
+  }
 `

--- a/src/signals/incident-management/containers/Dashboard/utils/get-max-range.test.ts
+++ b/src/signals/incident-management/containers/Dashboard/utils/get-max-range.test.ts
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (C) 2023 Gemeente Amsterdam
+
+import { getMaxRange } from './get-max-range'
+
+describe('getMaxRange', function () {
+  it('should return the correct max range when innerWidth is 1400', function () {
+    const expectedResult = 245.55555555555554
+    Object.defineProperty(window, 'innerWidth', {
+      writable: true,
+      configurable: true,
+      value: 1400,
+    })
+
+    expect(getMaxRange()).toEqual(expectedResult)
+  })
+
+  it('should return the correct max range when innerWidth is more than 1400', function () {
+    const expectedResult = 245.55555555555554
+    Object.defineProperty(window, 'innerWidth', {
+      writable: true,
+      configurable: true,
+      value: 2000,
+    })
+
+    expect(getMaxRange()).toEqual(expectedResult)
+  })
+
+  it('should return the correct max range when innerWidth is less than 1400', function () {
+    const expectedResult = 156.66666666666666
+    Object.defineProperty(window, 'innerWidth', {
+      writable: true,
+      configurable: true,
+      value: 1000,
+    })
+
+    expect(getMaxRange()).toEqual(expectedResult)
+  })
+})

--- a/src/signals/incident-management/containers/Dashboard/utils/get-max-range.ts
+++ b/src/signals/incident-management/containers/Dashboard/utils/get-max-range.ts
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (C) 2023 Gemeente Amsterdam
+export const getMaxRange = () => {
+  const { innerWidth } = window
+  const maxWidth = 1400
+  const innerWithCalc = innerWidth > maxWidth ? maxWidth : innerWidth
+  //padding between charts and margin on sides of charts combined is 160 pixels, Bar Chart gets 2/3 of the available space, Area Chart 1/3
+  const maxRange = ((innerWithCalc - 160) / 3) * 2
+  //the padding between the bars in the Bar Chart combined is 30 pixels
+  return maxRange / 3 - 30
+}


### PR DESCRIPTION
**Context**
The BarChart and the AreaChart weren't yet correctly positioned on the dashboard page. 

**Changes**
_As discussed with Linda, the next changes are to the design:_
- the max length of an individual bar in the barchart is now 204px
- the areachart is not sizeable aka it has hard coded a width and a height and only goes to the bottom on a breakpoint

_Changes not discussed with Lind_a:
- the placement of the Comparisonrate is different then from the design. That's because the areachart is different from the design. Alignment of the text with the text on the x-axis is the goal. In the design is the Comparisonrate just slightly before the V of Vr, the same is attempted here.

Ticket: [SIG-5007](https://gemeente-amsterdam.atlassian.net/browse/SIG-5007)

## Signalen

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
