### PR TITLE
[spike-5135] DNS change of Sentry

### DIFF
--- a/.github/review/values.yml
+++ b/.github/review/values.yml
@@ -112,4 +112,4 @@ config:
     responseType: code
     scope: openid
   sentry:
-    dsn: https://3de59e3a93034a348089131aa565bdf4@sentry.data.amsterdam.nl/27
+    dsn: https://3de59e3a93034a348089131aa565bdf4@sentry-new.data.amsterdam.nl/27

--- a/app.amsterdam.json
+++ b/app.amsterdam.json
@@ -127,7 +127,7 @@
     "scope": "openid"
   },
   "sentry": {
-    "dsn": "https://3de59e3a93034a348089131aa565bdf4@sentry.data.amsterdam.nl/27"
+    "dsn": "https://3de59e3a93034a348089131aa565bdf4@sentry-new.data.amsterdam.nl/27"
   },
   "azure": {
     "connectionString": "InstrumentationKey=c39a786a-82ac-471d-a0c6-feb41eb4967b;IngestionEndpoint=https://westeurope-5.in.applicationinsights.azure.com/;LiveEndpoint=https://westeurope.livediagnostics.monitor.azure.com/"


### PR DESCRIPTION
Sentry's new addres is sentry-new.data.amsterdam.nl

Release Notes

    Change Sentry dns


Ticket: [SIG-5135](https://gemeente-amsterdam.atlassian.net/browse/SIG-5135)

## Signalen

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
