### PR TITLE
[chore]: Make act async within SettingsModule.test.ts

### DIFF
--- a/src/signals/settings/SettingsModule.test.js
+++ b/src/signals/settings/SettingsModule.test.js
@@ -206,13 +206,13 @@ describe('signals/settings', () => {
 
     const url = `${SUBCATEGORY_URL}/1`
 
-    act(() => history.push(url))
+    await act(async () => history.push(url))
 
-    await waitFor(() =>
+    await waitFor(() => {
       expect(
         reactRouterDom.useLocation.mock.results.pop().value.pathname
       ).toEqual(url)
-    )
+    })
   })
 
   it('should allow routing to users page', async () => {


### PR DESCRIPTION
**context**
A lot of times the settings module is failing. This due to async stuff thats being called in the component. async(await act()... makes the test wait for the promises to resolve.

## Signalen

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
