### PR TITLE
[fix-5245]: Changed protected route to correct roleGroup

### DIFF
--- a/src/signals/settings/SettingsModule.tsx
+++ b/src/signals/settings/SettingsModule.tsx
@@ -184,7 +184,7 @@ const SettingsModule = () => {
           element={
             <ProtectedRoute
               component={SubcategoriesOverview}
-              roleGroup="subcategories"
+              roleGroup="categories"
             />
           }
         />
@@ -193,7 +193,7 @@ const SettingsModule = () => {
           element={
             <ProtectedRoute
               component={SubcategoryDetail}
-              roleGroup="subcategoryForm"
+              roleGroup="categoryForm"
             />
           }
         />
@@ -202,7 +202,7 @@ const SettingsModule = () => {
           element={
             <ProtectedRoute
               component={MainCategoriesOverview}
-              roleGroup="mainCategories"
+              roleGroup="categories"
             />
           }
         />
@@ -211,7 +211,7 @@ const SettingsModule = () => {
           element={
             <ProtectedRoute
               component={MainCategoryDetail}
-              roleGroup="mainCategoryForm"
+              roleGroup="categoryForm"
             />
           }
         />


### PR DESCRIPTION
Ticket: [SIG-5245](https://gemeente-amsterdam.atlassian.net/browse/SIG-5245)

I'd changed the roleGroup incorrectly when adding the settings for the main category, therefore users could not see the pages anymore. 

