### PR TITLE
[feature-5062]: Changed time presentation in helpText

### DIFF
--- a/.github/review/values.yml
+++ b/.github/review/values.yml
@@ -39,7 +39,7 @@ config:
       bestemd.
     district: Stadsdeel
     headerTitle: ''
-    helpText: Wij zijn bereikbaar van maandag tot en met vrijdag van 8.00 tot 18.00
+    helpText: Wij zijn bereikbaar van maandag tot en met vrijdag van 08.00 tot 18.00
       uur.
     helpTextHeader: Lukt het niet om een melding te doen? Bel het telefoonnummer [14
       020](tel:14020)

--- a/app.amsterdam.json
+++ b/app.amsterdam.json
@@ -33,7 +33,7 @@
     "consentToContactSharing": "Ja, ik geef de gemeente Amsterdam toestemming om mijn melding door te sturen naar andere organisaties als de melding niet voor de gemeente is bestemd.",
     "district": "Stadsdeel",
     "headerTitle": "",
-    "helpText": "Wij zijn bereikbaar van maandag tot en met vrijdag van 8.00 tot 18.00 uur.",
+    "helpText": "Wij zijn bereikbaar van maandag tot en met vrijdag van 08.00 tot 18.00 uur.",
     "helpTextHeader": "Lukt het niet om een melding te doen? Bel het telefoonnummer [14 020](tel:14020)",
     "logoDescription": "Gemeente Amsterdam logo - Home",
     "mapDescription": "Weet u het adres niet, bel dan 14 020 om telefonisch de melding te maken.",

--- a/app.base.json
+++ b/app.base.json
@@ -35,7 +35,7 @@
     "consentToContactSharing": "Ja, ik geef Signalen toestemming om mijn contactgegevens te delen met andere organisaties, als dat nodig is om mijn melding goed op te lossen.",
     "district": "Wijk",
     "headerTitle": "",
-    "helpText": "Wij zijn bereikbaar van maandag tot en met vrijdag van 8.00 tot 18.00 uur.",
+    "helpText": "Wij zijn bereikbaar van maandag tot en met vrijdag van 08.00 tot 18.00 uur.",
     "helpTextHeader": "Lukt het niet om een melding te doen? Bel het telefoonnummer [070-373 8393](tel:+31703738393)",
     "logoDescription": "Logo gemeente",
     "mapDescription": "Weet u het adres niet, bel dan 070-373 8393 om telefonisch de melding te maken.",


### PR DESCRIPTION
New policiy in municipality concerning presentation of time. Now hours have a zero prefixed if there is only one digit. Example: 8.00 hour becomes 08.00 hour. Changed it also in .github/review/values.yml so that texts still match.

Ticket: [SIG-5062](https://gemeente-amsterdam.atlassian.net/browse/SIG-5062)

## Signalen

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
