### PR TITLE
Fix display error for empty IncidentMap

### DIFF
--- a/src/signals/IncidentMap/components/IncidentMap/styled.ts
+++ b/src/signals/IncidentMap/components/IncidentMap/styled.ts
@@ -30,6 +30,7 @@ export const Wrapper = styled.div`
 `
 
 export const StyledMap = styled(Map)`
+  position: absolute;
   height: 100%;
   width: 100%;
   z-index: 0;


### PR DESCRIPTION
This fixes a display error for an empty IncidentMap.

**Before**

![image](https://github.com/Amsterdam/signals-frontend/assets/5213690/059896f4-ff16-4531-8d8a-9695a4aa3664)

**After**

![image](https://github.com/Amsterdam/signals-frontend/assets/5213690/cfc3e814-7678-44b5-95ad-83eeb65de368)
