### PR TITLE
[feat-5083] stop processing when category is Overig-overig and status is Afgehandeld

### DIFF
--- a/src/shared/services/api/api.js
+++ b/src/shared/services/api/api.js
@@ -100,7 +100,7 @@ export const getErrorMessage = (error, defaultErrorMessage = '') => {
 
   if (!status) {
     return (
-      error.message || defaultErrorMessage || errorMessageDictionary.default
+      error?.message || defaultErrorMessage || errorMessageDictionary.default
     )
   }
 

--- a/src/signals/incident-management/containers/IncidentDetail/IncidentDetail.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/IncidentDetail.test.js
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2018 - 2022 Vereniging van Nederlandse Gemeenten, Gemeente Amsterdam
-import { render, act, screen, waitFor, fireEvent } from '@testing-library/react'
+// Copyright (C) 2018 - 2023 Vereniging van Nederlandse Gemeenten, Gemeente Amsterdam
+
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import * as reactRedux from 'react-redux'
 import * as reactRouterDom from 'react-router-dom'
 
 import { showGlobalNotification } from 'containers/App/actions'
 import * as appSelectors from 'containers/App/selectors'
-import { VARIANT_ERROR, TYPE_LOCAL } from 'containers/Notification/constants'
+import { TYPE_LOCAL, VARIANT_ERROR } from 'containers/Notification/constants'
 import useEventEmitter from 'hooks/useEventEmitter'
 import * as categoriesSelectors from 'models/categories/selectors'
 import configuration from 'shared/services/configuration/configuration'
@@ -459,5 +460,61 @@ describe('signals/incident-management/containers/IncidentDetail', () => {
       expect(emit).not.toHaveBeenCalled()
       await screen.findByTestId('incident-detail')
     })
+
+    // it('should return an error message when patch is not allowed', async () => {
+    //   jest.mock(
+    //     'components/StatusForm/StatusForm',
+    //     () =>
+    //       ({ defaultTexts, childIncidents, onClose }: StatusFormProps) =>
+    //         (
+    //           <span data-testid="mock-legend-panel">
+    //             <input type="button" name="closeLegend" onClick={onClose} />
+    //           </span>
+    //         )
+    //   )
+    //   const withCategoryOverigOverig = { ...incidentFixture }
+    //   L
+    //   if (withCategoryOverigOverig.category?.main_slug) {
+    //     withCategoryOverigOverig.category.main_slug = 'overig'
+    //   }
+    //
+    //   if (withCategoryOverigOverig.category?.sub_slug) {
+    //     withCategoryOverigOverig.category.sub_slug = 'overig'
+    //   }
+    //   if (withCategoryOverigOverig.status?.state) {
+    //     withCategoryOverigOverig.status.state = 'o'
+    //   }
+    //
+    //   render(withAppContext(<IncidentDetail />))
+    //   mockRequestHandler({
+    //     url: API.INCIDENT,
+    //     method: 'patch',
+    //     status: 405,
+    //     body: 'Bad request',
+    //   })
+    //
+    //   expect(emit).not.toHaveBeenCalled()
+    //   expect(dispatch).not.toHaveBeenCalled()
+    //
+    //   act(() => {
+    //     userEvent.click(screen.getByTestId('add-note-save-note-button'))
+    //   })
+    //
+    //   await screen.findByTestId('incident-detail')
+    //
+    //   await waitFor(() => {
+    //     expect(dispatch).toHaveBeenCalledWith(
+    //       showGlobalNotification(
+    //         expect.objectContaining({
+    //           type: TYPE_LOCAL,
+    //           variant: VARIANT_ERROR,
+    //         })
+    //       )
+    //     )
+    //   })
+    //   expect(emit).not.toHaveBeenCalled()
+    //
+    //   await screen.findByTestId('incident-detail')
+    // })
   })
 })

--- a/src/signals/incident-management/containers/IncidentDetail/IncidentDetail.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/IncidentDetail.test.js
@@ -75,10 +75,6 @@ describe('signals/incident-management/containers/IncidentDetail', () => {
     jest.spyOn(reactRouterDom, 'useParams').mockImplementation(() => ({ id }))
   })
 
-  afterEach(() => {
-    configuration.__reset()
-  })
-
   it('should render correctly', async () => {
     render(withAppContext(<IncidentDetail />))
 
@@ -355,169 +351,110 @@ describe('signals/incident-management/containers/IncidentDetail', () => {
   })
 
   describe('handling errors', () => {
-    describe('handling errors with a note', () => {
-      beforeEach(async () => {
-        render(withAppContext(<IncidentDetail />))
+    beforeEach(async () => {
+      render(withAppContext(<IncidentDetail />))
 
-        await screen.findByTestId('incident-detail')
+      await screen.findByTestId('incident-detail')
 
-        act(() => {
-          userEvent.click(screen.getByText('Notitie toevoegen'))
-        })
-
-        act(() => {
-          userEvent.type(screen.getByTestId('add-note-text'), 'Foo bar baz')
-        })
-
-        await screen.findByTestId('incident-detail')
+      act(() => {
+        userEvent.click(screen.getByText('Notitie toevoegen'))
       })
 
-      it('should handle generic', async () => {
-        mockRequestHandler({
-          url: API.INCIDENT,
-          method: 'patch',
-          status: 400,
-          body: 'Bad request',
-        })
-
-        expect(emit).not.toHaveBeenCalled()
-        expect(storeDispatch).not.toHaveBeenCalled()
-
-        act(() => {
-          userEvent.click(screen.getByTestId('add-note-save-note-button'))
-        })
-
-        await screen.findByTestId('incident-detail')
-
-        await waitFor(() => {
-          expect(storeDispatch).toHaveBeenCalledWith(
-            showGlobalNotification(
-              expect.objectContaining({
-                type: TYPE_LOCAL,
-                variant: VARIANT_ERROR,
-              })
-            )
-          )
-        })
-        expect(emit).not.toHaveBeenCalled()
-        await screen.findByTestId('incident-detail')
+      act(() => {
+        userEvent.type(screen.getByTestId('add-note-text'), 'Foo bar baz')
       })
 
-      it('should handle 401', async () => {
-        mockRequestHandler({
-          url: API.INCIDENT,
-          method: 'patch',
-          status: 401,
-          body: 'Unauthorized',
-        })
-
-        expect(emit).not.toHaveBeenCalled()
-        expect(storeDispatch).not.toHaveBeenCalled()
-
-        act(() => {
-          userEvent.click(screen.getByTestId('add-note-save-note-button'))
-        })
-
-        await screen.findByTestId('incident-detail')
-
-        await waitFor(() => {
-          expect(storeDispatch).toHaveBeenCalledWith(
-            showGlobalNotification(
-              expect.objectContaining({
-                title: 'Geen bevoegdheid',
-              })
-            )
-          )
-        })
-        expect(emit).not.toHaveBeenCalled()
-      })
-
-      it('should handle 403', async () => {
-        mockRequestHandler({
-          url: API.INCIDENT,
-          method: 'patch',
-          status: 403,
-          body: 'Forbidden',
-        })
-
-        expect(emit).not.toHaveBeenCalled()
-        expect(storeDispatch).not.toHaveBeenCalled()
-
-        act(() => {
-          userEvent.click(screen.getByTestId('add-note-save-note-button'))
-        })
-
-        await screen.findByTestId('incident-detail')
-
-        await waitFor(() => {
-          expect(storeDispatch).toHaveBeenCalledWith(
-            showGlobalNotification(
-              expect.objectContaining({
-                title: 'Geen bevoegdheid',
-              })
-            )
-          )
-        })
-        expect(emit).not.toHaveBeenCalled()
-        await screen.findByTestId('incident-detail')
-      })
-    })
-  })
-
-  describe('handling other errors', () => {
-    afterEach(() => {
-      configuration.__reset()
+      await screen.findByTestId('incident-detail')
     })
 
-    it('handling errors with category overig overig', async () => {
-      const incident = {
-        ...incidentFixture,
-        status: {
-          ...incidentFixture.status,
-          state: 'o',
-        },
-        category: {
-          ...incidentFixture.category,
-          sub_slug: 'overig',
-          main_slug: 'overig',
-        },
-      }
-
+    it('should handle generic', async () => {
       mockRequestHandler({
         url: API.INCIDENT,
-        body: {
-          ...incident,
-          _links: { ...incident._links, 'sia:children': undefined },
-        },
+        method: 'patch',
+        status: 400,
+        body: 'Bad request',
       })
 
-      const { container } = render(withAppContext(<IncidentDetail />))
+      expect(emit).not.toHaveBeenCalled()
+      expect(storeDispatch).not.toHaveBeenCalled()
 
-      const editStatusButton = await screen.findByTestId('edit-status-button')
+      act(() => {
+        userEvent.click(screen.getByTestId('add-note-save-note-button'))
+      })
 
-      expect(screen.queryByTestId('status-form')).not.toBeInTheDocument()
-
-      userEvent.click(editStatusButton)
-
-      userEvent.click(screen.getByTestId('select-status'))
-
-      screen.getByRole('option', { name: 'Afgehandeld' }).click()
-
-      userEvent.type(container.querySelector('textarea'), 'test')
-
-      userEvent.click(screen.getByText('Verstuur'))
+      await screen.findByTestId('incident-detail')
 
       await waitFor(() => {
-        expect(storeDispatch).toHaveBeenCalledWith({
-          payload: {
-            message: 'Deze wijziging is niet toegestaan in deze situatie.',
-            title: 'Bewerking niet mogelijk',
-            type: 'local',
-            variant: 'error',
-          },
-          type: 'sia/App/SHOW_GLOBAL_NOTIFICATION',
-        })
+        expect(storeDispatch).toHaveBeenCalledWith(
+          showGlobalNotification(
+            expect.objectContaining({
+              type: TYPE_LOCAL,
+              variant: VARIANT_ERROR,
+            })
+          )
+        )
       })
+      expect(emit).not.toHaveBeenCalled()
+      await screen.findByTestId('incident-detail')
+    })
+
+    it('should handle 401', async () => {
+      mockRequestHandler({
+        url: API.INCIDENT,
+        method: 'patch',
+        status: 401,
+        body: 'Unauthorized',
+      })
+
+      expect(emit).not.toHaveBeenCalled()
+      expect(storeDispatch).not.toHaveBeenCalled()
+
+      act(() => {
+        userEvent.click(screen.getByTestId('add-note-save-note-button'))
+      })
+
+      await screen.findByTestId('incident-detail')
+
+      await waitFor(() => {
+        expect(storeDispatch).toHaveBeenCalledWith(
+          showGlobalNotification(
+            expect.objectContaining({
+              title: 'Geen bevoegdheid',
+            })
+          )
+        )
+      })
+      expect(emit).not.toHaveBeenCalled()
+    })
+
+    it('should handle 403', async () => {
+      mockRequestHandler({
+        url: API.INCIDENT,
+        method: 'patch',
+        status: 403,
+        body: 'Forbidden',
+      })
+
+      expect(emit).not.toHaveBeenCalled()
+      expect(storeDispatch).not.toHaveBeenCalled()
+
+      act(() => {
+        userEvent.click(screen.getByTestId('add-note-save-note-button'))
+      })
+
+      await screen.findByTestId('incident-detail')
+
+      await waitFor(() => {
+        expect(storeDispatch).toHaveBeenCalledWith(
+          showGlobalNotification(
+            expect.objectContaining({
+              title: 'Geen bevoegdheid',
+            })
+          )
+        )
+      })
+      expect(emit).not.toHaveBeenCalled()
+      await screen.findByTestId('incident-detail')
     })
   })
 })

--- a/src/signals/incident-management/containers/IncidentDetail/IncidentDetail.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/IncidentDetail.tsx
@@ -144,26 +144,19 @@ const IncidentDetail = () => {
     }
   }, [handleKeyUp, listenFor, unlisten])
 
-  const createErrorNotification = useCallback((error?) => {
-    const fetchError = error as Response
-    const title =
-      fetchError?.status === 401 || fetchError?.status === 403
-        ? 'Geen bevoegdheid'
-        : 'Bewerking niet mogelijk'
-
-    const message = getErrorMessage(
-      error,
-      'Deze wijziging is niet toegestaan in deze situatie.'
-    )
-
-    return { title, message }
-  }, [])
-
   useEffect(() => {
     dispatch({ type: SET_ERROR, payload: error })
 
     if (error) {
-      const { title, message } = createErrorNotification(error)
+      const fetchError = error as Response
+      const title =
+        fetchError?.status === 401 || fetchError.status === 403
+          ? 'Geen bevoegdheid'
+          : 'Bewerking niet mogelijk'
+      const message = getErrorMessage(
+        error,
+        'Deze wijziging is niet toegestaan in deze situatie.'
+      )
 
       storeDispatch(
         showGlobalNotification({
@@ -174,7 +167,7 @@ const IncidentDetail = () => {
         })
       )
     }
-  }, [createErrorNotification, error, storeDispatch])
+  }, [error, storeDispatch])
 
   useEffect(() => {
     if (!history) return
@@ -301,29 +294,9 @@ const IncidentDetail = () => {
   const updateDispatch = useCallback(
     (action) => {
       dispatch({ type: PATCH_START, payload: action.type })
-      const isAllowed =
-        !incident ||
-        !(
-          incident.category?.main_slug === 'overig' &&
-          incident.category?.sub_slug === 'overig' &&
-          action.patch.status.state === 'o'
-        )
-
-      if (isAllowed) {
-        patch(`${configuration.INCIDENT_PRIVATE_ENDPOINT}${id}`, action.patch)
-      } else {
-        const { title, message } = createErrorNotification()
-        storeDispatch(
-          showGlobalNotification({
-            title,
-            message,
-            variant: VARIANT_ERROR,
-            type: TYPE_LOCAL,
-          })
-        )
-      }
+      patch(`${configuration.INCIDENT_PRIVATE_ENDPOINT}${id}`, action.patch)
     },
-    [incident, patch, id, createErrorNotification, storeDispatch]
+    [id, patch]
   )
 
   const previewDispatch = useCallback((section, payload) => {

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.test.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.test.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2018 - 2022 Vereniging van Nederlandse Gemeenten, Gemeente Amsterdam
+// Copyright (C) 2018 - 2023 Vereniging van Nederlandse Gemeenten, Gemeente Amsterdam
 import { ThemeProvider } from '@amsterdam/asc-ui'
 import {
   getQueriesForElement,
@@ -717,29 +717,39 @@ describe('signals/incident-management/containers/IncidentDetail/components/Statu
   })
 
   it('is not possible to submit the status Afgehandeld when category is Overig-Overig', async () => {
-    const withCategoryOverigOverig = { ...incidentFixture }
-
-    if (withCategoryOverigOverig.category?.main_slug) {
-      withCategoryOverigOverig.category.main_slug = 'overig'
-    }
-
-    if (withCategoryOverigOverig.category?.sub_slug) {
-      withCategoryOverigOverig.category.sub_slug = 'overig'
-    }
-    if (withCategoryOverigOverig.status?.state) {
-      withCategoryOverigOverig.status.state = StatusCode.Afgehandeld
-    }
-
+    const withCategoryOverigOverig = {
+      ...incidentFixture,
+      category: {
+        ...incidentFixture.category,
+        main_slug: 'overig',
+        sub_slug: 'overig',
+      },
+      status: {
+        ...incidentFixture.status,
+        state: StatusCode.Afgehandeld,
+      },
+      reporter: {
+        ...incidentFixture.reporter,
+        email: 'me@email.com',
+        allows_contact: true,
+      },
+    } as Incident
+    // if (withCategoryOverigOverig.category?.main_slug) {
+    //   withCategoryOverigOverig.category.main_slug = 'overig'
+    // }
+    // if (withCategoryOverigOverig.category?.sub_slug) {
+    //   withCategoryOverigOverig.category.sub_slug = 'overig'
+    // }
+    // if (withCategoryOverigOverig.status?.state) {
+    //   withCategoryOverigOverig.status.state = StatusCode.Afgehandeld
+    // }
     render(renderWithContext(withCategoryOverigOverig))
-
     // Type a message in the text field
     const textarea = screen.getByRole('textbox')
     const value = 'Foo bar baz'
     userEvent.type(textarea, value)
-
     // submit the form
     userEvent.click(screen.getByRole('button', { name: 'Verstuur' }))
-
     // verify that 'update' has been called
     expect(update).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -750,7 +760,6 @@ describe('signals/incident-management/containers/IncidentDetail/components/Statu
       })
     )
   })
-
   it('opens the email preview modal and calls update after hitting the send button', async () => {
     const htmlString =
       '<!DOCTYPE html><html lang="nl"><head><meta charset="UTF-8"><title>Uw melding SIA-1</title></head><body><p>Geachte melder,</p><p>Op 9 februari 2022 om 13.00 uur hebt u een melding gedaan bij de gemeente. In deze e-mail leest u de stand van zaken van uw melding.</p><p><strong>U liet ons het volgende weten</strong><br />Just some text<br /> Some text on the next line</p><p><strong>Stand van zaken</strong><br />Wij pakken dit z.s.m. op</p><p><strong>Gegevens van uw melding</strong><br />Nummer: SIA-1<br />Gemeld op: 9 februari 2022, 13.00 uur<br />Plaats: Amstel 1, 1011 PN Amsterdam</p><p><strong>Meer weten?</strong><br />Voor vragen over uw melding in Amsterdam kunt u bellen met telefoonnummer 14 020, maandag tot en met vrijdag van 08.00 tot 18.00 uur. Voor Weesp kunt u bellen met 0294 491 391, maandag tot en met vrijdag van 08.30 tot 17.00 uur. Geef dan ook het nummer van uw melding door: SIA-1.</p><p>Met vriendelijke groet,</p><p>Gemeente Amsterdam</p></body></html>'
@@ -763,30 +772,23 @@ describe('signals/incident-management/containers/IncidentDetail/components/Statu
     if (withReporterEmailAndStatus?.status?.state) {
       withReporterEmailAndStatus.status.state = statusSendsEmailWhenSet.key
     }
-
     if (withReporterEmailAndStatus?.reporter) {
       withReporterEmailAndStatus.reporter.email = 'me@email.com'
       withReporterEmailAndStatus.reporter.allows_contact = true
     }
-
     // render component with incident status that automatically sends an email to the reporter
     render(renderWithContext(withReporterEmailAndStatus))
-
     // Type a message in the text field
     const textarea = screen.getByRole('textbox')
     const value = 'Foo bar baz'
     userEvent.type(textarea, value)
-
     // submit the form
     userEvent.click(screen.getByRole('button', { name: 'Verstuur' }))
-
     // verify that the email preview is shown and update has not been called yet
     await screen.findByText('Controleer bericht aan melder')
     expect(update).not.toHaveBeenCalled()
-
     // send the email
     userEvent.click(screen.getByTestId('submit-btn'))
-
     // verify that 'update' has been called
     expect(update).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -797,7 +799,6 @@ describe('signals/incident-management/containers/IncidentDetail/components/Statu
       })
     )
   })
-
   it('shows an error notification when no email preview is available', async () => {
     const mockErrorResponse = JSON.stringify({
       detail: 'No email preview available for given status transition',
@@ -807,22 +808,17 @@ describe('signals/incident-management/containers/IncidentDetail/components/Statu
     if (withReporterEmailAndStatus?.status?.state) {
       withReporterEmailAndStatus.status.state = statusSendsEmailWhenSet.key
     }
-
     if (withReporterEmailAndStatus?.reporter) {
       withReporterEmailAndStatus.reporter.email = 'me@email.com'
     }
-
     // render component with incident status that automatically sends an email to the reporter
     render(renderWithContext(withReporterEmailAndStatus))
-
     // Type a message in the text field
     const textarea = screen.getByRole('textbox')
     const value = 'Foo bar baz'
     userEvent.type(textarea, value)
-
     // submit the form
     userEvent.click(screen.getByRole('button', { name: 'Verstuur' }))
-
     await waitFor(() => {
       expect(actions.showGlobalNotification).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.test.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.test.tsx
@@ -724,39 +724,24 @@ describe('signals/incident-management/containers/IncidentDetail/components/Statu
         main_slug: 'overig',
         sub_slug: 'overig',
       },
-      status: {
-        ...incidentFixture.status,
-        state: StatusCode.Afgehandeld,
-      },
       reporter: {
         ...incidentFixture.reporter,
         email: 'me@email.com',
         allows_contact: true,
       },
     } as Incident
-    // if (withCategoryOverigOverig.category?.main_slug) {
-    //   withCategoryOverigOverig.category.main_slug = 'overig'
-    // }
-    // if (withCategoryOverigOverig.category?.sub_slug) {
-    //   withCategoryOverigOverig.category.sub_slug = 'overig'
-    // }
-    // if (withCategoryOverigOverig.status?.state) {
-    //   withCategoryOverigOverig.status.state = StatusCode.Afgehandeld
-    // }
+
     render(renderWithContext(withCategoryOverigOverig))
-    // Type a message in the text field
-    const textarea = screen.getByRole('textbox')
-    const value = 'Foo bar baz'
-    userEvent.type(textarea, value)
-    // submit the form
-    userEvent.click(screen.getByRole('button', { name: 'Verstuur' }))
-    // verify that 'update' has been called
-    expect(update).toHaveBeenCalledWith(
+
+    userEvent.selectOptions(screen.getByTestId('select-status'), [
+      StatusCode.Afgehandeld,
+    ])
+
+    expect(screen.getByRole('button', { name: 'Verstuur' })).toBeDisabled()
+    expect(actions.showGlobalNotification).toHaveBeenCalledWith(
       expect.objectContaining({
-        type: PATCH_TYPE_STATUS,
-        patch: {
-          status: expect.objectContaining({ text: value }),
-        },
+        title:
+          'Het is niet mogelijk een melding in categorie Overig - overig af te handelen',
       })
     )
   })

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.tsx
@@ -146,13 +146,11 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
       event.preventDefault()
       const textValue = state.text.value || state.text.defaultValue
 
-      const doEmailTemplate =
+      const hasSlugsOverigAndStatusAfgehandeld =
         incident &&
-        !(
-          incident.category?.main_slug === 'overig' &&
-          incident.category?.sub_slug === 'overig' &&
-          state.status.key === 'o'
-        )
+        incident.category?.main_slug === 'overig' &&
+        incident.category?.sub_slug === 'overig' &&
+        state.status.key === 'o'
 
       if (state.text.required && !textValue) {
         dispatch({
@@ -187,7 +185,7 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
         state.flags.hasEmail &&
         state.check.checked &&
         incident?.reporter?.allows_contact &&
-        doEmailTemplate
+        !hasSlugsOverigAndStatusAfgehandeld
       ) {
         getEmailTemplate(
           `${configuration.INCIDENTS_ENDPOINT}${incident.id}/email/preview`,
@@ -201,10 +199,7 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
       }
     },
     [
-      incident?.category?.main_slug,
-      incident?.category?.sub_slug,
-      incident?.reporter?.allows_contact,
-      incident?.id,
+      incident,
       state.flags.hasEmail,
       state.status.key,
       state.text.value,

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.tsx
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2019 - 2022 Gemeente Amsterdam, Vereniging van Nederlandse Gemeenten
 import type { FunctionComponent, Reducer, SyntheticEvent } from 'react'
-import { useCallback, useReducer, useContext, useState, useEffect } from 'react'
+import { useCallback, useContext, useEffect, useReducer, useState } from 'react'
 
 import { Alert, Heading, Label, Select } from '@amsterdam/asc-ui'
 import { useDispatch } from 'react-redux'
@@ -13,8 +13,8 @@ import { TYPE_LOCAL, VARIANT_ERROR } from 'containers/Notification/constants'
 import { useFetch } from 'hooks'
 import configuration from 'shared/services/configuration/configuration'
 import { changeStatusOptionList } from 'signals/incident-management/definitions/statusList'
-import { StatusCode } from 'signals/incident-management/definitions/types'
 import type { Status } from 'signals/incident-management/definitions/types'
+import { StatusCode } from 'signals/incident-management/definitions/types'
 import type { DefaultTexts as DefaultTextsType } from 'types/api/default-text'
 import type { Incident } from 'types/api/incident'
 
@@ -25,12 +25,12 @@ import type { State } from './reducer'
 import reducer, { init } from './reducer'
 import {
   AddNoteWrapper,
-  StyledCheckbox,
   Form,
-  StyledCheckboxLabel,
   StandardTextsButton,
   StyledAlert,
   StyledButton,
+  StyledCheckbox,
+  StyledCheckboxLabel,
   StyledH4,
   StyledLabel,
   StyledParagraph,
@@ -38,7 +38,7 @@ import {
 } from './styled'
 import { PATCH_TYPE_STATUS } from '../../constants'
 import IncidentDetailContext from '../../context'
-import type { IncidentChild, EmailTemplate } from '../../types'
+import type { EmailTemplate, IncidentChild } from '../../types'
 import EmailPreview from '../EmailPreview/EmailPreview'
 
 interface StatusFormProps {
@@ -144,8 +144,15 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
   const handleSubmit = useCallback(
     (event) => {
       event.preventDefault()
-
       const textValue = state.text.value || state.text.defaultValue
+
+      const doEmailTemplate =
+        incident &&
+        !(
+          incident.category?.main_slug === 'overig' &&
+          incident.category?.sub_slug === 'overig' &&
+          state.status.key === 'o'
+        )
 
       if (state.text.required && !textValue) {
         dispatch({
@@ -179,7 +186,8 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
         incident?.id &&
         state.flags.hasEmail &&
         state.check.checked &&
-        incident?.reporter?.allows_contact
+        incident?.reporter?.allows_contact &&
+        doEmailTemplate
       ) {
         getEmailTemplate(
           `${configuration.INCIDENTS_ENDPOINT}${incident.id}/email/preview`,
@@ -193,6 +201,9 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
       }
     },
     [
+      incident?.category?.main_slug,
+      incident?.category?.sub_slug,
+      incident?.reporter?.allows_contact,
       incident?.id,
       state.flags.hasEmail,
       state.status.key,
@@ -203,7 +214,6 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
       state.check.checked,
       onUpdate,
       getEmailTemplate,
-      incident?.reporter?.allows_contact,
     ]
   )
 


### PR DESCRIPTION
Process stopped when category is Overig-overig and status is Afgehandeld. Different to specification of Linda is that patch is triggert by clicking Verstuur and not when clicking Afgehandeld in drop-down. 

Changes:
- added a test in Statusform to see if category and subcategory are overig and if status is Afgehandeld. If so, don't create an email template..
- added a patch to an endpoint that does not accept the patch, so the response will be a 405. The 405 will trigger a global error message.

Ticket: [SIG-5083](https://gemeente-amsterdam.atlassian.net/browse/SIG-5083)

## Signalen

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
