### PR TITLE
[fix-5071]: highlight active menu

### DIFF
--- a/src/components/SiteHeader/styled.ts
+++ b/src/components/SiteHeader/styled.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2023 Gemeente Amsterdam
+// Copyright (C) 2019 - 2023 Gemeente Amsterdam
 import {
   breakpoint,
   Header as HeaderComponent,
@@ -56,9 +56,9 @@ export const StyledMenuButton = styled(MenuButton)<{ $active?: boolean }>`
   ${({ $active }) =>
     $active &&
     css`
-      span:last-child {
+      span > span {
         color: ${themeColor('secondary')};
-        border-bottom: 1px solid ${themeColor('secondary')};
+        border-bottom: 2px solid ${themeColor('secondary')};
       }
     `}
 `

--- a/src/signals/settings/components/PageHeader/index.tsx
+++ b/src/signals/settings/components/PageHeader/index.tsx
@@ -23,8 +23,6 @@ const StyledSection = styled.section<{ hasBackLink: boolean }>`
 const StyledHeading = styled(Heading)`
   margin: 0;
   line-height: 44px;
-  flex-basis: 100%;
-  width: 0;
 `
 
 const StyledHeadingWrapper = styled.div`


### PR DESCRIPTION
Ticket: [SIG-5071](https://gemeente-amsterdam.atlassian.net/browse/SIG-5071)

1) Highlighting of the menu went wrong:
before
<img width="335" alt="Screenshot 2023-03-30 at 10 21 05" src="https://user-images.githubusercontent.com/46756331/228774922-7a135893-66f8-4b7e-950f-203aec58a67b.png">
after
<img width="305" alt="Screenshot 2023-03-30 at 10 17 22" src="https://user-images.githubusercontent.com/46756331/228774984-ea91d1c5-1114-4e65-8960-9a88c71a5c21.png">

2) Some wrong styling added to header
before
<img width="1149" alt="Screenshot 2023-03-30 at 09 13 01" src="https://user-images.githubusercontent.com/46756331/228775079-ad7bf0ae-f11c-4cd8-bbfa-a77a97142e04.png">

after
<img width="1459" alt="Screenshot 2023-03-30 at 09 13 07" src="https://user-images.githubusercontent.com/46756331/228775109-a8e6c108-2bda-4b33-9b8e-a55a57e7abe9.png">

