### PR TITLE
[fix-5157] overflow wrap the description of an issue in mijn-meldingen

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ WORKDIR /app
 # Install dependencies and remove apt cache
 RUN apt-get update && apt-get install -y \
   git \
-  netcat \
   && rm -rf /var/lib/apt/lists/*
 
 # Change git URL because network is blocking git protocol...

--- a/src/signals/incident-management/containers/ReporterContainer/ReporterContainer.tsx
+++ b/src/signals/incident-management/containers/ReporterContainer/ReporterContainer.tsx
@@ -17,6 +17,7 @@ import { useFetchReporter, PAGE_SIZE } from './useFetchReporter'
 const Wrapper = styled.article`
   margin: ${themeSpacing(11)};
   margin-top: 0;
+  overflow-wrap: anywhere;
 `
 
 const StyledHeader = styled(Header)`

--- a/src/signals/my-incidents/components/IncidentsDetail/IncidentsDetail.tsx
+++ b/src/signals/my-incidents/components/IncidentsDetail/IncidentsDetail.tsx
@@ -10,6 +10,7 @@ import {
   StyledBacklink,
   StyledLink,
   Wrapper,
+  ContentWrapper,
 } from './styled'
 import { StyledHeading } from '../../pages/styled'
 import type { MyIncidentDetail } from '../../types'
@@ -29,7 +30,7 @@ export const IncidentsDetail = ({
   const attachments = _links?.['sia:attachments']
 
   return (
-    <div>
+    <ContentWrapper>
       <StyledBacklink to={`/mijn-meldingen/${token}`}>
         Mijn meldingen
       </StyledBacklink>
@@ -67,6 +68,6 @@ export const IncidentsDetail = ({
       <Wrapper>
         <ExtraProperties items={extra_properties} />
       </Wrapper>
-    </div>
+    </ContentWrapper>
   )
 }

--- a/src/signals/my-incidents/components/IncidentsDetail/styled.ts
+++ b/src/signals/my-incidents/components/IncidentsDetail/styled.ts
@@ -37,3 +37,8 @@ export const StyledLink = styled(Link)`
 export const Wrapper = styled.div`
   margin-bottom: ${themeSpacing(6)};
 `
+
+export const ContentWrapper = styled.div`
+  overflow-wrap: anywhere;
+  max-width: ${themeSpacing(160)};
+`


### PR DESCRIPTION
**Context:** 
In mijn-meldingen detail page the description of the issue overflows. You can't see the history since it gets pushed to the side. In the ReporterContainer (in the overview page of all issues from one complainer in the backoffice) the text also overflows.

**Changes:** 
Set the ContentWrapper of the incidentDetail to overflow-wrap: everywhere, set the max width to 2/3 of 960px. 
Set the Wrapper of the ReporterContainer to overflow-wrap: everywhere

Ticket: [SIG-5157](https://gemeente-amsterdam.atlassian.net/browse/SIG-5157)

## Signalen

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
