### PR TITLE
[chore]: Remove strike Alert

### DIFF
--- a/app.amsterdam.json
+++ b/app.amsterdam.json
@@ -19,8 +19,7 @@
     "showThorButton": true,
     "showVulaanControls": true,
     "useProjectenSignalType": false,
-    "showDashboard": true,
-    "showStrikeAlert": true
+    "showDashboard": true
   },
   "head": {
     "androidIcon": "/icon_192x192.png",

--- a/app.base.json
+++ b/app.base.json
@@ -21,8 +21,7 @@
     "showVulaanControls": false,
     "useProjectenSignalType": false,
     "enableForwardIncidentToExternal": false,
-    "showDashboard": false,
-    "showStrikeAlert": false
+    "showDashboard": false
   },
   "head": {
     "androidIcon": "/icon_192x192.png",

--- a/internals/schemas/app.schema.json
+++ b/internals/schemas/app.schema.json
@@ -142,10 +142,6 @@
         "showDashboard": {
           "description": "Shows the realtimedashboard",
           "type": "boolean"
-        },
-        "showStrikeAlert": {
-          "description": "Shows a striking alert on top of incident wizard.",
-          "type": "boolean"
         }
       },
       "required": [

--- a/src/signals/incident/components/IncidentWizard/IncidentWizard.tsx
+++ b/src/signals/incident/components/IncidentWizard/IncidentWizard.tsx
@@ -3,14 +3,12 @@ import type { FC } from 'react'
 // Copyright (C) 2018 - 2022 Gemeente Amsterdam
 import { useContext, useMemo, useRef } from 'react'
 
-import { Alert } from '@amsterdam/asc-ui'
 import { ascDefaultTheme, breakpoint, Paragraph } from '@amsterdam/asc-ui/lib'
 import { FormProvider, useForm } from 'react-hook-form'
 import { Route } from 'react-router-dom'
 
 import LoadingIndicator from 'components/LoadingIndicator'
 import AppContext from 'containers/App/context'
-import configuration from 'shared/services/configuration/configuration'
 import type {
   addToSelection,
   createIncident,
@@ -95,25 +93,6 @@ const IncidentWizard: FC<IncidentWizardProps> = ({
                 return onNext(wizardDefinition, wiz, incident)
               }}
             >
-              {history.location.pathname === '/incident/beschrijf' &&
-                configuration.featureFlags.showStrikeAlert && (
-                  <Alert
-                    level="error"
-                    outline
-                    style={{ marginTop: 60, marginBottom: 60 }}
-                  >
-                    Medewerkers van de gemeente staken van maandag 20 februari
-                    06.30 uur tot maandag 27 februari. Daarom kunnen wij geen
-                    meldingen oppakken over volle containers en afval en vuil op
-                    straat. Wij pakken wel meldingen op over overlast: onze
-                    handhavers zijn op straat, maar schrijven geen boetes uit.
-                    Het kan ook wat langer duren dan u van ons gewend bent
-                    voordat wij uw melding hebben afgehandeld. Lees meer in het{' '}
-                    <a href={'https://www.amsterdam.nl/nieuws/'}>
-                      nieuwsoverzicht.
-                    </a>
-                  </Alert>
-                )}
               {incidentContainer.loading || appContext.loading ? (
                 <LoadingIndicator />
               ) : (


### PR DESCRIPTION
Since the strike Alert was temporary I delete the whole functionality in this PR. 

### Release note
- Breaking change! Should remove the feature flag `showStrikeAlert` in the config files. 