### PR TITLE
[fix-5134]: doorgedraaide scroller Safari

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -26,6 +26,7 @@ const StyledModal = styled(ASCModal)`
   max-height: 100vh;
   height: 100vh;
   max-width: 1430px;
+  overflow-y: hidden;
 `
 
 const ModalInner = styled.div`


### PR DESCRIPTION
Ticket: [SIG-5134](https://gemeente-amsterdam.atlassian.net/browse/SIG-5134)

- Add overflow-y hidden to filter modal