### PR TITLE
[fix-5994]: pdf viewer

### DIFF
--- a/assets/images/icon-pdf.svg
+++ b/assets/images/icon-pdf.svg
@@ -1,0 +1,13 @@
+<svg width="41" height="52" viewBox="0 0 41 52" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_1338_106817)">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M26.8987 0H0.9375V52H40.2975V13.2763L26.8987 0ZM7.4975 45.5V6.5H23.8975V16.25H33.7375V45.5H7.4975Z" fill="#B4B4B4"/>
+<rect x="9.83984" y="22.75" width="21.32" height="3.25" fill="#B4B4B4"/>
+<rect x="9.83984" y="29.25" width="21.32" height="3.25" fill="#B4B4B4"/>
+<rect x="9.83984" y="35.75" width="21.32" height="3.25" fill="#B4B4B4"/>
+</g>
+<defs>
+<clipPath id="clip0_1338_106817">
+<rect width="41" height="52" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/src/components/HistoryList/HistoryList.tsx
+++ b/src/components/HistoryList/HistoryList.tsx
@@ -43,6 +43,7 @@ const Time = styled.div`
 const Action = styled.div`
   color: ${themeColor('tint', 'level7')};
   white-space: pre-line;
+  overflow-wrap: anywhere;
 
   @media ${breakpoint('min-width', 'tabletM')} {
     grid-column-start: 3;

--- a/src/signals/incident-management/containers/Dashboard/components/Filter/OptionsList.tsx
+++ b/src/signals/incident-management/containers/Dashboard/components/Filter/OptionsList.tsx
@@ -9,7 +9,7 @@ import { Option } from './Option'
 import { OptionUl } from './styled'
 import type { Filter } from './types'
 import IncidentManagementContext from '../../../../context'
-import { StyledLoadingIndicator } from '../../../IncidentDetail/components/Attachments/styles'
+import { StyledLoadingIndicator } from '../../../IncidentDetail/components/Attachments/styled'
 import { useRoveFocus } from '../../hooks/useRoveFocus'
 
 type Props = {

--- a/src/signals/incident-management/containers/IncidentDetail/components/Attachments/Attachments.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/Attachments/Attachments.tsx
@@ -40,6 +40,7 @@ import {
   Wrapper,
 } from './styled'
 import StyledUploadProgress from './UploadProgress'
+import { getAttachmentFileName } from './utils'
 import IncidentDetailContext from '../../context'
 import type { Files } from '../../hooks/useUpload'
 import type { Attachment } from '../../types'
@@ -153,7 +154,7 @@ const Attachments: FC<AttachmentsProps> = ({
         </Title>
       )}
       {attachments.map((attachment) => {
-        const fileName = attachment.location?.split('/').pop() || ''
+        const fileName = getAttachmentFileName(attachment.location)
 
         return (
           <StyledBox
@@ -165,7 +166,7 @@ const Attachments: FC<AttachmentsProps> = ({
           >
             {isPdf(attachment.location) ? (
               <StyledPdfImg
-                alt="pdf-icon"
+                alt="Pdf icon"
                 src={'/assets/images/icon-pdf.svg'}
               />
             ) : (

--- a/src/signals/incident-management/containers/IncidentDetail/components/Attachments/Attachments.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/Attachments/Attachments.tsx
@@ -27,7 +27,7 @@ import {
   StyledButtonWrapper,
   StyledDate,
   StyledDetails,
-  StyledDocument,
+  StyledPdfImg,
   StyledEmployee,
   StyledError,
   StyledGradient,
@@ -38,7 +38,7 @@ import {
   StyledUploadProgressError,
   Title,
   Wrapper,
-} from './styles'
+} from './styled'
 import StyledUploadProgress from './UploadProgress'
 import IncidentDetailContext from '../../context'
 import type { Files } from '../../hooks/useUpload'
@@ -164,16 +164,21 @@ const Attachments: FC<AttachmentsProps> = ({
             title={fileName}
           >
             {isPdf(attachment.location) ? (
-              <StyledDocument />
+              <StyledPdfImg
+                alt="pdf-icon"
+                src={'/assets/images/icon-pdf.svg'}
+              />
             ) : (
-              <StyledImg src={attachment.location} />
+              <>
+                <StyledImg src={attachment.location} />
+                <StyledGradient />
+              </>
             )}
-            <StyledGradient />
             <StyledBoxContent>
               {!attachment.created_by && (
                 <StyledReporter>Melder</StyledReporter>
               )}
-              <StyledDetails>
+              <StyledDetails isPdf={isPdf(attachment.location)}>
                 {fileName && <StyledName>{fileName}</StyledName>}
                 {attachment.created_by && (
                   <StyledEmployee>{attachment.created_by}</StyledEmployee>

--- a/src/signals/incident-management/containers/IncidentDetail/components/Attachments/styled.ts
+++ b/src/signals/incident-management/containers/IncidentDetail/components/Attachments/styled.ts
@@ -95,13 +95,12 @@ export const StyledReporter = styled.div`
 `
 
 export const StyledDetails = styled.div<{ isPdf?: boolean }>`
+  color: ${({ isPdf }) =>
+    isPdf ? themeColor('tint', 'level7') : themeColor('tint', 'level1')};
   grid-area: details;
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  color: ${themeColor('tint', 'level1')};
-  color: ${(isPdf) =>
-    isPdf ? themeColor('tint', 'level7') : themeColor('tint', 'level1')};
   font-size: 0.875rem;
   line-height: ${themeSpacing(5)};
 `

--- a/src/signals/incident-management/containers/IncidentDetail/components/Attachments/styled.ts
+++ b/src/signals/incident-management/containers/IncidentDetail/components/Attachments/styled.ts
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2022 Gemeente Amsterdam
-import { DocumentText } from '@amsterdam/asc-assets'
 import {
   themeSpacing,
   Heading,
@@ -63,11 +62,12 @@ export const StyledImg = styled.img`
   height: 100%;
   object-fit: cover;
 `
-
-export const StyledDocument = styled(DocumentText)`
+export const StyledPdfImg = styled.img`
   width: 100%;
   height: 100%;
-  object-fit: cover;
+  padding: 15px 0 65px 0;
+  color: black;
+  background-color: ${themeColor('tint', 'level3')};
 `
 
 export const StyledGradient = styled.div`
@@ -94,12 +94,14 @@ export const StyledReporter = styled.div`
   text-transform: uppercase;
 `
 
-export const StyledDetails = styled.div`
+export const StyledDetails = styled.div<{ isPdf?: boolean }>`
   grid-area: details;
   display: flex;
   flex-direction: column;
   overflow: hidden;
   color: ${themeColor('tint', 'level1')};
+  color: ${(isPdf) =>
+    isPdf ? themeColor('tint', 'level7') : themeColor('tint', 'level1')};
   font-size: 0.875rem;
   line-height: ${themeSpacing(5)};
 `

--- a/src/signals/incident-management/containers/IncidentDetail/components/Attachments/utils.test.ts
+++ b/src/signals/incident-management/containers/IncidentDetail/components/Attachments/utils.test.ts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (C) 2023 Gemeente Amsterdam
+import { getAttachmentFileName } from './utils'
+
+describe('utils', () => {
+  describe('getAttachmentFileName', () => {
+    it('should return correct name of svg', () => {
+      const location =
+        'https://siaweuaaks.blob.core.windows.net/files/attachments/2023/03/22/Screenshot_2022-11-01_at_15.46.27.png?se=2023-03-22T11%3A03%3A51Z&sp=r&sv=2021-08-06&sr=b&sig=70zthscotauInCE8pFi5Ku5fcoxj5rAL/PTc8VrCw48%3D'
+      const result = getAttachmentFileName(location)
+
+      expect(result).toEqual('Screenshot_2022-11-01_at_15.46.27.png')
+    })
+
+    it('should return correct name of PDF', () => {
+      const location =
+        'https://siaweuaaks.blob.core.windows.net/files/attachments/2023/03/22/221128_concept_gesprekswijzer_mijn_amsterdams_gesprek_1.pdf?se=2023-03-22T11%3A07%3A45Z&sp=r&sv=2021-08-06&sr=b&sig=KWlcHinTvgLTFPnjVQSdwSceicgjqB7gL/4qjFuYwuM%3D'
+      const result = getAttachmentFileName(location)
+
+      expect(result).toEqual(
+        '221128_concept_gesprekswijzer_mijn_amsterdams_gesprek_1.pdf'
+      )
+    })
+  })
+})

--- a/src/signals/incident-management/containers/IncidentDetail/components/Attachments/utils.ts
+++ b/src/signals/incident-management/containers/IncidentDetail/components/Attachments/utils.ts
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (C) 2023 Gemeente Amsterdam
+import type { Attachment } from '../../types'
+
+export const getAttachmentFileName = (location: Attachment['location']) =>
+  location.split('?')[0].split('/').pop()


### PR DESCRIPTION
Ticket: [SIG-5994](https://gemeente-amsterdam.atlassian.net/browse/SIG-5994)

## Fixing:
- PDF preview: new icon, grey background, black text
- Attachment naming (created util)
- Wrap very long file names