### PR TITLE
[feat-4997]: implement subfilter setting

### DIFF
--- a/app.amsterdam.json
+++ b/app.amsterdam.json
@@ -93,12 +93,6 @@
       "minZoom": 7,
       "zoom": 7
     },
-    "optionsIncidentMap": {
-      "hasSubfiltersEnabled": [
-        "afval",
-        "wegen-verkeer-straatmeubilair"
-      ]
-    },
     "tiles": {
       "args": [
         "https://{s}.data.amsterdam.nl/topo_rd/{z}/{x}/{y}.png"

--- a/app.base.json
+++ b/app.base.json
@@ -106,7 +106,6 @@
       "zoom": 12
     },
     "optionsIncidentMap": {
-      "hasSubfiltersEnabled": ["main-category-slug"],
       "zoom": 9,
       "flyToMinZoom": 12,
       "flyToMaxZoom": 14

--- a/internals/schemas/app.schema.json
+++ b/internals/schemas/app.schema.json
@@ -611,13 +611,6 @@
       "description": "Array with slugs of main categories that will show subfilters based on the connected subcategories. Note: main category 'overig', cannot have subcategory filters since it has the same slug as one of his subcategories.",
       "title": "OptionsIncidentMap",
       "properties": {
-        "hasSubfiltersEnabled": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "minItems": 0
-        },
         "zoom": {
           "type": "integer"
         },

--- a/internals/schemas/app.schema.json
+++ b/internals/schemas/app.schema.json
@@ -608,7 +608,6 @@
     "OptionsIncidentMap": {
       "type": "object",
       "additionalProperties": false,
-      "description": "Array with slugs of main categories that will show subfilters based on the connected subcategories. Note: main category 'overig', cannot have subcategory filters since it has the same slug as one of his subcategories.",
       "title": "OptionsIncidentMap",
       "properties": {
         "zoom": {

--- a/src/signals/IncidentMap/components/FilterPanel/FilterCategoryWithSub.test.tsx
+++ b/src/signals/IncidentMap/components/FilterPanel/FilterCategoryWithSub.test.tsx
@@ -5,18 +5,18 @@ import userEvent from '@testing-library/user-event'
 
 import { FilterCategoryWithSub } from './FilterCategoryWithSub'
 import type { Props } from './FilterCategoryWithSub'
-
+import type { Filter } from '../../types'
 const mockOnToggleCategory = jest.fn()
-const mockFilter = {
+const mockFilter: Filter = {
   name: 'Afval',
-  _display: 'mock_display',
+  public_name: 'mock_display',
   filterActive: true,
   slug: 'mockSlug',
   icon: '',
   subCategories: [
     {
       name: 'mockSubCategoryname1',
-      _display: 'mockSubCategory_display1',
+      public_name: 'mockSubCategory_display1',
       filterActive: true,
       slug: 'mockSubCategoryslug1',
       icon: 'https://ae70d54aca324d0480ca01934240c78f.objectstore.eu/signals/icons/categories/afval/afval.svg?temp_url_sig=6679c552c423eb18ffe55643e5692fb4c348bde4e2bde851f33a7aef8d0474fe&temp_url_expires=1665401494',
@@ -24,7 +24,7 @@ const mockFilter = {
     },
     {
       name: 'mockSubCategoryname2',
-      _display: '',
+      public_name: '',
       filterActive: true,
       slug: 'mockSubCategoryslug2',
       icon: 'https://ae70d54aca324d0480ca01934240c78f.objectstore.eu/signals/icons/categories/afval/afval.svg?temp_url_sig=6679c552c423eb18ffe55643e5692fb4c348bde4e2bde851f33a7aef8d0474fe&temp_url_expires=1665401494',

--- a/src/signals/IncidentMap/components/FilterPanel/FilterCategoryWithSub.tsx
+++ b/src/signals/IncidentMap/components/FilterPanel/FilterCategoryWithSub.tsx
@@ -20,7 +20,7 @@ export interface Props {
 
 export const FilterCategoryWithSub = ({ onToggleCategory, filter }: Props) => {
   const [showSubsection, setShowSubsection] = useState<boolean>(false)
-  const { name, filterActive, icon, subCategories, _display } = filter
+  const { name, filterActive, icon, subCategories, public_name } = filter
 
   if (!subCategories) return null
   return (
@@ -31,7 +31,7 @@ export const FilterCategoryWithSub = ({ onToggleCategory, filter }: Props) => {
             onToggleCategory(filter, !filterActive)
           }}
           selected={filterActive}
-          text={_display || name}
+          text={public_name || name}
           icon={icon}
         />
 
@@ -49,7 +49,8 @@ export const FilterCategoryWithSub = ({ onToggleCategory, filter }: Props) => {
         {subCategories
           .filter((subCategory) => subCategory.incidentsCount)
           .map((subCategory) => {
-            const { name, filterActive, icon, _display } = subCategory
+            const { name, filterActive, icon, public_name } = subCategory
+
             return (
               <Fragment key={name}>
                 <FilterCategory
@@ -57,7 +58,7 @@ export const FilterCategoryWithSub = ({ onToggleCategory, filter }: Props) => {
                     onToggleCategory(subCategory, !filterActive)
                   }}
                   selected={filterActive}
-                  text={_display || name}
+                  text={public_name || name}
                   icon={icon}
                 />
                 <Underlined />

--- a/src/signals/IncidentMap/components/FilterPanel/FilterPanel.tsx
+++ b/src/signals/IncidentMap/components/FilterPanel/FilterPanel.tsx
@@ -70,7 +70,8 @@ export const FilterPanel = ({ filters, setFilters, setMapMessage }: Props) => {
       {filters
         .filter((filter: Filter) => filter.incidentsCount)
         .map((filter: Filter) => {
-          const { name, filterActive, _display, icon, subCategories } = filter
+          const { name, filterActive, public_name, icon, subCategories } =
+            filter
 
           return subCategories ? (
             <FilterCategoryWithSub
@@ -85,7 +86,7 @@ export const FilterPanel = ({ filters, setFilters, setMapMessage }: Props) => {
                   toggleFilter(filter, !filterActive)
                 }}
                 selected={filterActive}
-                text={_display || name}
+                text={public_name || name}
                 icon={icon}
               />
               <Underlined />

--- a/src/signals/IncidentMap/components/FilterPanel/utils.test.ts
+++ b/src/signals/IncidentMap/components/FilterPanel/utils.test.ts
@@ -1,4 +1,3 @@
-import configuration from 'shared/services/configuration/configuration'
 import type Categories from 'types/api/categories'
 
 import { getFilterCategoriesWithIcons } from './utils'
@@ -8,12 +7,6 @@ import { fetchCategoriesResponse } from '../__test__'
 jest.mock('shared/services/configuration/configuration')
 
 describe('getFilterCategoriesWithIcon', () => {
-  beforeEach(() => {
-    configuration.map.optionsIncidentMap.hasSubfiltersEnabled = [
-      'afval',
-      'wegen-verkeer-straatmeubilair',
-    ]
-  })
   const mockData =
     fetchCategoriesResponse.results as unknown as Categories['results']
 

--- a/src/signals/IncidentMap/components/FilterPanel/utils.test.ts
+++ b/src/signals/IncidentMap/components/FilterPanel/utils.test.ts
@@ -46,22 +46,15 @@ describe('getFilterCategoriesWithIcon', () => {
 })
 
 describe('showSubCategoryFilter', () => {
-  beforeEach(() => {
-    configuration.map.optionsIncidentMap.hasSubfiltersEnabled = [
-      'afval',
-      'wegen-verkeer-straatmeubilair',
-    ]
-  })
-
   it('should return false on default', () => {
-    configuration.map.optionsIncidentMap.hasSubfiltersEnabled = []
-    const result = showSubCategoryFilter('afval')
+    const result = showSubCategoryFilter([], 'afval')
 
     expect(result).toEqual(false)
   })
 
   it('should return true when main category has subFilter enabled', () => {
-    const result = showSubCategoryFilter('afval')
+    const filterSlug = ['afval', 'wegen-verkeer-straatmeubilair']
+    const result = showSubCategoryFilter(filterSlug, 'afval')
 
     expect(result).toEqual(true)
   })

--- a/src/signals/IncidentMap/components/FilterPanel/utils.ts
+++ b/src/signals/IncidentMap/components/FilterPanel/utils.ts
@@ -1,6 +1,5 @@
 /* SPDX-License-Identifier: MPL-2.0 */
 /* Copyright (C) 2022 - 2023 Gemeente Amsterdam */
-import configuration from 'shared/services/configuration/configuration'
 import { defaultIcon } from 'shared/services/configuration/map-markers'
 import type { Category } from 'types/category'
 import type { SubCategory as SubCategoryBackend } from 'types/category'
@@ -9,13 +8,14 @@ import type { Filter, SubCategory } from '../../types'
 
 export const getFilterCategoriesWithIcons = (
   categories: Category[]
-): Filter[] => {
-  return categories
+): Filter[] =>
+  categories
     .filter(({ is_public_accessible }) => is_public_accessible)
     .map((category) => {
-      const { sub_categories, _display, _links, name, slug } = category
+      const { sub_categories, _display, _links, name, slug, configuration } =
+        category
 
-      const categoriesWithIcons: Filter = {
+      const categoryWithIcon: Filter = {
         _display,
         filterActive: true,
         icon: _links['sia:icon']?.href ?? defaultIcon,
@@ -24,18 +24,30 @@ export const getFilterCategoriesWithIcons = (
         incidentsCount: 0,
       }
 
-      if (sub_categories && showSubCategoryFilter(category.slug)) {
-        categoriesWithIcons.subCategories = getSubCategories(sub_categories)
+      if (sub_categories) {
+        const subCategories = getSubCategories(sub_categories)
+
+        if (
+          subCategories.length > 0 &&
+          configuration?.show_children_in_filter
+        ) {
+          categoryWithIcon.subCategories = subCategories
+          categoryWithIcon.show_children_in_filter =
+            configuration.show_children_in_filter
+        }
+
+        if (subCategories.length === 0) {
+          // Remove category filter without public_accessible subcategories
+          categoryWithIcon.filterActive = false
+        }
       }
 
-      return categoriesWithIcons
+      return categoryWithIcon
     })
-}
+    .filter((category) => category.filterActive)
 
-const getSubCategories = (
-  subCategories: SubCategoryBackend[]
-): SubCategory[] => {
-  return subCategories
+const getSubCategories = (subCategories: SubCategoryBackend[]): SubCategory[] =>
+  subCategories
     .filter(({ is_public_accessible }) => is_public_accessible)
     .map((subCategory) => {
       const { name, _display, slug, _links } = subCategory
@@ -48,7 +60,6 @@ const getSubCategories = (
         incidentsCount: 0,
       }
     })
-}
 
-export const showSubCategoryFilter = (slug: Category['slug']) =>
-  configuration.map.optionsIncidentMap.hasSubfiltersEnabled.includes(slug)
+export const showSubCategoryFilter = (array: string[], slug: string) =>
+  array.includes(slug)

--- a/src/signals/IncidentMap/components/FilterPanel/utils.ts
+++ b/src/signals/IncidentMap/components/FilterPanel/utils.ts
@@ -61,5 +61,5 @@ const getSubCategories = (subCategories: SubCategoryBackend[]): SubCategory[] =>
       }
     })
 
-export const showSubCategoryFilter = (array: string[], slug: string) =>
-  array.includes(slug)
+export const showSubCategoryFilter = (filterSlugs: string[], slug: string) =>
+  filterSlugs.includes(slug)

--- a/src/signals/IncidentMap/components/FilterPanel/utils.ts
+++ b/src/signals/IncidentMap/components/FilterPanel/utils.ts
@@ -12,11 +12,11 @@ export const getFilterCategoriesWithIcons = (
   categories
     .filter(({ is_public_accessible }) => is_public_accessible)
     .map((category) => {
-      const { sub_categories, _display, _links, name, slug, configuration } =
+      const { sub_categories, public_name, _links, name, slug, configuration } =
         category
 
       const categoryWithIcon: Filter = {
-        _display,
+        public_name,
         filterActive: true,
         icon: _links['sia:icon']?.href ?? defaultIcon,
         name,
@@ -50,9 +50,9 @@ const getSubCategories = (subCategories: SubCategoryBackend[]): SubCategory[] =>
   subCategories
     .filter(({ is_public_accessible }) => is_public_accessible)
     .map((subCategory) => {
-      const { name, _display, slug, _links } = subCategory
+      const { name, public_name, slug, _links } = subCategory
       return {
-        _display,
+        public_name,
         filterActive: true,
         icon: _links['sia:icon']?.href ?? defaultIcon,
         name,

--- a/src/signals/IncidentMap/components/IncidentMap/IncidentMap.test.tsx
+++ b/src/signals/IncidentMap/components/IncidentMap/IncidentMap.test.tsx
@@ -55,11 +55,11 @@ jest.mocked(reverseGeocoderService).mockImplementation(async () => {
 describe('IncidentMap', () => {
   beforeEach(() => {
     get.mockReset()
-    jest.mocked(usePaginatedIncidents).mockImplementation(() => ({
+    jest.mocked(usePaginatedIncidents).mockReturnValue({
       incidents: [],
       getIncidents: mockGetIncidents,
       error: null,
-    }))
+    })
   })
 
   it('should render the incident map correctly', () => {
@@ -84,11 +84,11 @@ describe('IncidentMap', () => {
   })
 
   it('shows a message when the API returns an error', () => {
-    jest.mocked(usePaginatedIncidents).mockImplementation(() => ({
+    jest.mocked(usePaginatedIncidents).mockReturnValue({
       incidents: [],
       getIncidents: jest.fn(),
       error: new Error(),
-    }))
+    })
 
     render(withAppContext(<IncidentMap />))
 
@@ -130,11 +130,11 @@ describe('IncidentMap', () => {
   })
 
   it('should close the error message when close button is clicked', () => {
-    jest.mocked(usePaginatedIncidents).mockImplementationOnce(() => ({
+    jest.mocked(usePaginatedIncidents).mockReturnValue({
       incidents: [],
       getIncidents: jest.fn(),
       error: new Error(),
-    }))
+    })
 
     render(withAppContext(<IncidentMap />))
     expect(

--- a/src/signals/IncidentMap/components/__test__/mock-filters.ts
+++ b/src/signals/IncidentMap/components/__test__/mock-filters.ts
@@ -7,6 +7,7 @@ export const mockFiltersShort: Filter[] = [
     icon: 'https://ae70d54aca324d0480ca01934240c78f.objectstore.eu/signals/icons/categories/afval/afval.svg?temp_url_sig=6679c552c423eb18ffe55643e5692fb4c348bde4e2bde851f33a7aef8d0474fe&temp_url_expires=1665401494',
     name: 'Afval',
     slug: 'afval',
+    show_children_in_filter: true,
     subCategories: [
       {
         public_name: 'Container bijplaatsing (Afval)',
@@ -44,6 +45,7 @@ export const mockFiltersLong = [
     icon: 'https://ae70d54aca324d0480ca01934240c78f.objectstore.eu/signals/icons/categories/afval/afval.svg?temp_url_sig=6679c552c423eb18ffe55643e5692fb4c348bde4e2bde851f33a7aef8d0474fe&temp_url_expires=1665401494',
     name: 'Afval',
     slug: 'afval',
+    show_children_in_filter: true,
     subCategories: [
       {
         _display: 'Container bijplaatsing (Afval)',
@@ -164,6 +166,7 @@ export const mockFiltersLong = [
     filterActive: true,
     name: 'Wegen, verkeer, straatmeubilair',
     slug: 'wegen-verkeer-straatmeubilair',
+    show_children_in_filter: true,
     subCategories: [
       {
         _display: 'Autom. Verzinkbare palen (Wegen, verkeer, straatmeubilair)',

--- a/src/signals/IncidentMap/components/__test__/mock-filters.ts
+++ b/src/signals/IncidentMap/components/__test__/mock-filters.ts
@@ -2,14 +2,14 @@ import type { Filter } from '../../types'
 
 export const mockFiltersShort: Filter[] = [
   {
-    _display: 'Afval',
+    public_name: 'Afval',
     filterActive: true,
     icon: 'https://ae70d54aca324d0480ca01934240c78f.objectstore.eu/signals/icons/categories/afval/afval.svg?temp_url_sig=6679c552c423eb18ffe55643e5692fb4c348bde4e2bde851f33a7aef8d0474fe&temp_url_expires=1665401494',
     name: 'Afval',
     slug: 'afval',
     subCategories: [
       {
-        _display: 'Container bijplaatsing (Afval)',
+        public_name: 'Container bijplaatsing (Afval)',
         filterActive: true,
         icon: 'https://ae70d54aca324d0480ca01934240c78f.objectstore.eu/signals/icons/categories/afval/afval.svg?temp_url_sig=6679c552c423eb18ffe55643e5692fb4c348bde4e2bde851f33a7aef8d0474fe&temp_url_expires=1665401494',
         name: 'Container bijplaatsing',
@@ -17,7 +17,7 @@ export const mockFiltersShort: Filter[] = [
         incidentsCount: 0,
       },
       {
-        _display: 'Container glas kapot (Afval)',
+        public_name: 'Container glas kapot (Afval)',
         filterActive: false,
         icon: 'https://ae70d54aca324d0480ca01934240c78f.objectstore.eu/signals/icons/categories/afval/container-glas-kapot/glas.svg?temp_url_sig=7b6c01926248bbb41d4de407f2e6a14f970d3d790ecc0d9ca6102bae2332e7c8&temp_url_expires=1665401494',
         name: 'Container glas kapot',
@@ -28,7 +28,7 @@ export const mockFiltersShort: Filter[] = [
     incidentsCount: 0,
   },
   {
-    _display: 'Openbaar groen en water',
+    public_name: 'Openbaar groen en water',
     filterActive: true,
     icon: 'https://ae70d54aca324d0480ca01934240c78f.objectstore.eu/signals/icons/categories/openbaar-groen-en-water/bomen_planten.svg?temp_url_sig=18c662680477047ec1edcb8c18bc67d4cfe6805fd129a5e6c1df5f84708df0b5&temp_url_expires=1665401494',
     name: 'Openbaar groen en water',
@@ -39,7 +39,7 @@ export const mockFiltersShort: Filter[] = [
 
 export const mockFiltersLong = [
   {
-    _display: 'Afval',
+    public_name: 'Afval',
     filterActive: true,
     icon: 'https://ae70d54aca324d0480ca01934240c78f.objectstore.eu/signals/icons/categories/afval/afval.svg?temp_url_sig=6679c552c423eb18ffe55643e5692fb4c348bde4e2bde851f33a7aef8d0474fe&temp_url_expires=1665401494',
     name: 'Afval',

--- a/src/signals/IncidentMap/components/utils/add-icons-to-incidents.test.ts
+++ b/src/signals/IncidentMap/components/utils/add-icons-to-incidents.test.ts
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (C) 2023 Gemeente Amsterdam
+import { addIconsToIncidents, getListOfIcons } from './add-icons-to-incidents'
+import { mockFiltersShort } from '../__test__/mock-filters'
+import { mockIncidentsWithoutIcon } from '../__test__/mock-incidents-without-icon'
+
+const mockFiltersAllActive = mockFiltersShort.map((filter) => {
+  if (filter.subCategories) {
+    return {
+      ...filter,
+      filterActive: true,
+      subCategories: filter.subCategories.map((subFilter) => {
+        return {
+          ...subFilter,
+          filterActive: true,
+        }
+      }),
+    }
+  }
+
+  return {
+    ...filter,
+    filterActive: true,
+  }
+})
+
+const mockListOfIcons = [
+  {
+    slug: 'afval',
+    icon: 'https://ae70d54aca324d0480ca01934240c78f.objectstore.eu/signals/icons/categories/afval/afval.svg?temp_url_sig=6679c552c423eb18ffe55643e5692fb4c348bde4e2bde851f33a7aef8d0474fe&temp_url_expires=1665401494',
+  },
+  {
+    slug: 'container-bijplaatsing',
+    icon: 'https://ae70d54aca324d0480ca01934240c78f.objectstore.eu/signals/icons/categories/afval/afval.svg?temp_url_sig=6679c552c423eb18ffe55643e5692fb4c348bde4e2bde851f33a7aef8d0474fe&temp_url_expires=1665401494',
+  },
+  {
+    slug: 'container-glas-kapot',
+    icon: 'https://ae70d54aca324d0480ca01934240c78f.objectstore.eu/signals/icons/categories/afval/container-glas-kapot/glas.svg?temp_url_sig=7b6c01926248bbb41d4de407f2e6a14f970d3d790ecc0d9ca6102bae2332e7c8&temp_url_expires=1665401494',
+  },
+  {
+    slug: 'openbaar-groen-en-water',
+    icon: 'https://ae70d54aca324d0480ca01934240c78f.objectstore.eu/signals/icons/categories/openbaar-groen-en-water/bomen_planten.svg?temp_url_sig=18c662680477047ec1edcb8c18bc67d4cfe6805fd129a5e6c1df5f84708df0b5&temp_url_expires=1665401494',
+  },
+]
+
+describe('add-icons-to-incident', () => {
+  describe('addIconsToIncidents', () => {
+    it('should return incidents with correct icon', () => {
+      const result = addIconsToIncidents(
+        mockFiltersAllActive,
+        mockIncidentsWithoutIcon,
+        mockListOfIcons
+      )
+
+      expect(result[0].properties.icon).toMatch(/afval.svg/)
+      expect(result[1].properties.icon).toMatch(/afval.svg/)
+      expect(result[2].properties.icon).toMatch(/glas.svg/)
+      // When subFilters are not enabled. All incidents in that category should get the icon of the main category.
+      expect(result[3].properties.icon).toMatch(/bomen_planten.svg/)
+    })
+
+    it('should return icon undefined when main category does not have one', () => {
+      const mockListOfIconsWithoutIcon = mockListOfIcons.map((iconObject) => {
+        if (iconObject.slug === 'openbaar-groen-en-water') {
+          return {
+            slug: iconObject.slug,
+          }
+        } else return iconObject
+      })
+
+      const result = addIconsToIncidents(
+        mockFiltersShort,
+        mockIncidentsWithoutIcon,
+        mockListOfIconsWithoutIcon
+      )
+
+      expect(result[0].properties.icon).toMatch(/afval.svg/)
+      expect(result[1].properties.icon).toMatch(/afval.svg/)
+      expect(result[3].properties.icon).toEqual(undefined)
+    })
+  })
+
+  describe('getListOfIcons', () => {
+    it('should return list of icons', () => {
+      const result = getListOfIcons(mockFiltersShort)
+
+      expect(result).toEqual(mockListOfIcons)
+    })
+  })
+})

--- a/src/signals/IncidentMap/components/utils/add-icons-to-incidents.ts
+++ b/src/signals/IncidentMap/components/utils/add-icons-to-incidents.ts
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (C) 2022 -2023 Gemeente Amsterdam
+import type { Filter, Incident, Icon } from '../../types'
+import { showSubCategoryFilter } from '../FilterPanel/utils'
+
+export const addIconsToIncidents = (
+  filters: Filter[],
+  incidents: Incident[],
+  listedIcons: Icon[]
+) => {
+  const mainCategoriesWithSub = filters
+    .filter((filter) => filter.show_children_in_filter)
+    .map((filter) => filter.slug)
+
+  return incidents.map((incident) => {
+    const hasSubFiltersEnabled = showSubCategoryFilter(
+      mainCategoriesWithSub,
+      incident.properties.category.parent.slug
+    )
+
+    const slug = hasSubFiltersEnabled
+      ? incident.properties.category.slug
+      : incident.properties.category.parent.slug
+
+    const icon = listedIcons.find((iconObj) => {
+      return iconObj.slug === slug
+    })
+    if (icon?.icon) {
+      return {
+        ...incident,
+        properties: {
+          ...incident.properties,
+          icon: icon.icon,
+        },
+      }
+    }
+
+    return incident
+  })
+}
+
+export const getListOfIcons = (filters: Filter[]) => {
+  const allFilters = filters.reduce((acc: Filter[], filter: Filter) => {
+    acc.push(filter)
+    if (filter.subCategories) {
+      acc.push(...filter.subCategories)
+    }
+    return acc
+  }, [])
+
+  return allFilters.map(createIcon)
+}
+
+const createIcon = (category: Filter): Icon => ({
+  slug: category.slug,
+  icon: category.icon,
+})

--- a/src/signals/IncidentMap/components/utils/get-filtered-incidents.test.ts
+++ b/src/signals/IncidentMap/components/utils/get-filtered-incidents.test.ts
@@ -1,41 +1,10 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2022 - 2023 Gemeente Amsterdam
-import configuration from 'shared/services/configuration/configuration'
-
 import { getFilteredIncidents } from './get-filtered-incidents'
 import { mockFiltersShort } from '../__test__/mock-filters'
 import { mockIncidentsWithoutIcon } from '../__test__/mock-incidents-without-icon'
 
-jest.mock('shared/services/configuration/configuration')
-
-const mockFiltersAllActive = mockFiltersShort.map((filter) => {
-  if (filter.subCategories) {
-    return {
-      ...filter,
-      filterActive: true,
-      subCategories: filter.subCategories.map((subFilter) => {
-        return {
-          ...subFilter,
-          filterActive: true,
-        }
-      }),
-    }
-  }
-
-  return {
-    ...filter,
-    filterActive: true,
-  }
-})
-
 describe('getFilteredIncidents', () => {
-  beforeEach(() => {
-    configuration.map.optionsIncidentMap.hasSubfiltersEnabled = [
-      'afval',
-      'wegen-verkeer-straatmeubilair',
-    ]
-  })
-
   it('should return only active incidents', () => {
     const result = getFilteredIncidents(
       mockFiltersShort,
@@ -43,34 +12,5 @@ describe('getFilteredIncidents', () => {
     )
 
     expect(result.length).toEqual(3)
-  })
-
-  it('should return incidents with correct icon', () => {
-    const result = getFilteredIncidents(
-      mockFiltersAllActive,
-      mockIncidentsWithoutIcon
-    )
-
-    expect(result[0].properties.icon).toMatch(/afval.svg/)
-    expect(result[1].properties.icon).toMatch(/afval.svg/)
-    expect(result[2].properties.icon).toMatch(/glas.svg/)
-    // When subFilters are not enabled. All incidents in that category should get the icon of the main category.
-    expect(result[3].properties.icon).toMatch(/bomen_planten.svg/)
-  })
-
-  it('should return icon undefined when main category does not have one', () => {
-    const mockFiltersWithoutIcon = [
-      mockFiltersShort[0],
-      { ...mockFiltersShort[1], icon: undefined },
-    ]
-
-    const result = getFilteredIncidents(
-      mockFiltersWithoutIcon,
-      mockIncidentsWithoutIcon
-    )
-
-    expect(result[0].properties.icon).toMatch(/afval.svg/)
-    expect(result[1].properties.icon).toMatch(/afval.svg/)
-    expect(result[2].properties.icon).toEqual(undefined)
   })
 })

--- a/src/signals/IncidentMap/components/utils/get-filtered-incidents.ts
+++ b/src/signals/IncidentMap/components/utils/get-filtered-incidents.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2022 -2023 Gemeente Amsterdam
-import type { Filter, Incident, Icon } from '../../types'
+import type { Filter, Incident } from '../../types'
 import { showSubCategoryFilter } from '../FilterPanel/utils'
 
 export const getFilteredIncidents = (
@@ -39,56 +39,3 @@ export const getFilteredIncidents = (
 
   return activeIncidents
 }
-
-export const addIconsToIncidents = (
-  filters: Filter[],
-  incidents: Incident[],
-  listedIcons: Icon[]
-) => {
-  const mainCategoriesWithSub = filters
-    .filter((filter) => filter.show_children_in_filter)
-    .map((filter) => filter.slug)
-
-  return incidents.map((incident) => {
-    const hasSubFiltersEnabled = showSubCategoryFilter(
-      mainCategoriesWithSub,
-      incident.properties.category.parent.slug
-    )
-
-    const slug = hasSubFiltersEnabled
-      ? incident.properties.category.slug
-      : incident.properties.category.parent.slug
-
-    const icon = listedIcons.find((iconObj) => {
-      return iconObj.slug === slug
-    })
-    if (icon?.icon) {
-      return {
-        ...incident,
-        properties: {
-          ...incident.properties,
-          icon: icon.icon,
-        },
-      }
-    }
-
-    return incident
-  })
-}
-
-export const getListOfIcons = (filters: Filter[]) => {
-  const allFilters = filters.reduce((acc: Filter[], filter: Filter) => {
-    acc.push(filter)
-    if (filter.subCategories) {
-      acc.push(...filter.subCategories)
-    }
-    return acc
-  }, [])
-
-  return allFilters.map(createIcon)
-}
-
-const createIcon = (category: Filter): Icon => ({
-  slug: category.slug,
-  icon: category.icon,
-})

--- a/src/signals/IncidentMap/components/utils/get-filtered-incidents.ts
+++ b/src/signals/IncidentMap/components/utils/get-filtered-incidents.ts
@@ -21,31 +21,37 @@ export const getFilteredIncidents = (
     return acc
   }, [])
 
+  const mainCategoriesWithSub = filters
+    .filter((filter) => filter.show_children_in_filter)
+    .map((filter) => filter.slug)
+
   const activeIncidents = incidents.filter((incident) => {
     const activeSlugs = activeFilters.map((filter) => filter.slug)
     return (
       activeSlugs.includes(incident.properties.category.slug) ||
-      (!showSubCategoryFilter(incident.properties.category.parent.slug) &&
+      (!showSubCategoryFilter(
+        mainCategoriesWithSub,
+        incident.properties.category.parent.slug
+      ) &&
         activeSlugs.includes(incident.properties.category.parent.slug))
     )
   })
 
-  const activeIncidentsWithIcon = addIconsToIncidents(
-    activeIncidents,
-    activeFilters
-  )
-
-  return activeIncidentsWithIcon
+  return activeIncidents
 }
 
-const addIconsToIncidents = (
-  activeIncidents: Incident[],
-  activeFilters: Filter[]
+export const addIconsToIncidents = (
+  filters: Filter[],
+  incidents: Incident[],
+  listedIcons: Icon[]
 ) => {
-  const listedIcons = getListOfIcons(activeFilters)
+  const mainCategoriesWithSub = filters
+    .filter((filter) => filter.show_children_in_filter)
+    .map((filter) => filter.slug)
 
-  return activeIncidents.map((incident) => {
+  return incidents.map((incident) => {
     const hasSubFiltersEnabled = showSubCategoryFilter(
+      mainCategoriesWithSub,
       incident.properties.category.parent.slug
     )
 
@@ -70,7 +76,7 @@ const addIconsToIncidents = (
   })
 }
 
-const getListOfIcons = (filters: Filter[]) => {
+export const getListOfIcons = (filters: Filter[]) => {
   const allFilters = filters.reduce((acc: Filter[], filter: Filter) => {
     acc.push(filter)
     if (filter.subCategories) {

--- a/src/signals/IncidentMap/components/utils/index.ts
+++ b/src/signals/IncidentMap/components/utils/index.ts
@@ -1,3 +1,7 @@
 export { updateFilterCategory } from './update-filter-category'
-export { getFilteredIncidents } from './get-filtered-incidents'
+export {
+  addIconsToIncidents,
+  getFilteredIncidents,
+  getListOfIcons,
+} from './get-filtered-incidents'
 export { countIncidentsPerFilter } from './count-incidents-per-filter'

--- a/src/signals/IncidentMap/components/utils/index.ts
+++ b/src/signals/IncidentMap/components/utils/index.ts
@@ -1,7 +1,4 @@
 export { updateFilterCategory } from './update-filter-category'
-export {
-  addIconsToIncidents,
-  getFilteredIncidents,
-  getListOfIcons,
-} from './get-filtered-incidents'
+export { getFilteredIncidents } from './get-filtered-incidents'
 export { countIncidentsPerFilter } from './count-incidents-per-filter'
+export { addIconsToIncidents, getListOfIcons } from './add-icons-to-incidents'

--- a/src/signals/IncidentMap/types/incident-map.ts
+++ b/src/signals/IncidentMap/types/incident-map.ts
@@ -21,7 +21,7 @@ export type Properties = {
 
 export type Filter = {
   name: string
-  _display?: string
+  public_name?: string | null
   filterActive: boolean
   slug: string
   icon?: string

--- a/src/signals/IncidentMap/types/incident-map.ts
+++ b/src/signals/IncidentMap/types/incident-map.ts
@@ -27,6 +27,7 @@ export type Filter = {
   icon?: string
   subCategories?: SubCategory[]
   incidentsCount: number
+  show_children_in_filter?: boolean
 }
 
 export type SubCategory = Omit<Filter, 'subCategories'>

--- a/src/signals/incident-management/containers/ReporterContainer/useFetchReporter.test.ts
+++ b/src/signals/incident-management/containers/ReporterContainer/useFetchReporter.test.ts
@@ -6,7 +6,6 @@ import * as reactRedux from 'react-redux'
 
 import { showGlobalNotification } from 'containers/App/actions'
 import { TYPE_LOCAL, VARIANT_ERROR } from 'containers/Notification/constants'
-import configuration from 'shared/services/configuration/configuration'
 import { store } from 'test/utils'
 import type { Incident } from 'types/api/incident'
 import type { Result } from 'types/api/reporter'
@@ -56,12 +55,6 @@ const REPORTER_MOCK: Result = {
 }
 
 describe('Fetch Reporter hook', () => {
-  beforeEach(() => {
-    configuration.map.optionsIncidentMap.hasSubfiltersEnabled = [
-      'afval',
-      'wegen-verkeer-straatmeubilair',
-    ]
-  })
   afterEach(cleanup)
   afterAll(() => {
     reduxSpy.mockRestore()

--- a/src/types/category.ts
+++ b/src/types/category.ts
@@ -47,7 +47,7 @@ export interface Category {
 export interface SubCategory {
   name: string
   slug: string
-  _display: string
+  public_name: string
   filterActive: boolean
   is_public_accessible: boolean
   _links: {


### PR DESCRIPTION
Ticket: [SIG-4997](https://gemeente-amsterdam.atlassian.net/browse/SIG-4997)

Implement the new main category setting of showing its subcategories as filters in the public incident map.

### RELEASE NOTES
- Removed IncidentMap configuration `hasSubfiltersEnabled`. This can be done in backoffice main category settings now.