### PR TITLE
[fix-5048]: Add status param to areaChart query

### DIFF
--- a/src/signals/incident-management/containers/Dashboard/components/AreaChart/AreaChart.test.tsx
+++ b/src/signals/incident-management/containers/Dashboard/components/AreaChart/AreaChart.test.tsx
@@ -4,7 +4,10 @@ import { render, screen } from '@testing-library/react'
 import * as reactRedux from 'react-redux'
 
 import useFetch from 'hooks/useFetch'
-import { useFetchResponse } from 'signals/IncidentMap/components/__test__/utils'
+import {
+  get,
+  useFetchResponse,
+} from 'signals/IncidentMap/components/__test__/utils'
 import { withAppContext } from 'test/utils'
 
 import { AreaChart } from './AreaChart'
@@ -55,6 +58,10 @@ describe('AreaChart', () => {
     render(withAppContext(<AreaChart />))
 
     expect(screen.getByTestId('loading-indicator')).toBeInTheDocument()
+    expect(get).toHaveBeenCalledWith(
+      'http://localhost:8000/signals/v1/private/signals/stats/past_week',
+      { status: 'o' }
+    )
   })
 
   it('should show one error', () => {

--- a/src/signals/incident-management/containers/Dashboard/components/AreaChart/AreaChart.tsx
+++ b/src/signals/incident-management/containers/Dashboard/components/AreaChart/AreaChart.tsx
@@ -43,7 +43,7 @@ export const AreaChart = () => {
 
   useEffect(() => {
     if (!rawData) {
-      getAreaChart(configuration.INCIDENTS_PAST_WEEK)
+      getAreaChart(configuration.INCIDENTS_PAST_WEEK, { status: 'o' })
     }
   }, [getAreaChart, rawData])
 


### PR DESCRIPTION
Ticket: [SIG-5048](https://gemeente-amsterdam.atlassian.net/browse/SIG-5048)

The area chart queried all indcidents instead of only the "afgehandelde" incidents. We had to add this status as param to the query. 
