### PR TITLE
Support lists in internal notes

### DIFF
--- a/src/components/HistoryList/HistoryList.tsx
+++ b/src/components/HistoryList/HistoryList.tsx
@@ -78,7 +78,9 @@ const HistoryList: FunctionComponent<HistoryListProps> = ({
           )}
           {description && (
             <span data-testid="history-list-item-description">
-              <Markdown allowedElements={['a', 'p']}>{description}</Markdown>
+              <Markdown allowedElements={['a', 'p', 'ul', 'ol', 'li']}>
+                {description}
+              </Markdown>
             </span>
           )}
         </Action>

--- a/src/components/Markdown/Markdown.test.tsx
+++ b/src/components/Markdown/Markdown.test.tsx
@@ -24,16 +24,29 @@ describe('Markdown', () => {
     expect(screen.getByText('Hic sunt')).toBeInTheDocument()
   })
 
+  it('parses an unordered list', () => {
+    render(
+      withAppContext(<Markdown allowedElements={['ul', 'li']}>- Test</Markdown>)
+    )
+    expect(screen.getByRole('list')).toBeInTheDocument()
+  })
+
+  it('parses an ordered list', () => {
+    render(
+      withAppContext(
+        <Markdown allowedElements={['ol', 'li']}>1. Test</Markdown>
+      )
+    )
+    expect(screen.getByRole('list')).toBeInTheDocument()
+  })
+
   it('skips unallowed markdown', () => {
     render(
       withAppContext(
-        <Markdown allowedElements={['a', 'p']}>
-          ## Heading level 2 * list item #1 * list item #2
-        </Markdown>
+        <Markdown allowedElements={['a', 'p']}>## Heading level 2</Markdown>
       )
     )
 
     expect(screen.queryByRole('heading')).not.toBeInTheDocument()
-    expect(screen.queryByRole('list')).not.toBeInTheDocument()
   })
 })

--- a/src/components/Markdown/Markdown.tsx
+++ b/src/components/Markdown/Markdown.tsx
@@ -2,7 +2,13 @@
 // Copyright (C) 2018 - 2022 Gemeente Amsterdam
 import type { ReactNode } from 'react'
 
-import { Link as AscLink } from '@amsterdam/asc-ui'
+import {
+  Link as AscLink,
+  List as AscList,
+  OrderedList as AscOrderedList,
+  ListItem,
+} from '@amsterdam/asc-ui'
+
 import ReactMarkdown from 'react-markdown'
 import type { ReactMarkdownOptions } from 'react-markdown'
 import styled from 'styled-components'
@@ -11,6 +17,26 @@ import Paragraph from 'components/Paragraph'
 
 const Link = styled(AscLink)`
   font-size: 1rem;
+`
+
+const List = styled(AscList)`
+  display: flex;
+  flex-direction: column;
+
+  li {
+    line-height: 1.5;
+    font-size: 1rem;
+  }
+`
+
+const OrderedList = styled(AscOrderedList)`
+  display: flex;
+  flex-direction: column;
+
+  li {
+    line-height: 1.5;
+    font-size: 1rem;
+  }
 `
 
 type Props = {
@@ -31,6 +57,9 @@ const Markdown = ({ children, hideTabindexLink, ...props }: Props) => (
       ),
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       p: ({ node, color, ...props }) => <Paragraph {...props} />,
+      ul: ({ node, ...props }) => <List variant="bullet" {...props} />,
+      ol: ({ node, ...props }) => <OrderedList {...props} />,
+      li: ({ node, ...props }) => <ListItem {...props} />,
     }}
     {...props}
   >


### PR DESCRIPTION
Fixes https://github.com/Signalen/product-steering/issues/304

This PR adds list and ordered list support in internal notes. Currently notes return empty when using lists, and this confuses users. This proposal supports the following syntaxes:

```markdown
- Item 1
- Item 2
- Item 3
```

```markdown
1. Item 1
2. Item 2
3. Item 3
```

## Screenshots

<kbd><img width="225" alt="Scherm­afbeelding 2023-02-21 om 19 07 44" src="https://user-images.githubusercontent.com/5213690/220437651-35932ce8-aab5-4d47-a957-e557c97d843b.png"></kbd>
<kbd><img width="225" alt="Scherm­afbeelding 2023-02-21 om 19 08 05" src="https://user-images.githubusercontent.com/5213690/220437655-3d944902-0841-4cdf-836e-2c7d8884537b.png"></kbd>
