### PR TITLE
[feat-5287]: Add new standard text page part 1

### DIFF
--- a/internals/mocks/fixtures/standard-texts/detail-post.json
+++ b/internals/mocks/fixtures/standard-texts/detail-post.json
@@ -1,0 +1,10 @@
+{
+    "id": 94,
+    "title": "Mooie titel",
+    "text": "Mooie tekst",
+    "active": false,
+    "state": "m",
+    "categories": [1],
+    "updated_at": "2023-07-19T11:34:06.320699+02:00",
+    "created_at": "2023-07-19T11:34:06.320681+02:00"
+}

--- a/internals/mocks/fixtures/standard-texts/index.ts
+++ b/internals/mocks/fixtures/standard-texts/index.ts
@@ -1,4 +1,5 @@
 import standardTexts from './default.json'
+import detailPost from './detail-post.json'
 import detail from './detail.json'
 import multicaseFilter from './filter-multi-case.json'
 import activeFilter from './filter-on-active.json'
@@ -9,6 +10,7 @@ import page2 from './page-two.json'
 export {
   activeFilter,
   detail,
+  detailPost,
   multicaseFilter,
   noResult,
   page2,

--- a/internals/testing/msw-server.ts
+++ b/internals/testing/msw-server.ts
@@ -28,6 +28,7 @@ import reportsFixture from '../mocks/fixtures/reports.json'
 import {
   activeFilter,
   detail,
+  detailPost,
   multicaseFilter,
   noResult,
   page2,
@@ -259,6 +260,8 @@ const handlers = [
     res(ctx.status(200), ctx.json(detail))
   ),
 
+  // PATCH
+
   rest.patch(API.INCIDENT, (_req, res, ctx) =>
     res(ctx.status(200), ctx.json(incidentFixture))
   ),
@@ -267,8 +270,14 @@ const handlers = [
     res(ctx.status(200), ctx.json(detail))
   ),
 
+  // POST
+
   rest.post(API.STANDARD_TEXTS_DETAIL_ENDPOINT, (_req, res, ctx) =>
     res(ctx.status(200), ctx.json(detail))
+  ),
+
+  rest.post(API.STANDARD_TEXTS_ENDPOINT, (_req, res, ctx) =>
+    res(ctx.status(201), ctx.json(detailPost))
   ),
 
   rest.post(API.QA_ANSWER, (_req, res, ctx) =>

--- a/internals/testing/msw-server.ts
+++ b/internals/testing/msw-server.ts
@@ -267,6 +267,10 @@ const handlers = [
     res(ctx.status(200), ctx.json(detail))
   ),
 
+  rest.post(API.STANDARD_TEXTS_DETAIL_ENDPOINT, (_req, res, ctx) =>
+    res(ctx.status(200), ctx.json(detail))
+  ),
+
   rest.post(API.QA_ANSWER, (_req, res, ctx) =>
     res(ctx.status(200), ctx.json(qaAnswerFixture))
   ),

--- a/src/hooks/useFetch.ts
+++ b/src/hooks/useFetch.ts
@@ -166,7 +166,6 @@ const useFetch = <T>(): FetchResponse<T> => {
             ? await fetchResponse.blob()
             : await fetchResponse.json()
         ) as Data
-
         if (fetchResponse.ok) {
           dispatch({ type: 'SET_GET_DATA', payload: responseData })
         } else {
@@ -313,6 +312,7 @@ const useFetch = <T>(): FetchResponse<T> => {
    * @property {Function} patch - Function that expects a URL and a data object as parameters
    * @property {Function} post - Function that expects a URL and a data object as parameters
    */
+
   return {
     del,
     get,

--- a/src/signals/incident-management/containers/StandardTextsAdmin/components/DetailPage/Detail.test.tsx
+++ b/src/signals/incident-management/containers/StandardTextsAdmin/components/DetailPage/Detail.test.tsx
@@ -159,9 +159,14 @@ describe('Detail', () => {
       const textArea = screen.getByPlaceholderText('Tekst')
       expect(textArea).toHaveValue('')
 
+      userEvent.type(titleInput, 'Mooie titel')
+      userEvent.type(textArea, 'Mooie tekst')
+
       expect(
         screen.queryByRole('button', { name: 'Verwijderen' })
       ).not.toBeInTheDocument()
+
+      // todo add subcats just for testing or spy on validation for this test
     })
   })
 

--- a/src/signals/incident-management/containers/StandardTextsAdmin/components/DetailPage/Detail.test.tsx
+++ b/src/signals/incident-management/containers/StandardTextsAdmin/components/DetailPage/Detail.test.tsx
@@ -2,7 +2,6 @@
 // Copyright (C) 2023 Gemeente Amsterdam
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { act } from 'react-dom/test-utils'
 import * as reactRedux from 'react-redux'
 import * as reactRouterDom from 'react-router-dom'
 
@@ -25,8 +24,14 @@ const dispatch = jest.fn()
 
 const id = 4
 
-jest.mock('../Subcategories', () => () => {
-  return <div>Subcategories</div>
+jest.mock('models/categories/selectors', () => {
+  const structuredCategorie = require('utils/__tests__/fixtures/categories_structured.json')
+  return {
+    __esModule: true,
+    ...jest.requireActual('models/categories/selectors'),
+    makeSelectStructuredCategories: () => structuredCategorie,
+    makeSelectSubCategories: () => mockSubcategory,
+  }
 })
 
 jest.mock('react-router-dom', () => ({
@@ -36,7 +41,7 @@ jest.mock('react-router-dom', () => ({
 
 describe('Detail', () => {
   beforeEach(() => {
-    jest.spyOn(reactRedux, 'useSelector').mockReturnValue(mockSubcategory)
+    // jest.spyOn(reactRedux, 'useSelector').mockReturnValue(mockSubcategory)
     jest.spyOn(reactRedux, 'useDispatch').mockImplementation(() => dispatch)
     jest
       .spyOn(reactRouterDom, 'useNavigate')
@@ -52,8 +57,6 @@ describe('Detail', () => {
 
   it('should render the Detail page', async () => {
     render(withAppContext(<Detail />))
-
-    act(() => {})
 
     await waitFor(() => {
       expect(screen.getByText('Standaardtekst wijzigen')).toBeInTheDocument()
@@ -154,10 +157,10 @@ describe('Detail', () => {
 
     await waitFor(() => {
       const titleInput = screen.getByPlaceholderText('Titel')
-      expect(titleInput).toHaveValue('')
+      // expect(titleInput).toHaveValue('')
 
       const textArea = screen.getByPlaceholderText('Tekst')
-      expect(textArea).toHaveValue('')
+      // expect(textArea).toHaveValue('')
 
       userEvent.type(titleInput, 'Mooie titel')
       userEvent.type(textArea, 'Mooie tekst')
@@ -165,8 +168,14 @@ describe('Detail', () => {
       expect(
         screen.queryByRole('button', { name: 'Verwijderen' })
       ).not.toBeInTheDocument()
+    })
 
-      // todo add subcats just for testing or spy on validation for this test
+    await waitFor(() => {
+      // todo make sure the post call is made by selecting a subcat and then save!
+
+      userEvent.click(screen.getByRole('button', { name: 'Opslaan' }))
+
+      expect(mockNavigate).toBeCalledWith('../')
     })
   })
 
@@ -260,7 +269,9 @@ describe('Detail', () => {
         userEvent.click(screen.getByText('Selecteer subcategorie(ën)'))
       })
 
-      expect(screen.getByText('Subcategories')).toBeInTheDocument()
+      expect(
+        screen.getByText('Standaardtekst toewijzen aan categorie(ën)')
+      ).toBeInTheDocument()
     })
   })
 })

--- a/src/signals/incident-management/containers/StandardTextsAdmin/components/DetailPage/Detail.test.tsx
+++ b/src/signals/incident-management/containers/StandardTextsAdmin/components/DetailPage/Detail.test.tsx
@@ -41,11 +41,8 @@ jest.mock('react-router-dom', () => ({
 
 describe('Detail', () => {
   beforeEach(() => {
-    // jest.spyOn(reactRedux, 'useSelector').mockReturnValue(mockSubcategory)
     jest.spyOn(reactRedux, 'useDispatch').mockImplementation(() => dispatch)
-    jest
-      .spyOn(reactRouterDom, 'useNavigate')
-      .mockImplementation(() => mockNavigate)
+
     jest
       .spyOn(reactRouterDom, 'useParams')
       .mockImplementation(() => ({ id: `${id}` }))
@@ -93,6 +90,9 @@ describe('Detail', () => {
   })
 
   it('navigates to the previous page when there is a change and the button Opslaan is clicked', async () => {
+    jest
+      .spyOn(reactRouterDom, 'useNavigate')
+      .mockImplementation(() => mockNavigate)
     render(withAppContext(<Detail />))
 
     await waitFor(async () => {
@@ -104,6 +104,9 @@ describe('Detail', () => {
   })
 
   it('navigates to the previous page when there is no change and the button Opslaan is clicked', async () => {
+    jest
+      .spyOn(reactRouterDom, 'useNavigate')
+      .mockImplementation(() => mockNavigate)
     render(withAppContext(<Detail />))
 
     await waitFor(() => {
@@ -113,6 +116,9 @@ describe('Detail', () => {
   })
 
   it('deletes the standard text when the button Verwijderen is pressed', async () => {
+    jest
+      .spyOn(reactRouterDom, 'useNavigate')
+      .mockImplementation(() => mockNavigate)
     render(withAppContext(<Detail />))
 
     await waitFor(() => {
@@ -124,6 +130,9 @@ describe('Detail', () => {
   })
 
   it('navigates to previous page when Annuleren is pressed', async () => {
+    jest
+      .spyOn(reactRouterDom, 'useNavigate')
+      .mockImplementation(() => mockNavigate)
     render(withAppContext(<Detail />))
 
     await waitFor(() => {
@@ -155,27 +164,47 @@ describe('Detail', () => {
 
     render(withAppContext(<Detail />))
 
-    await waitFor(() => {
-      const titleInput = screen.getByPlaceholderText('Titel')
-      // expect(titleInput).toHaveValue('')
+    const titleInput = screen.getByPlaceholderText('Titel')
+    const textArea = screen.getByPlaceholderText('Tekst')
 
-      const textArea = screen.getByPlaceholderText('Tekst')
-      // expect(textArea).toHaveValue('')
+    expect(titleInput).toHaveValue('')
+    expect(textArea).toHaveValue('')
+    expect(
+      screen.queryByRole('button', { name: 'Verwijderen' })
+    ).not.toBeInTheDocument()
 
-      userEvent.type(titleInput, 'Mooie titel')
-      userEvent.type(textArea, 'Mooie tekst')
+    userEvent.type(titleInput, 'Mooie titel')
+    userEvent.type(textArea, 'Mooie tekst')
 
-      expect(
-        screen.queryByRole('button', { name: 'Verwijderen' })
-      ).not.toBeInTheDocument()
+    expect(titleInput).toHaveValue('Mooie titel')
+    expect(textArea).toHaveValue('Mooie tekst')
+
+    const selectCategoryButton = screen.getByText('Selecteer subcategorie(ën)')
+
+    userEvent.click(selectCategoryButton)
+
+    expect(
+      screen.getByText('Standaardtekst toewijzen aan categorie(ën)')
+    ).toBeInTheDocument()
+
+    const categoryCheckbox = screen.getByRole('checkbox', {
+      name: 'Boom - boomstob',
     })
 
+    userEvent.click(categoryCheckbox)
+
+    expect(categoryCheckbox).toBeChecked()
+
+    userEvent.click(screen.getByRole('button', { name: 'Opslaan' }))
+
     await waitFor(() => {
-      // todo make sure the post call is made by selecting a subcat and then save!
+      expect(screen.getByText('Standaardtekst toevoegen')).toBeInTheDocument()
+    })
 
-      userEvent.click(screen.getByRole('button', { name: 'Opslaan' }))
+    userEvent.click(screen.getByRole('button', { name: 'Opslaan' }))
 
-      expect(mockNavigate).toBeCalledWith('../')
+    await waitFor(() => {
+      expect(screen.getByTestId('loading-indicator')).toBeInTheDocument()
     })
   })
 
@@ -203,7 +232,7 @@ describe('Detail', () => {
     })
 
     it('displays error notifications if there is no category, title and/or description present', async () => {
-      const mockErrorData: StandardTextDetailData = {
+      const mockData: StandardTextDetailData = {
         id: 5,
         active: true,
         categories: [],
@@ -218,7 +247,7 @@ describe('Detail', () => {
         status: 200,
         method: 'get',
         url: `${API.STANDARD_TEXTS_DETAIL_ENDPOINT}`,
-        body: mockErrorData,
+        body: mockData,
       })
 
       render(withAppContext(<Detail />))
@@ -238,6 +267,9 @@ describe('Detail', () => {
     })
 
     it('should add a new standard text and navigate back but invalidate', async () => {
+      jest
+        .spyOn(reactRouterDom, 'useNavigate')
+        .mockImplementation(() => mockNavigate)
       jest.spyOn(reactRouterDom, 'useParams').mockImplementation(() => ({}))
 
       render(withAppContext(<Detail />))

--- a/src/signals/incident-management/containers/StandardTextsAdmin/components/DetailPage/Detail.test.tsx
+++ b/src/signals/incident-management/containers/StandardTextsAdmin/components/DetailPage/Detail.test.tsx
@@ -93,12 +93,13 @@ describe('Detail', () => {
     jest
       .spyOn(reactRouterDom, 'useNavigate')
       .mockImplementation(() => mockNavigate)
+
     render(withAppContext(<Detail />))
 
-    await waitFor(async () => {
-      userEvent.click(screen.getByRole('checkbox', { name: 'Actief' }))
-      userEvent.click(screen.getByRole('button', { name: 'Opslaan' }))
+    userEvent.click(screen.getByRole('checkbox', { name: 'Actief' }))
 
+    await waitFor(() => {
+      userEvent.click(screen.getByRole('button', { name: 'Opslaan' }))
       expect(mockNavigate).toBeCalledWith('../')
     })
   })
@@ -115,33 +116,29 @@ describe('Detail', () => {
     })
   })
 
-  it('deletes the standard text when the button Verwijderen is pressed', async () => {
+  it('deletes the standard text when the button Verwijderen is pressed', () => {
     jest
       .spyOn(reactRouterDom, 'useNavigate')
       .mockImplementation(() => mockNavigate)
     render(withAppContext(<Detail />))
 
-    await waitFor(() => {
-      userEvent.click(screen.getByRole('button', { name: 'Verwijderen' }))
-    })
-    await waitFor(() => {
-      expect(mockNavigate).toBeCalledWith('../')
-    })
+    userEvent.click(screen.getByRole('button', { name: 'Verwijderen' }))
+
+    expect(mockNavigate).toBeCalledWith('../')
   })
 
-  it('navigates to previous page when Annuleren is pressed', async () => {
+  it('navigates to previous page when Annuleren is pressed', () => {
     jest
       .spyOn(reactRouterDom, 'useNavigate')
       .mockImplementation(() => mockNavigate)
     render(withAppContext(<Detail />))
 
-    await waitFor(() => {
-      userEvent.click(screen.getByRole('button', { name: 'Annuleer' }))
-      expect(mockNavigate).toBeCalledWith('../')
-    })
+    userEvent.click(screen.getByRole('button', { name: 'Annuleer' }))
+
+    expect(mockNavigate).toBeCalledWith('../')
   })
 
-  it('should change the state', async () => {
+  it('should change the state', () => {
     render(withAppContext(<Detail />))
 
     expect(
@@ -152,11 +149,9 @@ describe('Detail', () => {
       screen.getByRole('radio', { name: 'In afwachting van behandeling' })
     )
 
-    await waitFor(() => {
-      expect(
-        screen.getByRole('radio', { name: 'In afwachting van behandeling' })
-      ).toBeChecked()
-    })
+    expect(
+      screen.getByRole('radio', { name: 'In afwachting van behandeling' })
+    ).toBeChecked()
   })
 
   it('should render a create page', async () => {
@@ -197,9 +192,7 @@ describe('Detail', () => {
 
     userEvent.click(screen.getByRole('button', { name: 'Opslaan' }))
 
-    await waitFor(() => {
-      expect(screen.getByText('Standaardtekst toevoegen')).toBeInTheDocument()
-    })
+    expect(screen.getByText('Standaardtekst toevoegen')).toBeInTheDocument()
 
     userEvent.click(screen.getByRole('button', { name: 'Opslaan' }))
 
@@ -252,9 +245,9 @@ describe('Detail', () => {
 
       render(withAppContext(<Detail />))
 
-      await waitFor(() => {
-        userEvent.click(screen.getByRole('button', { name: 'Opslaan' }))
+      userEvent.click(screen.getByRole('button', { name: 'Opslaan' }))
 
+      await waitFor(() => {
         expect(
           screen.getByText('De standaardtekst kan niet worden opgeslagen')
         ).toBeInTheDocument()
@@ -274,17 +267,15 @@ describe('Detail', () => {
 
       render(withAppContext(<Detail />))
 
-      await waitFor(() => {
-        const titleInput = screen.getByPlaceholderText('Titel')
-        expect(titleInput).toBeInTheDocument()
+      const titleInput = screen.getByPlaceholderText('Titel')
+      expect(titleInput).toBeInTheDocument()
 
-        const textArea = screen.getByPlaceholderText('Tekst')
-        expect(textArea).toBeInTheDocument()
+      const textArea = screen.getByPlaceholderText('Tekst')
+      expect(textArea).toBeInTheDocument()
 
-        userEvent.type(titleInput, 'Nieuwe standaardtekst titel')
+      userEvent.type(titleInput, 'Nieuwe standaardtekst titel')
 
-        userEvent.type(textArea, 'Nieuwe standaardtekst')
-      })
+      userEvent.type(textArea, 'Nieuwe standaardtekst')
 
       await waitFor(() => {
         userEvent.click(screen.getByRole('button', { name: 'Opslaan' }))
@@ -297,9 +288,7 @@ describe('Detail', () => {
     it('should render the subcategories', async () => {
       render(withAppContext(<Detail />))
 
-      await waitFor(() => {
-        userEvent.click(screen.getByText('Selecteer subcategorie(ën)'))
-      })
+      userEvent.click(screen.getByText('Selecteer subcategorie(ën)'))
 
       expect(
         screen.getByText('Standaardtekst toewijzen aan categorie(ën)')

--- a/src/signals/incident-management/containers/StandardTextsAdmin/components/DetailPage/Detail.tsx
+++ b/src/signals/incident-management/containers/StandardTextsAdmin/components/DetailPage/Detail.tsx
@@ -56,8 +56,9 @@ const schema = yup.object({
 })
 
 export const Detail = () => {
-  const navigate = useNavigate()
   const [waitForTimeout, setWaitForTimeout] = useState(false)
+
+  const navigate = useNavigate()
   const dispatch = useDispatch()
   const params = useParams()
   const { get, data, isLoading, patch, del, post, isSuccess, error } =
@@ -67,23 +68,14 @@ export const Detail = () => {
     ? 'Standaardtekst wijzigen'
     : 'Standaardtekst toevoegen'
   const redirectURL = '../'
+
   const defaultValues: StandardTextForm | null = useMemo(() => {
-    if (data) {
-      return {
-        categories: data.categories,
-        state: data.state,
-        title: data.title,
-        text: data.text,
-        active: data.active,
-      }
-    } else {
-      return {
-        categories: [],
-        state: 'm',
-        title: '',
-        text: '',
-        active: false,
-      }
+    return {
+      categories: data?.categories ?? [],
+      state: data?.state ?? 'm',
+      title: data?.title ?? '',
+      text: data?.text ?? '',
+      active: data?.active ?? true,
     }
   }, [data])
 
@@ -204,7 +196,7 @@ export const Detail = () => {
                   }
                 />
               </Row>
-              {isLoading && <LoadingIndicator />}
+              {(isLoading || waitForTimeout) && <LoadingIndicator />}
               <Row>
                 <Column span={12}>
                   <Form onSubmit={handleSubmit(onSubmit)}>

--- a/src/signals/incident-management/containers/StandardTextsAdmin/components/DetailPage/Detail.tsx
+++ b/src/signals/incident-management/containers/StandardTextsAdmin/components/DetailPage/Detail.tsx
@@ -70,7 +70,7 @@ export const Detail = () => {
   const defaultValues: StandardTextForm | null = useMemo(() => {
     if (data) {
       return {
-        categories: data.categories, // fake data, when Selecteer subcategorieënpage has been made, this needs to deleted
+        categories: data.categories,
         state: data.state,
         title: data.title,
         text: data.text,

--- a/src/signals/incident-management/containers/StandardTextsAdmin/components/DetailPage/Detail.tsx
+++ b/src/signals/incident-management/containers/StandardTextsAdmin/components/DetailPage/Detail.tsx
@@ -148,6 +148,7 @@ export const Detail = () => {
       )
     }
   }, [dispatch, error])
+
   return (
     <FormProvider {...formMethods}>
       <Routes>

--- a/src/signals/incident-management/containers/StandardTextsAdmin/components/DetailPage/Detail.tsx
+++ b/src/signals/incident-management/containers/StandardTextsAdmin/components/DetailPage/Detail.tsx
@@ -60,7 +60,6 @@ export const Detail = () => {
   const [waitForTimeout, setWaitForTimeout] = useState(false)
   const dispatch = useDispatch()
   const params = useParams()
-  const isNewPage = location.pathname.split('/').pop() === 'new'
   const { get, data, isLoading, patch, del, post, isSuccess, error } =
     useFetch<StandardTextDetailData>()
 
@@ -68,7 +67,6 @@ export const Detail = () => {
     ? 'Standaardtekst wijzigen'
     : 'Standaardtekst toevoegen'
   const redirectURL = '../'
-
   const defaultValues: StandardTextForm | null = useMemo(() => {
     if (data) {
       return {
@@ -106,8 +104,7 @@ export const Detail = () => {
     const hasDirtyFields = Object.keys(formState.dirtyFields).length > 0
 
     !hasDirtyFields && navigate(redirectURL)
-
-    if (!isNewPage && params.id) {
+    if (params.id) {
       patch(
         `${configuration.STANDARD_TEXTS_ENDPOINT}${params.id}`,
         createPatch(getValues(), formState.dirtyFields)
@@ -115,15 +112,7 @@ export const Detail = () => {
     } else {
       post(`${configuration.STANDARD_TEXTS_ENDPOINT}`, createPost(getValues()))
     }
-  }, [
-    formState.dirtyFields,
-    navigate,
-    isNewPage,
-    params.id,
-    patch,
-    getValues,
-    post,
-  ])
+  }, [formState.dirtyFields, navigate, params.id, patch, getValues, post])
 
   const handleOnCancel = () => {
     navigate(redirectURL)
@@ -215,7 +204,7 @@ export const Detail = () => {
                   }
                 />
               </Row>
-              {(isLoading || waitForTimeout) && <LoadingIndicator />}
+              {isLoading && <LoadingIndicator />}
               <Row>
                 <Column span={12}>
                   <Form onSubmit={handleSubmit(onSubmit)}>

--- a/src/signals/incident-management/containers/StandardTextsAdmin/components/DetailPage/utils.ts
+++ b/src/signals/incident-management/containers/StandardTextsAdmin/components/DetailPage/utils.ts
@@ -22,3 +22,10 @@ export const createPatch = (
 
   return Object.assign({}, ...payload)
 }
+
+export const createPost = (data: StandardTextForm): StandardTextDetailData => {
+  const payload = Object.entries(data).map(([key, value]) => {
+    return { [key]: value }
+  })
+  return Object.assign({}, ...payload)
+}

--- a/src/signals/incident-management/containers/StandardTextsAdmin/components/OverviewPage/OverviewPage.tsx
+++ b/src/signals/incident-management/containers/StandardTextsAdmin/components/OverviewPage/OverviewPage.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect } from 'react'
 
 import { Row, Column } from '@amsterdam/asc-ui'
 import { useDispatch } from 'react-redux'
-import { useNavigate } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 
 import LoadingIndicator from 'components/LoadingIndicator'
 import { showGlobalNotification } from 'containers/App/actions'
@@ -109,7 +109,9 @@ export const OverviewPage = () => {
             setStatusFilter={setStatusFilter}
             setActiveFilter={setActiveFilter}
           />
-          <Button variant="secondary">Tekst toevoegen</Button>
+          <Link to="../new">
+            <Button variant="secondary">Tekst toevoegen</Button>
+          </Link>
         </div>
 
         <div>

--- a/src/signals/incident-management/index.js
+++ b/src/signals/incident-management/index.js
@@ -127,7 +127,13 @@ const IncidentManagement = () => {
           {configuration.featureFlags.showStandardTextAdminV2 && (
             <Route path={routes.standardTexts}>
               <Route index element={<StandardTextsAdmin />} />
-              <Route path={`:id/*`} element={<StandardTextsDetail />} />
+              {[':id/*', 'new/*'].map((path) => (
+                <Route
+                  key={path}
+                  path={path}
+                  element={<StandardTextsDetail />}
+                />
+              ))}
             </Route>
           )}
           <Route path={routes.signaling} element={<SignalingContainer />} />


### PR DESCRIPTION
##Context
As a back-officer I would like to add a new standard text. 

## Changes
- Added a link to button Tekst toevoegen on Overview page
- Added a createpost method
- OnSubmit checks per the url (params.id) if there needs to be a patch of a post triggered
- Routing 
- validation of form happens on onSubmit 
- button Verwijderen is conditional on params.id (whether there is an id in the url or not)
- Standard is state Gemeld selected

Ticket: [SIG-5287](https://gemeente-amsterdam.atlassian.net/browse/SIG-5287)

## Signalen

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
