### PR TITLE
Correctly detect an empty template string

### DIFF
--- a/src/utils/__tests__/parseTemplateString.test.ts
+++ b/src/utils/__tests__/parseTemplateString.test.ts
@@ -6,9 +6,11 @@ describe('parseTemplateString', () => {
   it('should correctly detect a templateString', () => {
     const templateString = 'This contains {{ a_template }} string'
     const noTemplateString = 'This does not contain a template string'
+    const emptyTemplateString = ''
 
     expect(isTemplateString(templateString)).toEqual(true)
     expect(isTemplateString(noTemplateString)).toEqual(false)
+    expect(isTemplateString(emptyTemplateString)).toEqual(false)
   })
 
   it('should correctly parse a templateString', () => {

--- a/src/utils/parseTemplateString.ts
+++ b/src/utils/parseTemplateString.ts
@@ -4,6 +4,10 @@
 const TEMPLATE_REGEX = /\{\{.+?\}\}/g
 
 export function isTemplateString(template: string): boolean {
+  if (!template) {
+    return false
+  }
+
   return (template.match(TEMPLATE_REGEX) || []).length > 0
 }
 


### PR DESCRIPTION
This fixes correct template string detection, for example when isTemplateString is set with null.