### PR TITLE
[feat-4997]: Add subcategory filter settings to main category

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
         "leaflet-gesture-handling": "^1.2.1",
         "leaflet.markercluster": "^1.5.0",
         "lodash": "^4.17.21",
-        "proj4": "^2.8.0",
         "react": "^17.0.2",
         "react-datepicker": "^3.8.0",
         "react-dom": "^17.0.2",

--- a/src/signals/IncidentMap/components/FilterPanel/FilterCategoryWithSub.test.tsx
+++ b/src/signals/IncidentMap/components/FilterPanel/FilterCategoryWithSub.test.tsx
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: MPL-2.0 */
-/* Copyright (C) 2022 Gemeente Amsterdam */
+/* Copyright (C) 2022 - 2023 Gemeente Amsterdam */
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 
@@ -24,7 +24,7 @@ const mockFilter = {
     },
     {
       name: 'mockSubCategoryname2',
-      _display: 'mockSubCategory_display2',
+      _display: '',
       filterActive: true,
       slug: 'mockSubCategoryslug2',
       icon: 'https://ae70d54aca324d0480ca01934240c78f.objectstore.eu/signals/icons/categories/afval/afval.svg?temp_url_sig=6679c552c423eb18ffe55643e5692fb4c348bde4e2bde851f33a7aef8d0474fe&temp_url_expires=1665401494',
@@ -60,6 +60,7 @@ describe('FilterCategoryWithSub', () => {
     const { container } = renderFilterCategoryWithSub({
       filter: mockNoSubCategoryFilter,
     })
+
     expect(container).toBeEmptyDOMElement()
   })
 
@@ -70,6 +71,7 @@ describe('FilterCategoryWithSub', () => {
     })
 
     userEvent.click(chevron)
+    expect(screen.getByText('mockSubCategoryname2')).toBeInTheDocument()
 
     const updatedChevron = screen.queryByRole('button', {
       name: 'Toon meer filter opties',
@@ -93,7 +95,7 @@ describe('FilterCategoryWithSub', () => {
     userEvent.click(chevron)
 
     const checkBox = screen.getByRole('checkbox', {
-      name: /mockSubCategoryname1/,
+      name: /mockSubCategory_display1/,
     })
 
     expect(checkBox).toBeInTheDocument()
@@ -117,5 +119,15 @@ describe('FilterCategoryWithSub', () => {
       filter: mockNoSubCategoryFilter,
     })
     expect(container).toBeEmptyDOMElement()
+  })
+
+  it('should render _display name when existing, else name', () => {
+    renderFilterCategoryWithSub()
+
+    expect(screen.getByText('mockSubCategory_display1')).toBeInTheDocument()
+    expect(
+      screen.queryByText('mockSubCategory_display2')
+    ).not.toBeInTheDocument()
+    expect(screen.getByText('mockSubCategoryname2')).toBeInTheDocument()
   })
 })

--- a/src/signals/IncidentMap/components/FilterPanel/FilterCategoryWithSub.tsx
+++ b/src/signals/IncidentMap/components/FilterPanel/FilterCategoryWithSub.tsx
@@ -49,7 +49,7 @@ export const FilterCategoryWithSub = ({ onToggleCategory, filter }: Props) => {
         {subCategories
           .filter((subCategory) => subCategory.incidentsCount)
           .map((subCategory) => {
-            const { name, filterActive, icon } = subCategory
+            const { name, filterActive, icon, _display } = subCategory
             return (
               <Fragment key={name}>
                 <FilterCategory
@@ -57,7 +57,7 @@ export const FilterCategoryWithSub = ({ onToggleCategory, filter }: Props) => {
                     onToggleCategory(subCategory, !filterActive)
                   }}
                   selected={filterActive}
-                  text={name}
+                  text={_display || name}
                   icon={icon}
                 />
                 <Underlined />

--- a/src/signals/IncidentMap/components/FilterPanel/FilterCategoryWithSub.tsx
+++ b/src/signals/IncidentMap/components/FilterPanel/FilterCategoryWithSub.tsx
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: MPL-2.0 */
-/* Copyright (C) 2022 Gemeente Amsterdam */
+/* Copyright (C) 2022 - 2023 Gemeente Amsterdam */
 import { Fragment, useState } from 'react'
 
 import { ChevronDown } from '@amsterdam/asc-assets'
@@ -20,7 +20,7 @@ export interface Props {
 
 export const FilterCategoryWithSub = ({ onToggleCategory, filter }: Props) => {
   const [showSubsection, setShowSubsection] = useState<boolean>(false)
-  const { name, filterActive, icon, subCategories } = filter
+  const { name, filterActive, icon, subCategories, _display } = filter
 
   if (!subCategories) return null
   return (
@@ -31,7 +31,7 @@ export const FilterCategoryWithSub = ({ onToggleCategory, filter }: Props) => {
             onToggleCategory(filter, !filterActive)
           }}
           selected={filterActive}
-          text={name}
+          text={_display || name}
           icon={icon}
         />
 

--- a/src/signals/settings/categories/components/CategoryForm.test.tsx
+++ b/src/signals/settings/categories/components/CategoryForm.test.tsx
@@ -21,6 +21,7 @@ const mockFormValues = {
   note: 'Test notes',
   n_days: 3,
   use_calendar_days: 1,
+  show_children_in_filter: true,
 }
 
 const defaultProps: Omit<Props, 'formMethods'> = {
@@ -87,6 +88,11 @@ describe('CategoryForm', () => {
     expect(screen.getByText('Openbaar tonen')).toBeInTheDocument()
     expect(screen.getByRole('textbox', { name: 'Notitie' })).toBeInTheDocument()
     expect(screen.getByText('Geschiedenis')).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        'Toon alle subcategorieën in het filter op de meldingenkaart die openbaar getoond mogen worden'
+      )
+    ).toBeInTheDocument()
 
     expect(screen.queryByText('Afhandeltermijn')).not.toBeInTheDocument()
     expect(

--- a/src/signals/settings/categories/components/CategoryForm.tsx
+++ b/src/signals/settings/categories/components/CategoryForm.tsx
@@ -121,30 +121,57 @@ export const CategoryForm = ({
                 </FieldGroup>
               )}
 
-              <Controller
-                name="is_public_accessible"
-                control={formMethods.control}
-                render={({ field: { name, value, onChange } }) => (
-                  <FieldGroup>
-                    <StyledHeading>Openbaar tonen</StyledHeading>
-                    <>
-                      <StyledLabel
-                        htmlFor={name}
-                        label={isPublicAccessibleLabel}
-                        data-testid="category-is-public-accessible"
-                        disabled={readOnly}
-                      >
-                        <Checkbox
-                          checked={value}
-                          name={name}
-                          id={name}
-                          onChange={onChange}
-                        />
-                      </StyledLabel>
-                    </>
-                  </FieldGroup>
+              <FieldGroup>
+                <StyledHeading>Openbaar tonen</StyledHeading>
+                <Controller
+                  name="is_public_accessible"
+                  control={formMethods.control}
+                  render={({ field: { name, value, onChange } }) => (
+                    <FieldGroup>
+                      <>
+                        <StyledLabel
+                          htmlFor={name}
+                          label={isPublicAccessibleLabel}
+                          data-testid="category-is-public-accessible"
+                          disabled={readOnly}
+                        >
+                          <Checkbox
+                            checked={value}
+                            name={name}
+                            id={name}
+                            onChange={onChange}
+                          />
+                        </StyledLabel>
+                      </>
+                    </FieldGroup>
+                  )}
+                />
+                {isMainCategory && (
+                  <Controller
+                    name="show_children_in_filter"
+                    control={formMethods.control}
+                    render={({ field: { name, value, onChange } }) => {
+                      return (
+                        <>
+                          <StyledLabel
+                            htmlFor={name}
+                            label="Toon alle subcategorieën in het filter op de meldingenkaart die openbaar getoond mogen worden"
+                            data-testid="show_children_in_filter"
+                            disabled={readOnly}
+                          >
+                            <Checkbox
+                              checked={value}
+                              name={name}
+                              id={name}
+                              onChange={onChange}
+                            />
+                          </StyledLabel>
+                        </>
+                      )
+                    }}
+                  />
                 )}
-              />
+              </FieldGroup>
 
               {formValues.is_public_accessible && (
                 <FieldGroup>

--- a/src/signals/settings/categories/components/CategoryForm.tsx
+++ b/src/signals/settings/categories/components/CategoryForm.tsx
@@ -128,21 +128,19 @@ export const CategoryForm = ({
                   control={formMethods.control}
                   render={({ field: { name, value, onChange } }) => (
                     <FieldGroup>
-                      <>
-                        <StyledLabel
-                          htmlFor={name}
-                          label={isPublicAccessibleLabel}
-                          data-testid="category-is-public-accessible"
-                          disabled={readOnly}
-                        >
-                          <Checkbox
-                            checked={value}
-                            name={name}
-                            id={name}
-                            onChange={onChange}
-                          />
-                        </StyledLabel>
-                      </>
+                      <StyledLabel
+                        htmlFor={name}
+                        label={isPublicAccessibleLabel}
+                        data-testid="category-is-public-accessible"
+                        disabled={readOnly}
+                      >
+                        <Checkbox
+                          checked={value}
+                          name={name}
+                          id={name}
+                          onChange={onChange}
+                        />
+                      </StyledLabel>
                     </FieldGroup>
                   )}
                 />
@@ -150,25 +148,21 @@ export const CategoryForm = ({
                   <Controller
                     name="show_children_in_filter"
                     control={formMethods.control}
-                    render={({ field: { name, value, onChange } }) => {
-                      return (
-                        <>
-                          <StyledLabel
-                            htmlFor={name}
-                            label="Toon alle subcategorieën in het filter op de meldingenkaart die openbaar getoond mogen worden"
-                            data-testid="show_children_in_filter"
-                            disabled={readOnly}
-                          >
-                            <Checkbox
-                              checked={value}
-                              name={name}
-                              id={name}
-                              onChange={onChange}
-                            />
-                          </StyledLabel>
-                        </>
-                      )
-                    }}
+                    render={({ field: { name, value, onChange } }) => (
+                      <StyledLabel
+                        htmlFor={name}
+                        label="Toon alle subcategorieën in het filter op de meldingenkaart die openbaar getoond mogen worden"
+                        data-testid="show_children_in_filter"
+                        disabled={readOnly}
+                      >
+                        <Checkbox
+                          checked={value}
+                          name={name}
+                          id={name}
+                          onChange={onChange}
+                        />
+                      </StyledLabel>
+                    )}
                   />
                 )}
               </FieldGroup>

--- a/src/signals/settings/categories/components/Detail.test.tsx
+++ b/src/signals/settings/categories/components/Detail.test.tsx
@@ -88,9 +88,6 @@ describe('Detail', () => {
       expect(screen.getByRole('textbox', { name: 'Naam' })).toHaveValue(
         'Afwatering brug'
       )
-      expect(screen.getByRole('textbox', { name: 'Naam' })).toHaveValue(
-        'Afwatering brug'
-      )
       expect(screen.getByRole('textbox', { name: 'Omschrijving' })).toHaveValue(
         'Dit is het verhaal van de brug die moest afwateren.'
       )
@@ -107,6 +104,24 @@ describe('Detail', () => {
         screen.getByRole('radio', { name: 'Niet actief' })
       ).not.toBeChecked()
       expect(screen.getByRole('textbox', { name: 'Notitie' })).toHaveValue('')
+    })
+  })
+
+  it('should render specific main category fields', async () => {
+    render(
+      withContext(
+        <MemoryRouter initialEntries={[mockLocation]}>
+          <CategoryDetail {...defaultProps} isMainCategory={true} />
+        </MemoryRouter>
+      )
+    )
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'Toon alle subcategorieën in het filter op de meldingenkaart die openbaar getoond mogen worden'
+        )
+      ).toBeInTheDocument()
     })
   })
 

--- a/src/signals/settings/categories/components/Detail.tsx
+++ b/src/signals/settings/categories/components/Detail.tsx
@@ -19,9 +19,9 @@ import type { Category } from 'types/category'
 import type { History } from 'types/history'
 
 import { CategoryForm } from './CategoryForm'
+import { getPatchPayload } from './utils'
 import useConfirmedCancel from '../../hooks/useConfirmedCancel'
 import useFetchResponseNotification from '../../hooks/useFetchResponseNotification'
-import { getPatchPayload } from '../subcategories/utils'
 import type { CategoryFormValues } from '../types'
 
 const DEFAULT_STATUS_OPTION = 'true'

--- a/src/signals/settings/categories/components/Detail.tsx
+++ b/src/signals/settings/categories/components/Detail.tsx
@@ -79,8 +79,12 @@ export const CategoryDetail = ({
       note: data.note,
       n_days: data.sla.n_days,
       use_calendar_days: data.sla.use_calendar_days ? 1 : 0,
+      ...(isMainCategory && {
+        show_children_in_filter:
+          data?.configuration?.show_children_in_filter || false,
+      }),
     }
-  }, [data])
+  }, [data, isMainCategory])
 
   const formMethods = useForm<CategoryFormValues>({
     reValidateMode: 'onSubmit',

--- a/src/signals/settings/categories/components/utils.test.ts
+++ b/src/signals/settings/categories/components/utils.test.ts
@@ -42,5 +42,26 @@ describe('utils', () => {
 
       expect(result).toEqual(mockMappedData)
     })
+
+    it('should map show_children_in_filter when input changed on main category', () => {
+      const mockFormDataMainCategory = {
+        ...mockFormData,
+        show_children_in_filter: false,
+      }
+      const mockDirtyFieldsMainCategory = {
+        show_children_in_filter: true,
+      }
+
+      const result = getPatchPayload(
+        mockFormDataMainCategory,
+        mockDirtyFieldsMainCategory
+      )
+
+      expect(result).toEqual({
+        configuration: {
+          show_children_in_filter: false,
+        },
+      })
+    })
   })
 })

--- a/src/signals/settings/categories/components/utils.tsx
+++ b/src/signals/settings/categories/components/utils.tsx
@@ -20,13 +20,13 @@ export const getPatchPayload = (
 
   const payloadResult = {
     ...payloadObject,
-    ...((payloadObject['n_days'] || payloadObject['use_calendar_days']) && {
+    ...(('n_days' in payloadObject || 'use_calendar_days' in payloadObject) && {
       new_sla: {
         n_days: payloadObject.n_days ?? formData.n_days,
         use_calendar_days: Boolean(Number(payloadObject.use_calendar_days)),
       },
     }),
-    ...(payloadObject['show_children_in_filter'] && {
+    ...('show_children_in_filter' in payloadObject && {
       configuration: {
         show_children_in_filter: payloadObject.show_children_in_filter,
       },

--- a/src/signals/settings/categories/subcategories/utils.tsx
+++ b/src/signals/settings/categories/subcategories/utils.tsx
@@ -18,18 +18,24 @@ export const getPatchPayload = (
 
   const payloadObject = Object.assign({}, ...payload)
 
-  if (payloadObject['n_days'] || payloadObject['use_calendar_days']) {
-    const updatedPayload = {
-      ...payloadObject,
+  const payloadResult = {
+    ...payloadObject,
+    ...((payloadObject['n_days'] || payloadObject['use_calendar_days']) && {
       new_sla: {
         n_days: payloadObject.n_days ?? formData.n_days,
         use_calendar_days: Boolean(Number(payloadObject.use_calendar_days)),
       },
-    }
+    }),
+    ...(payloadObject['show_children_in_filter'] && {
+      configuration: {
+        show_children_in_filter: payloadObject.show_children_in_filter,
+      },
+    }),
+  }
 
-    delete updatedPayload['n_days']
-    delete updatedPayload['use_calendar_days']
+  delete payloadResult['n_days']
+  delete payloadResult['use_calendar_days']
+  delete payloadResult['show_children_in_filter']
 
-    return updatedPayload
-  } else return payloadObject
+  return payloadResult
 }

--- a/src/signals/settings/categories/types.ts
+++ b/src/signals/settings/categories/types.ts
@@ -10,6 +10,7 @@ export interface CategoryFormValues {
   note: string | null
   public_name: string
   use_calendar_days: number
+  show_children_in_filter?: boolean
 }
 
 export interface CategoryFormPayload {
@@ -24,6 +25,9 @@ export interface CategoryFormPayload {
   }
   note: string | null
   public_name: string
+  configuration: {
+    show_children_in_filter: boolean
+  }
 }
 
 export type DirtyFields = Partial<{

--- a/src/types/category.ts
+++ b/src/types/category.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2021 Vereniging van Nederlandse Gemeenten, Gemeente Amsterdam
+// Copyright (C) 2021 - 2023 Vereniging van Nederlandse Gemeenten, Gemeente Amsterdam
 export interface CategoryDepartment {
   id: number
   code: string
@@ -39,6 +39,9 @@ export interface Category {
   public_name?: string | null
   _display?: string
   sub_categories?: SubCategory[]
+  configuration?: {
+    show_children_in_filter?: boolean
+  }
 }
 
 export interface SubCategory {

--- a/src/utils/__tests__/fixtures/categories_private.json
+++ b/src/utils/__tests__/fixtures/categories_private.json
@@ -145,7 +145,10 @@
           "can_view": true
         }
       ],
-      "note": ""
+      "note": "",
+      "configuration": {
+        "show_children_in_filter": true
+      }
     },
     {
       "_links": {


### PR DESCRIPTION
Ticket: [SIG-4997](https://gemeente-amsterdam.atlassian.net/browse/SIG-4997)

### Context
Adding new setting to the main category that changes whether the subcategories of this main categories are shown as filters on the public incident map

### Changes
- Add to form
- Fix mapper to create correct payload
- Fix naming issues on incident map
- Write/Update tests