### PR TITLE
[feat-5105] Wrap too long words

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/components/Detail/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/Detail/index.js
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2018 - 2022 Vereniging van Nederlandse Gemeenten, Gemeente Amsterdam
+// Copyright (C) 2018 - 2023 Vereniging van Nederlandse Gemeenten, Gemeente Amsterdam
 import { Fragment, useMemo, useContext } from 'react'
 
 import {
@@ -28,6 +28,7 @@ const Wrapper = styled.article`
 
 const Title = styled(Heading)`
   margin: ${themeSpacing(4)} 0;
+  overflow-wrap: anywhere;
 `
 
 const DefinitionList = styled.dl`

--- a/src/signals/incident/components/IncidentForm/styled.tsx
+++ b/src/signals/incident/components/IncidentForm/styled.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (C) 2023 Gemeente Amsterdam
 import styled from 'styled-components'
 
 export const Form = styled.form`

--- a/src/signals/incident/components/IncidentPreview/styled.tsx
+++ b/src/signals/incident/components/IncidentPreview/styled.tsx
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (C) 2023 Gemeente Amsterdam
 import { themeSpacing, themeColor, breakpoint } from '@amsterdam/asc-ui'
 import styled from 'styled-components'
 
@@ -37,6 +39,7 @@ export const Dl = styled.dl`
   margin: 0;
   padding: 0;
   line-height: 24px;
+  overflow-wrap: anywhere;
   dd:not(:last-of-type) {
     margin-bottom: ${themeSpacing(6)};
   }

--- a/src/signals/my-incidents/components/IncidentsList/styled.ts
+++ b/src/signals/my-incidents/components/IncidentsList/styled.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2022 Gemeente Amsterdam
+// Copyright (C) 2022-2023 Gemeente Amsterdam
 import { breakpoint, themeColor, themeSpacing, Link } from '@amsterdam/asc-ui'
 import styled from 'styled-components'
 
@@ -9,6 +9,7 @@ export const Divider = styled.div`
 `
 
 export const Wrapper = styled.div`
+  overflow-wrap: anywhere;
   margin: ${themeSpacing(4, 0)};
 `
 


### PR DESCRIPTION
**Context**
As a user I want to have text continue on the next line if it is otherwise too long. This doesn't happen in Samenvattingspagina (omschrijving), Backoffice detail pagina melding (omschrijving) and Mijn meldingen pagina (omschrijving). 


**Changes:**
- added overflow-wrap: anywhere; to css where text was not correctly wrapped (Samenvattingspagina (omschrijving), Backoffice detail pagina melding (omschrijving) and Mijn meldingen pagina (omschrijving)0

Ticket: [SIG-5105](https://gemeente-amsterdam.atlassian.net/browse/SIG-5105)

## Signalen

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
