### PR TITLE
[Spike-5135] change due to dns change of Sentry 

### DIFF
--- a/.github/review/values.yml
+++ b/.github/review/values.yml
@@ -112,4 +112,4 @@ config:
     responseType: code
     scope: openid
   sentry:
-    dsn: https://3de59e3a93034a348089131aa565bdf4@sentry.data.amsterdam.nl/27
+    dsn: https://3de59e3a93034a348089131aa565bdf4@sentry-new.data.amsterdam.nl/27

--- a/app.amsterdam.json
+++ b/app.amsterdam.json
@@ -127,7 +127,7 @@
     "scope": "openid"
   },
   "sentry": {
-    "dsn": "https://3de59e3a93034a348089131aa565bdf4@sentry.data.amsterdam.nl/27"
+    "dsn": "https://3de59e3a93034a348089131aa565bdf4@sentry-new.data.amsterdam.nl/27"
   },
   "azure": {
     "connectionString": "InstrumentationKey=c39a786a-82ac-471d-a0c6-feb41eb4967b;IngestionEndpoint=https://westeurope-5.in.applicationinsights.azure.com/;LiveEndpoint=https://westeurope.livediagnostics.monitor.azure.com/"

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.test.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.test.tsx
@@ -741,7 +741,7 @@ describe('signals/incident-management/containers/IncidentDetail/components/Statu
     expect(actions.showGlobalNotification).toHaveBeenCalledWith(
       expect.objectContaining({
         title:
-          'Het is niet mogelijk een melding in categorie Overig - overig af te handelen',
+          'Het is niet mogelijk een melding in de categorie Overig - Overig af te handelen. Plaats de melding in de best passende categorie.',
       })
     )
   })

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.tsx
@@ -239,7 +239,7 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
       storeDispatch(
         showGlobalNotification({
           title:
-            'Het is niet mogelijk een melding in categorie Overig - overig af te handelen',
+            'Het is niet mogelijk een melding in de categorie Overig - Overig af te handelen. Plaats de melding in de best passende categorie.',
           variant: VARIANT_ERROR,
           type: TYPE_LOCAL,
         })


### PR DESCRIPTION
Team Basis Support indicated there is a update regarding Sentry. The new url is sentry-new.data.amsterdam.nl. 

Ticket: [SIG-5135](https://gemeente-amsterdam.atlassian.net/browse/SIG-5135)

## Signalen

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
