### PR TITLE
[fix-5362]: Standaard teksten opslaan

### DIFF
--- a/src/components/RadioButtonList/RadioButtonList.tsx
+++ b/src/components/RadioButtonList/RadioButtonList.tsx
@@ -86,6 +86,7 @@ const RadioButtonList = <T extends RadioButtonOptionType>({
       >
         {radioOptions.map((option, index) => (
           <RadioButtonOption
+            key={index}
             option={option}
             index={index}
             formValidation={formValidation}

--- a/src/signals/incident-management/containers/StandardTextsAdmin/components/DetailPage/Detail.tsx
+++ b/src/signals/incident-management/containers/StandardTextsAdmin/components/DetailPage/Detail.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2023 Gemeente Amsterdam
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo } from 'react'
 
 import { Column, Row } from '@amsterdam/asc-ui'
 import { yupResolver } from '@hookform/resolvers/yup'
@@ -56,8 +56,6 @@ const schema = yup.object({
 })
 
 export const Detail = () => {
-  const [waitForTimeout, setWaitForTimeout] = useState(false)
-
   const navigate = useNavigate()
   const dispatch = useDispatch()
   const params = useParams()
@@ -85,7 +83,6 @@ export const Detail = () => {
   }))
 
   const formMethods = useForm<StandardTextForm>({
-    reValidateMode: 'onSubmit',
     resolver: yupResolver(schema),
     defaultValues: { ...defaultValues },
   })
@@ -102,9 +99,10 @@ export const Detail = () => {
       )
     } else if (hasDirtyFields) {
       post(`${configuration.STANDARD_TEXTS_ENDPOINT}`, createPost(getValues()))
+    } else {
+      navigate(redirectURL)
     }
-    navigate(redirectURL)
-  }, [formState.dirtyFields, navigate, params.id, patch, getValues, post])
+  }, [formState.dirtyFields, params.id, patch, getValues, post, navigate])
 
   const handleOnCancel = () => {
     navigate(redirectURL)
@@ -126,16 +124,9 @@ export const Detail = () => {
 
   useEffect(() => {
     if (isSuccess) {
-      setWaitForTimeout(true)
-
-      // Set delay to wait for search endpoint to be updated
-      const timer = setTimeout(() => {
-        navigate(redirectURL)
-      }, 750)
-
-      return () => clearTimeout(timer)
+      navigate(redirectURL)
     }
-  }, [isSuccess, navigate, waitForTimeout])
+  }, [isSuccess, navigate])
 
   useEffect(() => {
     if (error) {
@@ -194,7 +185,7 @@ export const Detail = () => {
                   }
                 />
               </Row>
-              {(isLoading || waitForTimeout) && <LoadingIndicator />}
+              {isLoading && <LoadingIndicator />}
               <Row>
                 <Column span={12}>
                   <Form onSubmit={handleSubmit(onSubmit)}>


### PR DESCRIPTION
Ticket: [SIG-5362](https://gemeente-amsterdam.atlassian.net/browse/SIG-5362)

Fixes:
- We redirected too fast to the overview page, therefore the post/patch request never came through
- Removed timeout since it didn't work. The overview page wasn't updated. Will create a backend story to wait until the search endpoint is updated before returning a success
- Changed the validation so that the validation error is removed when a category is selected