### PR TITLE
[feat-5373] Removed all references to useGisib featureflag.

### DIFF
--- a/app.amsterdam.json
+++ b/app.amsterdam.json
@@ -21,7 +21,6 @@
     "showStandardTextAdminV2": true,
     "showThorButton": true,
     "showVulaanControls": true,
-    "useGisib": true,
     "useProjectenSignalType": false
   },
   "head": {

--- a/app.base.json
+++ b/app.base.json
@@ -24,8 +24,7 @@
     "showMainCategories": false,
     "showStandardTextAdminV1": true,
     "showStandardTextAdminV2": false,
-    "disableClosingCategoryOverigOverig": false,
-    "useGisib": false
+    "disableClosingCategoryOverigOverig": false
   },
   "head": {
     "androidIcon": "/icon_192x192.png",

--- a/internals/schemas/app.schema.json
+++ b/internals/schemas/app.schema.json
@@ -150,10 +150,6 @@
           "description": "Disallows processing of an issue that has category Overig-overig and status Afgehandeld",
           "type": "boolean"
         },
-        "useGisib": {
-          "description": "When true, will use GISIB for the map",
-          "type": "boolean"
-        },
         "showStandardTextAdminV1": {
           "description": "Shows the old way of managing standard text for email responses.",
           "type": "boolean"

--- a/src/signals/incident/components/form/MapSelectors/Caterpillar/CaterpillarLayer/CaterpillarLayer.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Caterpillar/CaterpillarLayer/CaterpillarLayer.test.tsx
@@ -139,7 +139,6 @@ describe('CaterpillarLayer', () => {
   })
 
   it('should handle deselecting a tree', () => {
-    configuration.featureFlags.useGisib = true
     const featureId = 308778
     const selected = selection.find(({ id }) => id === featureId)
 

--- a/src/signals/incident/components/form/MapSelectors/Caterpillar/CaterpillarLayer/CaterpillarLayer.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Caterpillar/CaterpillarLayer/CaterpillarLayer.tsx
@@ -18,7 +18,6 @@ import type {
 } from 'signals/incident/components/form/MapSelectors/types'
 import type { Geometrie, Location } from 'types/incident'
 
-import configuration from '../../../../../../../shared/services/configuration/configuration'
 import StatusLayer from '../../Asset/Selector/StatusLayer'
 import { getFeatureStatusType } from '../../Asset/Selector/StatusLayer/utils'
 
@@ -32,9 +31,7 @@ export const CaterpillarLayer: FC = () => {
       // Caterpillar layer renders only a single feature type (oak tree)
       const featureType = meta.featureTypes[0]
 
-      const featureId = configuration.featureFlags.useGisib
-        ? feature.id
-        : (feature.properties[featureType.idField] as string)
+      const featureId = feature.id
 
       const isSelected = Boolean(
         selection?.find((item) => item.id === featureId)
@@ -121,11 +118,9 @@ export const CaterpillarLayer: FC = () => {
 
   return (
     <>
-      {configuration.featureFlags.useGisib
-        ? features
-            .filter((feature: any) => feature.geometry.coordinates.length > 0)
-            .map((feat) => getMarker(feat, featureStatusTypes))
-        : features.map((feat) => getMarker(feat, featureStatusTypes))}
+      {features
+        .filter((feature: any) => feature.geometry.coordinates.length > 0)
+        .map((feat) => getMarker(feat, featureStatusTypes))}
 
       {statusFeatures.length > 0 && featureStatusTypes && (
         <StatusLayer

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/eikenprocessierups.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/eikenprocessierups.ts
@@ -34,9 +34,7 @@ export const controls = {
       },
       shortLabel: 'Boom',
       pathMerge: 'extra_properties',
-      endpoint: configuration.featureFlags.useGisib
-        ? configuration.map.layers.eikenprocessierups
-        : 'https://services9.arcgis.com/YBT9ZoJBxXxS3cs6/arcgis/rest/services/EPR_2021_SIA_Amsterdam/FeatureServer/0/query?outFields=*&where=1%3D1&f=geojson&geometryType=esriGeometryEnvelope&geometry={{east},{south},{west},{north}}',
+      endpoint: configuration.map.layers.eikenprocessierups,
       maxNumberOfAssets:
         configuration.map.options?.maxNumberOfAssets.eikenProcessierups,
       featureTypes: [


### PR DESCRIPTION
##Context
As a developer I want to maintain my code, obsolete code should be removed. The featureFlwag useGisib had been mistakingly introduced and now needs to be removed.

## Changes

- removed feature flag UseGisib form app.base.json and app.amsterdam.json
- removed all usages of feature flag useGisib 
- old URL has been removed
- in a different subtask all necessary tests will be changed

subtask: Ticket: [SIG-5373](https://gemeente-amsterdam.atlassian.net/browse/SIG-5373)
main ticket: Ticket: [SIG-5320](https://gemeente-amsterdam.atlassian.net/browse/SIG-5320)

## Release Notes
Remove featureflag  useGisib svp.

## Signalen

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
