### PR TITLE
Set authorization header correctly for username autocomplete

### DIFF
--- a/src/components/AutoSuggest/AutoSuggest.tsx
+++ b/src/components/AutoSuggest/AutoSuggest.tsx
@@ -9,6 +9,7 @@ import { showGlobalNotification } from 'containers/App/actions'
 import { VARIANT_ERROR, TYPE_LOCAL } from 'containers/Notification/constants'
 import useDebounce from 'hooks/useDebounce'
 import { getErrorMessage } from 'shared/services/api/api'
+import { getAuthHeaders } from 'shared/services/auth/auth'
 import type { PdokResponse } from 'shared/services/map-location'
 import type { RevGeo } from 'types/pdok/revgeo'
 
@@ -27,6 +28,7 @@ export interface AutoSuggestProps {
   disabled?: boolean
   formatResponse: (data?: RevGeo) => Array<PdokResponse>
   id?: string
+  includeAuthHeaders?: boolean
   numOptionsDeterminer: (data?: RevGeo) => number
   onClear?: () => void
   onData?: (optionsList: any) => void
@@ -58,6 +60,7 @@ const AutoSuggest = ({
   disabled = false,
   formatResponse,
   id = '',
+  includeAuthHeaders = false,
   numOptionsDeterminer,
   onClear,
   onData,
@@ -196,7 +199,10 @@ const AutoSuggest = ({
           const response = await fetch(
             `${url}${encodeURIComponent(inputValue)}`,
             {
-              headers: requestHeaders,
+              headers: {
+                ...requestHeaders,
+                ...(includeAuthHeaders ? getAuthHeaders() : {}),
+              },
             }
           )
 

--- a/src/components/AutoSuggest/AutoSuggest.tsx
+++ b/src/components/AutoSuggest/AutoSuggest.tsx
@@ -229,7 +229,7 @@ const AutoSuggest = ({
         }
       }
     },
-    [dispatch, onClear, url]
+    [dispatch, includeAuthHeaders, onClear, url]
   )
 
   const debouncedServiceRequest = useDebounce(serviceRequest, INPUT_DELAY)

--- a/src/signals/incident-management/components/FilterForm/FilterForm.js
+++ b/src/signals/incident-management/components/FilterForm/FilterForm.js
@@ -644,6 +644,7 @@ const FilterForm = ({
                       : state.options.assigned_user_email
                   }
                   id="filter_assigned_user_email"
+                  includeAuthHeaders={true}
                   name="assigned_user_email"
                   onSelect={onAssignedSelect}
                   onClear={onAssignedClear}


### PR DESCRIPTION
The change in https://github.com/Amsterdam/signals-frontend/pull/2620 introduced a bug for autocompletion of the username filter. This PR fixes the bug.