### PR TITLE
Make zoomlevels of maps configurable

### DIFF
--- a/app.base.json
+++ b/app.base.json
@@ -120,6 +120,15 @@
       "assetsZoom": 13,
       "locationZoom": 14
     },
+    "optionsMyIncidentsMap": {
+      "zoom": 14
+    },
+    "optionsExternalReplyLocation": {
+      "zoom": 9
+    },
+    "optionsExternalReplyMap": {
+      "zoom": 10
+    },
     "tiles": {
       "args": [
         "https://service.pdok.nl/brt/achtergrondkaart/wmts/v2_0/standaard/EPSG:28992/{z}/{x}/{y}.png"

--- a/app.base.json
+++ b/app.base.json
@@ -94,8 +94,31 @@
       "minZoom": 7,
       "zoom": 7
     },
+    "optionsAreaMap": {
+      "zoom": 14,
+      "maxZoom": 15
+    },
+    "optionsOverviewMap": {
+      "flyToMinZoom": 11
+    },
+    "optionsSummaryMap": {
+      "zoom": 12
+    },
     "optionsIncidentMap": {
-      "hasSubfiltersEnabled": ["main-category-slug"]
+      "hasSubfiltersEnabled": ["main-category-slug"],
+      "zoom": 9,
+      "flyToMinZoom": 12,
+      "flyToMaxZoom": 14
+    },
+    "optionsMapInput": {
+      "zoom": 14
+    },
+    "optionsIncidentDetailLocation": {
+      "zoom": 9
+    },
+    "optionsAssetSelector": {
+      "assetsZoom": 13,
+      "locationZoom": 14
     },
     "tiles": {
       "args": [

--- a/internals/schemas/app.schema.json
+++ b/internals/schemas/app.schema.json
@@ -406,6 +406,15 @@
         "optionsAssetSelector": {
           "$ref": "#/definitions/OptionsAssetSelector"
         },
+        "optionsMyIncidentsMap": {
+          "$ref": "#/definitions/OptionsMyIncidentsMap"
+        },
+        "optionsExternalReplyLocation": {
+          "$ref": "#/definitions/OptionsExternalReplyLocation"
+        },
+        "optionsExternalReplyMap": {
+          "$ref": "#/definitions/OptionsExternalReplyMap"
+        },
         "tiles": {
           "$ref": "#/definitions/Tiles"
         },
@@ -628,8 +637,6 @@
     "OptionsIncidentDetailLocation": {
       "type": "object",
       "additionalProperties": false,
-      "description": "Options for map input",
-      "title": "OptionsMapInput",
       "properties": {
         "zoom": {
           "type": "integer"
@@ -639,13 +646,38 @@
     "OptionsAssetSelector": {
       "type": "object",
       "additionalProperties": false,
-      "description": "Options for asset selector",
-      "title": "OptionsMapInput",
       "properties": {
         "assetsZoom": {
           "type": "integer"
         },
         "locationZoom": {
+          "type": "integer"
+        }
+      }
+    },
+    "OptionsMyIncidentsMap": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "zoom": {
+          "type": "integer"
+        }
+      }
+    },
+    "OptionsExternalReplyLocation": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "zoom": {
+          "type": "integer"
+        }
+      }
+    },
+    "OptionsExternalReplyMap": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "zoom": {
           "type": "integer"
         }
       }

--- a/internals/schemas/app.schema.json
+++ b/internals/schemas/app.schema.json
@@ -385,8 +385,26 @@
         "optionsBackOffice": {
           "$ref": "#/definitions/OptionsBackOffice"
         },
+        "optionsAreaMap": {
+          "$ref": "#/definitions/OptionsAreaMap"
+        },
+        "optionsOverviewMap": {
+          "$ref": "#/definitions/OptionsOverviewMap"
+        },
+        "optionsSummaryMap": {
+          "$ref": "#/definitions/OptionsSummaryMap"
+        },
         "optionsIncidentMap": {
           "$ref": "#/definitions/OptionsIncidentMap"
+        },
+        "optionsMapInput": {
+          "$ref": "#/definitions/OptionsMapInput"
+        },
+        "optionsIncidentDetailLocation": {
+          "$ref": "#/definitions/OptionsIncidentDetailLocation"
+        },
+        "optionsAssetSelector": {
+          "$ref": "#/definitions/OptionsAssetSelector"
         },
         "tiles": {
           "$ref": "#/definitions/Tiles"
@@ -544,6 +562,36 @@
       "required": [],
       "title": "OptionsBackOffice"
     },
+    "OptionsAreaMap": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "zoom": {
+          "type": "integer"
+        },
+        "maxZoom": {
+          "type": "integer"
+        }
+      }
+    },
+    "OptionsOverviewMap": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "flyToMinZoom": {
+          "type": "integer"
+        }
+      }
+    },
+    "OptionsSummaryMap": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "zoom": {
+          "type": "integer"
+        }
+      }
+    },
     "OptionsIncidentMap": {
       "type": "object",
       "additionalProperties": false,
@@ -556,6 +604,49 @@
             "type": "string"
           },
           "minItems": 0
+        },
+        "zoom": {
+          "type": "integer"
+        },
+        "flyToMaxZoom": {
+          "type": "integer"
+        },
+        "flyToMinZoom": {
+          "type": "integer"
+        }
+      }
+    },
+    "OptionsMapInput": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "zoom": {
+          "type": "integer"
+        }
+      }
+    },
+    "OptionsIncidentDetailLocation": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Options for map input",
+      "title": "OptionsMapInput",
+      "properties": {
+        "zoom": {
+          "type": "integer"
+        }
+      }
+    },
+    "OptionsAssetSelector": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Options for asset selector",
+      "title": "OptionsMapInput",
+      "properties": {
+        "assetsZoom": {
+          "type": "integer"
+        },
+        "locationZoom": {
+          "type": "integer"
         }
       }
     },

--- a/src/components/AreaMap/AreaMap.tsx
+++ b/src/components/AreaMap/AreaMap.tsx
@@ -12,6 +12,7 @@ import styled from 'styled-components'
 import Map from 'components/Map'
 import MapCloseButton from 'components/MapCloseButton'
 import MarkerCluster from 'components/MarkerCluster'
+import configuration from 'shared/services/configuration/configuration'
 import {
   closedIncidentIcon,
   openIncidentIcon,
@@ -26,16 +27,14 @@ import type { Incident } from 'types/api/incident'
 
 import type { Feature } from './types'
 
-export const DEFAULT_ZOOM = 14
-const MAX_ZOOM = 15
 const FOCUS_RADIUS_METERS = 50
 const CURRENT_INCIDENT_MARKER_Z = -100 // Show below incident markers
 
 const AREA_MAP_OPTIONS: MapOptions = {
   ...MAP_OPTIONS,
   scrollWheelZoom: true,
-  zoom: DEFAULT_ZOOM,
-  maxZoom: MAX_ZOOM,
+  zoom: configuration.map.optionsAreaMap.zoom,
+  maxZoom: configuration.map.optionsAreaMap.maxZoom,
 }
 
 const Wrapper = styled.div`

--- a/src/components/OverviewMap/OverviewMap.tsx
+++ b/src/components/OverviewMap/OverviewMap.tsx
@@ -137,7 +137,11 @@ const OverviewMap: FC<OverviewMapProps> = ({
 
       if (map) {
         const currentZoom = map.getZoom()
-        map.flyTo(option.data.location, currentZoom < 11 ? 11 : currentZoom)
+        const flyToMinZoom = configuration.map.optionsOverviewMap.flyToMinZoom
+        map.flyTo(
+          option.data.location,
+          currentZoom < flyToMinZoom ? flyToMinZoom : currentZoom
+        )
       }
     },
     [map, dispatch]

--- a/src/components/Summary/Summary.tsx
+++ b/src/components/Summary/Summary.tsx
@@ -27,7 +27,6 @@ import { showMap } from 'signals/incident/containers/IncidentContainer/actions'
 
 const mapWidth = 640
 const mapHeight = 180
-const mapZoom = 12
 const iconSize = 40
 
 const Wrapper = styled.div`
@@ -94,7 +93,7 @@ const Summary: FC<SummaryProps> = ({
 
   const options = {
     ...MAP_OPTIONS,
-    zoom: mapZoom,
+    zoom: configuration.map.optionsSummaryMap.zoom,
     attributionControl: false,
     center,
   }

--- a/src/signals/IncidentMap/components/IncidentLayer/IncidentLayer.tsx
+++ b/src/signals/IncidentMap/components/IncidentLayer/IncidentLayer.tsx
@@ -9,6 +9,7 @@ import type { LeafletEvent } from 'leaflet'
 import L from 'leaflet'
 
 import MarkerCluster from 'components/MarkerCluster'
+import configuration from 'shared/services/configuration/configuration'
 import {
   dynamicIcon,
   selectedMarkerIcon,
@@ -17,7 +18,6 @@ import type { Bbox } from 'signals/incident/components/form/MapSelectors/hooks/u
 import useBoundingBox from 'signals/incident/components/form/MapSelectors/hooks/useBoundingBox'
 
 import type { Incident, Properties } from '../../types'
-import { DEFAULT_ZOOM } from '../utils'
 
 const clusterLayerOptions = {
   zoomToBoundsOnClick: true,
@@ -94,7 +94,7 @@ export const IncidentLayer = ({
         let marker = L.marker(latlng, {
           icon: dynamicIcon(incident.properties?.icon),
           alt: incident.properties.category.name,
-          keyboard: zoomLevel >= DEFAULT_ZOOM,
+          keyboard: zoomLevel >= configuration.map.optionsIncidentMap.zoom,
         })
         // Matching on created_at since incidents do not have an ID
         if (
@@ -104,7 +104,7 @@ export const IncidentLayer = ({
           marker = L.marker(latlng, {
             icon: selectedMarkerIcon,
             alt: incident.properties.category.name,
-            keyboard: zoomLevel >= DEFAULT_ZOOM,
+            keyboard: zoomLevel >= configuration.map.optionsIncidentMap.zoom,
           })
           selectedMarkerRef.current = marker
         }
@@ -151,7 +151,7 @@ export const IncidentLayer = ({
       setInstance={setLayerInstance}
       getIsSelectedCluster={getIsSelectedCluster}
       spiderfySelectedCluster={false}
-      keyboard={zoomLevel >= DEFAULT_ZOOM}
+      keyboard={zoomLevel >= configuration.map.optionsIncidentMap.zoom}
     />
   )
 }

--- a/src/signals/IncidentMap/components/IncidentMap/IncidentMap.tsx
+++ b/src/signals/IncidentMap/components/IncidentMap/IncidentMap.tsx
@@ -6,6 +6,7 @@ import { ViewerContainer } from '@amsterdam/arm-core'
 import type { LatLngLiteral, Map as MapType } from 'leaflet'
 import { throttle, isEqual } from 'lodash'
 
+import configuration from 'shared/services/configuration/configuration'
 import { dynamicIcon } from 'shared/services/configuration/map-markers'
 import MAP_OPTIONS from 'shared/services/configuration/map-options'
 import { formatAddress } from 'shared/services/format-address'
@@ -17,7 +18,7 @@ import type { Bbox } from 'signals/incident/components/form/MapSelectors/hooks/u
 import { Pin } from './Pin'
 import { StyledMap, StyledParagraph, Wrapper } from './styled'
 import usePaginatedIncidents from './usePaginatedIncidents'
-import { getZoom } from './utils'
+import { getFlyToZoom } from './utils'
 import type { Filter, Incident, Properties } from '../../types'
 import { AddressLocation } from '../AddressLocation'
 import { AddressSearchMobile } from '../AddressLocation'
@@ -26,11 +27,7 @@ import { isMobile, useDeviceMode } from '../DrawerOverlay/utils'
 import { FilterPanel } from '../FilterPanel'
 import { GPSLocation } from '../GPSLocation'
 import { IncidentLayer } from '../IncidentLayer'
-import {
-  countIncidentsPerFilter,
-  DEFAULT_ZOOM,
-  getFilteredIncidents,
-} from '../utils'
+import { countIncidentsPerFilter, getFilteredIncidents } from '../utils'
 
 export const IncidentMap = () => {
   const [bbox, setBbox] = useState<Bbox | undefined>()
@@ -73,7 +70,7 @@ export const IncidentMap = () => {
           lat: sanitizedCoords.lat - 0.0003,
           lng: sanitizedCoords.lng,
         }
-        const zoom = getZoom(map)
+        const zoom = getFlyToZoom(map)
         map.flyTo(coords, zoom)
       }
 
@@ -152,7 +149,7 @@ export const IncidentMap = () => {
     }
   }, [coordinates])
 
-  const zoomLevel = map?.getZoom() || DEFAULT_ZOOM
+  const zoomLevel = map?.getZoom() || configuration.map.optionsIncidentMap.zoom
 
   return (
     <Wrapper>
@@ -164,7 +161,7 @@ export const IncidentMap = () => {
           ...MAP_OPTIONS,
           dragging: true,
           scrollWheelZoom: true,
-          zoom: 9,
+          zoom: configuration.map.optionsIncidentMap.zoom,
           attributionControl: false,
         }}
       >

--- a/src/signals/IncidentMap/components/IncidentMap/Pin.test.tsx
+++ b/src/signals/IncidentMap/components/IncidentMap/Pin.test.tsx
@@ -4,9 +4,10 @@
 import { render, screen } from '@testing-library/react'
 import type { Map } from 'leaflet'
 
+import configuration from 'shared/services/configuration/configuration'
+
 import type { Props } from './Pin'
 import { Pin } from './Pin'
-import configuration from 'shared/services/configuration/configuration'
 import { DeviceMode } from '../DrawerOverlay/types'
 
 jest.mock('@amsterdam/react-maps', () => ({

--- a/src/signals/IncidentMap/components/IncidentMap/Pin.test.tsx
+++ b/src/signals/IncidentMap/components/IncidentMap/Pin.test.tsx
@@ -6,7 +6,7 @@ import type { Map } from 'leaflet'
 
 import type { Props } from './Pin'
 import { Pin } from './Pin'
-import { DEFAULT_ZOOM } from '../../../../components/AreaMap/AreaMap'
+import configuration from 'shared/services/configuration/configuration'
 import { DeviceMode } from '../DrawerOverlay/types'
 
 jest.mock('@amsterdam/react-maps', () => ({
@@ -46,7 +46,7 @@ describe('Pin', () => {
 
     expect(defaultProps.map.flyTo).toHaveBeenCalledWith(
       { lat: coords.lat, lng: coords.lng },
-      DEFAULT_ZOOM
+      configuration.map.optionsIncidentMap.flyToMaxZoom
     )
     expect(defaultProps.closeOverlay).not.toHaveBeenCalled()
   })

--- a/src/signals/IncidentMap/components/IncidentMap/Pin.tsx
+++ b/src/signals/IncidentMap/components/IncidentMap/Pin.tsx
@@ -6,7 +6,7 @@ import { useEffect } from 'react'
 import { Marker } from '@amsterdam/react-maps'
 import type { LatLngLiteral, Map } from 'leaflet'
 
-import { DEFAULT_ZOOM } from 'components/AreaMap/AreaMap'
+import configuration from 'shared/services/configuration/configuration'
 import { markerIcon } from 'shared/services/configuration/map-markers'
 
 import type { DeviceMode } from '../DrawerOverlay/types'
@@ -24,7 +24,7 @@ export const Pin = ({ map, coordinates, mode, closeOverlay }: Props) => {
     if (isMobile(mode)) {
       closeOverlay()
     }
-    map.flyTo(coordinates, DEFAULT_ZOOM)
+    map.flyTo(coordinates, configuration.map.optionsIncidentMap.flyToMaxZoom)
   }, [closeOverlay, coordinates, map, mode])
 
   return (

--- a/src/signals/IncidentMap/components/IncidentMap/utils.test.ts
+++ b/src/signals/IncidentMap/components/IncidentMap/utils.test.ts
@@ -2,37 +2,39 @@
 // Copyright (C) 2022 Gemeente Amsterdam
 import type { Map } from 'leaflet'
 
-import { getZoom } from './utils'
-import { DEFAULT_ZOOM } from '../utils'
+import configuration from 'shared/services/configuration/configuration'
+import { getFlyToZoom } from './utils'
 
 describe('utils', () => {
-  describe('getZoom', () => {
+  describe('getFlyToZoom', () => {
     it('should return the correct value', () => {
       /**
        * The map can be zoomed in to max 16 and zoomed out to max 8.
        * The default zoom is set to 14.
        */
 
-      const mapMockZoomOut = {
+      const mapMockZoomIn = {
         getZoom: jest.fn(() => 16),
       } as unknown as Map
 
-      const result = getZoom(mapMockZoomOut)
+      const result = getFlyToZoom(mapMockZoomIn)
 
-      expect(result).toEqual(DEFAULT_ZOOM)
+      expect(result).toEqual(configuration.map.optionsIncidentMap.flyToMaxZoom)
 
-      const mapMockZoomIn = {
+      const mapMockZoomOut = {
         getZoom: jest.fn(() => 10),
       } as unknown as Map
 
-      const secondResult = getZoom(mapMockZoomIn)
-      expect(secondResult).toEqual(12)
+      const secondResult = getFlyToZoom(mapMockZoomOut)
+      expect(secondResult).toEqual(
+        configuration.map.optionsIncidentMap.flyToMinZoom
+      )
 
       const mapMockZoomNull = {
-        getZoom: jest.fn(() => DEFAULT_ZOOM),
+        getZoom: jest.fn(() => 14),
       } as unknown as Map
 
-      const thirdResult = getZoom(mapMockZoomNull)
+      const thirdResult = getFlyToZoom(mapMockZoomNull)
       expect(thirdResult).toEqual(14)
     })
   })

--- a/src/signals/IncidentMap/components/IncidentMap/utils.test.ts
+++ b/src/signals/IncidentMap/components/IncidentMap/utils.test.ts
@@ -3,6 +3,7 @@
 import type { Map } from 'leaflet'
 
 import configuration from 'shared/services/configuration/configuration'
+
 import { getFlyToZoom } from './utils'
 
 describe('utils', () => {

--- a/src/signals/IncidentMap/components/IncidentMap/utils.ts
+++ b/src/signals/IncidentMap/components/IncidentMap/utils.ts
@@ -1,20 +1,19 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2022 Gemeente Amsterdam
 import type { Map } from 'leaflet'
-
-import { DEFAULT_ZOOM } from '../utils'
+import configuration from 'shared/services/configuration/configuration'
 
 /**
  * To get a good user experience on mobile when using flyTo you want to zoom out to a set MAX_ZOOM when
  * the zoom exceeds the default zoom, and zoom to a set MIN_ZOOM when zoom it too small.
  */
-export const getZoom = (map: Map) => {
+export const getFlyToZoom = (map: Map) => {
   const currentZoom = map.getZoom()
-  const MIN_ZOOM = 12
-  const MAX_ZOOM = DEFAULT_ZOOM
+  const MIN_ZOOM = configuration.map.optionsIncidentMap.flyToMinZoom
+  const MAX_ZOOM = configuration.map.optionsIncidentMap.flyToMaxZoom
 
   const aboveMaxZoom = currentZoom > MAX_ZOOM
   const BelowMinZoom = currentZoom < MIN_ZOOM
 
-  return aboveMaxZoom ? DEFAULT_ZOOM : BelowMinZoom ? MIN_ZOOM : currentZoom
+  return aboveMaxZoom ? MAX_ZOOM : BelowMinZoom ? MIN_ZOOM : currentZoom
 }

--- a/src/signals/IncidentMap/components/IncidentMap/utils.ts
+++ b/src/signals/IncidentMap/components/IncidentMap/utils.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2022 Gemeente Amsterdam
 import type { Map } from 'leaflet'
+
 import configuration from 'shared/services/configuration/configuration'
 
 /**

--- a/src/signals/IncidentMap/components/utils/index.ts
+++ b/src/signals/IncidentMap/components/utils/index.ts
@@ -1,4 +1,3 @@
 export { updateFilterCategory } from './update-filter-category'
 export { getFilteredIncidents } from './get-filtered-incidents'
 export { countIncidentsPerFilter } from './count-incidents-per-filter'
-export * from './constants'

--- a/src/signals/incident-management/components/MapInput/index.tsx
+++ b/src/signals/incident-management/components/MapInput/index.tsx
@@ -31,7 +31,7 @@ export const MapInput = (props: Props) => {
     ...MAP_OPTIONS,
     ...(configuration.map.optionsBackOffice || {}),
     center,
-    zoom: 14,
+    zoom: configuration.map.optionsMapInput.zoom,
   }
 
   const onLocationChange = (location: Location) => {

--- a/src/signals/incident-management/containers/IncidentDetail/components/Detail/components/Location/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/Detail/components/Location/index.js
@@ -20,7 +20,6 @@ import HighLight from '../../../Highlight'
 
 const mapWidth = 80
 const mapHeight = 80
-const mapZoom = 9
 
 const MapTile = styled.div`
   float: left;
@@ -89,7 +88,7 @@ const Location = ({ location }) => {
                 key={`${lat},${lng}`}
                 value={location}
                 icon={smallMarkerIcon}
-                zoom={mapZoom}
+                zoom={configuration.map.optionsIncidentDetailLocation.zoom}
               />
             </MapTile>
           )}

--- a/src/signals/incident-management/containers/IncidentDetail/components/LocationPreview/index.js
+++ b/src/signals/incident-management/containers/IncidentDetail/components/LocationPreview/index.js
@@ -5,6 +5,7 @@ import { useContext } from 'react'
 import { Button, themeSpacing, Row, Column } from '@amsterdam/asc-ui'
 import styled from 'styled-components'
 
+import configuration from 'shared/services/configuration/configuration'
 import { markerIcon } from 'shared/services/configuration/map-markers'
 
 import MapDetail from '../../../../../../components/MapDetail'
@@ -53,7 +54,7 @@ const LocationPreview = () => {
           value={location}
           icon={markerIcon}
           hasZoomControls
-          zoom={14}
+          zoom={configuration.map.optionsMapInput.zoom}
         />
       </StyledColumn>
     </Wrapper>

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/Selector.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/Selector.tsx
@@ -48,11 +48,12 @@ import AssetLayer from './WfsLayer/AssetLayer'
 import { MapMessage, ZoomMessage } from '../../components/MapMessage'
 import { selectionIsUndetermined } from '../../constants'
 
-const MAP_CONTAINER_ZOOM_LEVEL: ZoomLevel = {
-  max: 13,
+const MAP_ASSETS_ZOOM_LEVEL: ZoomLevel = {
+  max: configuration.map.optionsAssetSelector.assetsZoom,
 }
 
-export const MAP_LOCATION_ZOOM = 14
+export const MAP_LOCATION_ZOOM =
+  configuration.map.optionsAssetSelector.locationZoom
 
 const Selector: FC = () => {
   // to be replaced with MOUNT_NODE
@@ -71,8 +72,6 @@ const Selector: FC = () => {
 
   const mapOptions: MapOptions = useMemo(
     () => ({
-      minZoom: 7,
-      maxZoom: 16,
       ...MAP_OPTIONS,
       center,
       dragging: true,
@@ -202,7 +201,7 @@ const Selector: FC = () => {
               {hasFeatureTypes && (
                 <ZoomMessage
                   data-testid="zoom-message"
-                  zoomLevel={MAP_CONTAINER_ZOOM_LEVEL}
+                  zoomLevel={MAP_ASSETS_ZOOM_LEVEL}
                 >
                   Zoom in om de {meta?.language?.objectTypePlural || 'objecten'}{' '}
                   te zien
@@ -227,10 +226,10 @@ const Selector: FC = () => {
           }
         />
 
-        <WfsLayer zoomLevel={MAP_CONTAINER_ZOOM_LEVEL}>
+        <WfsLayer zoomLevel={MAP_ASSETS_ZOOM_LEVEL}>
           <>
             <Layer />
-            <NearbyLayer zoomLevel={MAP_CONTAINER_ZOOM_LEVEL} />
+            <NearbyLayer zoomLevel={MAP_ASSETS_ZOOM_LEVEL} />
           </>
         </WfsLayer>
 

--- a/src/signals/incident/containers/ExternalReplyContainer/components/Location/Location.tsx
+++ b/src/signals/incident/containers/ExternalReplyContainer/components/Location/Location.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components'
 
 import MapDetail from 'components/MapDetail'
 import Paragraph from 'components/Paragraph'
+import configuration from 'shared/services/configuration/configuration'
 import { smallMarkerIcon } from 'shared/services/configuration/map-markers'
 import type { Address as AddressType } from 'types/address'
 
@@ -20,7 +21,7 @@ export const MapThumbnail = styled(MapDetail).attrs({
   canFocusMarker: false,
   hasZoomControls: false,
   icon: smallMarkerIcon,
-  zoom: 9,
+  zoom: configuration.map.optionsExternalReplyLocation.zoom,
 })`
   width: 80px;
   height: 80px;

--- a/src/signals/incident/containers/ExternalReplyContainer/styled.ts
+++ b/src/signals/incident/containers/ExternalReplyContainer/styled.ts
@@ -4,6 +4,7 @@ import { Heading, Row, themeSpacing } from '@amsterdam/asc-ui'
 import styled from 'styled-components'
 
 import MapDetail from 'components/MapDetail'
+import configuration from 'shared/services/configuration/configuration'
 import { markerIcon } from 'shared/services/configuration/map-markers'
 
 import ExplanationSection from './components/ExplanationSection'
@@ -30,7 +31,7 @@ export const Map = styled(MapDetail).attrs({
   canFocusMarker: false,
   hasZoomControls: true,
   icon: markerIcon,
-  zoom: 10,
+  zoom: configuration.map.optionsExternalReplyMap.zoom,
 })`
   width: 100%;
   height: 500px;

--- a/src/signals/my-incidents/components/Map/Map.tsx
+++ b/src/signals/my-incidents/components/Map/Map.tsx
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2022 Gemeente Amsterdam
+import configuration from 'shared/services/configuration/configuration'
 import type Location from 'types/location'
 
 import { StyledCloseButton, StyledMapDetail, StyledMapViewer } from './styled'
@@ -16,7 +17,7 @@ export const Map = ({ location, close }: Props) => (
       value={location}
       icon={markerIcon}
       hasZoomControls
-      zoom={14}
+      zoom={configuration.map.optionsMyIncidentsMap.zoom}
     />
     <StyledCloseButton close={close} />
   </StyledMapViewer>


### PR DESCRIPTION
This PR makes sure all zoomlevels that are present in the codebase can be configured. This allows using other base maps in other projections and still use sensible zoomlevels.

The configuration defaults to EPSG:28992 projection and the zoomlevels that were previously hardcoded. So this PR does not introduce any functional changes.

Fixes [Teams issue](https://teams.microsoft.com/l/entity/com.microsoft.teamspace.tab.planner/tt.c_19:e201681cf65b453db9a98a67467c603a@thread.skype_p_dFQcO7x3vUWrWQ8CGTkI6ZcAD6mW_h_1670844429492?tenantId=6ef029ab-3fd7-4d98-9b0e-d1f5fedea6d1&webUrl=https%3A%2F%2Ftasks.teams.microsoft.com%2Fteamsui%2FpersonalApp%2Falltasklists&context=%7B%22subEntityId%22%3A%22%2Fboard%2Ftask%2FFGW_5LOtEE6gEAEeVJKg4JcAPk8I%22%2C%22channelId%22%3A%2219%3Ae201681cf65b453db9a98a67467c603a%40thread.skype%22%7D).