### PR TITLE
[feat-5007]: Align graphs on multiple screens

### DIFF
--- a/src/components/SiteHeader/index.js
+++ b/src/components/SiteHeader/index.js
@@ -27,7 +27,7 @@ import configuration from 'shared/services/configuration/configuration'
 
 import useTallHeader from '../../hooks/useTallHeader'
 
-const MENU_BREAKPOINT = 1320
+export const MENU_BREAKPOINT = 1320
 
 const StyledHeader = styled(HeaderComponent)`
   ${({ isFrontOffice, tall }) =>

--- a/src/signals/incident-management/containers/Dashboard/Dashboard.tsx
+++ b/src/signals/incident-management/containers/Dashboard/Dashboard.tsx
@@ -2,10 +2,8 @@
 // Copyright (C) 2023 Gemeente Amsterdam
 import { useState } from 'react'
 
-import { Row } from '@amsterdam/asc-ui'
-
 import { AreaChart, BarChart, Filter } from './components'
-import { StyledRow } from './styled'
+import { StyledRow, Wrapper } from './styled'
 
 const Dashboard = () => {
   const [queryString, setQueryString] = useState<string>('')
@@ -15,10 +13,10 @@ const Dashboard = () => {
       <StyledRow data-testid="menu">
         <Filter callback={setQueryString} />
       </StyledRow>
-      <Row data-testid="menu">
+      <Wrapper data-testid="menu">
         <BarChart queryString={queryString} />
         <AreaChart />
-      </Row>
+      </Wrapper>
     </>
   )
 }

--- a/src/signals/incident-management/containers/Dashboard/charts/getAreaChartSpec.test.ts
+++ b/src/signals/incident-management/containers/Dashboard/charts/getAreaChartSpec.test.ts
@@ -247,7 +247,7 @@ describe('getAreaChartSpec', () => {
             ],
           },
         ],
-        "width": 430,
+        "width": "container",
       }
     `)
   })

--- a/src/signals/incident-management/containers/Dashboard/charts/getAreaChartSpec.ts
+++ b/src/signals/incident-management/containers/Dashboard/charts/getAreaChartSpec.ts
@@ -10,7 +10,7 @@ export const getAreaChartSpec = (
   today: Today
 ): VisualizationSpec => ({
   $schema: 'https://vega.github.io/schema/vega-lite/v5.json',
-  width: 430,
+  width: 'container',
   height: 220,
   data: {
     values,

--- a/src/signals/incident-management/containers/Dashboard/charts/getBarChartSpecs.test.ts
+++ b/src/signals/incident-management/containers/Dashboard/charts/getBarChartSpecs.test.ts
@@ -150,7 +150,7 @@ describe('getAreaChartSpec', () => {
                       0,
                       6513,
                     ],
-                    "rangeMax": 275,
+                    "rangeMax": 250,
                   },
                   "title": null,
                 },

--- a/src/signals/incident-management/containers/Dashboard/charts/getBarChartSpecs.ts
+++ b/src/signals/incident-management/containers/Dashboard/charts/getBarChartSpecs.ts
@@ -11,7 +11,7 @@ export const getBarChartSpecs = (
   $schema: 'https://vega.github.io/schema/vega-lite/v5.json',
   description: 'A bar chart showing showing number of incidents per status',
   data: {
-    values: values,
+    values,
   },
   spacing: 5,
   facet: {
@@ -40,7 +40,7 @@ export const getBarChartSpecs = (
             title: null,
             scale: {
               domain: [0, maxDomain],
-              rangeMax: 275,
+              rangeMax: 250,
             },
             axis: null,
           },

--- a/src/signals/incident-management/containers/Dashboard/components/AreaChart/AreaChart.tsx
+++ b/src/signals/incident-management/containers/Dashboard/components/AreaChart/AreaChart.tsx
@@ -14,7 +14,7 @@ import { useFetch } from 'hooks'
 import configuration from 'shared/services/configuration/configuration'
 
 import { ComparisonRate } from './ComparisonRate'
-import { AreaChartWrapper as Wrapper } from './styled'
+import { AreaChartWrapper as Wrapper, StyledAreaChart } from './styled'
 import type { ComparisonRateType } from './types'
 import { formatData, getMaxDomain, getToday, getPercentage } from './utils'
 import { INCIDENTS_URL } from '../../../../routes'
@@ -86,7 +86,7 @@ export const AreaChart = () => {
     <Link to={{ pathname: INCIDENTS_URL, state: { useBacklink: true } }}>
       <Wrapper>
         <ModuleTitle title="Afgehandelde meldingen afgelopen 7 dagen" />
-        <div id="area-chart" data-testid="area-chart" />
+        <StyledAreaChart id="area-chart" data-testid="area-chart" />
         {comparisonRate && <ComparisonRate comparisonRate={comparisonRate} />}
       </Wrapper>
     </Link>

--- a/src/signals/incident-management/containers/Dashboard/components/AreaChart/styled.ts
+++ b/src/signals/incident-management/containers/Dashboard/components/AreaChart/styled.ts
@@ -3,8 +3,13 @@
 import { themeColor, themeSpacing } from '@amsterdam/asc-ui'
 import styled from 'styled-components'
 
-export const AreaChartWrapper = styled.span`
+export const AreaChartWrapper = styled.div`
   position: relative;
+  width: 430px;
+`
+
+export const StyledAreaChart = styled.div`
+  width: 100%;
 `
 
 export const ComparisonRateWrapper = styled.span`

--- a/src/signals/incident-management/containers/Dashboard/components/BarChart/BarChart.tsx
+++ b/src/signals/incident-management/containers/Dashboard/components/BarChart/BarChart.tsx
@@ -10,7 +10,7 @@ import { showGlobalNotification } from 'containers/App/actions'
 import { VARIANT_ERROR, TYPE_LOCAL } from 'containers/Notification/constants'
 import { useFetchAll } from 'hooks'
 
-import { StyledBarChart, Wrapper } from './styled'
+import { Wrapper } from './styled'
 import type { RawData } from './types'
 import {
   getMaxDomain,
@@ -81,7 +81,7 @@ export const BarChart = ({ queryString }: Props) => {
         title="Openstaande meldingen tot en met vandaag"
         amount={total?.toString()}
       />
-      <StyledBarChart data-testid="bar-chart" id="bar-chart" />
+      <div data-testid="bar-chart" id="bar-chart" />
     </Wrapper>
   )
 }

--- a/src/signals/incident-management/containers/Dashboard/components/BarChart/styled.tsx
+++ b/src/signals/incident-management/containers/Dashboard/components/BarChart/styled.tsx
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2023 Gemeente Amsterdam
-
+import { breakpoint } from '@amsterdam/asc-ui'
 import styled from 'styled-components'
 
-export const Wrapper = styled.span`
-  position: relative;
-`
-
-export const StyledBarChart = styled.div`
+export const Wrapper = styled.div`
   width: 100%;
+
+  @media screen and ${breakpoint('min-width', 'laptop')} {
+    margin-right: 60px;
+  }
 `

--- a/src/signals/incident-management/containers/Dashboard/components/BarChart/styled.tsx
+++ b/src/signals/incident-management/containers/Dashboard/components/BarChart/styled.tsx
@@ -1,12 +1,13 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2023 Gemeente Amsterdam
-import { breakpoint } from '@amsterdam/asc-ui'
 import styled from 'styled-components'
+
+import { MENU_BREAKPOINT } from 'components/SiteHeader/index'
 
 export const Wrapper = styled.div`
   width: 100%;
 
-  @media screen and ${breakpoint('min-width', 'laptop')} {
+  @media screen and (min-width: ${MENU_BREAKPOINT + 1}px) {
     margin-right: 60px;
   }
 `

--- a/src/signals/incident-management/containers/Dashboard/styled.ts
+++ b/src/signals/incident-management/containers/Dashboard/styled.ts
@@ -3,8 +3,21 @@
 import { themeColor } from '@amsterdam/asc-ui'
 import styled from 'styled-components'
 
+import { MENU_BREAKPOINT } from 'components/SiteHeader/index'
+
 export const StyledRow = styled.div`
   width: 100%;
   background-color: ${themeColor('tint', 'level2')};
   margin: 0;
+`
+
+export const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  margin: 0 60px;
+
+  @media screen and (min-width: ${MENU_BREAKPOINT + 1}px) {
+    flex-direction: row;
+  }
 `


### PR DESCRIPTION
Ticket: [SIG-5007](https://gemeente-amsterdam.atlassian.net/browse/SIG-5007)

### Context
The aim was to make the graphs respond to any screen size. However, it seemed very hard/impossible to make a bar chart with facets respond to a certain width. Therefore we chose to make the graphs fixed size and wrap them the on the same breakpoint as the menu changes.

### Changes
- Set breakpoint of graphs to that of the menu
