### PR TITLE
[fix-5132]: Remove configuration field on patch request

### DIFF
--- a/src/signals/settings/categories/Detail/index.js
+++ b/src/signals/settings/categories/Detail/index.js
@@ -30,6 +30,7 @@ const getTransformedData = (formData) => {
   const transformedData = { ...formData, new_sla: formData.sla }
 
   delete transformedData.sla
+  delete transformedData.configuration
 
   return transformedData
 }


### PR DESCRIPTION
Ticket: [SIG-5132](https://gemeente-amsterdam.atlassian.net/browse/SIG-5132)

Because we send all fields of the api response as payload with a patch request we got an error with the latest backend update. They put a new field `configuration` that is required, but we do not send any value with it.

Removing the field for now. A full refactor of the components concerned is on the way in [this ticket](https://gemeente-amsterdam.atlassian.net/browse/SIG-4996)
