### PR TITLE
[feat-4983]: Add version number fe to docker hub workflow

### DIFF
--- a/.github/workflows/build_and_push_to_docker_hub.yml
+++ b/.github/workflows/build_and_push_to_docker_hub.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Build the release Docker image
         run: |
-          docker build -t signalen/frontend:${{ github.event.release.tag_name }} .
+          docker build --build-arg FRONTEND_TAG=${{ github.event.release.tag_name }} -t signalen/frontend:${{ github.event.release.tag_name }} .
       - name: Build the latest Docker image
         run: |
           docker build -t signalen/frontend:latest .


### PR DESCRIPTION
So docker can pick it up and provide it to the fe, showing to in the console.

Ticket: [SIG-4983](https://gemeente-amsterdam.atlassian.net/browse/SIG-4983)

## Signalen

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
