### PR TITLE
[fix-5056]: kto negative feedback

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.tsx
@@ -57,7 +57,7 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
   const { incident, update } = useContext(IncidentDetailContext)
   const storeDispatch = useDispatch()
   const incidentAsIncident = incident as Incident
-
+  const [emailIsNotSend, setEmailIsNotSend] = useState(false)
   const [modalStandardTextIsOpen, setModalStandardTextIsOpen] = useState(false)
   const [modalEmailPreviewIsOpen, setModalEmailPreviewIsOpen] = useState(false)
   const [state, dispatch] = useReducer<
@@ -220,6 +220,14 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
   }, [])
 
   const onStatusChange = useCallback((event) => {
+    if (
+      !configuration.featureFlags.reporterMailHandledNegativeContactEnabled &&
+      event.target.value === StatusCode.Afgehandeld &&
+      state.status.key === StatusCode.VerzoekTotHeropenen
+    ) {
+      setEmailIsNotSend(true)
+    }
+
     const selectedStatus = changeStatusOptionList.find(
       (status) => event.target.value === status.key
     )
@@ -318,7 +326,7 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
               {constants.DEELMELDING_EXPLANATION}
             </Alert>
           ))}
-        {!state.flags.isSplitIncident && (
+        {!state.flags.isSplitIncident && !emailIsNotSend && (
           <div>
             {state.flags.hasEmail ? (
               incident?.reporter?.allows_contact ? (
@@ -346,6 +354,11 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
                 {constants.NO_REPORTER_EMAIL}
               </div>
             )}
+          </div>
+        )}
+        {emailIsNotSend && (
+          <div data-testid="no-emaiI-is-sent-warning">
+            {constants.NO_EMAIL_IS_SENT}
           </div>
         )}
       </StyledSection>

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/constants.ts
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/constants.ts
@@ -14,6 +14,7 @@ export const DEELMELDINGEN_STILL_OPEN_CONTENT = `Als je de hoofdmelding nu afhan
   Handel de hoofdmelding pas af als alle deelmeldingen zijn opgelost of als de deelmeldingen niet meer nodig zijn.`
 export const NO_REPORTER_EMAIL = `De melder heeft geen e-mailadres opgegeven, er wordt geen bericht verstuurd.`
 export const NO_CONTACT_ALLOWED = `Er wordt geen bericht verstuurd.`
+export const NO_EMAIL_IS_SENT = 'Er wordt geen bericht verstuurd.'
 
 export const DEFAULT_TEXT_MAX_LENGTH = 3000
 export const DEFAULT_TEXT_LABEL = 'Bericht aan melder'

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/utils.test.ts
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/utils.test.ts
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (C) 2023 Gemeente Amsterdam
+import configuration from 'shared/services/configuration/configuration'
+import { StatusCode } from 'signals/incident-management/definitions/types'
+
+import { emailSentWhenStatusChangedTo } from './utils'
+
+jest.mock('shared/services/configuration/configuration')
+
+describe('utils', () => {
+  // This utils tests were never written and therefore are incomplete. Out of scope to write them all now.
+
+  describe('emailSentWhenStatusChangedTo', () => {
+    afterEach(() => {
+      jest.clearAllMocks()
+    })
+
+    it('should return true when status change form Verzoek tot Heropenen naar Afgehandeld in new kto process', () => {
+      configuration.featureFlags.reporterMailHandledNegativeContactEnabled =
+        true
+      const params = {
+        toStatus: StatusCode.Afgehandeld,
+        fromStatus: StatusCode.VerzoekTotHeropenen,
+        isSplitIncident: false,
+      }
+
+      const result = emailSentWhenStatusChangedTo(params)
+
+      expect(result).toEqual(true)
+    })
+
+    it('should return false when status change form Verzoek tot Heropenen naar Afgehandeld in old kto process', () => {
+      configuration.featureFlags.reporterMailHandledNegativeContactEnabled =
+        false
+      const params = {
+        toStatus: StatusCode.Afgehandeld,
+        fromStatus: StatusCode.VerzoekTotHeropenen,
+        isSplitIncident: false,
+      }
+
+      const result = emailSentWhenStatusChangedTo(params)
+
+      expect(result).toEqual(false)
+    })
+  })
+})

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/utils.ts
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/utils.ts
@@ -2,6 +2,7 @@
 // Copyright (C) 2020 - 2021 Gemeente Amsterdam
 import type { AlertLevel } from '@amsterdam/asc-ui'
 
+import configuration from 'shared/services/configuration/configuration'
 import {
   changeStatusOptionList,
   isStatusClosed,
@@ -12,6 +13,7 @@ import * as constants from './constants'
 
 export const emailSentWhenStatusChangedTo = ({
   toStatus,
+  fromStatus,
   isSplitIncident,
 }: {
   toStatus: StatusCode
@@ -19,6 +21,14 @@ export const emailSentWhenStatusChangedTo = ({
   isSplitIncident: boolean
 }): boolean => {
   if (isSplitIncident) return false
+
+  if (
+    !configuration.featureFlags.reporterMailHandledNegativeContactEnabled &&
+    fromStatus === StatusCode.VerzoekTotHeropenen &&
+    toStatus === StatusCode.Afgehandeld
+  ) {
+    return false
+  }
 
   return Boolean(
     changeStatusOptionList.find(
@@ -36,7 +46,10 @@ export const textIsRequired = ({
   toStatus: StatusCode
   isSplitIncident: boolean
 }): boolean => {
-  if (isSplitIncident) {
+  if (
+    isSplitIncident ||
+    !configuration.featureFlags.reporterMailHandledNegativeContactEnabled
+  ) {
     return [
       StatusCode.Afgehandeld,
       StatusCode.Ingepland,


### PR DESCRIPTION
Ticket: [SIG-5056](https://gemeente-amsterdam.atlassian.net/browse/SIG-5056)

### Context
The negative kto flow had a bug. When in the old flow (`reporterMailHandledNegativeContactEnabled: false`) and the user agreed to receive emails and the status of an incident went from "Verzoek tot heropenen" to "Afgehandeld" the backend did not send an email while the frontend thought it should. 
The backend was correct, since in the old flow in this scenario no email is send. 
This PR fixes the frontend so it shows a message "Email is not send", does not trigger the backend and making a note required. 

Attempt from the FE of sending an email while it should not. 
<img width="1370" alt="Screenshot 2023-02-27 at 14 50 35" src="https://user-images.githubusercontent.com/46756331/221821308-064a6b3a-5b98-40dc-a46d-e2839116568c.png">

Status after fix. Scenario of the old flow: 
<img width="491" alt="Screenshot 2023-02-28 at 11 07 52" src="https://user-images.githubusercontent.com/46756331/221822576-b065d2e8-c8e0-44ee-b894-a41e8caed786.png">


Status after fix. Scenario of the new flow: 

<img width="493" alt="Screenshot 2023-02-28 at 11 07 25" src="https://user-images.githubusercontent.com/46756331/221822430-5cf686cd-b53b-437c-8f50-ade201935f25.png">

