### PR TITLE
[feat-5083] text change after feedback from Linda

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.test.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.test.tsx
@@ -741,7 +741,7 @@ describe('signals/incident-management/containers/IncidentDetail/components/Statu
     expect(actions.showGlobalNotification).toHaveBeenCalledWith(
       expect.objectContaining({
         title:
-          'Het is niet mogelijk een melding in categorie Overig - overig af te handelen',
+          'Het is niet mogelijk een melding in de categorie Overig - Overig af te handelen. Plaats de melding in de best passende categorie.',
       })
     )
   })

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.tsx
@@ -239,7 +239,7 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
       storeDispatch(
         showGlobalNotification({
           title:
-            'Het is niet mogelijk een melding in categorie Overig - overig af te handelen',
+            'Het is niet mogelijk een melding in de categorie Overig - Overig af te handelen. Plaats de melding in de best passende categorie.',
           variant: VARIANT_ERROR,
           type: TYPE_LOCAL,
         })


### PR DESCRIPTION
Text of global warning needed info on what the official needed to do. Changed to 'Het is niet mogelijk een melding in de categorie Overig - Overig af te handelen. Plaats de melding in de best passende categorie.'

Ticket: [SIG-5083](https://gemeente-amsterdam.atlassian.net/browse/SIG-5083)

## Signalen

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
