### PR TITLE
[fix-5065]: Remove container details when type: nearby

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/components/Detail/components/ExtraProperties/index.test.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/Detail/components/ExtraProperties/index.test.tsx
@@ -2,6 +2,8 @@
 // Copyright (C) 2021 - 2022 Gemeente Amsterdam
 import { render, screen } from '@testing-library/react'
 
+import { NEARBY_TYPE } from 'signals/incident/components/form/MapSelectors/constants'
+
 import ExtraProperties from '.'
 import type { Item } from './types'
 
@@ -144,6 +146,11 @@ describe('<ExtraProperties />', () => {
             type: 'Onbekend',
             description: undefined,
           } as unknown as Item,
+          {
+            id: '5678.1234.23-03-2023',
+            type: NEARBY_TYPE,
+            description: '23 maart 2023',
+          } as unknown as Item,
         ],
         category_url:
           '/signals/v1/public/terms/categories/afval/sub_categories/container-voor-papier-is-stuk',
@@ -173,6 +180,10 @@ describe('<ExtraProperties />', () => {
     )
     expect(screen.getByTestId('extra-properties-value')).not.toHaveTextContent(
       /undefined/
+    )
+    // Container input with type "nearby" should not show container details in backoffice since they do not exist.
+    expect(screen.getByTestId('extra-properties-value')).not.toHaveTextContent(
+      /23 maart 2023 - 5678.1234.23-03-2023/
     )
   })
 

--- a/src/signals/incident-management/containers/IncidentDetail/components/Detail/components/ExtraProperties/index.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/Detail/components/ExtraProperties/index.tsx
@@ -3,6 +3,8 @@
 import { Fragment } from 'react'
 import type { FunctionComponent } from 'react'
 
+import { NEARBY_TYPE } from 'signals/incident/components/form/MapSelectors/constants'
+
 import type {
   Answer,
   MappedLegacyItem,
@@ -24,6 +26,11 @@ const getValue = (answer: Answer | LegacyAnswer): string | JSX.Element[] => {
 
       if ((item as ContainerMapInput)?.type) {
         const containerAnswer = item as ContainerMapInput
+
+        if (containerAnswer.type === NEARBY_TYPE) {
+          return <></>
+        }
+
         return (
           <div key={containerAnswer.id}>
             {[containerAnswer.description, containerAnswer.id]
@@ -72,7 +79,6 @@ const ExtraProperties: FunctionComponent<ExtraPropertiesProps> = ({
       }))
 
   return (
-    // TypeScript does not support arrays as a return type in function components - return a fragment as a workaround.
     <Fragment>
       {itemList.map((item) => (
         <Fragment key={item.id}>


### PR DESCRIPTION
Ticket: [SIG-5065](https://gemeente-amsterdam.atlassian.net/browse/SIG-5065)

### Context
Incidents that are created based on a previous incident in the container category get the type "nearby" and some details of the old melding. In the backoffice we want to show the container details, but this is not possible. 

### Fix
When the type is set to "nearby" we don't show any container details in the backoffice.

**Bug**


**Fix**
