### PR TITLE
[feat]: Add icon to main categorie overview

### DIFF
--- a/src/components/DataView/__tests__/DataView.test.js
+++ b/src/components/DataView/__tests__/DataView.test.js
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2020 - 2021 Gemeente Amsterdam
-import { render, within, fireEvent } from '@testing-library/react'
+// SPDX-License-Identifier MPL-2.0
+// Copyright (C) 2020 - 2023 Gemeente Amsterdam
+import { screen, render, within, fireEvent } from '@testing-library/react'
 
 import data from 'utils/__tests__/fixtures/filteredUserData.json'
 
@@ -628,5 +628,38 @@ describe('DataView with data', () => {
     allRows.forEach((row, rowIDX) =>
       expect(row.dataset.itemId).toBe(String(data[rowIDX][headers[0]]))
     )
+  })
+
+  it('should render icon if available', () => {
+    const onItemClickHandler = jest.fn()
+
+    const dataWithIcon = [
+      {
+        'Openbare Naam': 'hoofdcategorie - openbare naame',
+        fk: '177',
+        Hoofdcategorie: 'hoofdcategorie test',
+        Icoon:
+          'https://siaweuaaks.blob.core.windows.net/files/icons/categories/0-hoofdcategorie-test/glas-icon.svg?se=2023-04-25T15%3A16%3A27Z&sp=r&sv=2021-08-06&sr=b&sig=GtCGkYzJhlkzlRrVAShohBuCQ0mq%2BojItkjJvPRWFBY%3D',
+        id: 'https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/0-hoofdcategorie-test',
+      },
+      {
+        'Openbare Naam': 'Afval',
+        fk: '156',
+        Hoofdcategorie: 'Afval',
+        Icoon: 'Niet ingesteld',
+        id: 'https://acc.api.meldingen.amsterdam.nl/signals/v1/public/terms/categories/afval',
+      },
+    ]
+
+    render(
+      dataViewWithProps({
+        data: dataWithIcon,
+        onItemClick: onItemClickHandler,
+        primaryKeyColumn: headers[1],
+      })
+    )
+
+    expect(screen.getByRole('img', { name: 'Icoon' })).toBeInTheDocument()
+    expect(screen.getByText('Niet ingesteld')).toBeInTheDocument()
   })
 })

--- a/src/components/DataView/components/DataViewBody/index.js
+++ b/src/components/DataView/components/DataViewBody/index.js
@@ -1,10 +1,15 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2020 - 2021 Gemeente Amsterdam
+// Copyright (C) 2020 - 2023 Gemeente Amsterdam
 import { useMemo } from 'react'
 
 import PropTypes from 'prop-types'
 
-import { StyledTR, StyledTD } from 'components/DataView/styled'
+import {
+  StyledTR,
+  StyledTD,
+  StyledImg,
+  StyledImageTD,
+} from 'components/DataView/styled'
 
 const DataViewBody = ({
   data,
@@ -27,15 +32,29 @@ const DataViewBody = ({
           onClick={onItemClick}
           data-testid="data-view-body-row"
         >
-          {visibleColumns.map((column, idx) => (
-            <StyledTD
-              // eslint-disable-next-line react/no-array-index-key
-              key={`${JSON.stringify(column)}${idx}`}
-              data-testid="data-view-body-row-value"
-            >
-              {row[column]}
-            </StyledTD>
-          ))}
+          {visibleColumns.map((column, idx) => {
+            if (column === 'Icoon' && row[column] !== 'Niet ingesteld') {
+              return (
+                <StyledImageTD
+                  // eslint-disable-next-line react/no-array-index-key
+                  key={`${JSON.stringify(column)}${idx}`}
+                  data-testid="data-view-body-row-value"
+                >
+                  <StyledImg alt="Icoon" src={row[column]} />
+                </StyledImageTD>
+              )
+            }
+
+            return (
+              <StyledTD
+                // eslint-disable-next-line react/no-array-index-key
+                key={`${JSON.stringify(column)}${idx}`}
+                data-testid="data-view-body-row-value"
+              >
+                {row[column]}
+              </StyledTD>
+            )
+          })}
           {dataColumnsMissing > 0 && (
             <StyledTD
               colSpan={dataColumnsMissing > 1 ? dataColumnsMissing : undefined}

--- a/src/components/DataView/styled.js
+++ b/src/components/DataView/styled.js
@@ -33,3 +33,13 @@ export const StyledTD = styled.td`
   padding: ${themeSpacing(2)};
   cursor: pointer;
 `
+
+export const StyledImageTD = styled.td`
+  cursor: pointer;
+  padding: 0;
+`
+
+export const StyledImg = styled.img`
+  display: flex;
+  margin-left: 8px;
+`

--- a/src/signals/settings/categories/main-categories/Overview.test.tsx
+++ b/src/signals/settings/categories/main-categories/Overview.test.tsx
@@ -70,7 +70,7 @@ describe('OverviewContainer', () => {
         name: 'Wegen, verkeer, straatmeubilair - publiek',
       })
     ).toBeInTheDocument()
-    expect(screen.getByRole('cell', { name: 'Ingesteld' })).toBeInTheDocument()
+    expect(screen.getByRole('img', { name: 'Icoon' })).toBeInTheDocument()
   })
 
   it('should render loading when categories are not there', () => {

--- a/src/signals/settings/utils/filterData.test.js
+++ b/src/signals/settings/utils/filterData.test.js
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2019 - 2021 Gemeente Amsterdam
+// Copyright (C) 2019 - 2023 Gemeente Amsterdam
+import categories from 'utils/__tests__/fixtures/categories_structured.json'
 import usersJSON from 'utils/__tests__/fixtures/users.json'
 
 import filterData from './filterData'
@@ -11,7 +12,7 @@ const colMap = {
   username: 'Gebruikersnaam',
 }
 
-describe('signals/settings/users/containers/Overview/hooks/filterData', () => {
+describe('filterData', () => {
   it('should filter out keys', () => {
     const filteredData = filterData(usersJSON.results, colMap)
     const filteredKeys = Object.keys(filteredData[0]).sort()
@@ -59,5 +60,47 @@ describe('signals/settings/users/containers/Overview/hooks/filterData', () => {
     expect(filterData(undefined, colMap)).toEqual([])
     expect(filterData(null, colMap)).toEqual([])
     expect(filterData(0, colMap)).toEqual([])
+  })
+
+  it('should return public name if existing or else return default value', () => {
+    const colMapCategories = {
+      fk: 'fk',
+      id: 'id',
+      value: 'Hoofdcategorie',
+      public_name: 'Openbare Naam',
+      _links: 'Icoon',
+    }
+
+    const mockMainCategories = [
+      categories.afval,
+      categories['wegen-verkeer-straatmeubilair'],
+    ]
+    const filteredData = filterData(mockMainCategories, colMapCategories)
+
+    expect(filteredData[0]['Openbare Naam']).toEqual('Afval')
+    expect(filteredData[1]['Openbare Naam']).toEqual(
+      'Wegen, verkeer, straatmeubilair - publiek'
+    )
+  })
+
+  it('should return icon if existing else return "Niet ingesteld', () => {
+    const colMapCategories = {
+      fk: 'fk',
+      id: 'id',
+      value: 'Hoofdcategorie',
+      public_name: 'Openbare Naam',
+      _links: 'Icoon',
+    }
+
+    const mockMainCategories = [
+      categories.afval,
+      categories['wegen-verkeer-straatmeubilair'],
+    ]
+    const filteredData = filterData(mockMainCategories, colMapCategories)
+
+    expect(filteredData[0]['Icoon']).toEqual('Niet ingesteld')
+    expect(filteredData[1]['Icoon']).toEqual(
+      'https://siaweuaaks.blob.core.windows.net/files/icons/categories/0-hoofdcategorie-test/glas-icon.svg?se=2023-04-24T11%3A56%3A30Z&sp=r&sv=2021-08-06&sr=b&sig=cAl/7CfiwBu1yE/whi6bxc8BMlIxP9CHtnyO9YoapdA%3D'
+    )
   })
 })

--- a/src/signals/settings/utils/filterData.ts
+++ b/src/signals/settings/utils/filterData.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2019 - 2021 Gemeente Amsterdam
+// Copyright (C) 2019 - 2023 Gemeente Amsterdam
 type Data = Array<Record<string, any>>
 type ColMap = Record<string, any>
 
@@ -28,12 +28,13 @@ const filterData = (data: Data, colMap: ColMap): Array<typeof colMap> => {
             }
 
             if (key === 'public_name') {
-              value = value || 'Niet ingesteld'
+              value = value || item.value
             }
 
             if (key === '_links') {
-              // TODO: Make images possible in StyledDataView
-              value = value['sia:icon'] ? 'Ingesteld' : 'Niet ingesteld'
+              value = value['sia:icon']
+                ? value['sia:icon'].href
+                : 'Niet ingesteld'
             }
 
             obj[colMap[key]] = value

--- a/src/utils/__tests__/fixtures/categories_structured.json
+++ b/src/utils/__tests__/fixtures/categories_structured.json
@@ -71,6 +71,7 @@
   },
   "afval": {
     "_display": "Afval",
+    "public_name": null,
     "fk": 79,
     "sla": {
       "n_days": null,
@@ -194,7 +195,9 @@
       "sia:status-message-templates": {
         "href": "https://acc.api.data.amsterdam.nl/signals/v1/private/terms/categories/wegen-verkeer-straatmeubilair/status-message-templates"
       },
-      "sia:icon": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/0-hoofdcategorie-test/glas-icon.svg?se=2023-04-24T11%3A56%3A30Z&sp=r&sv=2021-08-06&sr=b&sig=cAl/7CfiwBu1yE/whi6bxc8BMlIxP9CHtnyO9YoapdA%3D"
+      "sia:icon": {
+        "href": "https://siaweuaaks.blob.core.windows.net/files/icons/categories/0-hoofdcategorie-test/glas-icon.svg?se=2023-04-24T11%3A56%3A30Z&sp=r&sv=2021-08-06&sr=b&sig=cAl/7CfiwBu1yE/whi6bxc8BMlIxP9CHtnyO9YoapdA%3D"
+      }
     },
     "id": "https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair",
     "is_active": true,


### PR DESCRIPTION
### Context
On the main categorie overview page in settings we want to show the icons that are set per category

### Changes
- Add ability to add icons to the overview row
- Change tests