### PR TITLE
[feat-5008]: Use dashboardfilters in overview page

### DIFF
--- a/src/components/DataView/__tests__/DataView.test.js
+++ b/src/components/DataView/__tests__/DataView.test.js
@@ -5,6 +5,7 @@ import { render, within, fireEvent } from '@testing-library/react'
 import data from 'utils/__tests__/fixtures/filteredUserData.json'
 
 import DataView from '..'
+import { sortAlphabetic } from '../../../utils/sortAlphabetic'
 
 const TEXT_FILTER = 'test filter'
 const TEXT_HEADER = 'test header'
@@ -14,14 +15,6 @@ const createFilters = (num) => createFilledArray(num, renderDiv(TEXT_FILTER))
 const createHeaders = (num) => createFilledArray(num, TEXT_HEADER)
 const headers = Object.keys(data[0])
 const filters = createFilters(headers.length)
-
-const sortAlphabetic = (a, b) => {
-  const _a = a.toLowerCase()
-  const _b = b.toLowerCase()
-
-  // eslint-disable-next-line no-nested-ternary
-  return _a > _b ? 1 : _a < _b ? -1 : 0
-}
 
 const sortAlphabeticReversed = (a, b) => {
   const _a = a.toLowerCase()

--- a/src/signals/incident-management/components/FilterForm/FilterForm.js
+++ b/src/signals/incident-management/components/FilterForm/FilterForm.js
@@ -180,7 +180,6 @@ const FilterForm = ({
       if (showNotification) {
         return
       }
-
       if (isNewFilter && hasName) {
         onSaveFilter(formData)
       }

--- a/src/signals/incident-management/containers/Dashboard/components/Filter/Filter.test.tsx
+++ b/src/signals/incident-management/containers/Dashboard/components/Filter/Filter.test.tsx
@@ -4,20 +4,15 @@ import { act, fireEvent, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import * as reactRouterDom from 'react-router-dom'
 
-import departmentsFixture from 'utils/__tests__/fixtures/departments.json'
+import departmentsCategoriesFixture from 'utils/__tests__/fixtures/departmentsCategories.json'
 
 import { Filter } from './Filter'
-import { withAppContext } from '../../../../../../test/utils'
 import history from '../../../../../../utils/history'
 import IncidentManagementContext from '../../../../context'
 
 const mockCallback = jest.fn()
 
 window.HTMLElement.prototype.scrollIntoView = jest.fn()
-
-const departments = departmentsFixture.results
-
-const oneDepartment = [departmentsFixture.results[0]]
 
 jest.mock('react-router-dom', () => ({
   __esModule: true,
@@ -41,7 +36,7 @@ const renderWithContext = (
       setDashboardFilter: mockSetDashboardFilter,
       dashboardFilter,
       departmentsWithResponsibleCategories: {
-        departments: departmentsCustom || departments,
+        departments: departmentsCustom || departmentsCategoriesFixture,
         isLoading,
       },
     }}
@@ -60,7 +55,7 @@ describe('FilterComponent', () => {
 
     expect(
       screen.queryByRole('combobox', {
-        name: 'Politie',
+        name: 'Parkeren',
       })
     ).not.toBeInTheDocument()
 
@@ -110,7 +105,7 @@ describe('FilterComponent', () => {
     )
 
     expect(
-      screen.queryByRole('option', { name: 'Bedrijfsafval' })
+      screen.queryByRole('option', { name: 'Grofvuil' })
     ).toBeInTheDocument()
 
     userEvent.click(
@@ -121,12 +116,12 @@ describe('FilterComponent', () => {
 
     userEvent.click(
       screen.getByRole('option', {
-        name: 'Politie',
+        name: 'Parkeren',
       })
     )
 
     expect(
-      screen.queryByRole('combobox', { name: 'Bedrijfsafval' })
+      screen.queryByRole('combobox', { name: 'Grofvuil' })
     ).not.toBeInTheDocument()
 
     expect(
@@ -160,20 +155,20 @@ describe('FilterComponent', () => {
 
     screen
       .getByRole('option', {
-        name: 'Bedrijfsafval',
+        name: 'Grofvuil',
       })
       .focus()
 
     expect(
       screen.getByRole('option', {
-        name: 'Bedrijfsafval',
+        name: 'Grofvuil',
       })
     ).toBeInTheDocument()
 
     act(() => {
       fireEvent.keyDown(
         screen.getByRole('option', {
-          name: 'Bedrijfsafval',
+          name: 'Grofvuil',
         }),
         { code: 'Space' }
       )
@@ -181,7 +176,7 @@ describe('FilterComponent', () => {
 
     expect(
       screen.getByRole('combobox', {
-        name: 'Bedrijfsafval',
+        name: 'Grofvuil',
       })
     ).toBeInTheDocument()
 
@@ -202,7 +197,7 @@ describe('FilterComponent', () => {
 
     expect(
       screen.queryByRole('combobox', {
-        name: 'Bedrijfsafval',
+        name: 'Grofvuil',
       })
     ).not.toBeInTheDocument()
   })
@@ -240,7 +235,9 @@ describe('FilterComponent', () => {
       })
     )
 
-    expect(mockCallback).toBeCalledWith('department=AEG&category=Huisafval')
+    expect(mockCallback).toBeCalledWith(
+      'department=AEG&category_slug=huisafval'
+    )
 
     expect(mockCallback).toBeCalledTimes(3)
 
@@ -252,7 +249,9 @@ describe('FilterComponent', () => {
   })
 
   it('should hide department button when there is only one', () => {
-    const { rerender } = render(renderWithContext({}, false, oneDepartment))
+    const { rerender } = render(
+      renderWithContext({}, false, [departmentsCategoriesFixture[0]])
+    )
 
     expect(
       screen.queryByRole('combobox', {
@@ -301,14 +300,14 @@ describe('FilterComponent', () => {
 
     expect(
       screen.queryByRole('option', {
-        name: 'Asbest / accu',
+        name: 'Auto- / scooter- / bromfiets(wrak)',
       })
     ).toHaveFocus()
 
     act(() => {
       fireEvent.keyDown(
         screen.getByRole('option', {
-          name: 'Asbest / accu',
+          name: 'Grofvuil',
         }),
         { code: 'ArrowDown' }
       )
@@ -316,7 +315,7 @@ describe('FilterComponent', () => {
 
     expect(
       screen.queryByRole('option', {
-        name: 'Auto- / scooter- / bromfiets(wrak)',
+        name: 'Blokkade van de vaarweg',
       })
     ).toHaveFocus()
 
@@ -405,31 +404,7 @@ describe('FilterComponent', () => {
       state: null,
     }))
 
-    const mockSetDashboardFilter = jest.fn()
-    render(
-      withAppContext(
-        <IncidentManagementContext.Provider
-          value={{
-            setDashboardFilter: mockSetDashboardFilter,
-            dashboardFilter: {
-              priority: { value: 'normal', display: 'Normaal' },
-            },
-            departmentsWithResponsibleCategories: {
-              isLoading: false,
-              departments: [
-                {
-                  display: 'Actie Service Centrum',
-                  value: 'ASC',
-                  category_names: [],
-                },
-              ],
-            },
-          }}
-        >
-          <Filter callback={mockCallback} />
-        </IncidentManagementContext.Provider>
-      )
-    )
+    render(renderWithContext({}, false, [departmentsCategoriesFixture[0]]))
 
     expect(
       screen.queryByRole('combobox', {
@@ -447,9 +422,9 @@ describe('FilterComponent', () => {
     })
 
     expect(mockSetDashboardFilter).toHaveBeenLastCalledWith({
-      category: { display: '', value: '' },
+      category_slug: { display: '', value: '' },
       department: { display: 'Actie Service Centrum', value: 'ASC' },
-      district: { display: '', value: '' },
+      stadsdeel: { display: '', value: '' },
       priority: { display: '', value: '' },
       punctuality: { display: '', value: '' },
     })

--- a/src/signals/incident-management/containers/Dashboard/components/Filter/Filter.tsx
+++ b/src/signals/incident-management/containers/Dashboard/components/Filter/Filter.tsx
@@ -74,7 +74,7 @@ export const Filter = ({ callback }: Props) => {
         handleCallback()
 
         if (name === 'department') {
-          resetField('category')
+          resetField('category_slug')
         }
       }
     })

--- a/src/signals/incident-management/containers/Dashboard/components/Filter/OptionsList.tsx
+++ b/src/signals/incident-management/containers/Dashboard/components/Filter/OptionsList.tsx
@@ -41,7 +41,7 @@ const OptionsList = ({
   }, [activeFilter, getValues, setCurrentFocus])
 
   if (
-    ['category', 'department'].includes(activeFilter.name) &&
+    ['category_slug', 'department'].includes(activeFilter.name) &&
     departmentsWithResponsibleCategories?.isLoading
   ) {
     return <StyledLoadingIndicator />

--- a/src/signals/incident-management/containers/Dashboard/components/Filter/constants.ts
+++ b/src/signals/incident-management/containers/Dashboard/components/Filter/constants.ts
@@ -2,8 +2,8 @@
 // Copyright (C) 2023 Gemeente Amsterdam
 export const filterNames = [
   'department',
-  'category',
+  'category_slug',
   'priority',
   'punctuality',
-  'district',
+  'stadsdeel',
 ]

--- a/src/signals/incident-management/containers/Dashboard/hooks/useDepartments.test.ts
+++ b/src/signals/incident-management/containers/Dashboard/hooks/useDepartments.test.ts
@@ -24,12 +24,21 @@ const fetchResponseMock = [
         is_responsible: true,
         category: {
           name: 'A',
+          slug: 'c',
+        },
+      },
+      {
+        is_responsible: true,
+        category: {
+          name: 'A',
+          slug: 'b',
         },
       },
       {
         is_responsible: false,
         category: {
           name: 'B',
+          slug: 'a',
         },
       },
     ],
@@ -48,7 +57,7 @@ describe('useDepartments', () => {
     })
   })
 
-  it('should return departments', () => {
+  it('should return departments and sort categories', () => {
     jest.mocked(useFetchAll as any).mockImplementation(() => ({
       data: fetchResponseMock,
       isLoading: false,
@@ -60,9 +69,24 @@ describe('useDepartments', () => {
     expect(result.current).toEqual({
       departments: [
         {
-          value: 'CCA',
-          display: 'CCA',
-          category_names: ['A'],
+          code: 'CCA',
+          name: 'CCA',
+          categories: [
+            {
+              category: {
+                name: 'A',
+                slug: 'b',
+              },
+              is_responsible: true,
+            },
+            {
+              category: {
+                name: 'A',
+                slug: 'c',
+              },
+              is_responsible: true,
+            },
+          ],
         },
       ],
       isLoading: false,

--- a/src/signals/incident-management/containers/Dashboard/hooks/useDepartments.ts
+++ b/src/signals/incident-management/containers/Dashboard/hooks/useDepartments.ts
@@ -8,14 +8,18 @@ import { useFetchAll } from 'hooks'
 import { makeSelectDepartments } from 'models/departments/selectors'
 import CONFIGURATION from 'shared/services/configuration/configuration'
 import type { ApplicationRootState } from 'types'
-import type { Department, DepartmentResponsible } from 'types/api/incident'
+import type { Department } from 'types/api/incident'
+import type { DepartmentDetails } from 'types/api/incident'
+import type { Category } from 'types/api/incident'
+
+import { sortAlphabetic } from '../../../../../utils/sortAlphabetic'
 
 const cachedDepartments: { [key: string]: any } = {}
 export const useDepartments = (): {
-  departments?: DepartmentResponsible[]
+  departments?: DepartmentDetails[]
   isLoading: boolean
 } => {
-  const [departments, setDepartments] = useState<DepartmentResponsible[]>()
+  const [departments, setDepartments] = useState<DepartmentDetails[]>()
 
   const departmentsFromStore = useSelector<
     ApplicationRootState,
@@ -50,19 +54,15 @@ export const useDepartments = (): {
       const responsibleData = data
         .map((item) => {
           return {
-            value: item.code,
-            display: item.name,
-            category_names: item.categories
-              .map((category: any) => {
-                if (category.is_responsible) {
-                  return category.category.name
-                }
-              })
-              .filter(Boolean)
-              .sort(),
+            ...item,
+            categories: item.categories
+              .filter((category: Category) => category.is_responsible)
+              .sort((a: Category, b: Category) =>
+                sortAlphabetic(a.category.slug, b.category.slug)
+              ),
           }
         })
-        .filter((item) => item.category_names.length > 0)
+        .filter((item) => item.categories.length > 0)
       setDepartments(responsibleData)
     }
   }, [data])

--- a/src/signals/incident-management/containers/Dashboard/hooks/useFilter.test.ts
+++ b/src/signals/incident-management/containers/Dashboard/hooks/useFilter.test.ts
@@ -6,18 +6,20 @@ import React from 'react'
 import { renderHook } from '@testing-library/react-hooks'
 import * as reactRedux from 'react-redux'
 
+import departmentFixture from 'utils/__tests__/fixtures/department.json'
 import departmentsFixture from 'utils/__tests__/fixtures/departments.json'
 
 import { useFilters } from './useFilter'
 
 const departments = departmentsFixture.results
+const department = departmentFixture
 
 describe('useFilter', () => {
   beforeEach(() => {
     jest.spyOn(reactRedux, 'useSelector').mockReturnValue(departments)
     jest.spyOn(React, 'useContext').mockReturnValue({
       departmentsWithResponsibleCategories: {
-        departments,
+        departments: [department],
       },
     })
   })
@@ -25,20 +27,19 @@ describe('useFilter', () => {
   it('should select the first department by default and its associated categories', () => {
     const { result } = renderHook(useFilters)
     expect(result.current[0].name).toBe('department')
-    expect(result.current[1].name).toBe('category')
-    expect(result.current[1].options[0].value).toBe('Asbest / accu')
+    expect(result.current[1].name).toBe('category_slug')
+    expect(result.current[1].options[0].value).toBe('boom-boomstob')
   })
 
   it('should return filter data, including categories based on the first department name', () => {
     const { result } = renderHook(useFilters, {
       initialProps: {
-        value: 'AEG',
-        display: 'Afval en Grondstoffen',
+        value: 'ASC',
+        display: 'Actie Service Centrum',
       },
     })
-
     expect(result.current[0].name).toBe('department')
-    expect(result.current[1].name).toBe('category')
-    expect(result.current[1].options[0].value).toBe('Bedrijfsafval')
+    expect(result.current[1].name).toBe('category_slug')
+    expect(result.current[1].options[0].value).toBe('boom-boomstob')
   })
 })

--- a/src/signals/incident-management/containers/Dashboard/hooks/useFilter.ts
+++ b/src/signals/incident-management/containers/Dashboard/hooks/useFilter.ts
@@ -17,8 +17,8 @@ export const useFilters = (selectedDepartment?: Option): Filter[] => {
     () =>
       departments?.map(
         (department): Option => ({
-          display: department.display,
-          value: department.value,
+          display: department.name,
+          value: department.code,
         })
       ),
     [departments]
@@ -26,13 +26,12 @@ export const useFilters = (selectedDepartment?: Option): Filter[] => {
 
   return useMemo(() => {
     const value: string | undefined =
-      selectedDepartment?.value || (departments && departments[0]?.value)
-
+      selectedDepartment?.value || (departments && departments[0]?.code)
     const categories = departments
-      ?.find((department) => department.value === value)
-      ?.category_names.map((category: string) => ({
-        value: category,
-        display: category,
+      ?.find((department) => department.code === value)
+      ?.categories.map((category) => ({
+        value: category.category.slug,
+        display: category.category.name,
       }))
 
     return [
@@ -42,7 +41,7 @@ export const useFilters = (selectedDepartment?: Option): Filter[] => {
         options: departmentOptions || [],
       },
       {
-        name: 'category',
+        name: 'category_slug',
         display: 'Categorie',
         options: categories || [],
       },
@@ -69,7 +68,7 @@ export const useFilters = (selectedDepartment?: Option): Filter[] => {
         })),
       },
       {
-        name: 'district',
+        name: 'stadsdeel',
         display: 'Stadsdeel',
         options: stadsdeelList.map((item) => ({
           value: item.key,

--- a/src/signals/incident-management/containers/FilterTagList/FilterTagList.js
+++ b/src/signals/incident-management/containers/FilterTagList/FilterTagList.js
@@ -121,7 +121,9 @@ export const FilterTagListComponent = (props) => {
     routingDepartments,
   } = props
   const { sources } = useContext(AppContext)
-  const { districts } = useContext(IncidentManagementContext)
+  const { districts, setDashboardFilter } = useContext(
+    IncidentManagementContext
+  )
 
   const map = {
     ...dataLists,
@@ -173,7 +175,13 @@ export const FilterTagListComponent = (props) => {
           : renderTag(tag, mainCategories, map[tagKey])
       )}
       {showClearButton && (
-        <Button variant="textButton" onClick={props.onClear}>
+        <Button
+          variant="textButton"
+          onClick={() => {
+            props.onClear()
+            setDashboardFilter(null)
+          }}
+        >
           Wis filter
         </Button>
       )}

--- a/src/signals/incident-management/containers/FilterTagList/FilterTagList.test.js
+++ b/src/signals/incident-management/containers/FilterTagList/FilterTagList.test.js
@@ -27,10 +27,14 @@ Enzyme.configure({ adapter: new Adapter() })
 
 jest.mock('shared/services/configuration/configuration')
 
+const setDashboardFilter = jest.fn()
+
 const withContext = (Component) =>
   withAppContext(
     <AppContext.Provider value={{ sources }}>
-      <IncidentManagementContext.Provider value={{ districts }}>
+      <IncidentManagementContext.Provider
+        value={{ districts, setDashboardFilter }}
+      >
         {Component}
       </IncidentManagementContext.Provider>
     </AppContext.Provider>

--- a/src/signals/incident-management/containers/IncidentOverviewPage/index.js
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/index.js
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2018 - 2021 Gemeente Amsterdam
-import { useEffect, useState, useCallback, useMemo } from 'react'
+import { useEffect, useState, useCallback, useMemo, useContext } from 'react'
 
 import { Row, Column } from '@amsterdam/asc-ui'
 import PropTypes from 'prop-types'
@@ -52,6 +52,7 @@ import {
   StyledPagination,
   StyledBackLink,
 } from './styled'
+import IncidentManagementContext from '../../context'
 import { DASHBOARD_URL, MAP_URL } from '../../routes'
 import FilterTagList from '../FilterTagList/FilterTagList'
 
@@ -122,6 +123,20 @@ export const IncidentOverviewPageContainerComponent = ({
     applyFilterAction(parseToAPIData(filter))
   }
 
+  const { dashboardFilter } = useContext(IncidentManagementContext)
+  useEffect(() => {
+    if (dashboardFilter) {
+      const options = Object.fromEntries(
+        Object.entries(dashboardFilter)
+          .filter(([k, v]) => v.value && k !== 'department')
+          .map(([k, v]) =>
+            k === 'punctuality' ? [k, v.value] : [k, [v.value]]
+          )
+      )
+      applyFilterAction({ options })
+    }
+  }, [applyFilterAction, dashboardFilter])
+
   useEffect(() => {
     listenFor('keydown', escFunction)
     listenFor('openFilter', openFilterModal)
@@ -164,7 +179,7 @@ export const IncidentOverviewPageContainerComponent = ({
       data-testid="incident-management-overview-page"
     >
       <Row>
-        {location.state?.useBacklink && (
+        {location.state?.useBacklink && dashboardFilter && (
           <StyledBackLink
             to={{
               pathname: DASHBOARD_URL,
@@ -175,23 +190,25 @@ export const IncidentOverviewPageContainerComponent = ({
         )}
         <TitleRow>
           <PageHeader />
-          <ButtonWrapper>
-            <StyledButton
-              data-testid="my-filters-modal-btn"
-              color="primary"
-              onClick={openMyFiltersModal}
-            >
-              Mijn filters
-            </StyledButton>
+          {!dashboardFilter && (
+            <ButtonWrapper>
+              <StyledButton
+                data-testid="my-filters-modal-btn"
+                color="primary"
+                onClick={openMyFiltersModal}
+              >
+                Mijn filters
+              </StyledButton>
 
-            <StyledButton
-              data-testid="filter-modal-btn"
-              color="primary"
-              onClick={openFilterModal}
-            >
-              Filter
-            </StyledButton>
-          </ButtonWrapper>
+              <StyledButton
+                data-testid="filter-modal-btn"
+                color="primary"
+                onClick={openFilterModal}
+              >
+                Filter
+              </StyledButton>
+            </ButtonWrapper>
+          )}
         </TitleRow>
 
         {modalMyFiltersIsOpen && (

--- a/src/signals/incident-management/containers/IncidentOverviewPage/index.test.js
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/index.test.js
@@ -62,6 +62,8 @@ jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
 }))
 
+const mockApplyFilterAction = jest.fn()
+
 describe('signals/incident-management/containers/IncidentOverviewPage', () => {
   let props
 
@@ -80,10 +82,11 @@ describe('signals/incident-management/containers/IncidentOverviewPage', () => {
       orderingChangedAction: jest.fn(),
       pageChangedAction: jest.fn(),
       clearFiltersAction: jest.fn(),
+      applyFilterAction: mockApplyFilterAction,
     }
   })
 
-  it('should render a backlink to dashboard', () => {
+  it('should render a backlink to dashboard, hide filters and call mockApplyFilterAction', async () => {
     jest.spyOn(reactRouterDom, 'useLocation').mockImplementationOnce(() => ({
       state: {
         useBacklink: true,
@@ -91,13 +94,23 @@ describe('signals/incident-management/containers/IncidentOverviewPage', () => {
     }))
 
     render(
-      withAppContext(<IncidentOverviewPageContainerComponent {...props} />)
+      withAppContext(<IncidentOverviewPageContainerComponent {...props} />, {
+        stadsdeel: { value: 'O' },
+      })
     )
 
     expect(screen.getByText('Terug naar dashboard')).toBeTruthy()
+
+    expect(mockApplyFilterAction).toBeCalledWith({
+      options: { stadsdeel: ['O'] },
+    })
+
+    expect(screen.queryByText('Mijn filters')).not.toBeInTheDocument()
   })
 
-  it('should not render a backlink to dashboard', () => {
+  it('should not render a backlink to dashboard, show mijn filters and dont call mockApplyFilterAction', () => {
+    mockApplyFilterAction.mockReset()
+
     jest.spyOn(reactRouterDom, 'useLocation').mockImplementationOnce(() => ({
       state: null,
     }))
@@ -107,6 +120,12 @@ describe('signals/incident-management/containers/IncidentOverviewPage', () => {
     )
 
     expect(screen.queryByText('Terug naar dashboard')).toBe(null)
+
+    expect(mockApplyFilterAction).not.toBeCalledWith({
+      options: { stadsdeel: ['O'] },
+    })
+
+    expect(screen.getByText('Mijn filters')).toBeInTheDocument()
   })
 
   it('should render modal buttons', () => {

--- a/src/signals/incident-management/context.ts
+++ b/src/signals/incident-management/context.ts
@@ -5,7 +5,7 @@ import { createContext } from 'react'
 
 import type { Option } from './containers/Dashboard/components/Filter/types'
 import type { Definition } from './definitions/types'
-import type { DepartmentResponsible } from '../../types/api/incident'
+import type { DepartmentDetails } from '../../types/api/incident'
 
 const initialContext = {
   districts: undefined,
@@ -13,11 +13,11 @@ const initialContext = {
 }
 
 const IncidentManagementContext = createContext<{
-  setDashboardFilter: Dispatch<{ [key: string]: Option }>
+  setDashboardFilter: Dispatch<{ [key: string]: Option } | null>
   dashboardFilter?: { [key: string]: Option }
   districts?: Definition[]
   departmentsWithResponsibleCategories?: {
-    departments: DepartmentResponsible[]
+    departments: DepartmentDetails[]
     isLoading: boolean
   }
 }>(initialContext)

--- a/src/signals/shared/filter/parse.js
+++ b/src/signals/shared/filter/parse.js
@@ -124,7 +124,6 @@ export const parseInputFormData = (filterData, fixtureData = {}) => {
  */
 export const parseToAPIData = (filterData) => {
   const options = clonedeep(filterData.options || {})
-
   Object.keys(options)
     .filter(
       (fieldName) =>

--- a/src/test/utils.js
+++ b/src/test/utils.js
@@ -18,6 +18,7 @@ import usersJSON from 'utils/__tests__/fixtures/users.json'
 
 import configureStore from '../configureStore'
 import constructYupResolver from '../signals/incident/services/yup-resolver'
+import IncidentManagementContext from '../signals/incident-management/context'
 
 export const history = createMemoryHistory()
 
@@ -58,10 +59,18 @@ export const store = configureStore({}, history)
 
 loadModels(store)
 
-export const withAppContext = (Component) => (
+export const withAppContext = (Component, dashboardFilter = null) => (
   <ThemeProvider>
     <Provider store={store}>
-      <ConnectedRouter history={history}>{Component}</ConnectedRouter>
+      <ConnectedRouter history={history}>
+        <IncidentManagementContext.Provider
+          value={{
+            dashboardFilter,
+          }}
+        >
+          {Component}
+        </IncidentManagementContext.Provider>
+      </ConnectedRouter>
     </Provider>
   </ThemeProvider>
 )

--- a/src/types/api/incident.ts
+++ b/src/types/api/incident.ts
@@ -14,10 +14,38 @@ export interface Department {
   category_names: string[]
 }
 
-export type DepartmentResponsible = {
-  display: string
-  value: string
-  category_names: string[]
+export interface DepartmentDetails {
+  _display: string
+  id: number
+  name: string
+  code: string
+  is_intern: boolean
+  can_direct: true
+  categories: Category[]
+}
+
+export interface Category {
+  id: number
+  is_responsible: boolean
+  can_view: boolean
+  category: {
+    _links: {
+      self: {
+        href: string
+      }
+    }
+    _display: string
+    departments: {
+      code: string
+      name: string
+      is_intern: boolean
+    }[]
+    handling_message: string
+    handling: string
+    is_active: boolean
+    name: string
+    slug: string
+  }
 }
 
 export enum Priority {

--- a/src/utils/__tests__/fixtures/departmentsCategories.json
+++ b/src/utils/__tests__/fixtures/departmentsCategories.json
@@ -1,0 +1,7346 @@
+[
+    {
+        "_links": {
+            "self": {
+                "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/private/departments/6"
+            }
+        },
+        "_display": "ASC (Actie Service Centrum)",
+        "id": 6,
+        "name": "Actie Service Centrum",
+        "code": "ASC",
+        "is_intern": true,
+        "categories": [
+            {
+                "id": 9536,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-in-de-openbare-ruimte/sub_categories/auto-scooter-bromfietswrak"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-in-de-openbare-ruimte/openbare_ruimte.svg?se=2023-02-16T14%3A14%3A51Z&sp=r&sv=2021-08-06&sr=b&sig=ULGCxkgnVb75rfh1Ki05MwGx6IjhUi99/x4ESV31W5w%3D"
+                        }
+                    },
+                    "_display": "Auto- / scooter- / bromfiets(wrak) (Overlast in de openbare ruimte)",
+                    "id": 34,
+                    "name": "Auto- / scooter- / bromfiets(wrak)",
+                    "slug": "auto-scooter-bromfietswrak",
+                    "handling": "A3WMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "THO",
+                            "name": "THOR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "Het wrak van een auto, scooter of bromfiets.",
+                    "handling_message": "We laten u binnen 3 weken weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 9513,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-op-het-water/sub_categories/blokkade-van-de-vaarweg"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-op-het-water/boten.svg?se=2023-02-16T14%3A14%3A51Z&sp=r&sv=2021-08-06&sr=b&sig=t2l0v5yMll7742zZhtCIG4NoDLaQ/28SSKDThSAQwaM%3D"
+                        }
+                    },
+                    "_display": "Blokkade van de vaarweg (Overlast op het water)",
+                    "id": 134,
+                    "name": "Blokkade van de vaarweg",
+                    "slug": "blokkade-van-de-vaarweg",
+                    "handling": "STOPEC3",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "WAT",
+                            "name": "Waternet",
+                            "is_intern": false
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "dit is een omschrijving",
+                    "handling_message": "Gevaarlijke situaties pakken wij zo snel mogelijk op. We laten u binnen 3 werkdagen weten wat we hebben gedaan. We houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 9537,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/openbaar-groen-en-water/sub_categories/boom-illegale-kap"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/openbaar-groen-en-water/bomen_planten.svg?se=2023-02-16T14%3A14%3A51Z&sp=r&sv=2021-08-06&sr=b&sig=qMgU2J3OmA0P4SJOp12NmQbd2Tp6Vo%2B%2BAf5cxHHRcnM%3D"
+                        }
+                    },
+                    "_display": "Boom - illegale kap (Openbaar groen en water)",
+                    "id": 115,
+                    "name": "Boom - illegale kap",
+                    "slug": "boom-illegale-kap",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "THO",
+                            "name": "THOR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 9573,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/bruin-en-witgoed"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/afval/afval.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=3rppZzgnU1Kt0BY4fXxsjdkvBpa5OWthAyA5lDlGVUM%3D"
+                        }
+                    },
+                    "_display": "Bruin- en witgoed (Afval)",
+                    "id": 160,
+                    "name": "Bruin- en witgoed",
+                    "slug": "bruin-en-witgoed",
+                    "handling": "A3DEC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "AEG",
+                            "name": "Afval en Grondstoffen",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "Bruin en witgoed zijn zaken als: wasmachines, koelkasten, magnetrons of andere zaken met een motor en kleine electrische huishoudelijke spullen.",
+                    "handling_message": "Wij handelen uw melding binnen drie werkdagen af. Als u een mailadres hebt opgegeven, zullen we u op de hoogte houden."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 9574,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/container-bijplaatsing"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/afval/afval.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=3rppZzgnU1Kt0BY4fXxsjdkvBpa5OWthAyA5lDlGVUM%3D"
+                        }
+                    },
+                    "_display": "Container bijplaatsing (Afval)",
+                    "id": 171,
+                    "name": "Container bijplaatsing",
+                    "slug": "container-bijplaatsing",
+                    "handling": "A3DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "AEG",
+                            "name": "Afval en Grondstoffen",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "Meldingen bijplaatsing naast container",
+                    "handling_message": "Wij gaan aan het werk met uw melding. Als het dringend is komen we direct in actie. U hoort binnen 3 werkdagen wat wij hebben gedaan."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 9575,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/container-glas-kapot"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/afval/container-glas-kapot/glas_KRwRU5f.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=3DHb5nt0lkiOj4lqFL4z684F9zZFnOov29sNjq1Mh5A%3D"
+                        }
+                    },
+                    "_display": "Container glas kapot (Afval)",
+                    "id": 132,
+                    "name": "Container glas kapot",
+                    "slug": "container-glas-kapot",
+                    "handling": "A3WMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "AEG",
+                            "name": "Afval en Grondstoffen",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "We laten u binnen 3 weken weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\r\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 9576,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/container-glas-vol"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/afval/container-glas-vol/glas.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=mNXJEx5bp0aiIWTmVobH4NalDs9Ht%2Bfr1H%2BmQTZXNUw%3D"
+                        }
+                    },
+                    "_display": "Container glas vol (Afval)",
+                    "id": 133,
+                    "name": "Container glas vol",
+                    "slug": "container-glas-vol",
+                    "handling": "A3WMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "AEG",
+                            "name": "Afval en Grondstoffen",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "We laten u binnen 3 weken weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\r\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 9577,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/container-is-kapot"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/afval/container-is-kapot/restafval.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=GSqVY/5VWgXKX0A7bURXtqh0t2ZzBHCOuZKRvS8jVSA%3D"
+                        }
+                    },
+                    "_display": "Container is kapot (Afval)",
+                    "id": 8,
+                    "name": "Container is kapot",
+                    "slug": "container-is-kapot",
+                    "handling": "A3DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "AEG",
+                            "name": "Afval en Grondstoffen",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "Een verhaal over een kapotte container",
+                    "handling_message": "We laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 9578,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/container-is-vol"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/afval/afval.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=3rppZzgnU1Kt0BY4fXxsjdkvBpa5OWthAyA5lDlGVUM%3D"
+                        }
+                    },
+                    "_display": "Container is vol (Afval)",
+                    "id": 6,
+                    "name": "Container is vol",
+                    "slug": "container-is-vol",
+                    "handling": "A3DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "AEG",
+                            "name": "Afval en Grondstoffen",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "Dit is een testje",
+                    "handling_message": "We laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 9579,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/container-voor-papier-is-stuk"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/afval/container-voor-papier-is-stuk/papier_Nc0penm.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=n4hy%2BbOwcH8hmMdammldq9AyfapFJ0zF7s/hJofZ27Y%3D"
+                        }
+                    },
+                    "_display": "Container papier kapot (Afval)",
+                    "id": 89,
+                    "name": "Container papier kapot",
+                    "slug": "container-voor-papier-is-stuk",
+                    "handling": "A3DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "AEG",
+                            "name": "Afval en Grondstoffen",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "We laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\r\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 9580,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/container-voor-papier-is-vol"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/afval/container-voor-papier-is-vol/papier_nVx8l5z.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=a7B/cjAN08ePEGBUjQJ5SpxiBMXyQ50ujHYAZsQAkvI%3D"
+                        }
+                    },
+                    "_display": "Container papier vol (Afval)",
+                    "id": 90,
+                    "name": "Container papier vol",
+                    "slug": "container-voor-papier-is-vol",
+                    "handling": "A3DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "AEG",
+                            "name": "Afval en Grondstoffen",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "We laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\r\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 9582,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/container-voor-plastic-afval-is-kapot"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/afval/afval.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=3rppZzgnU1Kt0BY4fXxsjdkvBpa5OWthAyA5lDlGVUM%3D"
+                        }
+                    },
+                    "_display": "Container plastic kapot (Afval)",
+                    "id": 13,
+                    "name": "Container plastic kapot",
+                    "slug": "container-voor-plastic-afval-is-kapot",
+                    "handling": "A3DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "AEG",
+                            "name": "Afval en Grondstoffen",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "We laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 9581,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/container-voor-plastic-afval-is-vol"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/afval/afval.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=3rppZzgnU1Kt0BY4fXxsjdkvBpa5OWthAyA5lDlGVUM%3D"
+                        }
+                    },
+                    "_display": "Container plastic afval vol (Afval)",
+                    "id": 12,
+                    "name": "Container plastic afval vol",
+                    "slug": "container-voor-plastic-afval-is-vol",
+                    "handling": "A3DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "AEG",
+                            "name": "Afval en Grondstoffen",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "We laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 9523,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-van-en-door-personen-of-groepen/sub_categories/daklozen-bedelen"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-van-en-door-personen-of-groepen/personen.svg?se=2023-02-16T14%3A14%3A51Z&sp=r&sv=2021-08-06&sr=b&sig=78eKfpAw8t04pHkmX/H1jJTwIkOhoVjSE8X80eDNfVY%3D"
+                        }
+                    },
+                    "_display": "Daklozen / bedelen (Overlast van en door personen of groepen)",
+                    "id": 59,
+                    "name": "Daklozen / bedelen",
+                    "slug": "daklozen-bedelen",
+                    "handling": "A3DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "THO",
+                            "name": "THOR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "Overlast van zwerver",
+                    "handling_message": "We laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 9521,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-van-en-door-personen-of-groepen/sub_categories/drank-en-drugsoverlast"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-van-en-door-personen-of-groepen/personen.svg?se=2023-02-16T14%3A14%3A51Z&sp=r&sv=2021-08-06&sr=b&sig=78eKfpAw8t04pHkmX/H1jJTwIkOhoVjSE8X80eDNfVY%3D"
+                        }
+                    },
+                    "_display": "Drank- / drugsoverlast (Overlast van en door personen of groepen)",
+                    "id": 61,
+                    "name": "Drank- / drugsoverlast",
+                    "slug": "drank-en-drugsoverlast",
+                    "handling": "A3DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "AB",
+                            "name": "Amsterdamse Bos",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "THO",
+                            "name": "THOR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "We laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 9583,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/grofvuil"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/afval/afval.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=3rppZzgnU1Kt0BY4fXxsjdkvBpa5OWthAyA5lDlGVUM%3D"
+                        }
+                    },
+                    "_display": "Grofvuil (Afval)",
+                    "id": 2,
+                    "name": "Grofvuil",
+                    "slug": "grofvuil",
+                    "handling": "A3DEVOMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "AEG",
+                            "name": "Afval en Grondstoffen",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "VIS",
+                            "name": "V&OR - VIS",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "Meubels of andere grote spullen uit uw huis, grote elektrische apparaten, snoeiafval, hout en glas.",
+                    "handling_message": "We laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken. We houden u op de hoogte."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 9584,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/handhaving-op-afval"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/afval/afval.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=3rppZzgnU1Kt0BY4fXxsjdkvBpa5OWthAyA5lDlGVUM%3D"
+                        }
+                    },
+                    "_display": "Handhaving op afval (Afval)",
+                    "id": 91,
+                    "name": "Handhaving op afval",
+                    "slug": "handhaving-op-afval",
+                    "handling": "A3DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "THO",
+                            "name": "THOR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "We laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 9533,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-in-de-openbare-ruimte/sub_categories/hinderlijk-geplaatst-object"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-in-de-openbare-ruimte/openbare_ruimte.svg?se=2023-02-16T14%3A14%3A51Z&sp=r&sv=2021-08-06&sr=b&sig=ULGCxkgnVb75rfh1Ki05MwGx6IjhUi99/x4ESV31W5w%3D"
+                        }
+                    },
+                    "_display": "Hinderlijk geplaatst object (Overlast in de openbare ruimte)",
+                    "id": 37,
+                    "name": "Hinderlijk geplaatst object",
+                    "slug": "hinderlijk-geplaatst-object",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "THO",
+                            "name": "THOR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 9585,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/huisafval"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/afval/afval.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=3rppZzgnU1Kt0BY4fXxsjdkvBpa5OWthAyA5lDlGVUM%3D"
+                        }
+                    },
+                    "_display": "Huisafval (Afval)",
+                    "id": 3,
+                    "name": "Huisafval",
+                    "slug": "huisafval",
+                    "handling": "A3DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "AEG",
+                            "name": "Afval en Grondstoffen",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "VIS",
+                            "name": "V&OR - VIS",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "We laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 9524,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-van-en-door-personen-of-groepen/sub_categories/jongerenoverlast"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-van-en-door-personen-of-groepen/personen.svg?se=2023-02-16T14%3A14%3A51Z&sp=r&sv=2021-08-06&sr=b&sig=78eKfpAw8t04pHkmX/H1jJTwIkOhoVjSE8X80eDNfVY%3D"
+                        }
+                    },
+                    "_display": "Jongerenoverlast (Overlast van en door personen of groepen)",
+                    "id": 58,
+                    "name": "Jongerenoverlast",
+                    "slug": "jongerenoverlast",
+                    "handling": "A3DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "THO",
+                            "name": "THOR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "We laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 9586,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/kerstbomen"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/afval/afval.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=3rppZzgnU1Kt0BY4fXxsjdkvBpa5OWthAyA5lDlGVUM%3D"
+                        }
+                    },
+                    "_display": "Kerstbomen (Afval)",
+                    "id": 162,
+                    "name": "Kerstbomen",
+                    "slug": "kerstbomen",
+                    "handling": "A3DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "AEG",
+                            "name": "Afval en Grondstoffen",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "Meldingen over aangeboden/gedumpte Kerstbomen",
+                    "handling_message": "Wij hebben uw melding doorgestuurd naar de uitvoering. Normaal gesproken handelen wij uw melding binnen 3 werkdagen af. Helaas is in verband met corona ons ziekteverzuim hoger dan normaal. Wij doen ons uiterste best om uw melding zo snel mogelijk af te handelen. Uiteraard houden wij rekening met meldingen die urgent zijn."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 9520,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-van-en-door-personen-of-groepen/sub_categories/loslopende-agressieve-honden"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-van-en-door-personen-of-groepen/personen.svg?se=2023-02-16T14%3A14%3A51Z&sp=r&sv=2021-08-06&sr=b&sig=78eKfpAw8t04pHkmX/H1jJTwIkOhoVjSE8X80eDNfVY%3D"
+                        }
+                    },
+                    "_display": "Loslopende agressieve honden (Overlast van en door personen of groepen)",
+                    "id": 174,
+                    "name": "Loslopende agressieve honden",
+                    "slug": "loslopende-agressieve-honden",
+                    "handling": "EMPTY",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "AEG",
+                            "name": "Afval en Grondstoffen",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "AB",
+                            "name": "Amsterdamse Bos",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "Overlast loslopende/agressieve honden",
+                    "handling_message": "Wij gaan aan het werk met uw melding. Als het dringend is komen we direct in actie. U hoort binnen 3 werkdagen wat wij hebben gedaan."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 9532,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-in-de-openbare-ruimte/sub_categories/lozing-dumping-bodemverontreiniging"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-in-de-openbare-ruimte/openbare_ruimte.svg?se=2023-02-16T14%3A14%3A51Z&sp=r&sv=2021-08-06&sr=b&sig=ULGCxkgnVb75rfh1Ki05MwGx6IjhUi99/x4ESV31W5w%3D"
+                        }
+                    },
+                    "_display": "Lozing / dumping / bodemverontreiniging (Overlast in de openbare ruimte)",
+                    "id": 29,
+                    "name": "Lozing / dumping / bodemverontreiniging",
+                    "slug": "lozing-dumping-bodemverontreiniging",
+                    "handling": "A3DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "THO",
+                            "name": "THOR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "We laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 9531,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-in-de-openbare-ruimte/sub_categories/markten"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-in-de-openbare-ruimte/openbare_ruimte.svg?se=2023-02-16T14%3A14%3A51Z&sp=r&sv=2021-08-06&sr=b&sig=ULGCxkgnVb75rfh1Ki05MwGx6IjhUi99/x4ESV31W5w%3D"
+                        }
+                    },
+                    "_display": "Markten (Overlast in de openbare ruimte)",
+                    "id": 157,
+                    "name": "Markten",
+                    "slug": "markten",
+                    "handling": "HANDLING_MARKTEN",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "blah",
+                    "handling_message": "Wij beoordelen uw melding. Urgente meldingen pakken we zo snel mogelijk op. Overige meldingen handelen we binnen drie dagen af. Als u een mailadres hebt opgegeven, zullen we u op de hoogte houden."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 9510,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-op-het-water/sub_categories/olie-op-het-water"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-op-het-water/boten.svg?se=2023-02-16T14%3A14%3A51Z&sp=r&sv=2021-08-06&sr=b&sig=t2l0v5yMll7742zZhtCIG4NoDLaQ/28SSKDThSAQwaM%3D"
+                        }
+                    },
+                    "_display": "Olie op het water (Overlast op het water)",
+                    "id": 135,
+                    "name": "Olie op het water",
+                    "slug": "olie-op-het-water",
+                    "handling": "STOPEC3",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "WAT",
+                            "name": "Waternet",
+                            "is_intern": false
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Gevaarlijke situaties pakken wij zo snel mogelijk op. We laten u binnen 3 werkdagen weten wat we hebben gedaan. We houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 9505,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overig/sub_categories/overig"
+                        }
+                    },
+                    "_display": "Overig (Overig)",
+                    "id": 76,
+                    "name": "Overig",
+                    "slug": "overig",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 9587,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/overig-afval"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/afval/overig-afval/restafval.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=IFkRI30iyakB/Le4FrPNGB2SV0fJuaj%2BcpgrNu0M/wI%3D"
+                        }
+                    },
+                    "_display": "Overig afval (Afval)",
+                    "id": 11,
+                    "name": "Overig afval",
+                    "slug": "overig-afval",
+                    "handling": "REST",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "AEG",
+                            "name": "Afval en Grondstoffen",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "Wij bekijken uw melding en zorgen dat het juiste onderdeel van de gemeente deze gaat behandelen. Heeft u contactgegevens achtergelaten? Dan nemen wij bij onduidelijkheid contact met u op."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 9509,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-op-het-water/sub_categories/overig-boten"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-op-het-water/boten.svg?se=2023-02-16T14%3A14%3A50Z&sp=r&sv=2021-08-06&sr=b&sig=GD1NlBrGqC7eBoWvb8oPAbY9CYub03Q5QQh%2B9r6HKPk%3D"
+                        }
+                    },
+                    "_display": "Overige boten (Overlast op het water)",
+                    "id": 75,
+                    "name": "Overige boten",
+                    "slug": "overig-boten",
+                    "handling": "WS3EC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "WAT",
+                            "name": "Waternet",
+                            "is_intern": false
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "We geven uw melding door aan onze handhavers. Zij beoordelen of het nodig is direct actie te ondernemen. Bijvoorbeeld omdat er olie lekt of omdat de situatie gevaar oplevert voor andere boten.\n\nAls er geen directe actie nodig is, dan pakken we uw melding op buiten het vaarseizoen (september - maart).\n"
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 9530,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-in-de-openbare-ruimte/sub_categories/overig-openbare-ruimte"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-in-de-openbare-ruimte/openbare_ruimte.svg?se=2023-02-16T14%3A14%3A51Z&sp=r&sv=2021-08-06&sr=b&sig=ULGCxkgnVb75rfh1Ki05MwGx6IjhUi99/x4ESV31W5w%3D"
+                        }
+                    },
+                    "_display": "Overig openbare ruimte (Overlast in de openbare ruimte)",
+                    "id": 39,
+                    "name": "Overig openbare ruimte",
+                    "slug": "overig-openbare-ruimte",
+                    "handling": "A3WMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "We laten u binnen 3 weken weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 9504,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overig/sub_categories/overige-dienstverlening"
+                        }
+                    },
+                    "_display": "Overige dienstverlening (Overig)",
+                    "id": 101,
+                    "name": "Overige dienstverlening",
+                    "slug": "overige-dienstverlening",
+                    "handling": "REST",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Wij bekijken uw melding en zorgen dat het juiste onderdeel van de gemeente deze gaat behandelen. Heeft u contactgegevens achtergelaten? Dan nemen wij bij onduidelijkheid contact met u op."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 9526,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-van-en-door-personen-of-groepen/sub_categories/overige-overlast-door-personen"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-van-en-door-personen-of-groepen/personen.svg?se=2023-02-16T14%3A14%3A51Z&sp=r&sv=2021-08-06&sr=b&sig=78eKfpAw8t04pHkmX/H1jJTwIkOhoVjSE8X80eDNfVY%3D"
+                        }
+                    },
+                    "_display": "Overige overlast door personen (Overlast van en door personen of groepen)",
+                    "id": 55,
+                    "name": "Overige overlast door personen",
+                    "slug": "overige-overlast-door-personen",
+                    "handling": "REST",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "THO",
+                            "name": "THOR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Wij bekijken uw melding en zorgen dat het juiste onderdeel van de gemeente deze gaat behandelen. Heeft u contactgegevens achtergelaten? Dan nemen wij bij onduidelijkheid contact met u op."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 9527,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-van-en-door-personen-of-groepen/sub_categories/overlast-door-afsteken-vuurwerk"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-van-en-door-personen-of-groepen/personen.svg?se=2023-02-16T14%3A14%3A51Z&sp=r&sv=2021-08-06&sr=b&sig=78eKfpAw8t04pHkmX/H1jJTwIkOhoVjSE8X80eDNfVY%3D"
+                        }
+                    },
+                    "_display": "Overlast door afsteken vuurwerk (Overlast van en door personen of groepen)",
+                    "id": 54,
+                    "name": "Overlast door afsteken vuurwerk",
+                    "slug": "overlast-door-afsteken-vuurwerk",
+                    "handling": "A3DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "THO",
+                            "name": "THOR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "We laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 9516,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-bedrijven-en-horeca/sub_categories/overlast-door-bezoekers-niet-op-terras"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-bedrijven-en-horeca/bedrijven.svg?se=2023-02-16T14%3A14%3A51Z&sp=r&sv=2021-08-06&sr=b&sig=FFcAN4IlJE9ZoPBbkP4FV2PEI9vBByJSc8%2BYizg2nBg%3D"
+                        }
+                    },
+                    "_display": "Overlast door bezoekers (niet op terras) (Overlast Bedrijven en Horeca)",
+                    "id": 67,
+                    "name": "Overlast door bezoekers (niet op terras)",
+                    "slug": "overlast-door-bezoekers-niet-op-terras",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "THO",
+                            "name": "THOR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 9512,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-op-het-water/sub_categories/overlast-op-het-water-geluid"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-op-het-water/boten.svg?se=2023-02-16T14%3A14%3A51Z&sp=r&sv=2021-08-06&sr=b&sig=t2l0v5yMll7742zZhtCIG4NoDLaQ/28SSKDThSAQwaM%3D"
+                        }
+                    },
+                    "_display": "Geluid op het water (Overlast op het water)",
+                    "id": 71,
+                    "name": "Geluid op het water",
+                    "slug": "overlast-op-het-water-geluid",
+                    "handling": "WS1EC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "WAT",
+                            "name": "Waternet",
+                            "is_intern": false
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "We geven uw melding door aan de handhavers. Als dat mogelijk is ondernemen zij direct actie, maar zij kunnen niet altijd snel genoeg aanwezig zijn.\n\nBlijf overlast aan ons melden. Ook als we niet altijd direct iets voor u kunnen doen. We gebruiken alle meldingen om overlast in de toekomst te kunnen beperken."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 9506,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-op-het-water/sub_categories/overlast-op-het-water-gezonken-boot"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-op-het-water/boten.svg?se=2023-02-16T14%3A14%3A50Z&sp=r&sv=2021-08-06&sr=b&sig=GD1NlBrGqC7eBoWvb8oPAbY9CYub03Q5QQh%2B9r6HKPk%3D"
+                        }
+                    },
+                    "_display": "Wrak in het water (Overlast op het water)",
+                    "id": 72,
+                    "name": "Wrak in het water",
+                    "slug": "overlast-op-het-water-gezonken-boot",
+                    "handling": "WS2EC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "WAT",
+                            "name": "Waternet",
+                            "is_intern": false
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "We geven uw melding door aan onze handhavers. Zij beoordelen of het nodig is direct actie te ondernemen. Bijvoorbeeld omdat er olie lekt of omdat de situatie gevaar oplevert voor andere boten.\n\nAls er geen directe actie nodig is, dan pakken we uw melding op buiten het vaarseizoen (september - maart).\n\nBekijk in welke situaties we een wrak weghalen. Boten die vol met water staan, maar nog wél drijven, mogen we bijvoorbeeld niet weghalen."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 9507,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-op-het-water/sub_categories/overlast-op-het-water-snel-varen"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-op-het-water/boten.svg?se=2023-02-16T14%3A14%3A50Z&sp=r&sv=2021-08-06&sr=b&sig=GD1NlBrGqC7eBoWvb8oPAbY9CYub03Q5QQh%2B9r6HKPk%3D"
+                        }
+                    },
+                    "_display": "Snel varen (Overlast op het water)",
+                    "id": 69,
+                    "name": "Snel varen",
+                    "slug": "overlast-op-het-water-snel-varen",
+                    "handling": "WS1EC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "WAT",
+                            "name": "Waternet",
+                            "is_intern": false
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "We geven uw melding door aan de handhavers. Als dat mogelijk is ondernemen zij direct actie, maar zij kunnen niet altijd snel genoeg aanwezig zijn.\n\nBlijf overlast aan ons melden. Ook als we niet altijd direct iets voor u kunnen doen. We gebruiken alle meldingen om overlast in de toekomst te kunnen beperken."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 9525,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-van-en-door-personen-of-groepen/sub_categories/overlast-van-taxis-bussen-en-fietstaxis"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-van-en-door-personen-of-groepen/personen.svg?se=2023-02-16T14%3A14%3A51Z&sp=r&sv=2021-08-06&sr=b&sig=78eKfpAw8t04pHkmX/H1jJTwIkOhoVjSE8X80eDNfVY%3D"
+                        }
+                    },
+                    "_display": "Overlast van taxi's, bussen en fietstaxi's (Overlast van en door personen of groepen)",
+                    "id": 57,
+                    "name": "Overlast van taxi's, bussen en fietstaxi's",
+                    "slug": "overlast-van-taxis-bussen-en-fietstaxis",
+                    "handling": "A3DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "THO",
+                            "name": "THOR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "We laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 9529,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-in-de-openbare-ruimte/sub_categories/parkeeroverlast"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-in-de-openbare-ruimte/openbare_ruimte.svg?se=2023-02-16T14%3A14%3A51Z&sp=r&sv=2021-08-06&sr=b&sig=ULGCxkgnVb75rfh1Ki05MwGx6IjhUi99/x4ESV31W5w%3D"
+                        }
+                    },
+                    "_display": "Parkeeroverlast (Overlast in de openbare ruimte)",
+                    "id": 30,
+                    "name": "Parkeeroverlast",
+                    "slug": "parkeeroverlast",
+                    "handling": "A3DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "THO",
+                            "name": "THOR",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "VOR",
+                            "name": "V&OR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "We laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 9588,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/puin-sloopafval"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/afval/afval.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=3rppZzgnU1Kt0BY4fXxsjdkvBpa5OWthAyA5lDlGVUM%3D"
+                        }
+                    },
+                    "_display": "Puin- / sloopafval (Afval)",
+                    "id": 5,
+                    "name": "Puin- / sloopafval",
+                    "slug": "puin-sloopafval",
+                    "handling": "A3DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "AEG",
+                            "name": "Afval en Grondstoffen",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "We laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 9493,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/schoon/sub_categories/putrioleringverstopt"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/schoon/onderhoud.svg?se=2023-02-16T14%3A14%3A50Z&sp=r&sv=2021-08-06&sr=b&sig=EvN83H5iaSSgg2HJ5YwznGFIOeasvlUv2VPI0lPtRTc%3D"
+                        }
+                    },
+                    "_display": "Put / riolering verstopt (Schoon)",
+                    "id": 170,
+                    "name": "Put / riolering verstopt",
+                    "slug": "putrioleringverstopt",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "CCA",
+                            "name": "CCA",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 9511,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-op-het-water/sub_categories/scheepvaart-nautisch-toezicht"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-op-het-water/boten.svg?se=2023-02-16T14%3A14%3A51Z&sp=r&sv=2021-08-06&sr=b&sig=t2l0v5yMll7742zZhtCIG4NoDLaQ/28SSKDThSAQwaM%3D"
+                        }
+                    },
+                    "_display": "Nautisch toezicht / vaargedrag (Overlast op het water)",
+                    "id": 73,
+                    "name": "Nautisch toezicht / vaargedrag",
+                    "slug": "scheepvaart-nautisch-toezicht",
+                    "handling": "WS3EC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "WAT",
+                            "name": "Waternet",
+                            "is_intern": false
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "We geven uw melding door aan onze handhavers. Zij beoordelen of het nodig is direct actie te ondernemen. Bijvoorbeeld omdat er olie lekt of omdat de situatie gevaar oplevert voor andere boten.\n\nAls er geen directe actie nodig is, dan pakken we uw melding op buiten het vaarseizoen (september - maart)."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 9528,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-in-de-openbare-ruimte/sub_categories/stank-geluidsoverlast"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-in-de-openbare-ruimte/openbare_ruimte.svg?se=2023-02-16T14%3A14%3A51Z&sp=r&sv=2021-08-06&sr=b&sig=ULGCxkgnVb75rfh1Ki05MwGx6IjhUi99/x4ESV31W5w%3D"
+                        }
+                    },
+                    "_display": "Stank- / geluidsoverlast (Overlast in de openbare ruimte)",
+                    "id": 32,
+                    "name": "Stank- / geluidsoverlast",
+                    "slug": "stank-geluidsoverlast",
+                    "handling": "A3WMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "THO",
+                            "name": "THOR",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "VTH",
+                            "name": "VTH",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "We laten u binnen 3 weken weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 9495,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/schoon/sub_categories/uitwerpselen"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/schoon/onderhoud.svg?se=2023-02-16T14%3A14%3A50Z&sp=r&sv=2021-08-06&sr=b&sig=EvN83H5iaSSgg2HJ5YwznGFIOeasvlUv2VPI0lPtRTc%3D"
+                        }
+                    },
+                    "_display": "Uitwerpselen (Schoon)",
+                    "id": 139,
+                    "name": "Uitwerpselen",
+                    "slug": "uitwerpselen",
+                    "handling": "A3WMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "THO",
+                            "name": "THOR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "We laten u binnen 3 weken weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 9590,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/verkeersoverlast"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/wegen-verkeer-straatmeubilair/verkeer.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=3bw2HLwEgw3EuJ8FdZXiGk90B3GVdBqys1oBUJJjDZo%3D"
+                        }
+                    },
+                    "_display": "Verkeersoverlast (Wegen, verkeer, straatmeubilair)",
+                    "id": 103,
+                    "name": "Verkeersoverlast",
+                    "slug": "verkeersoverlast",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "THO",
+                            "name": "THOR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 9522,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-van-en-door-personen-of-groepen/sub_categories/wildplassen-poepen-overgeven"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-van-en-door-personen-of-groepen/personen.svg?se=2023-02-16T14%3A14%3A51Z&sp=r&sv=2021-08-06&sr=b&sig=78eKfpAw8t04pHkmX/H1jJTwIkOhoVjSE8X80eDNfVY%3D"
+                        }
+                    },
+                    "_display": "Wildplassen / poepen / overgeven (Overlast van en door personen of groepen)",
+                    "id": 60,
+                    "name": "Wildplassen / poepen / overgeven",
+                    "slug": "wildplassen-poepen-overgeven",
+                    "handling": "A3DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "THO",
+                            "name": "THOR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "We laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            }
+        ],
+        "can_direct": true
+    },
+    {
+        "_links": {
+            "self": {
+                "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/private/departments/5"
+            }
+        },
+        "_display": "AEG (Afval en Grondstoffen)",
+        "id": 5,
+        "name": "Afval en Grondstoffen",
+        "code": "AEG",
+        "is_intern": true,
+        "categories": [
+            {
+                "id": 3366,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/bruin-en-witgoed"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/afval/afval.svg?se=2023-02-16T14%3A14%3A51Z&sp=r&sv=2021-08-06&sr=b&sig=Jw8mfPs7xL5hEr8LO6tT/GZlKOWVMERdUwl%2BwjZnC8Y%3D"
+                        }
+                    },
+                    "_display": "Bruin- en witgoed (Afval)",
+                    "id": 160,
+                    "name": "Bruin- en witgoed",
+                    "slug": "bruin-en-witgoed",
+                    "handling": "A3DEC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "AEG",
+                            "name": "Afval en Grondstoffen",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "Bruin en witgoed zijn zaken als: wasmachines, koelkasten, magnetrons of andere zaken met een motor en kleine electrische huishoudelijke spullen.",
+                    "handling_message": "Wij handelen uw melding binnen drie werkdagen af. Als u een mailadres hebt opgegeven, zullen we u op de hoogte houden."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 6045,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/container-bijplaatsing"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/afval/afval.svg?se=2023-02-16T14%3A14%3A51Z&sp=r&sv=2021-08-06&sr=b&sig=Jw8mfPs7xL5hEr8LO6tT/GZlKOWVMERdUwl%2BwjZnC8Y%3D"
+                        }
+                    },
+                    "_display": "Container bijplaatsing (Afval)",
+                    "id": 171,
+                    "name": "Container bijplaatsing",
+                    "slug": "container-bijplaatsing",
+                    "handling": "A3DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "AEG",
+                            "name": "Afval en Grondstoffen",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "Meldingen bijplaatsing naast container",
+                    "handling_message": "Wij gaan aan het werk met uw melding. Als het dringend is komen we direct in actie. U hoort binnen 3 werkdagen wat wij hebben gedaan."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 3353,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/container-glas-kapot"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/afval/container-glas-kapot/glas_KRwRU5f.svg?se=2023-02-16T14%3A14%3A50Z&sp=r&sv=2021-08-06&sr=b&sig=D37s6jA%2BS/KPVxulvtUEj5Z/OgsT4nxyotdn62kzhQY%3D"
+                        }
+                    },
+                    "_display": "Container glas kapot (Afval)",
+                    "id": 132,
+                    "name": "Container glas kapot",
+                    "slug": "container-glas-kapot",
+                    "handling": "A3WMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "AEG",
+                            "name": "Afval en Grondstoffen",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "We laten u binnen 3 weken weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\r\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 3354,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/container-glas-vol"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/afval/container-glas-vol/glas.svg?se=2023-02-16T14%3A14%3A50Z&sp=r&sv=2021-08-06&sr=b&sig=d5ttwpIfjkzoTYcxDf4k6/2T0UPFAVXsWny27%2BcKZIg%3D"
+                        }
+                    },
+                    "_display": "Container glas vol (Afval)",
+                    "id": 133,
+                    "name": "Container glas vol",
+                    "slug": "container-glas-vol",
+                    "handling": "A3WMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "AEG",
+                            "name": "Afval en Grondstoffen",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "We laten u binnen 3 weken weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\r\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 3355,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/container-is-kapot"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/afval/container-is-kapot/restafval.svg?se=2023-02-16T14%3A14%3A50Z&sp=r&sv=2021-08-06&sr=b&sig=JA0dNNUCb04oBOzOShEI0ud4/WWHG9KkYWSASrywIZ4%3D"
+                        }
+                    },
+                    "_display": "Container is kapot (Afval)",
+                    "id": 8,
+                    "name": "Container is kapot",
+                    "slug": "container-is-kapot",
+                    "handling": "A3DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "AEG",
+                            "name": "Afval en Grondstoffen",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "Een verhaal over een kapotte container",
+                    "handling_message": "We laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 3356,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/container-is-vol"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/afval/afval.svg?se=2023-02-16T14%3A14%3A50Z&sp=r&sv=2021-08-06&sr=b&sig=MsxDorupcWardNHYUlRCEsPUD/PHPh0FFMQ627aRlYw%3D"
+                        }
+                    },
+                    "_display": "Container is vol (Afval)",
+                    "id": 6,
+                    "name": "Container is vol",
+                    "slug": "container-is-vol",
+                    "handling": "A3DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "AEG",
+                            "name": "Afval en Grondstoffen",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "Dit is een testje",
+                    "handling_message": "We laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 3357,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/container-voor-papier-is-stuk"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/afval/container-voor-papier-is-stuk/papier_Nc0penm.svg?se=2023-02-16T14%3A14%3A50Z&sp=r&sv=2021-08-06&sr=b&sig=3VgpFIPj8wvB1l0pvnIYlkWzV6hBX5ZV12VX8yMbFss%3D"
+                        }
+                    },
+                    "_display": "Container papier kapot (Afval)",
+                    "id": 89,
+                    "name": "Container papier kapot",
+                    "slug": "container-voor-papier-is-stuk",
+                    "handling": "A3DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "AEG",
+                            "name": "Afval en Grondstoffen",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "We laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\r\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 3358,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/container-voor-papier-is-vol"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/afval/container-voor-papier-is-vol/papier_nVx8l5z.svg?se=2023-02-16T14%3A14%3A50Z&sp=r&sv=2021-08-06&sr=b&sig=LNss9eBslsEzNbvnv0mH9cox00nz0Qg4sNUuatd8KY8%3D"
+                        }
+                    },
+                    "_display": "Container papier vol (Afval)",
+                    "id": 90,
+                    "name": "Container papier vol",
+                    "slug": "container-voor-papier-is-vol",
+                    "handling": "A3DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "AEG",
+                            "name": "Afval en Grondstoffen",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "We laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\r\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 3360,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/container-voor-plastic-afval-is-kapot"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/afval/afval.svg?se=2023-02-16T14%3A14%3A50Z&sp=r&sv=2021-08-06&sr=b&sig=MsxDorupcWardNHYUlRCEsPUD/PHPh0FFMQ627aRlYw%3D"
+                        }
+                    },
+                    "_display": "Container plastic kapot (Afval)",
+                    "id": 13,
+                    "name": "Container plastic kapot",
+                    "slug": "container-voor-plastic-afval-is-kapot",
+                    "handling": "A3DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "AEG",
+                            "name": "Afval en Grondstoffen",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "We laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 3359,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/container-voor-plastic-afval-is-vol"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/afval/afval.svg?se=2023-02-16T14%3A14%3A50Z&sp=r&sv=2021-08-06&sr=b&sig=MsxDorupcWardNHYUlRCEsPUD/PHPh0FFMQ627aRlYw%3D"
+                        }
+                    },
+                    "_display": "Container plastic afval vol (Afval)",
+                    "id": 12,
+                    "name": "Container plastic afval vol",
+                    "slug": "container-voor-plastic-afval-is-vol",
+                    "handling": "A3DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "AEG",
+                            "name": "Afval en Grondstoffen",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "We laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 3361,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/grofvuil"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/afval/afval.svg?se=2023-02-16T14%3A14%3A50Z&sp=r&sv=2021-08-06&sr=b&sig=MsxDorupcWardNHYUlRCEsPUD/PHPh0FFMQ627aRlYw%3D"
+                        }
+                    },
+                    "_display": "Grofvuil (Afval)",
+                    "id": 2,
+                    "name": "Grofvuil",
+                    "slug": "grofvuil",
+                    "handling": "A3DEVOMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "AEG",
+                            "name": "Afval en Grondstoffen",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "VIS",
+                            "name": "V&OR - VIS",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "Meubels of andere grote spullen uit uw huis, grote elektrische apparaten, snoeiafval, hout en glas.",
+                    "handling_message": "We laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken. We houden u op de hoogte."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 3363,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/huisafval"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/afval/afval.svg?se=2023-02-16T14%3A14%3A51Z&sp=r&sv=2021-08-06&sr=b&sig=Jw8mfPs7xL5hEr8LO6tT/GZlKOWVMERdUwl%2BwjZnC8Y%3D"
+                        }
+                    },
+                    "_display": "Huisafval (Afval)",
+                    "id": 3,
+                    "name": "Huisafval",
+                    "slug": "huisafval",
+                    "handling": "A3DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "AEG",
+                            "name": "Afval en Grondstoffen",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "VIS",
+                            "name": "V&OR - VIS",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "We laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 4740,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/kerstbomen"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/afval/afval.svg?se=2023-02-16T14%3A14%3A51Z&sp=r&sv=2021-08-06&sr=b&sig=Jw8mfPs7xL5hEr8LO6tT/GZlKOWVMERdUwl%2BwjZnC8Y%3D"
+                        }
+                    },
+                    "_display": "Kerstbomen (Afval)",
+                    "id": 162,
+                    "name": "Kerstbomen",
+                    "slug": "kerstbomen",
+                    "handling": "A3DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "AEG",
+                            "name": "Afval en Grondstoffen",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "Meldingen over aangeboden/gedumpte Kerstbomen",
+                    "handling_message": "Wij hebben uw melding doorgestuurd naar de uitvoering. Normaal gesproken handelen wij uw melding binnen 3 werkdagen af. Helaas is in verband met corona ons ziekteverzuim hoger dan normaal. Wij doen ons uiterste best om uw melding zo snel mogelijk af te handelen. Uiteraard houden wij rekening met meldingen die urgent zijn."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 6118,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-van-en-door-personen-of-groepen/sub_categories/loslopende-agressieve-honden"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-van-en-door-personen-of-groepen/personen.svg?se=2023-02-16T14%3A14%3A51Z&sp=r&sv=2021-08-06&sr=b&sig=78eKfpAw8t04pHkmX/H1jJTwIkOhoVjSE8X80eDNfVY%3D"
+                        }
+                    },
+                    "_display": "Loslopende agressieve honden (Overlast van en door personen of groepen)",
+                    "id": 174,
+                    "name": "Loslopende agressieve honden",
+                    "slug": "loslopende-agressieve-honden",
+                    "handling": "EMPTY",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "AEG",
+                            "name": "Afval en Grondstoffen",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "AB",
+                            "name": "Amsterdamse Bos",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "Overlast loslopende/agressieve honden",
+                    "handling_message": "Wij gaan aan het werk met uw melding. Als het dringend is komen we direct in actie. U hoort binnen 3 werkdagen wat wij hebben gedaan."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 3364,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/overig-afval"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/afval/overig-afval/restafval.svg?se=2023-02-16T14%3A14%3A51Z&sp=r&sv=2021-08-06&sr=b&sig=RXfx9FEK80dIohueCdcXOKV/z3Y0wnenEQYlILRyYdc%3D"
+                        }
+                    },
+                    "_display": "Overig afval (Afval)",
+                    "id": 11,
+                    "name": "Overig afval",
+                    "slug": "overig-afval",
+                    "handling": "REST",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "AEG",
+                            "name": "Afval en Grondstoffen",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "Wij bekijken uw melding en zorgen dat het juiste onderdeel van de gemeente deze gaat behandelen. Heeft u contactgegevens achtergelaten? Dan nemen wij bij onduidelijkheid contact met u op."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 3365,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/puin-sloopafval"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/afval/afval.svg?se=2023-02-16T14%3A14%3A51Z&sp=r&sv=2021-08-06&sr=b&sig=Jw8mfPs7xL5hEr8LO6tT/GZlKOWVMERdUwl%2BwjZnC8Y%3D"
+                        }
+                    },
+                    "_display": "Puin- / sloopafval (Afval)",
+                    "id": 5,
+                    "name": "Puin- / sloopafval",
+                    "slug": "puin-sloopafval",
+                    "handling": "A3DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "AEG",
+                            "name": "Afval en Grondstoffen",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "We laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 6069,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/rolcontainer-is-kapot"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/afval/afval.svg?se=2023-02-16T14%3A14%3A51Z&sp=r&sv=2021-08-06&sr=b&sig=Jw8mfPs7xL5hEr8LO6tT/GZlKOWVMERdUwl%2BwjZnC8Y%3D"
+                        }
+                    },
+                    "_display": "Rolcontainer is kapot (Afval)",
+                    "id": 172,
+                    "name": "Rolcontainer is kapot",
+                    "slug": "rolcontainer-is-kapot",
+                    "handling": "EMPTY",
+                    "departments": [
+                        {
+                            "code": "AEG",
+                            "name": "Afval en Grondstoffen",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "Aanvragen rolcontainer(s) bewoners, defecte rolcontainer(s) bewoners, wisselen rolcontainer(s) bewoners",
+                    "handling_message": "Wij gaan aan het werk met uw melding. Als het dringend is komen we direct in actie. U hoort binnen 10 werkdagen wat wij hebben gedaan."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 6093,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/rolcontainer-is-vol"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/afval/afval.svg?se=2023-02-16T14%3A14%3A51Z&sp=r&sv=2021-08-06&sr=b&sig=Jw8mfPs7xL5hEr8LO6tT/GZlKOWVMERdUwl%2BwjZnC8Y%3D"
+                        }
+                    },
+                    "_display": "Rolcontainer is vol (Afval)",
+                    "id": 173,
+                    "name": "Rolcontainer is vol",
+                    "slug": "rolcontainer-is-vol",
+                    "handling": "A3DMC",
+                    "departments": [
+                        {
+                            "code": "AEG",
+                            "name": "Afval en Grondstoffen",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "Meldingen rolcontainer(s) bewoners  vol/niet geleegd.",
+                    "handling_message": "Wij gaan aan het werk met uw melding. Als het dringend is komen we direct in actie. U hoort binnen 3 werkdagen wat wij hebben gedaan."
+                },
+                "is_responsible": true,
+                "can_view": true
+            }
+        ],
+        "can_direct": false
+    },
+    {
+        "_links": {
+            "self": {
+                "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/private/departments/20"
+            }
+        },
+        "_display": "AB (Amsterdamse Bos)",
+        "id": 20,
+        "name": "Amsterdamse Bos",
+        "code": "AB",
+        "is_intern": true,
+        "categories": [
+            {
+                "id": 9435,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-van-en-door-personen-of-groepen/sub_categories/drank-en-drugsoverlast"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-van-en-door-personen-of-groepen/personen.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=YUlj6ADSxN6kN90S2Ipz7EkFjVe1wkdiAjz7BnIpbf0%3D"
+                        }
+                    },
+                    "_display": "Drank- / drugsoverlast (Overlast van en door personen of groepen)",
+                    "id": 61,
+                    "name": "Drank- / drugsoverlast",
+                    "slug": "drank-en-drugsoverlast",
+                    "handling": "A3DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "AB",
+                            "name": "Amsterdamse Bos",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "THO",
+                            "name": "THOR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "We laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 9434,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-van-en-door-personen-of-groepen/sub_categories/loslopende-agressieve-honden"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-van-en-door-personen-of-groepen/personen.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=YUlj6ADSxN6kN90S2Ipz7EkFjVe1wkdiAjz7BnIpbf0%3D"
+                        }
+                    },
+                    "_display": "Loslopende agressieve honden (Overlast van en door personen of groepen)",
+                    "id": 174,
+                    "name": "Loslopende agressieve honden",
+                    "slug": "loslopende-agressieve-honden",
+                    "handling": "EMPTY",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "AEG",
+                            "name": "Afval en Grondstoffen",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "AB",
+                            "name": "Amsterdamse Bos",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "Overlast loslopende/agressieve honden",
+                    "handling_message": "Wij gaan aan het werk met uw melding. Als het dringend is komen we direct in actie. U hoort binnen 3 werkdagen wat wij hebben gedaan."
+                },
+                "is_responsible": true,
+                "can_view": true
+            }
+        ],
+        "can_direct": false
+    },
+    {
+        "_links": {
+            "self": {
+                "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/private/departments/12"
+            }
+        },
+        "_display": "CCA (CCA)",
+        "id": 12,
+        "name": "CCA",
+        "code": "CCA",
+        "is_intern": true,
+        "categories": [
+            {
+                "id": 5457,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/schoon/sub_categories/putrioleringverstopt"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/schoon/onderhoud.svg?se=2023-02-16T14%3A14%3A51Z&sp=r&sv=2021-08-06&sr=b&sig=59vHvN9AcI9TG5mr1qumaQlY4AokycSQ6NrhSDuUwBM%3D"
+                        }
+                    },
+                    "_display": "Put / riolering verstopt (Schoon)",
+                    "id": 170,
+                    "name": "Put / riolering verstopt",
+                    "slug": "putrioleringverstopt",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "CCA",
+                            "name": "CCA",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            }
+        ],
+        "can_direct": false
+    },
+    {
+        "_links": {
+            "self": {
+                "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/private/departments/16"
+            }
+        },
+        "_display": "FB (FB)",
+        "id": 16,
+        "name": "FB",
+        "code": "FB",
+        "is_intern": true,
+        "categories": [
+            {
+                "id": 2908,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/asbest-accu"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/afval/afval.svg?se=2023-02-16T14%3A14%3A51Z&sp=r&sv=2021-08-06&sr=b&sig=Jw8mfPs7xL5hEr8LO6tT/GZlKOWVMERdUwl%2BwjZnC8Y%3D"
+                        }
+                    },
+                    "_display": "Asbest / accu (Afval)",
+                    "id": 10,
+                    "name": "Asbest / accu",
+                    "slug": "asbest-accu",
+                    "handling": "A3DMC",
+                    "departments": [
+                        {
+                            "code": "FB",
+                            "name": "FB",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "THO",
+                            "name": "THOR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "Alles met betrekking tot asbest gerelateerd afval en bijtende/corrosieve vloeistoffen.",
+                    "handling_message": "We laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail.  [Bekijk de kaart met slimme apparaten](https://slimmeapparaten.amsterdam.nl)"
+                },
+                "is_responsible": true,
+                "can_view": true
+            }
+        ],
+        "can_direct": false
+    },
+    {
+        "_links": {
+            "self": {
+                "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/private/departments/8"
+            }
+        },
+        "_display": "GGD (GGD)",
+        "id": 8,
+        "name": "GGD",
+        "code": "GGD",
+        "is_intern": false,
+        "categories": [
+            {
+                "id": 3695,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-van-dieren/sub_categories/dode-dieren"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-van-dieren/dieren.svg?se=2023-02-16T14%3A14%3A51Z&sp=r&sv=2021-08-06&sr=b&sig=wzh/2teWg%2BeTOpGOUHKl%2BW8fRTzRe4iVyazMbMgBPCY%3D"
+                        }
+                    },
+                    "_display": "Dode dieren (Overlast van dieren)",
+                    "id": 51,
+                    "name": "Dode dieren",
+                    "slug": "dode-dieren",
+                    "handling": "A3DMC",
+                    "departments": [
+                        {
+                            "code": "GGD",
+                            "name": "GGD",
+                            "is_intern": false
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "We laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 3696,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-van-dieren/sub_categories/duiven"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-van-dieren/dieren.svg?se=2023-02-16T14%3A14%3A51Z&sp=r&sv=2021-08-06&sr=b&sig=wzh/2teWg%2BeTOpGOUHKl%2BW8fRTzRe4iVyazMbMgBPCY%3D"
+                        }
+                    },
+                    "_display": "Duiven (Overlast van dieren)",
+                    "id": 48,
+                    "name": "Duiven",
+                    "slug": "duiven",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "GGD",
+                            "name": "GGD",
+                            "is_intern": false
+                        },
+                        {
+                            "code": "STL",
+                            "name": "Stadsloket",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "Duiven duiven en nog eens duiven in de servicebelofte. !één twryÿ"
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 3697,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-van-dieren/sub_categories/ganzen"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-van-dieren/dieren.svg?se=2023-02-16T14%3A14%3A51Z&sp=r&sv=2021-08-06&sr=b&sig=wzh/2teWg%2BeTOpGOUHKl%2BW8fRTzRe4iVyazMbMgBPCY%3D"
+                        }
+                    },
+                    "_display": "Ganzen (Overlast van dieren)",
+                    "id": 47,
+                    "name": "Ganzen",
+                    "slug": "ganzen",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "GGD",
+                            "name": "GGD",
+                            "is_intern": false
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail. GEES"
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 3698,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-van-dieren/sub_categories/meeuwen"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-van-dieren/dieren.svg?se=2023-02-16T14%3A14%3A51Z&sp=r&sv=2021-08-06&sr=b&sig=wzh/2teWg%2BeTOpGOUHKl%2BW8fRTzRe4iVyazMbMgBPCY%3D"
+                        }
+                    },
+                    "_display": "Meeuwen (Overlast van dieren)",
+                    "id": 49,
+                    "name": "Meeuwen",
+                    "slug": "meeuwen",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "GGD",
+                            "name": "GGD",
+                            "is_intern": false
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 3699,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-van-dieren/sub_categories/overig-dieren"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-van-dieren/dieren.svg?se=2023-02-16T14%3A14%3A51Z&sp=r&sv=2021-08-06&sr=b&sig=wzh/2teWg%2BeTOpGOUHKl%2BW8fRTzRe4iVyazMbMgBPCY%3D"
+                        }
+                    },
+                    "_display": "Overig dieren (Overlast van dieren)",
+                    "id": 52,
+                    "name": "Overig dieren",
+                    "slug": "overig-dieren",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "GGD",
+                            "name": "GGD",
+                            "is_intern": false
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 3700,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-van-dieren/sub_categories/ratten"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-van-dieren/dieren.svg?se=2023-02-16T14%3A14%3A51Z&sp=r&sv=2021-08-06&sr=b&sig=wzh/2teWg%2BeTOpGOUHKl%2BW8fRTzRe4iVyazMbMgBPCY%3D"
+                        }
+                    },
+                    "_display": "Ratten (Overlast van dieren)",
+                    "id": 46,
+                    "name": "Ratten",
+                    "slug": "ratten",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "GGD",
+                            "name": "GGD",
+                            "is_intern": false
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 3694,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-van-dieren/sub_categories/ratten-in-en-rond-woning"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-van-dieren/dieren.svg?se=2023-02-16T14%3A14%3A51Z&sp=r&sv=2021-08-06&sr=b&sig=wzh/2teWg%2BeTOpGOUHKl%2BW8fRTzRe4iVyazMbMgBPCY%3D"
+                        }
+                    },
+                    "_display": "Ratten – in en rond een woning (Overlast van dieren)",
+                    "id": 159,
+                    "name": "Ratten – in en rond een woning",
+                    "slug": "ratten-in-en-rond-woning",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "GGD",
+                            "name": "GGD",
+                            "is_intern": false
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "De GGD adviseert particulieren over de bestrijding en voert de werkzaamheden uit bij rattenoverlast in en rond woningen of tuinen. Rattenoverlast in de openbare ruimte (waaronder binnentuinen, straten en pleinen) moeten in de daarvoor bedoelde categorie worden geplaatst.",
+                    "handling_message": "Wij laten u binnen 5 werkdagen weten wat wij met uw melding gaan doen. Wij melden u ook wanneer we dat gaan doen. Dit doen we via e-mail, als u een mailadres hebt opgegeven."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 3701,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-van-dieren/sub_categories/wespen"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-van-dieren/dieren.svg?se=2023-02-16T14%3A14%3A51Z&sp=r&sv=2021-08-06&sr=b&sig=wzh/2teWg%2BeTOpGOUHKl%2BW8fRTzRe4iVyazMbMgBPCY%3D"
+                        }
+                    },
+                    "_display": "Wespen (Overlast van dieren)",
+                    "id": 50,
+                    "name": "Wespen",
+                    "slug": "wespen",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "GGD",
+                            "name": "GGD",
+                            "is_intern": false
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            }
+        ],
+        "can_direct": false
+    },
+    {
+        "_links": {
+            "self": {
+                "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/private/departments/18"
+            }
+        },
+        "_display": "OOV (Openbare Orde & Veiligheid)",
+        "id": 18,
+        "name": "Openbare Orde & Veiligheid",
+        "code": "OOV",
+        "is_intern": true,
+        "categories": [
+            {
+                "id": 3287,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/ondermijning/sub_categories/vermoeden"
+                        }
+                    },
+                    "_display": "Vermoeden (Ondermijning)",
+                    "id": 100,
+                    "name": "Vermoeden",
+                    "slug": "vermoeden",
+                    "handling": "ONDERMIJNING",
+                    "departments": [
+                        {
+                            "code": "OOV",
+                            "name": "Openbare Orde & Veiligheid",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "Bedankt voor uw melding. Wij nemen deze mee in ons onderzoek."
+                },
+                "is_responsible": true,
+                "can_view": true
+            }
+        ],
+        "can_direct": false
+    },
+    {
+        "_links": {
+            "self": {
+                "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/private/departments/21"
+            }
+        },
+        "_display": "PRK (Parkeren)",
+        "id": 21,
+        "name": "Parkeren",
+        "code": "PRK",
+        "is_intern": false,
+        "categories": [
+            {
+                "id": 4120,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/parkeerautomaten"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/wegen-verkeer-straatmeubilair/verkeer.svg?se=2023-02-16T14%3A14%3A54Z&sp=r&sv=2021-08-06&sr=b&sig=Z0KR2%2B6u9tPL%2BHJxG7f0Kks/sY0jC5AI1oPNDXICaxU%3D"
+                        }
+                    },
+                    "_display": "Parkeerautomaten (Wegen, verkeer, straatmeubilair)",
+                    "id": 127,
+                    "name": "Parkeerautomaten",
+                    "slug": "parkeerautomaten",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "PRK",
+                            "name": "Parkeren",
+                            "is_intern": false
+                        },
+                        {
+                            "code": "VOR",
+                            "name": "V&OR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            }
+        ],
+        "can_direct": false
+    },
+    {
+        "_links": {
+            "self": {
+                "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/private/departments/13"
+            }
+        },
+        "_display": "STL (Stadsloket)",
+        "id": 13,
+        "name": "Stadsloket",
+        "code": "STL",
+        "is_intern": true,
+        "categories": [
+            {
+                "id": 3786,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-van-dieren/sub_categories/duiven"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-van-dieren/dieren.svg?se=2023-02-16T14%3A14%3A51Z&sp=r&sv=2021-08-06&sr=b&sig=wzh/2teWg%2BeTOpGOUHKl%2BW8fRTzRe4iVyazMbMgBPCY%3D"
+                        }
+                    },
+                    "_display": "Duiven (Overlast van dieren)",
+                    "id": 48,
+                    "name": "Duiven",
+                    "slug": "duiven",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "GGD",
+                            "name": "GGD",
+                            "is_intern": false
+                        },
+                        {
+                            "code": "STL",
+                            "name": "Stadsloket",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "Duiven duiven en nog eens duiven in de servicebelofte. !één twryÿ"
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 3789,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/oplaadpunt"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/wegen-verkeer-straatmeubilair/verkeer.svg?se=2023-02-16T14%3A14%3A51Z&sp=r&sv=2021-08-06&sr=b&sig=GlOgIkNZI0AASV9bPHu%2BmfQLOsOB6UtEgelfg9HGiyQ%3D"
+                        }
+                    },
+                    "_display": "Oplaadpunt (Wegen, verkeer, straatmeubilair)",
+                    "id": 136,
+                    "name": "Oplaadpunt",
+                    "slug": "oplaadpunt",
+                    "handling": "TECHNISCHE_STORING",
+                    "departments": [
+                        {
+                            "code": "STL",
+                            "name": "Stadsloket",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "VOR",
+                            "name": "V&OR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Technische storingen worden meestal automatisch gemeld en binnen enkele dagen opgelost. Het beantwoorden van vragen kan tot drie weken duren. We houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            }
+        ],
+        "can_direct": false
+    },
+    {
+        "_links": {
+            "self": {
+                "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/private/departments/4"
+            }
+        },
+        "_display": "STW (Stadswerken)",
+        "id": 4,
+        "name": "Stadswerken",
+        "code": "STW",
+        "is_intern": true,
+        "categories": [
+            {
+                "id": 4921,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/civiele-constructies/sub_categories/afwatering-brug"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/civiele-constructies/bruggen_kades.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=GKwCD96edAza6SpN7iHi/4sH1Yqs1lyOkFYpd0ZTUPw%3D"
+                        }
+                    },
+                    "_display": "Afwatering brug (Civiele Constructies)",
+                    "id": 145,
+                    "name": "Afwatering brug",
+                    "slug": "afwatering-brug",
+                    "handling": "URGENTE_MELDINGEN",
+                    "departments": [
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "VOR",
+                            "name": "V&OR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "Dit is het verhaal van de brug die helemaal niet moest afwateren",
+                    "handling_message": "Wij beoordelen uw melding. Urgente meldingen pakken we zo snel mogelijk op. Overige meldingen handelen we binnen een week af. We houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 4973,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/openbaar-groen-en-water/sub_categories/boom"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/openbaar-groen-en-water/bomen_planten.svg?se=2023-02-16T14%3A14%3A54Z&sp=r&sv=2021-08-06&sr=b&sig=fuPz4MAhufKZ4SO2oRlgKkk9F5sIoPKxIU5xcdkrgXM%3D"
+                        }
+                    },
+                    "_display": "Boom - dood (Openbaar groen en water)",
+                    "id": 40,
+                    "name": "Boom - dood",
+                    "slug": "boom",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "Boom dood",
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 4970,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/openbaar-groen-en-water/sub_categories/boom-afval"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/openbaar-groen-en-water/bomen_planten.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=tv0NnpbO7NQeq1zO0CUJJq9w%2Bb4x8c39ooKzlCuIWHQ%3D"
+                        }
+                    },
+                    "_display": "Boom - plastic en overig afval (Openbaar groen en water)",
+                    "id": 118,
+                    "name": "Boom - plastic en overig afval",
+                    "slug": "boom-afval",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 4972,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/openbaar-groen-en-water/sub_categories/boom-noodkap"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/openbaar-groen-en-water/bomen_planten.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=tv0NnpbO7NQeq1zO0CUJJq9w%2Bb4x8c39ooKzlCuIWHQ%3D"
+                        }
+                    },
+                    "_display": "Boom - noodkap (Openbaar groen en water)",
+                    "id": 114,
+                    "name": "Boom - noodkap",
+                    "slug": "boom-noodkap",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "Bomen die in geval van nood gekapt moeten worden.",
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 4971,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/openbaar-groen-en-water/sub_categories/boom-overig"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/openbaar-groen-en-water/bomen_planten.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=tv0NnpbO7NQeq1zO0CUJJq9w%2Bb4x8c39ooKzlCuIWHQ%3D"
+                        }
+                    },
+                    "_display": "Boom - overig (Openbaar groen en water)",
+                    "id": 117,
+                    "name": "Boom - overig",
+                    "slug": "boom-overig",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 4974,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/openbaar-groen-en-water/sub_categories/boom-stormschade"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/openbaar-groen-en-water/bomen_planten.svg?se=2023-02-16T14%3A14%3A54Z&sp=r&sv=2021-08-06&sr=b&sig=fuPz4MAhufKZ4SO2oRlgKkk9F5sIoPKxIU5xcdkrgXM%3D"
+                        }
+                    },
+                    "_display": "Boom - stormschade (Openbaar groen en water)",
+                    "id": 156,
+                    "name": "Boom - stormschade",
+                    "slug": "boom-stormschade",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "VOR",
+                            "name": "V&OR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 4963,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/openbaar-groen-en-water/sub_categories/boom-verzoek-inspectie"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/openbaar-groen-en-water/bomen_planten.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=tv0NnpbO7NQeq1zO0CUJJq9w%2Bb4x8c39ooKzlCuIWHQ%3D"
+                        }
+                    },
+                    "_display": "Boom - verzoek inspectie (Openbaar groen en water)",
+                    "id": 155,
+                    "name": "Boom - verzoek inspectie",
+                    "slug": "boom-verzoek-inspectie",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 4964,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/openbaar-groen-en-water/sub_categories/boomziekten-en-plagen"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/openbaar-groen-en-water/bomen_planten.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=tv0NnpbO7NQeq1zO0CUJJq9w%2Bb4x8c39ooKzlCuIWHQ%3D"
+                        }
+                    },
+                    "_display": "Boom - ziekten en plagen (Openbaar groen en water)",
+                    "id": 154,
+                    "name": "Boom - ziekten en plagen",
+                    "slug": "boomziekten-en-plagen",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "Bomen die een ziekte hebben.",
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 4920,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/civiele-constructies/sub_categories/bruggen"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/civiele-constructies/bruggen_kades.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=GKwCD96edAza6SpN7iHi/4sH1Yqs1lyOkFYpd0ZTUPw%3D"
+                        }
+                    },
+                    "_display": "Brug (Civiele Constructies)",
+                    "id": 142,
+                    "name": "Brug",
+                    "slug": "bruggen",
+                    "handling": "A3WEC",
+                    "departments": [
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "WAT",
+                            "name": "Waternet",
+                            "is_intern": false
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Wij handelen uw melding binnen drie weken af. U ontvangt dan geen apart bericht meer. [Gemeente Amsterdam](http://www.amsterdam.nl) En anders hoort u - via e-mail - wanneer wij uw melding kunnen oppakken."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 4954,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/schoon/sub_categories/drijfvuil-niet-bevaarbaar-water"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/schoon/onderhoud.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=0zESrpLqvoZEGaozcFoOirbp3ofw%2Bp/Xh%2BGLyL/5/wY%3D"
+                        }
+                    },
+                    "_display": "Drijfvuil niet-bevaarbaar water (Schoon)",
+                    "id": 108,
+                    "name": "Drijfvuil niet-bevaarbaar water",
+                    "slug": "drijfvuil-niet-bevaarbaar-water",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 4977,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/openbaar-groen-en-water/sub_categories/eikenprocessierups"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/openbaar-groen-en-water/bomen_planten.svg?se=2023-02-16T14%3A14%3A54Z&sp=r&sv=2021-08-06&sr=b&sig=fuPz4MAhufKZ4SO2oRlgKkk9F5sIoPKxIU5xcdkrgXM%3D"
+                        }
+                    },
+                    "_display": "Eikenprocessierups (Openbaar groen en water)",
+                    "id": 161,
+                    "name": "Eikenprocessierups",
+                    "slug": "eikenprocessierups",
+                    "handling": "EMPTY",
+                    "departments": [
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Uw melding wordt beoordeeld en indien nodig ingepland: wij laten u binnen twee weken weten hoe en wanneer uw melding wordt afgehandeld. Als u een mailadres hebt opgegeven, zullen we u op de hoogte houden."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 4942,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/fietsrek-nietje"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/wegen-verkeer-straatmeubilair/verkeer.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=D8/mf3sa2SvtN68kxXlTDQHv/81KlIr76imbj/rX3eU%3D"
+                        }
+                    },
+                    "_display": "Fietsrek / nietje (Wegen, verkeer, straatmeubilair)",
+                    "id": 20,
+                    "name": "Fietsrek / nietje",
+                    "slug": "fietsrek-nietje",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 4953,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/schoon/sub_categories/gladheid-bladeren"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/schoon/onderhoud.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=0zESrpLqvoZEGaozcFoOirbp3ofw%2Bp/Xh%2BGLyL/5/wY%3D"
+                        }
+                    },
+                    "_display": "Gladheid door blad (Schoon)",
+                    "id": 109,
+                    "name": "Gladheid door blad",
+                    "slug": "gladheid-bladeren",
+                    "handling": "GLADZC",
+                    "departments": [
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Bij gladheid door sneeuw of bladeren pakken we hoofdwegen en fietsroutes als eerste aan. Andere meldingen behandelen we als de belangrijkste routes zijn gedaan."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 4952,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/schoon/sub_categories/gladheid-olie"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/schoon/onderhoud.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=0zESrpLqvoZEGaozcFoOirbp3ofw%2Bp/Xh%2BGLyL/5/wY%3D"
+                        }
+                    },
+                    "_display": "Gladheid door olie op de weg (Schoon)",
+                    "id": 110,
+                    "name": "Gladheid door olie op de weg",
+                    "slug": "gladheid-olie",
+                    "handling": "GLAD_OLIE",
+                    "departments": [
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Gaat het om gladheid door een ongeluk (olie of frituurvet op de weg)? Dan pakken we uw melding zo snel mogelijk op. In ieder geval binnen 3 werkdagen."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 4951,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/schoon/sub_categories/gladheid-winterdienst"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/schoon/onderhoud.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=0zESrpLqvoZEGaozcFoOirbp3ofw%2Bp/Xh%2BGLyL/5/wY%3D"
+                        }
+                    },
+                    "_display": "Gladheid winterdienst (Schoon)",
+                    "id": 140,
+                    "name": "Gladheid winterdienst",
+                    "slug": "gladheid-winterdienst",
+                    "handling": "GLADZC",
+                    "departments": [
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Bij gladheid door sneeuw of bladeren pakken we hoofdwegen en fietsroutes als eerste aan. Andere meldingen behandelen we als de belangrijkste routes zijn gedaan."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 4950,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/schoon/sub_categories/graffitiwildplak"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/schoon/onderhoud.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=0zESrpLqvoZEGaozcFoOirbp3ofw%2Bp/Xh%2BGLyL/5/wY%3D"
+                        }
+                    },
+                    "_display": "Graffiti / wildplak (Schoon)",
+                    "id": 141,
+                    "name": "Graffiti / wildplak",
+                    "slug": "graffitiwildplak",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 4965,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/openbaar-groen-en-water/sub_categories/japanse-duizendknoop"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/openbaar-groen-en-water/bomen_planten.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=tv0NnpbO7NQeq1zO0CUJJq9w%2Bb4x8c39ooKzlCuIWHQ%3D"
+                        }
+                    },
+                    "_display": "Japanse duizendknoop (Openbaar groen en water)",
+                    "id": 153,
+                    "name": "Japanse duizendknoop",
+                    "slug": "japanse-duizendknoop",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 4918,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/civiele-constructies/sub_categories/kades"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/civiele-constructies/bruggen_kades.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=GKwCD96edAza6SpN7iHi/4sH1Yqs1lyOkFYpd0ZTUPw%3D"
+                        }
+                    },
+                    "_display": "Kades (Civiele Constructies)",
+                    "id": 119,
+                    "name": "Kades",
+                    "slug": "kades",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 4985,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-in-de-openbare-ruimte/sub_categories/lozing-dumping-bodemverontreiniging"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-in-de-openbare-ruimte/openbare_ruimte.svg?se=2023-02-16T14%3A14%3A54Z&sp=r&sv=2021-08-06&sr=b&sig=0%2BBsES/ExcLQ90p4T5R1JkhuIgBnbD6FZvxVwBKkQLk%3D"
+                        }
+                    },
+                    "_display": "Lozing / dumping / bodemverontreiniging (Overlast in de openbare ruimte)",
+                    "id": 29,
+                    "name": "Lozing / dumping / bodemverontreiniging",
+                    "slug": "lozing-dumping-bodemverontreiniging",
+                    "handling": "A3DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "THO",
+                            "name": "THOR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "We laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 4969,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/openbaar-groen-en-water/sub_categories/maaien-snoeien"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/openbaar-groen-en-water/bomen_planten.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=tv0NnpbO7NQeq1zO0CUJJq9w%2Bb4x8c39ooKzlCuIWHQ%3D"
+                        }
+                    },
+                    "_display": "Maaien (Openbaar groen en water)",
+                    "id": 41,
+                    "name": "Maaien",
+                    "slug": "maaien-snoeien",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "blah",
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 4986,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-in-de-openbare-ruimte/sub_categories/markten"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-in-de-openbare-ruimte/openbare_ruimte.svg?se=2023-02-16T14%3A14%3A54Z&sp=r&sv=2021-08-06&sr=b&sig=0%2BBsES/ExcLQ90p4T5R1JkhuIgBnbD6FZvxVwBKkQLk%3D"
+                        }
+                    },
+                    "_display": "Markten (Overlast in de openbare ruimte)",
+                    "id": 157,
+                    "name": "Markten",
+                    "slug": "markten",
+                    "handling": "HANDLING_MARKTEN",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "blah",
+                    "handling_message": "Wij beoordelen uw melding. Urgente meldingen pakken we zo snel mogelijk op. Overige meldingen handelen we binnen drie dagen af. Als u een mailadres hebt opgegeven, zullen we u op de hoogte houden."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 4917,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/civiele-constructies/sub_categories/oevers"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/civiele-constructies/bruggen_kades.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=GKwCD96edAza6SpN7iHi/4sH1Yqs1lyOkFYpd0ZTUPw%3D"
+                        }
+                    },
+                    "_display": "Oevers (Civiele Constructies)",
+                    "id": 147,
+                    "name": "Oevers",
+                    "slug": "oevers",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 4940,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/omleiding"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/wegen-verkeer-straatmeubilair/verkeer.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=D8/mf3sa2SvtN68kxXlTDQHv/81KlIr76imbj/rX3eU%3D"
+                        }
+                    },
+                    "_display": "Wegwerkzaamheden (Wegen, verkeer, straatmeubilair)",
+                    "id": 146,
+                    "name": "Wegwerkzaamheden",
+                    "slug": "omleiding",
+                    "handling": "3WGM",
+                    "departments": [
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "Wij handelen uw melding binnen drie weken af. U ontvangt dan geen apart bericht meer."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 4939,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/omleiding-belijning-verkeer"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/wegen-verkeer-straatmeubilair/verkeer.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=D8/mf3sa2SvtN68kxXlTDQHv/81KlIr76imbj/rX3eU%3D"
+                        }
+                    },
+                    "_display": "Omleiding / belijning verkeer (Wegen, verkeer, straatmeubilair)",
+                    "id": 17,
+                    "name": "Omleiding / belijning verkeer",
+                    "slug": "omleiding-belijning-verkeer",
+                    "handling": "A3WEC",
+                    "departments": [
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Wij handelen uw melding binnen drie weken af. U ontvangt dan geen apart bericht meer.\nEn anders hoort u - via e-mail - wanneer wij uw melding kunnen oppakken."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 5058,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/onderhoud-fietspad"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/wegen-verkeer-straatmeubilair/verkeer.svg?se=2023-02-16T14%3A14%3A51Z&sp=r&sv=2021-08-06&sr=b&sig=GlOgIkNZI0AASV9bPHu%2BmfQLOsOB6UtEgelfg9HGiyQ%3D"
+                        }
+                    },
+                    "_display": "Onderhoud fietspad (Wegen, verkeer, straatmeubilair)",
+                    "id": 168,
+                    "name": "Onderhoud fietspad",
+                    "slug": "onderhoud-fietspad",
+                    "handling": "A3DEC",
+                    "departments": [
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "Verzakkingen in/van fietspad, missende tegels, wortelopdruk in het fietspad, scheuren in fietspad",
+                    "handling_message": "Wij handelen uw melding binnen een week af. Als u een mailadres hebt opgegeven, zullen we u op de hoogte houden."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 4938,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/onderhoud-stoep-straat-en-fietspad"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/wegen-verkeer-straatmeubilair/verkeer.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=D8/mf3sa2SvtN68kxXlTDQHv/81KlIr76imbj/rX3eU%3D"
+                        }
+                    },
+                    "_display": "Onderhoud stoep, straat en fietspad (Wegen, verkeer, straatmeubilair)",
+                    "id": 14,
+                    "name": "Onderhoud stoep, straat en fietspad",
+                    "slug": "onderhoud-stoep-straat-en-fietspad",
+                    "handling": "A3DEC",
+                    "departments": [
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "Hieronder vallen alle meldingen van Onderhoud stoep, straat en fietspad.",
+                    "handling_message": "Wij handelen uw melding binnen drie werkdagen af. U ontvangt dan geen apart bericht meer.\nEn anders hoort u - via e-mail - wanneer wij uw melding kunnen oppakken."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 4968,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/openbaar-groen-en-water/sub_categories/onkruid"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/openbaar-groen-en-water/bomen_planten.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=tv0NnpbO7NQeq1zO0CUJJq9w%2Bb4x8c39ooKzlCuIWHQ%3D"
+                        }
+                    },
+                    "_display": "Onkruid in het groen (Openbaar groen en water)",
+                    "id": 42,
+                    "name": "Onkruid in het groen",
+                    "slug": "onkruid",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "VOR",
+                            "name": "V&OR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 4949,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/schoon/sub_categories/onkruid-verharding"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/schoon/onderhoud.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=0zESrpLqvoZEGaozcFoOirbp3ofw%2Bp/Xh%2BGLyL/5/wY%3D"
+                        }
+                    },
+                    "_display": "Onkruid op verharding (Schoon)",
+                    "id": 111,
+                    "name": "Onkruid op verharding",
+                    "slug": "onkruid-verharding",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 4878,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/overig-afval"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/afval/overig-afval/restafval.svg?se=2023-02-16T14%3A14%3A51Z&sp=r&sv=2021-08-06&sr=b&sig=RXfx9FEK80dIohueCdcXOKV/z3Y0wnenEQYlILRyYdc%3D"
+                        }
+                    },
+                    "_display": "Overig afval (Afval)",
+                    "id": 11,
+                    "name": "Overig afval",
+                    "slug": "overig-afval",
+                    "handling": "REST",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "AEG",
+                            "name": "Afval en Grondstoffen",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "Wij bekijken uw melding en zorgen dat het juiste onderdeel van de gemeente deze gaat behandelen. Heeft u contactgegevens achtergelaten? Dan nemen wij bij onduidelijkheid contact met u op."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 4967,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/openbaar-groen-en-water/sub_categories/overig-groen-en-water"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/openbaar-groen-en-water/bomen_planten.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=tv0NnpbO7NQeq1zO0CUJJq9w%2Bb4x8c39ooKzlCuIWHQ%3D"
+                        }
+                    },
+                    "_display": "Overig groen en water (Openbaar groen en water)",
+                    "id": 45,
+                    "name": "Overig groen en water",
+                    "slug": "overig-groen-en-water",
+                    "handling": "REST",
+                    "departments": [
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Wij bekijken uw melding en zorgen dat het juiste onderdeel van de gemeente deze gaat behandelen. Heeft u contactgegevens achtergelaten? Dan nemen wij bij onduidelijkheid contact met u op."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 4936,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/overig-wegen-verkeer-straatmeubilair"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/wegen-verkeer-straatmeubilair/verkeer.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=D8/mf3sa2SvtN68kxXlTDQHv/81KlIr76imbj/rX3eU%3D"
+                        }
+                    },
+                    "_display": "Overig Wegen, verkeer, straatmeubilair (Wegen, verkeer, straatmeubilair)",
+                    "id": 27,
+                    "name": "Overig Wegen, verkeer, straatmeubilair",
+                    "slug": "overig-wegen-verkeer-straatmeubilair",
+                    "handling": "REST",
+                    "departments": [
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Wij bekijken uw melding en zorgen dat het juiste onderdeel van de gemeente deze gaat behandelen. Heeft u contactgegevens achtergelaten? Dan nemen wij bij onduidelijkheid contact met u op."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 4948,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/schoon/sub_categories/prullenbak-vol"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/schoon/onderhoud.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=0zESrpLqvoZEGaozcFoOirbp3ofw%2Bp/Xh%2BGLyL/5/wY%3D"
+                        }
+                    },
+                    "_display": "Prullenbak is vol (Schoon)",
+                    "id": 149,
+                    "name": "Prullenbak is vol",
+                    "slug": "prullenbak-vol",
+                    "handling": "A3DEC",
+                    "departments": [
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "Wij handelen uw melding binnen drie werkdagen af. U ontvangt dan geen apart bericht meer.\nEn anders hoort u - via e-mail - wanneer wij uw melding kunnen oppakken."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 4933,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/prullenbakkapot"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/wegen-verkeer-straatmeubilair/verkeer.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=D8/mf3sa2SvtN68kxXlTDQHv/81KlIr76imbj/rX3eU%3D"
+                        }
+                    },
+                    "_display": "Prullenbak is kapot (Wegen, verkeer, straatmeubilair)",
+                    "id": 151,
+                    "name": "Prullenbak is kapot",
+                    "slug": "prullenbakkapot",
+                    "handling": "A3DEC",
+                    "departments": [
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Wij handelen uw melding binnen drie werkdagen af. U ontvangt dan geen apart bericht meer.\nEn anders hoort u - via e-mail - wanneer wij uw melding kunnen oppakken."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 5082,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/put-riool-kapot"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/wegen-verkeer-straatmeubilair/verkeer.svg?se=2023-02-16T14%3A14%3A51Z&sp=r&sv=2021-08-06&sr=b&sig=GlOgIkNZI0AASV9bPHu%2BmfQLOsOB6UtEgelfg9HGiyQ%3D"
+                        }
+                    },
+                    "_display": "Put / Riool kapot (Wegen, verkeer, straatmeubilair)",
+                    "id": 169,
+                    "name": "Put / Riool kapot",
+                    "slug": "put-riool-kapot",
+                    "handling": "A3DEC",
+                    "departments": [
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "Meldingen die betrekking hebben op een kapotte kolk en riolering.",
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld.  Als u een mailadres hebt opgegeven, zullen we u op de hoogte houden."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 5458,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/schoon/sub_categories/putrioleringverstopt"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/schoon/onderhoud.svg?se=2023-02-16T14%3A14%3A51Z&sp=r&sv=2021-08-06&sr=b&sig=59vHvN9AcI9TG5mr1qumaQlY4AokycSQ6NrhSDuUwBM%3D"
+                        }
+                    },
+                    "_display": "Put / riolering verstopt (Schoon)",
+                    "id": 170,
+                    "name": "Put / riolering verstopt",
+                    "slug": "putrioleringverstopt",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "CCA",
+                            "name": "CCA",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 4916,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/civiele-constructies/sub_categories/sluis"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/civiele-constructies/bruggen_kades.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=GKwCD96edAza6SpN7iHi/4sH1Yqs1lyOkFYpd0ZTUPw%3D"
+                        }
+                    },
+                    "_display": "Sluis (Civiele Constructies)",
+                    "id": 143,
+                    "name": "Sluis",
+                    "slug": "sluis",
+                    "handling": "URGENTE_MELDINGEN",
+                    "departments": [
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "VOR",
+                            "name": "V&OR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "Wij beoordelen uw melding. Urgente meldingen pakken we zo snel mogelijk op. Overige meldingen handelen we binnen een week af. We houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 4966,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/openbaar-groen-en-water/sub_categories/snoeien"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/openbaar-groen-en-water/bomen_planten.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=tv0NnpbO7NQeq1zO0CUJJq9w%2Bb4x8c39ooKzlCuIWHQ%3D"
+                        }
+                    },
+                    "_display": "Snoeien (Openbaar groen en water)",
+                    "id": 112,
+                    "name": "Snoeien",
+                    "slug": "snoeien",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 4931,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/speelplaats"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/wegen-verkeer-straatmeubilair/verkeer.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=D8/mf3sa2SvtN68kxXlTDQHv/81KlIr76imbj/rX3eU%3D"
+                        }
+                    },
+                    "_display": "Speelplaats (Wegen, verkeer, straatmeubilair)",
+                    "id": 22,
+                    "name": "Speelplaats",
+                    "slug": "speelplaats",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 4930,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/sportvoorziening"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/wegen-verkeer-straatmeubilair/verkeer.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=3bw2HLwEgw3EuJ8FdZXiGk90B3GVdBqys1oBUJJjDZo%3D"
+                        }
+                    },
+                    "_display": "Sportvoorziening (Wegen, verkeer, straatmeubilair)",
+                    "id": 23,
+                    "name": "Sportvoorziening",
+                    "slug": "sportvoorziening",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 4915,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/civiele-constructies/sub_categories/steiger"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/civiele-constructies/bruggen_kades.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=GKwCD96edAza6SpN7iHi/4sH1Yqs1lyOkFYpd0ZTUPw%3D"
+                        }
+                    },
+                    "_display": "Steiger (Civiele Constructies)",
+                    "id": 120,
+                    "name": "Steiger",
+                    "slug": "steiger",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 4928,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/straatmeubilair"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/wegen-verkeer-straatmeubilair/verkeer.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=3bw2HLwEgw3EuJ8FdZXiGk90B3GVdBqys1oBUJJjDZo%3D"
+                        }
+                    },
+                    "_display": "Straatmeubilair (Wegen, verkeer, straatmeubilair)",
+                    "id": 19,
+                    "name": "Straatmeubilair",
+                    "slug": "straatmeubilair",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 4947,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/schoon/sub_categories/uitwerpselen"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/schoon/onderhoud.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=0zESrpLqvoZEGaozcFoOirbp3ofw%2Bp/Xh%2BGLyL/5/wY%3D"
+                        }
+                    },
+                    "_display": "Uitwerpselen (Schoon)",
+                    "id": 139,
+                    "name": "Uitwerpselen",
+                    "slug": "uitwerpselen",
+                    "handling": "A3WMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "THO",
+                            "name": "THOR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "We laten u binnen 3 weken weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 4946,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/schoon/sub_categories/veegzwerfvuil"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/schoon/onderhoud.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=0zESrpLqvoZEGaozcFoOirbp3ofw%2Bp/Xh%2BGLyL/5/wY%3D"
+                        }
+                    },
+                    "_display": "Veeg- / zwerfvuil (Schoon)",
+                    "id": 148,
+                    "name": "Veeg- / zwerfvuil",
+                    "slug": "veegzwerfvuil",
+                    "handling": "A3DEC",
+                    "departments": [
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "Wij handelen uw melding binnen vijf werkdagen af. U ontvangt dan geen apart bericht meer.\nEn anders hoort u - via e-mail - wanneer wij uw melding kunnen oppakken."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 4925,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/verkeersbord-verkeersafzetting"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/wegen-verkeer-straatmeubilair/verkeer.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=3bw2HLwEgw3EuJ8FdZXiGk90B3GVdBqys1oBUJJjDZo%3D"
+                        }
+                    },
+                    "_display": "Verkeersbord / verkeersafzetting (Wegen, verkeer, straatmeubilair)",
+                    "id": 15,
+                    "name": "Verkeersbord / verkeersafzetting",
+                    "slug": "verkeersbord-verkeersafzetting",
+                    "handling": "A3DEC",
+                    "departments": [
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "Wij handelen uw melding binnen drie werkdagen af. U ontvangt dan geen apart bericht meer.\nEn anders hoort u - via e-mail - wanneer wij uw melding kunnen oppakken."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 4914,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/civiele-constructies/sub_categories/watergangen"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/civiele-constructies/bruggen_kades.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=GKwCD96edAza6SpN7iHi/4sH1Yqs1lyOkFYpd0ZTUPw%3D"
+                        }
+                    },
+                    "_display": "Watergangen (Civiele Constructies)",
+                    "id": 144,
+                    "name": "Watergangen",
+                    "slug": "watergangen",
+                    "handling": "URGENTE_MELDINGEN",
+                    "departments": [
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "VOR",
+                            "name": "V&OR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "Wij beoordelen uw melding. Urgente meldingen pakken we zo snel mogelijk op. Overige meldingen handelen we binnen een week af. We houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            }
+        ],
+        "can_direct": false
+    },
+    {
+        "_links": {
+            "self": {
+                "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/private/departments/2"
+            }
+        },
+        "_display": "THO (THOR)",
+        "id": 2,
+        "name": "THOR",
+        "code": "THO",
+        "is_intern": true,
+        "categories": [
+            {
+                "id": 3682,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/asbest-accu"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/afval/afval.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=3rppZzgnU1Kt0BY4fXxsjdkvBpa5OWthAyA5lDlGVUM%3D"
+                        }
+                    },
+                    "_display": "Asbest / accu (Afval)",
+                    "id": 10,
+                    "name": "Asbest / accu",
+                    "slug": "asbest-accu",
+                    "handling": "A3DMC",
+                    "departments": [
+                        {
+                            "code": "FB",
+                            "name": "FB",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "THO",
+                            "name": "THOR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "Alles met betrekking tot asbest gerelateerd afval en bijtende/corrosieve vloeistoffen.",
+                    "handling_message": "We laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail.  [Bekijk de kaart met slimme apparaten](https://slimmeapparaten.amsterdam.nl)"
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 3670,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-in-de-openbare-ruimte/sub_categories/auto-scooter-bromfietswrak"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-in-de-openbare-ruimte/openbare_ruimte.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=3z0auMEv3IP0mWhJtsDZHSozcC1VUdmJsZjIYkM8YyE%3D"
+                        }
+                    },
+                    "_display": "Auto- / scooter- / bromfiets(wrak) (Overlast in de openbare ruimte)",
+                    "id": 34,
+                    "name": "Auto- / scooter- / bromfiets(wrak)",
+                    "slug": "auto-scooter-bromfietswrak",
+                    "handling": "A3WMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "THO",
+                            "name": "THOR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "Het wrak van een auto, scooter of bromfiets.",
+                    "handling_message": "We laten u binnen 3 weken weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 3665,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/openbaar-groen-en-water/sub_categories/boom-illegale-kap"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/openbaar-groen-en-water/bomen_planten.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=gnznXtmgckcbYXAEXXq9uUUsoXRFSJ/6mV22Z8fOW%2BI%3D"
+                        }
+                    },
+                    "_display": "Boom - illegale kap (Openbaar groen en water)",
+                    "id": 115,
+                    "name": "Boom - illegale kap",
+                    "slug": "boom-illegale-kap",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "THO",
+                            "name": "THOR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 3688,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-van-en-door-personen-of-groepen/sub_categories/daklozen-bedelen"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-van-en-door-personen-of-groepen/personen.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=Zyz35Dlq6tZ2b%2BNsfDxguHBmtpmRoY%2B5a9SImT8NdNY%3D"
+                        }
+                    },
+                    "_display": "Daklozen / bedelen (Overlast van en door personen of groepen)",
+                    "id": 59,
+                    "name": "Daklozen / bedelen",
+                    "slug": "daklozen-bedelen",
+                    "handling": "A3DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "THO",
+                            "name": "THOR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "Overlast van zwerver",
+                    "handling_message": "We laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 3690,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-van-en-door-personen-of-groepen/sub_categories/drank-en-drugsoverlast"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-van-en-door-personen-of-groepen/personen.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=Zyz35Dlq6tZ2b%2BNsfDxguHBmtpmRoY%2B5a9SImT8NdNY%3D"
+                        }
+                    },
+                    "_display": "Drank- / drugsoverlast (Overlast van en door personen of groepen)",
+                    "id": 61,
+                    "name": "Drank- / drugsoverlast",
+                    "slug": "drank-en-drugsoverlast",
+                    "handling": "A3DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "AB",
+                            "name": "Amsterdamse Bos",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "THO",
+                            "name": "THOR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "We laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 3671,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-in-de-openbare-ruimte/sub_categories/fietswrak"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-in-de-openbare-ruimte/openbare_ruimte.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=3z0auMEv3IP0mWhJtsDZHSozcC1VUdmJsZjIYkM8YyE%3D"
+                        }
+                    },
+                    "_display": "Fietswrak (Overlast in de openbare ruimte)",
+                    "id": 31,
+                    "name": "Fietswrak",
+                    "slug": "fietswrak",
+                    "handling": "A3WMC",
+                    "departments": [
+                        {
+                            "code": "THO",
+                            "name": "THOR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "We laten u binnen 3 weken weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 3681,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/handhaving-op-afval"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/afval/afval.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=3rppZzgnU1Kt0BY4fXxsjdkvBpa5OWthAyA5lDlGVUM%3D"
+                        }
+                    },
+                    "_display": "Handhaving op afval (Afval)",
+                    "id": 91,
+                    "name": "Handhaving op afval",
+                    "slug": "handhaving-op-afval",
+                    "handling": "A3DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "THO",
+                            "name": "THOR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "We laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 3672,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-in-de-openbare-ruimte/sub_categories/hinderlijk-geplaatst-object"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-in-de-openbare-ruimte/openbare_ruimte.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=3z0auMEv3IP0mWhJtsDZHSozcC1VUdmJsZjIYkM8YyE%3D"
+                        }
+                    },
+                    "_display": "Hinderlijk geplaatst object (Overlast in de openbare ruimte)",
+                    "id": 37,
+                    "name": "Hinderlijk geplaatst object",
+                    "slug": "hinderlijk-geplaatst-object",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "THO",
+                            "name": "THOR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 3687,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-van-en-door-personen-of-groepen/sub_categories/jongerenoverlast"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-van-en-door-personen-of-groepen/personen.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=YUlj6ADSxN6kN90S2Ipz7EkFjVe1wkdiAjz7BnIpbf0%3D"
+                        }
+                    },
+                    "_display": "Jongerenoverlast (Overlast van en door personen of groepen)",
+                    "id": 58,
+                    "name": "Jongerenoverlast",
+                    "slug": "jongerenoverlast",
+                    "handling": "A3DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "THO",
+                            "name": "THOR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "We laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 3668,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-in-de-openbare-ruimte/sub_categories/lozing-dumping-bodemverontreiniging"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-in-de-openbare-ruimte/openbare_ruimte.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=3z0auMEv3IP0mWhJtsDZHSozcC1VUdmJsZjIYkM8YyE%3D"
+                        }
+                    },
+                    "_display": "Lozing / dumping / bodemverontreiniging (Overlast in de openbare ruimte)",
+                    "id": 29,
+                    "name": "Lozing / dumping / bodemverontreiniging",
+                    "slug": "lozing-dumping-bodemverontreiniging",
+                    "handling": "A3DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "THO",
+                            "name": "THOR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "We laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 3685,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-van-en-door-personen-of-groepen/sub_categories/overige-overlast-door-personen"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-van-en-door-personen-of-groepen/personen.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=YUlj6ADSxN6kN90S2Ipz7EkFjVe1wkdiAjz7BnIpbf0%3D"
+                        }
+                    },
+                    "_display": "Overige overlast door personen (Overlast van en door personen of groepen)",
+                    "id": 55,
+                    "name": "Overige overlast door personen",
+                    "slug": "overige-overlast-door-personen",
+                    "handling": "REST",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "THO",
+                            "name": "THOR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Wij bekijken uw melding en zorgen dat het juiste onderdeel van de gemeente deze gaat behandelen. Heeft u contactgegevens achtergelaten? Dan nemen wij bij onduidelijkheid contact met u op."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 3684,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-van-en-door-personen-of-groepen/sub_categories/overlast-door-afsteken-vuurwerk"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-van-en-door-personen-of-groepen/personen.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=YUlj6ADSxN6kN90S2Ipz7EkFjVe1wkdiAjz7BnIpbf0%3D"
+                        }
+                    },
+                    "_display": "Overlast door afsteken vuurwerk (Overlast van en door personen of groepen)",
+                    "id": 54,
+                    "name": "Overlast door afsteken vuurwerk",
+                    "slug": "overlast-door-afsteken-vuurwerk",
+                    "handling": "A3DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "THO",
+                            "name": "THOR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "We laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 3691,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-bedrijven-en-horeca/sub_categories/overlast-door-bezoekers-niet-op-terras"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-bedrijven-en-horeca/bedrijven.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=SNr33LSFXZY77b6FvC0xRyrwufl9l%2B1b0BvnJZbgjiI%3D"
+                        }
+                    },
+                    "_display": "Overlast door bezoekers (niet op terras) (Overlast Bedrijven en Horeca)",
+                    "id": 67,
+                    "name": "Overlast door bezoekers (niet op terras)",
+                    "slug": "overlast-door-bezoekers-niet-op-terras",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "THO",
+                            "name": "THOR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 3686,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-van-en-door-personen-of-groepen/sub_categories/overlast-van-taxis-bussen-en-fietstaxis"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-van-en-door-personen-of-groepen/personen.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=YUlj6ADSxN6kN90S2Ipz7EkFjVe1wkdiAjz7BnIpbf0%3D"
+                        }
+                    },
+                    "_display": "Overlast van taxi's, bussen en fietstaxi's (Overlast van en door personen of groepen)",
+                    "id": 57,
+                    "name": "Overlast van taxi's, bussen en fietstaxi's",
+                    "slug": "overlast-van-taxis-bussen-en-fietstaxis",
+                    "handling": "A3DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "THO",
+                            "name": "THOR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "We laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 3669,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-in-de-openbare-ruimte/sub_categories/parkeeroverlast"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-in-de-openbare-ruimte/openbare_ruimte.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=3z0auMEv3IP0mWhJtsDZHSozcC1VUdmJsZjIYkM8YyE%3D"
+                        }
+                    },
+                    "_display": "Parkeeroverlast (Overlast in de openbare ruimte)",
+                    "id": 30,
+                    "name": "Parkeeroverlast",
+                    "slug": "parkeeroverlast",
+                    "handling": "A3DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "THO",
+                            "name": "THOR",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "VOR",
+                            "name": "V&OR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "We laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 3667,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-in-de-openbare-ruimte/sub_categories/stank-geluidsoverlast"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-in-de-openbare-ruimte/openbare_ruimte.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=3z0auMEv3IP0mWhJtsDZHSozcC1VUdmJsZjIYkM8YyE%3D"
+                        }
+                    },
+                    "_display": "Stank- / geluidsoverlast (Overlast in de openbare ruimte)",
+                    "id": 32,
+                    "name": "Stank- / geluidsoverlast",
+                    "slug": "stank-geluidsoverlast",
+                    "handling": "A3WMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "THO",
+                            "name": "THOR",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "VTH",
+                            "name": "VTH",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "We laten u binnen 3 weken weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 3673,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/schoon/sub_categories/uitwerpselen"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/schoon/onderhoud.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=MuinB1NhGkHaYjJlZPVU2HfBVlL2G1aSUVxCKGUieY4%3D"
+                        }
+                    },
+                    "_display": "Uitwerpselen (Schoon)",
+                    "id": 139,
+                    "name": "Uitwerpselen",
+                    "slug": "uitwerpselen",
+                    "handling": "A3WMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "THO",
+                            "name": "THOR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "We laten u binnen 3 weken weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 3676,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/verkeersoverlast"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/wegen-verkeer-straatmeubilair/verkeer.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=3bw2HLwEgw3EuJ8FdZXiGk90B3GVdBqys1oBUJJjDZo%3D"
+                        }
+                    },
+                    "_display": "Verkeersoverlast (Wegen, verkeer, straatmeubilair)",
+                    "id": 103,
+                    "name": "Verkeersoverlast",
+                    "slug": "verkeersoverlast",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "THO",
+                            "name": "THOR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 3689,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-van-en-door-personen-of-groepen/sub_categories/wildplassen-poepen-overgeven"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-van-en-door-personen-of-groepen/personen.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=Zyz35Dlq6tZ2b%2BNsfDxguHBmtpmRoY%2B5a9SImT8NdNY%3D"
+                        }
+                    },
+                    "_display": "Wildplassen / poepen / overgeven (Overlast van en door personen of groepen)",
+                    "id": 60,
+                    "name": "Wildplassen / poepen / overgeven",
+                    "slug": "wildplassen-poepen-overgeven",
+                    "handling": "A3DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "THO",
+                            "name": "THOR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "We laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            }
+        ],
+        "can_direct": false
+    },
+    {
+        "_links": {
+            "self": {
+                "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/private/departments/9"
+            }
+        },
+        "_display": "VOR (V&OR)",
+        "id": 9,
+        "name": "V&OR",
+        "code": "VOR",
+        "is_intern": true,
+        "categories": [
+            {
+                "id": 5055,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/civiele-constructies/sub_categories/afwatering-brug"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/civiele-constructies/bruggen_kades.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=NtJDnLpIrH0bQal4Ql2ZVAfiDNX0Ta6MVhzsZrSmzK8%3D"
+                        }
+                    },
+                    "_display": "Afwatering brug (Civiele Constructies)",
+                    "id": 145,
+                    "name": "Afwatering brug",
+                    "slug": "afwatering-brug",
+                    "handling": "URGENTE_MELDINGEN",
+                    "departments": [
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "VOR",
+                            "name": "V&OR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "Dit is het verhaal van de brug die helemaal niet moest afwateren",
+                    "handling_message": "Wij beoordelen uw melding. Urgente meldingen pakken we zo snel mogelijk op. Overige meldingen handelen we binnen een week af. We houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 5028,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/autom-verzinkbare-palen"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/wegen-verkeer-straatmeubilair/verkeer.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=3bw2HLwEgw3EuJ8FdZXiGk90B3GVdBqys1oBUJJjDZo%3D"
+                        }
+                    },
+                    "_display": "Autom. Verzinkbare palen (Wegen, verkeer, straatmeubilair)",
+                    "id": 92,
+                    "name": "Autom. Verzinkbare palen",
+                    "slug": "autom-verzinkbare-palen",
+                    "handling": "A3WEC",
+                    "departments": [
+                        {
+                            "code": "VOR",
+                            "name": "V&OR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "Wij handelen uw melding binnen drie weken af. U ontvangt dan geen apart bericht meer.\nEn anders hoort u - via e-mail - wanneer wij uw melding kunnen oppakken."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 5029,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/bewegwijzering"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/wegen-verkeer-straatmeubilair/verkeer.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=3bw2HLwEgw3EuJ8FdZXiGk90B3GVdBqys1oBUJJjDZo%3D"
+                        }
+                    },
+                    "_display": "Bewegwijzering (Wegen, verkeer, straatmeubilair)",
+                    "id": 93,
+                    "name": "Bewegwijzering",
+                    "slug": "bewegwijzering",
+                    "handling": "A3WEC",
+                    "departments": [
+                        {
+                            "code": "VOR",
+                            "name": "V&OR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "test",
+                    "handling_message": "Wij handelen uw melding binnen drie weken af. U ontvangt dan geen apart bericht meer.\nEn anders hoort u - via e-mail - wanneer wij uw melding kunnen oppakken."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 5023,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/openbaar-groen-en-water/sub_categories/boom-aanvraag-plaatsing"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/openbaar-groen-en-water/bomen_planten.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=gnznXtmgckcbYXAEXXq9uUUsoXRFSJ/6mV22Z8fOW%2BI%3D"
+                        }
+                    },
+                    "_display": "Boom - aanvraag plaatsing (Openbaar groen en water)",
+                    "id": 113,
+                    "name": "Boom - aanvraag plaatsing",
+                    "slug": "boom-aanvraag-plaatsing",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "VOR",
+                            "name": "V&OR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 5024,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/openbaar-groen-en-water/sub_categories/boom-stormschade"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/openbaar-groen-en-water/bomen_planten.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=gnznXtmgckcbYXAEXXq9uUUsoXRFSJ/6mV22Z8fOW%2BI%3D"
+                        }
+                    },
+                    "_display": "Boom - stormschade (Openbaar groen en water)",
+                    "id": 156,
+                    "name": "Boom - stormschade",
+                    "slug": "boom-stormschade",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "VOR",
+                            "name": "V&OR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 5030,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/camerasystemen"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/wegen-verkeer-straatmeubilair/verkeer.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=3bw2HLwEgw3EuJ8FdZXiGk90B3GVdBqys1oBUJJjDZo%3D"
+                        }
+                    },
+                    "_display": "Camerasystemen (Wegen, verkeer, straatmeubilair)",
+                    "id": 94,
+                    "name": "Camerasystemen",
+                    "slug": "camerasystemen",
+                    "handling": "A3WEC",
+                    "departments": [
+                        {
+                            "code": "VOR",
+                            "name": "V&OR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Wij handelen uw melding binnen drie weken af. U ontvangt dan geen apart bericht meer.\nEn anders hoort u - via e-mail - wanneer wij uw melding kunnen oppakken."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 5031,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/klok"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/wegen-verkeer-straatmeubilair/verkeer.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=D8/mf3sa2SvtN68kxXlTDQHv/81KlIr76imbj/rX3eU%3D"
+                        }
+                    },
+                    "_display": "Klok (Wegen, verkeer, straatmeubilair)",
+                    "id": 25,
+                    "name": "Klok",
+                    "slug": "klok",
+                    "handling": "KLOKLICHTZC",
+                    "departments": [
+                        {
+                            "code": "VOR",
+                            "name": "V&OR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Gevaarlijke situaties zullen wij zo snel mogelijk verhelpen, andere situaties kunnen wat langer duren. Wij kunnen u hier helaas niet altijd van op de hoogte houden."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 5034,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/lantaarnpaal-straatverlichting"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/wegen-verkeer-straatmeubilair/lantaarnpaal-straatverlichting/licht.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=w%2BtEDYtkGCvV7jHUVo2I36oiqGT%2BuMhtRVRX3PY1Y%2BU%3D"
+                        }
+                    },
+                    "_display": "Straatverlichting (Wegen, verkeer, straatmeubilair)",
+                    "id": 104,
+                    "name": "Straatverlichting",
+                    "slug": "lantaarnpaal-straatverlichting",
+                    "handling": "LIGHTING",
+                    "departments": [
+                        {
+                            "code": "VOR",
+                            "name": "V&OR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "Dit is een tekst",
+                    "handling_message": "Het herstellen van problemen met de openbare verlichting lukt doorgaans binnen 21 werkdagen. Bij gevaarlijke situaties wordt de melding meteen opgepakt."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 5025,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/openbaar-groen-en-water/sub_categories/onkruid"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/openbaar-groen-en-water/bomen_planten.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=gnznXtmgckcbYXAEXXq9uUUsoXRFSJ/6mV22Z8fOW%2BI%3D"
+                        }
+                    },
+                    "_display": "Onkruid in het groen (Openbaar groen en water)",
+                    "id": 42,
+                    "name": "Onkruid in het groen",
+                    "slug": "onkruid",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "VOR",
+                            "name": "V&OR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 5037,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/oplaadpunt"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/wegen-verkeer-straatmeubilair/verkeer.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=D8/mf3sa2SvtN68kxXlTDQHv/81KlIr76imbj/rX3eU%3D"
+                        }
+                    },
+                    "_display": "Oplaadpunt (Wegen, verkeer, straatmeubilair)",
+                    "id": 136,
+                    "name": "Oplaadpunt",
+                    "slug": "oplaadpunt",
+                    "handling": "TECHNISCHE_STORING",
+                    "departments": [
+                        {
+                            "code": "STL",
+                            "name": "Stadsloket",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "VOR",
+                            "name": "V&OR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Technische storingen worden meestal automatisch gemeld en binnen enkele dagen opgelost. Het beantwoorden van vragen kan tot drie weken duren. We houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 5032,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/parkeer-verwijssysteem"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/wegen-verkeer-straatmeubilair/verkeer.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=D8/mf3sa2SvtN68kxXlTDQHv/81KlIr76imbj/rX3eU%3D"
+                        }
+                    },
+                    "_display": "Parkeer verwijssysteem (Wegen, verkeer, straatmeubilair)",
+                    "id": 96,
+                    "name": "Parkeer verwijssysteem",
+                    "slug": "parkeer-verwijssysteem",
+                    "handling": "A3WEC",
+                    "departments": [
+                        {
+                            "code": "VOR",
+                            "name": "V&OR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Wij handelen uw melding binnen drie weken af. U ontvangt dan geen apart bericht meer.\nEn anders hoort u - via e-mail - wanneer wij uw melding kunnen oppakken."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 5027,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/parkeerautomaten"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/wegen-verkeer-straatmeubilair/verkeer.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=3bw2HLwEgw3EuJ8FdZXiGk90B3GVdBqys1oBUJJjDZo%3D"
+                        }
+                    },
+                    "_display": "Parkeerautomaten (Wegen, verkeer, straatmeubilair)",
+                    "id": 127,
+                    "name": "Parkeerautomaten",
+                    "slug": "parkeerautomaten",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "PRK",
+                            "name": "Parkeren",
+                            "is_intern": false
+                        },
+                        {
+                            "code": "VOR",
+                            "name": "V&OR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 5045,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-in-de-openbare-ruimte/sub_categories/parkeeroverlast"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-in-de-openbare-ruimte/openbare_ruimte.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=Ougrp8HFdH/towk1DpGyPktYWHjzgmm735CAQSI2daU%3D"
+                        }
+                    },
+                    "_display": "Parkeeroverlast (Overlast in de openbare ruimte)",
+                    "id": 30,
+                    "name": "Parkeeroverlast",
+                    "slug": "parkeeroverlast",
+                    "handling": "A3DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "THO",
+                            "name": "THOR",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "VOR",
+                            "name": "V&OR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "We laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 5053,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/civiele-constructies/sub_categories/sluis"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/civiele-constructies/bruggen_kades.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=NtJDnLpIrH0bQal4Ql2ZVAfiDNX0Ta6MVhzsZrSmzK8%3D"
+                        }
+                    },
+                    "_display": "Sluis (Civiele Constructies)",
+                    "id": 143,
+                    "name": "Sluis",
+                    "slug": "sluis",
+                    "handling": "URGENTE_MELDINGEN",
+                    "departments": [
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "VOR",
+                            "name": "V&OR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "Wij beoordelen uw melding. Urgente meldingen pakken we zo snel mogelijk op. Overige meldingen handelen we binnen een week af. We houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 5033,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/stadsplattegronden"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/wegen-verkeer-straatmeubilair/verkeer.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=D8/mf3sa2SvtN68kxXlTDQHv/81KlIr76imbj/rX3eU%3D"
+                        }
+                    },
+                    "_display": "Stadsplattegronden (Wegen, verkeer, straatmeubilair)",
+                    "id": 97,
+                    "name": "Stadsplattegronden",
+                    "slug": "stadsplattegronden",
+                    "handling": "A3WEC",
+                    "departments": [
+                        {
+                            "code": "VOR",
+                            "name": "V&OR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "Wij handelen uw melding binnen drie weken af. U ontvangt dan geen apart bericht meer.\nEn anders hoort u - via e-mail - wanneer wij uw melding kunnen oppakken."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 5035,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/verkeerslicht"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/wegen-verkeer-straatmeubilair/verkeer.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=D8/mf3sa2SvtN68kxXlTDQHv/81KlIr76imbj/rX3eU%3D"
+                        }
+                    },
+                    "_display": "Verkeerslicht (Wegen, verkeer, straatmeubilair)",
+                    "id": 26,
+                    "name": "Verkeerslicht",
+                    "slug": "verkeerslicht",
+                    "handling": "STOPEC",
+                    "departments": [
+                        {
+                            "code": "VOR",
+                            "name": "V&OR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "Gevaarlijke situaties zullen wij zo snel mogelijk verhelpen, andere situaties handelen wij meestal binnen 5 werkdagen af. U ontvangt dan geen apart bericht meer.\nAls we uw melding niet binnen 5 werkdagen kunnen afhandelen, hoort u - via e-mail – hoe wij uw melding oppakken."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 5036,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair/sub_categories/verkeerssituaties"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/wegen-verkeer-straatmeubilair/verkeer.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=D8/mf3sa2SvtN68kxXlTDQHv/81KlIr76imbj/rX3eU%3D"
+                        }
+                    },
+                    "_display": "Verkeerssituaties (Wegen, verkeer, straatmeubilair)",
+                    "id": 102,
+                    "name": "Verkeerssituaties",
+                    "slug": "verkeerssituaties",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "VOR",
+                            "name": "V&OR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 5054,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/civiele-constructies/sub_categories/watergangen"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/civiele-constructies/bruggen_kades.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=NtJDnLpIrH0bQal4Ql2ZVAfiDNX0Ta6MVhzsZrSmzK8%3D"
+                        }
+                    },
+                    "_display": "Watergangen (Civiele Constructies)",
+                    "id": 144,
+                    "name": "Watergangen",
+                    "slug": "watergangen",
+                    "handling": "URGENTE_MELDINGEN",
+                    "departments": [
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "VOR",
+                            "name": "V&OR",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "Wij beoordelen uw melding. Urgente meldingen pakken we zo snel mogelijk op. Overige meldingen handelen we binnen een week af. We houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            }
+        ],
+        "can_direct": false
+    },
+    {
+        "_links": {
+            "self": {
+                "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/private/departments/17"
+            }
+        },
+        "_display": "VIS (V&OR - VIS)",
+        "id": 17,
+        "name": "V&OR - VIS",
+        "code": "VIS",
+        "is_intern": true,
+        "categories": [
+            {
+                "id": 3768,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/grofvuil"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/afval/afval.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=3rppZzgnU1Kt0BY4fXxsjdkvBpa5OWthAyA5lDlGVUM%3D"
+                        }
+                    },
+                    "_display": "Grofvuil (Afval)",
+                    "id": 2,
+                    "name": "Grofvuil",
+                    "slug": "grofvuil",
+                    "handling": "A3DEVOMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "AEG",
+                            "name": "Afval en Grondstoffen",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "VIS",
+                            "name": "V&OR - VIS",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "Meubels of andere grote spullen uit uw huis, grote elektrische apparaten, snoeiafval, hout en glas.",
+                    "handling_message": "We laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken. We houden u op de hoogte."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 3767,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/afval/sub_categories/huisafval"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/afval/afval.svg?se=2023-02-16T14%3A14%3A52Z&sp=r&sv=2021-08-06&sr=b&sig=3rppZzgnU1Kt0BY4fXxsjdkvBpa5OWthAyA5lDlGVUM%3D"
+                        }
+                    },
+                    "_display": "Huisafval (Afval)",
+                    "id": 3,
+                    "name": "Huisafval",
+                    "slug": "huisafval",
+                    "handling": "A3DMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "AEG",
+                            "name": "Afval en Grondstoffen",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "VIS",
+                            "name": "V&OR - VIS",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "We laten u binnen 3 werkdagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            }
+        ],
+        "can_direct": false
+    },
+    {
+        "_links": {
+            "self": {
+                "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/private/departments/15"
+            }
+        },
+        "_display": "VTH (VTH)",
+        "id": 15,
+        "name": "VTH",
+        "code": "VTH",
+        "is_intern": true,
+        "categories": [
+            {
+                "id": 1492,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-in-de-openbare-ruimte/sub_categories/bouw-sloopoverlast"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-in-de-openbare-ruimte/openbare_ruimte.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=Ougrp8HFdH/towk1DpGyPktYWHjzgmm735CAQSI2daU%3D"
+                        }
+                    },
+                    "_display": "Bouw- / sloopoverlast (Overlast in de openbare ruimte)",
+                    "id": 33,
+                    "name": "Bouw- / sloopoverlast",
+                    "slug": "bouw-sloopoverlast",
+                    "handling": "A3WMC",
+                    "departments": [
+                        {
+                            "code": "VTH",
+                            "name": "VTH",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "We laten u binnen 3 weken weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 1491,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-bedrijven-en-horeca/sub_categories/geluidsoverlast-installaties"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-bedrijven-en-horeca/bedrijven.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=SNr33LSFXZY77b6FvC0xRyrwufl9l%2B1b0BvnJZbgjiI%3D"
+                        }
+                    },
+                    "_display": "Geluidsoverlast installaties (Overlast Bedrijven en Horeca)",
+                    "id": 63,
+                    "name": "Geluidsoverlast installaties",
+                    "slug": "geluidsoverlast-installaties",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "VTH",
+                            "name": "VTH",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 1490,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-bedrijven-en-horeca/sub_categories/geluidsoverlast-muziek"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-bedrijven-en-horeca/bedrijven.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=SNr33LSFXZY77b6FvC0xRyrwufl9l%2B1b0BvnJZbgjiI%3D"
+                        }
+                    },
+                    "_display": "Geluidsoverlast muziek (Overlast Bedrijven en Horeca)",
+                    "id": 62,
+                    "name": "Geluidsoverlast muziek",
+                    "slug": "geluidsoverlast-muziek",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "VTH",
+                            "name": "VTH",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 1489,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-bedrijven-en-horeca/sub_categories/overig-horecabedrijven"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-bedrijven-en-horeca/bedrijven.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=SNr33LSFXZY77b6FvC0xRyrwufl9l%2B1b0BvnJZbgjiI%3D"
+                        }
+                    },
+                    "_display": "Overig bedrijven / horeca (Overlast Bedrijven en Horeca)",
+                    "id": 68,
+                    "name": "Overig bedrijven / horeca",
+                    "slug": "overig-horecabedrijven",
+                    "handling": "REST",
+                    "departments": [
+                        {
+                            "code": "VTH",
+                            "name": "VTH",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Wij bekijken uw melding en zorgen dat het juiste onderdeel van de gemeente deze gaat behandelen. Heeft u contactgegevens achtergelaten? Dan nemen wij bij onduidelijkheid contact met u op."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 1488,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-bedrijven-en-horeca/sub_categories/overlast-terrassen"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-bedrijven-en-horeca/bedrijven.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=SNr33LSFXZY77b6FvC0xRyrwufl9l%2B1b0BvnJZbgjiI%3D"
+                        }
+                    },
+                    "_display": "Overlast terrassen (Overlast Bedrijven en Horeca)",
+                    "id": 64,
+                    "name": "Overlast terrassen",
+                    "slug": "overlast-terrassen",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "VTH",
+                            "name": "VTH",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 1486,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-in-de-openbare-ruimte/sub_categories/stank-geluidsoverlast"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-in-de-openbare-ruimte/openbare_ruimte.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=Ougrp8HFdH/towk1DpGyPktYWHjzgmm735CAQSI2daU%3D"
+                        }
+                    },
+                    "_display": "Stank- / geluidsoverlast (Overlast in de openbare ruimte)",
+                    "id": 32,
+                    "name": "Stank- / geluidsoverlast",
+                    "slug": "stank-geluidsoverlast",
+                    "handling": "A3WMC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "THO",
+                            "name": "THOR",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "VTH",
+                            "name": "VTH",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "We laten u binnen 3 weken weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 1487,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-bedrijven-en-horeca/sub_categories/stankoverlast"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-bedrijven-en-horeca/bedrijven.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=SNr33LSFXZY77b6FvC0xRyrwufl9l%2B1b0BvnJZbgjiI%3D"
+                        }
+                    },
+                    "_display": "Stankoverlast (Overlast Bedrijven en Horeca)",
+                    "id": 66,
+                    "name": "Stankoverlast",
+                    "slug": "stankoverlast",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "VTH",
+                            "name": "VTH",
+                            "is_intern": true
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            }
+        ],
+        "can_direct": false
+    },
+    {
+        "_links": {
+            "self": {
+                "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/private/departments/23"
+            }
+        },
+        "_display": "VTH (VTH)",
+        "id": 23,
+        "name": "VTH",
+        "code": "VTH",
+        "is_intern": false,
+        "categories": [
+            {
+                "id": 4231,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/wonen/sub_categories/woningkwaliteit"
+                        }
+                    },
+                    "_display": "Woningkwaliteit (Wonen)",
+                    "id": 126,
+                    "name": "Woningkwaliteit",
+                    "slug": "woningkwaliteit",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "VTH",
+                            "name": "VTH",
+                            "is_intern": false
+                        },
+                        {
+                            "code": "WON",
+                            "name": "Wonen",
+                            "is_intern": false
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            }
+        ],
+        "can_direct": false
+    },
+    {
+        "_links": {
+            "self": {
+                "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/private/departments/3"
+            }
+        },
+        "_display": "WAT (Waternet)",
+        "id": 3,
+        "name": "Waternet",
+        "code": "WAT",
+        "is_intern": false,
+        "categories": [
+            {
+                "id": 2447,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-op-het-water/sub_categories/blokkade-van-de-vaarweg"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-op-het-water/boten.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=9vylQ8EDUlNUbiOmIGUNXOc6LMs%2BCda5hAgfltemzfk%3D"
+                        }
+                    },
+                    "_display": "Blokkade van de vaarweg (Overlast op het water)",
+                    "id": 134,
+                    "name": "Blokkade van de vaarweg",
+                    "slug": "blokkade-van-de-vaarweg",
+                    "handling": "STOPEC3",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "WAT",
+                            "name": "Waternet",
+                            "is_intern": false
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "dit is een omschrijving",
+                    "handling_message": "Gevaarlijke situaties pakken wij zo snel mogelijk op. We laten u binnen 3 werkdagen weten wat we hebben gedaan. We houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 2439,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/civiele-constructies/sub_categories/brug-bediening"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/civiele-constructies/bruggen_kades.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=NtJDnLpIrH0bQal4Ql2ZVAfiDNX0Ta6MVhzsZrSmzK8%3D"
+                        }
+                    },
+                    "_display": "Brug bediening (Civiele Constructies)",
+                    "id": 122,
+                    "name": "Brug bediening",
+                    "slug": "brug-bediening",
+                    "handling": "A3WEC",
+                    "departments": [
+                        {
+                            "code": "WAT",
+                            "name": "Waternet",
+                            "is_intern": false
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "Wij handelen uw melding binnen drie weken af. U ontvangt dan geen apart bericht meer.\n\nEn anders hoort u - via e-mail - wanneer wij uw melding kunnen oppakken.\n\nBedankt, hoor."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 2441,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/civiele-constructies/sub_categories/bruggen"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/civiele-constructies/bruggen_kades.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=NtJDnLpIrH0bQal4Ql2ZVAfiDNX0Ta6MVhzsZrSmzK8%3D"
+                        }
+                    },
+                    "_display": "Brug (Civiele Constructies)",
+                    "id": 142,
+                    "name": "Brug",
+                    "slug": "bruggen",
+                    "handling": "A3WEC",
+                    "departments": [
+                        {
+                            "code": "STW",
+                            "name": "Stadswerken",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "WAT",
+                            "name": "Waternet",
+                            "is_intern": false
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Wij handelen uw melding binnen drie weken af. U ontvangt dan geen apart bericht meer. [Gemeente Amsterdam](http://www.amsterdam.nl) En anders hoort u - via e-mail - wanneer wij uw melding kunnen oppakken."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 2453,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/schoon/sub_categories/drijfvuil-bevaarbaar-water"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/schoon/onderhoud.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=0zESrpLqvoZEGaozcFoOirbp3ofw%2Bp/Xh%2BGLyL/5/wY%3D"
+                        }
+                    },
+                    "_display": "Drijfvuil bevaarbaar water (Schoon)",
+                    "id": 138,
+                    "name": "Drijfvuil bevaarbaar water",
+                    "slug": "drijfvuil-bevaarbaar-water",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "WAT",
+                            "name": "Waternet",
+                            "is_intern": false
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 2448,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-op-het-water/sub_categories/olie-op-het-water"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-op-het-water/boten.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=9vylQ8EDUlNUbiOmIGUNXOc6LMs%2BCda5hAgfltemzfk%3D"
+                        }
+                    },
+                    "_display": "Olie op het water (Overlast op het water)",
+                    "id": 135,
+                    "name": "Olie op het water",
+                    "slug": "olie-op-het-water",
+                    "handling": "STOPEC3",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "WAT",
+                            "name": "Waternet",
+                            "is_intern": false
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Gevaarlijke situaties pakken wij zo snel mogelijk op. We laten u binnen 3 werkdagen weten wat we hebben gedaan. We houden u op de hoogte via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 2446,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-op-het-water/sub_categories/overig-boten"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-op-het-water/boten.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=9vylQ8EDUlNUbiOmIGUNXOc6LMs%2BCda5hAgfltemzfk%3D"
+                        }
+                    },
+                    "_display": "Overige boten (Overlast op het water)",
+                    "id": 75,
+                    "name": "Overige boten",
+                    "slug": "overig-boten",
+                    "handling": "WS3EC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "WAT",
+                            "name": "Waternet",
+                            "is_intern": false
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "We geven uw melding door aan onze handhavers. Zij beoordelen of het nodig is direct actie te ondernemen. Bijvoorbeeld omdat er olie lekt of omdat de situatie gevaar oplevert voor andere boten.\n\nAls er geen directe actie nodig is, dan pakken we uw melding op buiten het vaarseizoen (september - maart).\n"
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 2443,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-op-het-water/sub_categories/overlast-op-het-water-geluid"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-op-het-water/boten.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=9vylQ8EDUlNUbiOmIGUNXOc6LMs%2BCda5hAgfltemzfk%3D"
+                        }
+                    },
+                    "_display": "Geluid op het water (Overlast op het water)",
+                    "id": 71,
+                    "name": "Geluid op het water",
+                    "slug": "overlast-op-het-water-geluid",
+                    "handling": "WS1EC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "WAT",
+                            "name": "Waternet",
+                            "is_intern": false
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "We geven uw melding door aan de handhavers. Als dat mogelijk is ondernemen zij direct actie, maar zij kunnen niet altijd snel genoeg aanwezig zijn.\n\nBlijf overlast aan ons melden. Ook als we niet altijd direct iets voor u kunnen doen. We gebruiken alle meldingen om overlast in de toekomst te kunnen beperken."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 2444,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-op-het-water/sub_categories/overlast-op-het-water-gezonken-boot"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-op-het-water/boten.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=9vylQ8EDUlNUbiOmIGUNXOc6LMs%2BCda5hAgfltemzfk%3D"
+                        }
+                    },
+                    "_display": "Wrak in het water (Overlast op het water)",
+                    "id": 72,
+                    "name": "Wrak in het water",
+                    "slug": "overlast-op-het-water-gezonken-boot",
+                    "handling": "WS2EC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "WAT",
+                            "name": "Waternet",
+                            "is_intern": false
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "We geven uw melding door aan onze handhavers. Zij beoordelen of het nodig is direct actie te ondernemen. Bijvoorbeeld omdat er olie lekt of omdat de situatie gevaar oplevert voor andere boten.\n\nAls er geen directe actie nodig is, dan pakken we uw melding op buiten het vaarseizoen (september - maart).\n\nBekijk in welke situaties we een wrak weghalen. Boten die vol met water staan, maar nog wél drijven, mogen we bijvoorbeeld niet weghalen."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 2442,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-op-het-water/sub_categories/overlast-op-het-water-snel-varen"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-op-het-water/boten.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=9vylQ8EDUlNUbiOmIGUNXOc6LMs%2BCda5hAgfltemzfk%3D"
+                        }
+                    },
+                    "_display": "Snel varen (Overlast op het water)",
+                    "id": 69,
+                    "name": "Snel varen",
+                    "slug": "overlast-op-het-water-snel-varen",
+                    "handling": "WS1EC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "WAT",
+                            "name": "Waternet",
+                            "is_intern": false
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "We geven uw melding door aan de handhavers. Als dat mogelijk is ondernemen zij direct actie, maar zij kunnen niet altijd snel genoeg aanwezig zijn.\n\nBlijf overlast aan ons melden. Ook als we niet altijd direct iets voor u kunnen doen. We gebruiken alle meldingen om overlast in de toekomst te kunnen beperken."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 2445,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/overlast-op-het-water/sub_categories/scheepvaart-nautisch-toezicht"
+                        },
+                        "sia:icon": {
+                            "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/overlast-op-het-water/boten.svg?se=2023-02-16T14%3A14%3A53Z&sp=r&sv=2021-08-06&sr=b&sig=9vylQ8EDUlNUbiOmIGUNXOc6LMs%2BCda5hAgfltemzfk%3D"
+                        }
+                    },
+                    "_display": "Nautisch toezicht / vaargedrag (Overlast op het water)",
+                    "id": 73,
+                    "name": "Nautisch toezicht / vaargedrag",
+                    "slug": "scheepvaart-nautisch-toezicht",
+                    "handling": "WS3EC",
+                    "departments": [
+                        {
+                            "code": "ASC",
+                            "name": "Actie Service Centrum",
+                            "is_intern": true
+                        },
+                        {
+                            "code": "WAT",
+                            "name": "Waternet",
+                            "is_intern": false
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "We geven uw melding door aan onze handhavers. Zij beoordelen of het nodig is direct actie te ondernemen. Bijvoorbeeld omdat er olie lekt of omdat de situatie gevaar oplevert voor andere boten.\n\nAls er geen directe actie nodig is, dan pakken we uw melding op buiten het vaarseizoen (september - maart)."
+                },
+                "is_responsible": true,
+                "can_view": true
+            }
+        ],
+        "can_direct": false
+    },
+    {
+        "_links": {
+            "self": {
+                "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/private/departments/19"
+            }
+        },
+        "_display": "WON (Wonen)",
+        "id": 19,
+        "name": "Wonen",
+        "code": "WON",
+        "is_intern": false,
+        "categories": [
+            {
+                "id": 4494,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/wonen/sub_categories/leegstand"
+                        }
+                    },
+                    "_display": "Leegstand (Wonen)",
+                    "id": 129,
+                    "name": "Leegstand",
+                    "slug": "leegstand",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "WON",
+                            "name": "Wonen",
+                            "is_intern": false
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 4495,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/wonen/sub_categories/onderhuur-en-adreskwaliteit"
+                        }
+                    },
+                    "_display": "Onderhuur en adreskwaliteit (Wonen)",
+                    "id": 128,
+                    "name": "Onderhuur en adreskwaliteit",
+                    "slug": "onderhuur-en-adreskwaliteit",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "WON",
+                            "name": "Wonen",
+                            "is_intern": false
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 4496,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/wonen/sub_categories/vakantieverhuur"
+                        }
+                    },
+                    "_display": "Vakantieverhuur (Wonen)",
+                    "id": 125,
+                    "name": "Vakantieverhuur",
+                    "slug": "vakantieverhuur",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "WON",
+                            "name": "Wonen",
+                            "is_intern": false
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 6141,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/wonen/sub_categories/wonen-ondermijning"
+                        }
+                    },
+                    "_display": "Wonen ondermijning (Wonen)",
+                    "id": 175,
+                    "name": "Wonen ondermijning",
+                    "slug": "wonen-ondermijning",
+                    "handling": "EMPTY",
+                    "departments": [
+                        {
+                            "code": "WON",
+                            "name": "Wonen",
+                            "is_intern": false
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "Criminele bewoning of activiteiten in een woning of woonboot, zoals een wietplantage of prostitutie.",
+                    "handling_message": "U hoort binnen 10 werkdagen wat wij met uw melding gaan doen. En u hoort hoe lang het gaat duren."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 4499,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/wonen/sub_categories/wonen-overig"
+                        }
+                    },
+                    "_display": "Overige Wonen (Wonen)",
+                    "id": 158,
+                    "name": "Overige Wonen",
+                    "slug": "wonen-overig",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "WON",
+                            "name": "Wonen",
+                            "is_intern": false
+                        }
+                    ],
+                    "is_active": true,
+                    "description": null,
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 4497,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/wonen/sub_categories/woningdelen-spookburgers"
+                        }
+                    },
+                    "_display": "Woningdelen / spookburgers (Wonen)",
+                    "id": 130,
+                    "name": "Woningdelen / spookburgers",
+                    "slug": "woningdelen-spookburgers",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "WON",
+                            "name": "Wonen",
+                            "is_intern": false
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            },
+            {
+                "id": 4498,
+                "category": {
+                    "_links": {
+                        "curies": {
+                            "name": "sia",
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/relations"
+                        },
+                        "self": {
+                            "href": "https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/wonen/sub_categories/woningkwaliteit"
+                        }
+                    },
+                    "_display": "Woningkwaliteit (Wonen)",
+                    "id": 126,
+                    "name": "Woningkwaliteit",
+                    "slug": "woningkwaliteit",
+                    "handling": "I5DMC",
+                    "departments": [
+                        {
+                            "code": "VTH",
+                            "name": "VTH",
+                            "is_intern": false
+                        },
+                        {
+                            "code": "WON",
+                            "name": "Wonen",
+                            "is_intern": false
+                        }
+                    ],
+                    "is_active": true,
+                    "description": "",
+                    "handling_message": "Uw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail."
+                },
+                "is_responsible": true,
+                "can_view": true
+            }
+        ],
+        "can_direct": false
+    }
+]

--- a/src/utils/__tests__/sortAlphabetic.test.ts
+++ b/src/utils/__tests__/sortAlphabetic.test.ts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (C) 2023 Gemeente Amsterdam
+import { sortAlphabetic } from '../sortAlphabetic'
+
+describe('sortAlphabetic', () => {
+  it('should sort alphebetic', () => {
+    expect(['b', 'c', 'a'].sort(sortAlphabetic)).toEqual(['a', 'b', 'c'])
+  })
+})

--- a/src/utils/sortAlphabetic.ts
+++ b/src/utils/sortAlphabetic.ts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (C) 2023 Gemeente Amsterdam
+export const sortAlphabetic = (a: string, b: string) => {
+  const _a = a.toLowerCase()
+  const _b = b.toLowerCase()
+
+  // eslint-disable-next-line no-nested-ternary
+  return _a > _b ? 1 : _a < _b ? -1 : 0
+}


### PR DESCRIPTION
Use dashboardfilters in overview page

When clicking a graph, use the filter values for the overviewpage. I changed the filter names a bit, so they are the same as in overview, though partly dutch.

Ticket: [SIG-5008](https://gemeente-amsterdam.atlassian.net/browse/SIG-5008)

## Signalen

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
