### PR TITLE
Chore bump package in e2e-package-lock.json

### DIFF
--- a/e2e-tests/package-lock.json
+++ b/e2e-tests/package-lock.json
@@ -9521,9 +9521,9 @@
       }
     },
     "node_modules/word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.4.tgz",
+      "integrity": "sha512-2V81OA4ugVo5pRo46hAoD2ivUJx8jXmWXfUkY4KFNw0hEptvN0QfH3K4nHiwzGeKl5rFKedV48QVoqYavy4YpA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -16855,9 +16855,9 @@
       "dev": true
     },
     "word-wrap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.4.tgz",
+      "integrity": "sha512-2V81OA4ugVo5pRo46hAoD2ivUJx8jXmWXfUkY4KFNw0hEptvN0QfH3K4nHiwzGeKl5rFKedV48QVoqYavy4YpA==",
       "dev": true
     },
     "wrap-ansi": {


### PR DESCRIPTION
Bumped word-wrap package in e2e-package-lock.json to 1.2.4

Tests failed on Github due to coverage. Latest version of main has coverageproblem solved, so I copied changes and made a new PR.


## Signalen

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
