### PR TITLE
[feat-5057]: Show be and fe version numbers

### DIFF
--- a/src/signals/settings/components/Overview/components/Overview.tsx
+++ b/src/signals/settings/components/Overview/components/Overview.tsx
@@ -1,3 +1,4 @@
+// Copyright (C) 2023 Gemeente Amsterdam
 import type { FunctionComponent } from 'react'
 import { useEffect } from 'react'
 
@@ -8,14 +9,7 @@ import {
   ThumbnailResults,
   Download,
 } from '@amsterdam/asc-assets'
-import {
-  TopTaskLink,
-  CompactThemeProvider,
-  themeSpacing,
-  Row,
-} from '@amsterdam/asc-ui'
-import { NavLink } from 'react-router-dom'
-import styled from 'styled-components'
+import { CompactThemeProvider, Row } from '@amsterdam/asc-ui'
 
 import PageHeader from 'signals/settings/components/PageHeader'
 import {
@@ -26,6 +20,13 @@ import {
   EXPORT_URL,
 } from 'signals/settings/routes'
 
+import {
+  StyledVersionNumbers,
+  StyledNavLink,
+  StyledTopTaskLink,
+  Item,
+  Wrapper,
+} from './styled'
 import useFetch from '../../../../../hooks/useFetch'
 import configuration from '../../../../../shared/services/configuration/configuration'
 
@@ -41,30 +42,6 @@ interface Props {
   showItems: Record<Keys, boolean | undefined>
 }
 
-const Wrapper = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-`
-
-const Item = styled.div`
-  flex: 1;
-  padding-right: ${themeSpacing(8)};
-  &:last-of-type {
-    padding-right: 0;
-  }
-`
-
-const StyledNavLink = styled(NavLink)`
-  margin-bottom: ${themeSpacing(4)};
-  display: block;
-  text-decoration: none;
-`
-
-const StyledTopTaskLink = styled(TopTaskLink)`
-  min-height: 132px;
-  font-weight: 700;
-`
-
 const Overview: FunctionComponent<Props> = ({ showItems }) => {
   const { data, get } = useFetch<{ version: string }>()
 
@@ -79,7 +56,12 @@ const Overview: FunctionComponent<Props> = ({ showItems }) => {
   return (
     <CompactThemeProvider>
       <PageHeader title="Instellingen">
-        <span>Versienummer: {data?.version}</span>
+        <StyledVersionNumbers>
+          {`
+            Versienummer frontend: ${process.env.FRONTEND_TAG}
+            Versienummer backend: ${data?.version}
+          `}
+        </StyledVersionNumbers>
       </PageHeader>
       <Row>
         <Wrapper>

--- a/src/signals/settings/components/Overview/components/__tests__/Overview.test.tsx
+++ b/src/signals/settings/components/Overview/components/__tests__/Overview.test.tsx
@@ -9,8 +9,16 @@ import Overview from '../Overview'
 jest.mock('hooks/useFetch')
 
 describe('Overview component', () => {
+  const env = process.env
+
   beforeEach(() => {
+    jest.resetModules()
+    process.env = { ...env }
     jest.mocked(useFetch).mockImplementation(() => useFetchResponse)
+  })
+
+  afterEach(() => {
+    process.env = env
   })
 
   it('should render', () => {
@@ -166,7 +174,9 @@ describe('Overview component', () => {
     expect(screen.getByTestId('export')).toBeInTheDocument()
   })
 
-  it('should show a version number of the be running', () => {
+  it('should show a version numbers of the fe and be running', () => {
+    process.env.FRONTEND_TAG = '123'
+
     jest.mocked(useFetch).mockImplementation(() => ({
       ...useFetchResponse,
       get: jest.fn(),
@@ -188,6 +198,7 @@ describe('Overview component', () => {
       )
     )
 
-    expect(screen.getByText('Versienummer: 123')).toBeTruthy()
+    expect(screen.getByText(/Versienummer backend: 123/)).toBeTruthy()
+    expect(screen.getByText(/Versienummer frontend: 123/)).toBeTruthy()
   })
 })

--- a/src/signals/settings/components/Overview/components/styled.ts
+++ b/src/signals/settings/components/Overview/components/styled.ts
@@ -1,0 +1,31 @@
+import { themeSpacing, TopTaskLink } from '@amsterdam/asc-ui'
+import { NavLink } from 'react-router-dom'
+import styled from 'styled-components'
+
+export const Wrapper = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+`
+
+export const Item = styled.div`
+  flex: 1;
+  padding-right: ${themeSpacing(8)};
+  &:last-of-type {
+    padding-right: 0;
+  }
+`
+
+export const StyledNavLink = styled(NavLink)`
+  margin-bottom: ${themeSpacing(4)};
+  display: block;
+  text-decoration: none;
+`
+
+export const StyledTopTaskLink = styled(TopTaskLink)`
+  min-height: 132px;
+  font-weight: 700;
+`
+
+export const StyledVersionNumbers = styled.span`
+  white-space: pre-line;
+`


### PR DESCRIPTION
## for testers
At instellingen show be & fe versions. Also move Overview styled components to styled folder.

Ticket: [SIG-5057](https://gemeente-amsterdam.atlassian.net/browse/SIG-5057)

## Signalen

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
