### PR TITLE
Add healthz endpoint for monitoring

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -25,6 +25,12 @@ server {
         deny all;
     }
 
+    location /healthz {
+            access_log off;
+            add_header 'Content-Type' 'application/json';
+            return 200 '{"status":"UP"}';
+    }
+
     location / {
         alias /usr/share/nginx/html/;
         try_files $uri $uri/ @index;


### PR DESCRIPTION
This adds a `/healthz` endpoint to the container for monitoring purposes. Calls to this endpoint are not logged.