### PR TITLE
[feat-5007]: Align graphs on multiple screens

### DIFF
--- a/src/signals/incident-management/containers/Dashboard/Dashboard.tsx
+++ b/src/signals/incident-management/containers/Dashboard/Dashboard.tsx
@@ -2,23 +2,21 @@
 // Copyright (C) 2023 Gemeente Amsterdam
 import { useState } from 'react'
 
-import { Row } from '@amsterdam/asc-ui'
-
 import { AreaChart, BarChart, Filter } from './components'
-import { StyledRow } from './styled'
+import { FilterWrapper, StyledRow } from './styled'
 
 const Dashboard = () => {
   const [queryString, setQueryString] = useState<string>('')
 
   return (
     <>
-      <StyledRow data-testid="menu">
+      <FilterWrapper data-testid="menu">
         <Filter callback={setQueryString} />
-      </StyledRow>
-      <Row data-testid="menu">
+      </FilterWrapper>
+      <StyledRow data-testid="menu">
         <BarChart queryString={queryString} />
         <AreaChart />
-      </Row>
+      </StyledRow>
     </>
   )
 }

--- a/src/signals/incident-management/containers/Dashboard/Dashboard.tsx
+++ b/src/signals/incident-management/containers/Dashboard/Dashboard.tsx
@@ -13,7 +13,7 @@ const Dashboard = () => {
       <FilterWrapper data-testid="menu">
         <Filter callback={setQueryString} />
       </FilterWrapper>
-      <StyledRow data-testid="menu">
+      <StyledRow>
         <BarChart queryString={queryString} />
         <AreaChart />
       </StyledRow>

--- a/src/signals/incident-management/containers/Dashboard/components/AreaChart/styled.ts
+++ b/src/signals/incident-management/containers/Dashboard/components/AreaChart/styled.ts
@@ -3,7 +3,7 @@
 import { themeColor, themeSpacing } from '@amsterdam/asc-ui'
 import styled from 'styled-components'
 
-export const AreaChartWrapper = styled.span`
+export const AreaChartWrapper = styled.div`
   position: relative;
 `
 

--- a/src/signals/incident-management/containers/Dashboard/components/BarChart/BarChart.tsx
+++ b/src/signals/incident-management/containers/Dashboard/components/BarChart/BarChart.tsx
@@ -10,7 +10,7 @@ import { showGlobalNotification } from 'containers/App/actions'
 import { VARIANT_ERROR, TYPE_LOCAL } from 'containers/Notification/constants'
 import { useFetchAll } from 'hooks'
 
-import { StyledBarChart, Wrapper } from './styled'
+import { Wrapper } from './styled'
 import type { RawData } from './types'
 import {
   getMaxDomain,
@@ -81,7 +81,7 @@ export const BarChart = ({ queryString }: Props) => {
         title="Openstaande meldingen tot en met vandaag"
         amount={total?.toString()}
       />
-      <StyledBarChart data-testid="bar-chart" id="bar-chart" />
+      <div data-testid="bar-chart" id="bar-chart" />
     </Wrapper>
   )
 }

--- a/src/signals/incident-management/containers/Dashboard/components/BarChart/styled.tsx
+++ b/src/signals/incident-management/containers/Dashboard/components/BarChart/styled.tsx
@@ -6,7 +6,3 @@ import styled from 'styled-components'
 export const Wrapper = styled.span`
   position: relative;
 `
-
-export const StyledBarChart = styled.div`
-  width: 100%;
-`

--- a/src/signals/incident-management/containers/Dashboard/styled.ts
+++ b/src/signals/incident-management/containers/Dashboard/styled.ts
@@ -1,10 +1,17 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2023 Gemeente Amsterdam
-import { themeColor } from '@amsterdam/asc-ui'
+import { breakpoint, themeColor } from '@amsterdam/asc-ui'
+import { Row } from '@amsterdam/asc-ui'
 import styled from 'styled-components'
 
-export const StyledRow = styled.div`
+export const FilterWrapper = styled.div`
   width: 100%;
   background-color: ${themeColor('tint', 'level2')};
   margin: 0;
+`
+
+export const StyledRow = styled(Row)`
+  @media only screen and ${breakpoint('min-width', 'laptopM')} {
+    padding: 0 60px;
+  }
 `


### PR DESCRIPTION
Ticket: [SIG-5007](https://gemeente-amsterdam.atlassian.net/browse/SIG-5007)

### Context
The aim was to make the graphs respond to any screen size. However, it seemed very hard/impossible to make a bar chart with facets respond to a certain width. Therefore we chose to make the graphs fixed size and wrap them the on the same breakpoint as the menu changes.
