### PR TITLE
[fix]: Fix menu item text

### DIFF
--- a/src/components/SiteHeader/MenuItems.tsx
+++ b/src/components/SiteHeader/MenuItems.tsx
@@ -83,7 +83,8 @@ export const MenuItems = ({ onLogOut, showItems, onLinkClick }: Props) => {
               to="/manage/v1/standaardteksten"
               $active={activeMenuItem.includes('/manage/v1/standaardteksten')}
             >
-              Standaard teksten (v1)
+              Standaard teksten
+              {configuration.featureFlags.showStandardTextAdminV2 && ' (v1)'}
             </StyledMenuButton>
           </MenuItem>
         )}
@@ -97,7 +98,8 @@ export const MenuItems = ({ onLogOut, showItems, onLinkClick }: Props) => {
               to="/manage/v2/standaardteksten"
               $active={activeMenuItem.includes('/manage/v2/standaardteksten')}
             >
-              Standaard teksten (v2)
+              Standaard teksten
+              {configuration.featureFlags.showStandardTextAdminV1 && ' (v2)'}
             </StyledMenuButton>
           </MenuItem>
         )}

--- a/src/components/SiteHeader/SiteHeader.test.tsx
+++ b/src/components/SiteHeader/SiteHeader.test.tsx
@@ -288,12 +288,12 @@ describe('components/SiteHeader', () => {
 
     const { getByText } = render(withAppContext(<SiteHeader {...props} />))
 
-    expect(getByText('Standaard teksten (v1)')).toBeInTheDocument()
+    expect(getByText('Standaard teksten')).toBeInTheDocument()
   })
 
   it('should show Standard Teksten based on feature flag', () => {
     jest.spyOn(auth, 'getIsAuthenticated').mockImplementation(() => true)
-    configuration.featureFlags.showStandardTextAdminV1 = false
+    configuration.featureFlags.showStandardTextAdminV1 = true
     configuration.featureFlags.showStandardTextAdminV2 = true
     const props = {
       ...defaultProps,
@@ -303,11 +303,9 @@ describe('components/SiteHeader', () => {
       },
     }
 
-    const { getByText, queryByText } = render(
-      withAppContext(<SiteHeader {...props} />)
-    )
+    const { getByText } = render(withAppContext(<SiteHeader {...props} />))
 
-    expect(queryByText('Standaard teksten (v1)')).not.toBeInTheDocument()
+    expect(getByText('Standaard teksten (v1)')).toBeInTheDocument()
     expect(getByText('Standaard teksten (v2)')).toBeInTheDocument()
   })
 


### PR DESCRIPTION
Ticket: none

This way the (v1) is only shown when both pages are enabled and vice versa.
