### PR TITLE
Add FRONTEND_TAG to Github Container Registry builds as build argument

### DIFF
--- a/.github/workflows/build_and_push_to_github_container_registry.yml
+++ b/.github/workflows/build_and_push_to_github_container_registry.yml
@@ -63,6 +63,8 @@ jobs:
         id: build-and-push
         uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a
         with:
+          build-args: |
+            FRONTEND_TAG=${{ steps.meta.outputs.version }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Currently frontend version tags are not included in builds that are pushed to Github Container Registry.