### PR TITLE
[feat-5164] Change in aanvullende vragen afval

### DIFF
--- a/src/signals/incident/definitions/__tests__/wizard-step-4-summary.test.js
+++ b/src/signals/incident/definitions/__tests__/wizard-step-4-summary.test.js
@@ -4,12 +4,12 @@ import configuration from 'shared/services/configuration/configuration'
 
 import PreviewComponents from '../../components/IncidentPreview/components'
 import step4, {
-  renderPreview,
-  summary,
   Label,
-  ObjectLabel,
-  SCSVLabel,
   Null,
+  ObjectLabel,
+  renderPreview,
+  SCSVLabel,
+  summary,
 } from '../wizard-step-4-summary'
 
 const { previewFactory } = step4
@@ -147,13 +147,26 @@ describe('Wizard summary', () => {
             canBeNull: true,
             label: 'Wanneer was het?',
             optional: true,
-            render: expect.any(Function),
+            render: PreviewComponents.DateTime,
           },
           extra_afval: {
-            label: 'Waar komt het afval vandaan, denkt u?',
+            label: 'Welk afval is verkeerd neergezet?',
             optional: true,
-            render: expect.any(Function),
+            render: Label,
             canBeNull: false,
+          },
+          extra_afval_eigenaar: {
+            label:
+              'Weet u wie de eigenaar is van het verkeerd geplaatste afval? Bijvoorbeeld omdat u dat ziet aan een adressticker of iets anders?',
+            optional: true,
+            render: ObjectLabel,
+            canBeNull: false,
+          },
+          extra_afval_eigenaar_ja: {
+            canBeNull: false,
+            label: undefined,
+            optional: true,
+            render: Null,
           },
           ...expectedLocation,
         },

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/afval.test.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/afval.test.ts
@@ -4,6 +4,12 @@ describe('definition afval', () => {
   it('has a defined set of controls', () => {
     const keys = Object.keys(afval)
 
-    expect(keys).toStrictEqual(['locatie', 'dateTime', 'extra_afval'])
+    expect(keys).toStrictEqual([
+      'locatie',
+      'dateTime',
+      'extra_afval',
+      'extra_afval_eigenaar',
+      'extra_afval_eigenaar_ja',
+    ])
   })
 })

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/afval.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/afval.ts
@@ -31,11 +31,46 @@ export const controls = {
       ifOneOf: {
         subcategory: ['grofvuil', 'huisafval', 'puin-sloopafval'],
       },
-      label: 'Waar komt het afval vandaan, denkt u?',
-      shortLabel: 'Waar vandaan',
+      label: 'Welk afval is verkeerd neergezet?',
+      subtitle:
+        'U helpt ons door zoveel mogelijk informatie te geven over het soort afval: huisafval, bedrijfsafval, grofvuil of dozen en papier.',
+      shortLabel: 'Welke soort',
       pathMerge: 'extra_properties',
     },
-    render: QuestionFieldType.TextareaInput,
+    options: {
+      validators: ['required'],
+    },
+    render: QuestionFieldType.TextInput,
+  },
+  extra_afval_eigenaar: {
+    meta: {
+      ifOneOf: {
+        subcategory: ['grofvuil', 'huisafval', 'puin-sloopafval'],
+      },
+      label:
+        'Weet u wie de eigenaar is van het verkeerd geplaatste afval? Bijvoorbeeld omdat u dat ziet aan een adressticker of iets anders?',
+      shortLabel: 'Welke eigenaar',
+      pathMerge: 'extra_properties',
+      values: {
+        ja: 'Ja',
+        nee: 'Nee',
+      },
+    },
+    options: {
+      validators: ['required'],
+    },
+    render: QuestionFieldType.RadioInput,
+  },
+  extra_afval_eigenaar_ja: {
+    meta: {
+      ifOneOf: {
+        extra_afval_eigenaar: 'ja',
+      },
+      value:
+        'We willen graag telefonisch contact met u hierover. Als u dat goed vindt, vul dan uw telefoonnummer in op de volgende pagina.',
+      type: 'info',
+    },
+    render: QuestionFieldType.PlainText,
   },
 }
 


### PR DESCRIPTION
In order to prioritise issue for HH additional questions for adval are being asked. Contrary to design the textareainput has been changed to textinput. Otherwise the question can't be made required.

Ticket: [SIG-5164](https://gemeente-amsterdam.atlassian.net/browse/SIG-5164)

## Signalen

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
