### PR TITLE
[fix-5292]: disappearing notification

### DIFF
--- a/src/components/Notification/__tests__/Notification.test.tsx
+++ b/src/components/Notification/__tests__/Notification.test.tsx
@@ -225,30 +225,6 @@ describe('components/Notification', () => {
     expect(onClose).not.toHaveBeenCalled()
   })
 
-  it('does not use timeouts to time navigation actions for TYPE_GLOBAL', () => {
-    const onClose = jest.fn()
-
-    render(
-      withAppContext(
-        <Notification title="Foo bar" type={TYPE_GLOBAL} onClose={onClose} />
-      )
-    )
-
-    expect(onClose).not.toHaveBeenCalled()
-
-    act(() => {
-      jest.advanceTimersByTime(SLIDEUP_TIMEOUT)
-    })
-
-    expect(onClose).not.toHaveBeenCalled()
-
-    act(() => {
-      jest.advanceTimersByTime(ONCLOSE_TIMEOUT)
-    })
-
-    expect(onClose).not.toHaveBeenCalled()
-  })
-
   it('hides the component after a specific amount of time and executes callback function', () => {
     const onClose = jest.fn()
 

--- a/src/components/Notification/index.tsx
+++ b/src/components/Notification/index.tsx
@@ -10,7 +10,6 @@ import { useLocation } from 'react-router-dom'
 import {
   ONCLOSE_TIMEOUT,
   SLIDEUP_TIMEOUT,
-  TYPE_GLOBAL,
   TYPE_LOCAL,
   VARIANT_ERROR,
   VARIANT_NOTICE,
@@ -37,7 +36,7 @@ interface NotificationProps {
 /**
  * Component that shows a title, a close button and, optionally, a message in a full-width bar with
  * a coloured background. The component slides up automatically after eight seconds, but only when
- * its variant is not VARIANT_ERROR and its type is not TYPE_GLOBAL.
+ * its variant is not VARIANT_ERROR.
  */
 const Notification: FunctionComponent<NotificationProps> = ({
   title,
@@ -76,11 +75,7 @@ const Notification: FunctionComponent<NotificationProps> = ({
   }, [onClose, type, location])
 
   useEffect(() => {
-    if (
-      variant === VARIANT_ERROR ||
-      type === TYPE_GLOBAL ||
-      typeof onClose !== 'function'
-    ) {
+    if (variant === VARIANT_ERROR || typeof onClose !== 'function') {
       return undefined
     }
 

--- a/src/signals/incident/containers/KtoContainer/KtoContainer.tsx
+++ b/src/signals/incident/containers/KtoContainer/KtoContainer.tsx
@@ -11,6 +11,7 @@ import LoadingIndicator from 'components/LoadingIndicator'
 import useFetch from 'hooks/useFetch'
 import configuration from 'shared/services/configuration/configuration'
 import reducer from 'signals/incident/containers/IncidentContainer/reducer'
+import { isFetchError } from 'signals/shared/type-guards'
 
 import KtoForm from './components/KtoForm/KtoForm'
 import {
@@ -27,7 +28,7 @@ import type {
   State,
   OptionMapped,
 } from './types'
-import { isFetchError, sortByTopic, stripLastNonLetterChar } from './utils'
+import { sortByTopic, stripLastNonLetterChar } from './utils'
 import injectReducer from '../../../../utils/injectReducer'
 
 const initialState: State = {

--- a/src/signals/incident/containers/KtoContainer/utils.ts
+++ b/src/signals/incident/containers/KtoContainer/utils.ts
@@ -1,5 +1,3 @@
-import type { FetchError } from 'hooks/useFetch'
-
 import type { FormData, OptionMapped } from './types'
 
 const mergeAnswers = (
@@ -51,12 +49,6 @@ export const sortByTopic = (array: OptionMapped[]) => {
       return 0
     }
   })
-}
-
-export const isFetchError = (
-  error?: boolean | FetchError
-): error is FetchError => {
-  return (error as FetchError).detail !== undefined
 }
 
 export const stripLastNonLetterChar = (inputString: string) => {

--- a/src/signals/settings/hooks/useFetchResponseNotification.test.ts
+++ b/src/signals/settings/hooks/useFetchResponseNotification.test.ts
@@ -6,7 +6,7 @@ import * as reactRouterDom from 'react-router-dom'
 
 import { showGlobalNotification } from 'containers/App/actions'
 import {
-  TYPE_LOCAL,
+  TYPE_GLOBAL,
   VARIANT_ERROR,
   VARIANT_SUCCESS,
 } from 'containers/Notification/constants'
@@ -31,6 +31,12 @@ jest.spyOn(reactRouterDom, 'useNavigate').mockImplementation(() => navigateSpy)
 const dispatch = jest.fn()
 jest.spyOn(reactRedux, 'useDispatch').mockImplementation(() => dispatch)
 
+const defaultProps = {
+  entityName: 'Categorie',
+  isLoading: false,
+  redirectURL: '../overview',
+}
+
 describe('signals/settings/hooks/useFetchResponseNotification', () => {
   afterEach(() => {
     navigateSpy.mockReset()
@@ -39,18 +45,25 @@ describe('signals/settings/hooks/useFetchResponseNotification', () => {
 
   it('should not do anything', () => {
     renderHook(() =>
-      withAppContext(useFetchResponseNotification({ isLoading: true }))
-    )
-
-    renderHook(() =>
       withAppContext(
-        useFetchResponseNotification({ isLoading: true, error: new Error() })
+        useFetchResponseNotification({ ...defaultProps, isLoading: true })
       )
     )
 
     renderHook(() =>
       withAppContext(
         useFetchResponseNotification({
+          ...defaultProps,
+          isLoading: true,
+          error: new Error(),
+        })
+      )
+    )
+
+    renderHook(() =>
+      withAppContext(
+        useFetchResponseNotification({
+          ...defaultProps,
           isLoading: true,
           error: new Error(),
           isSuccess: true,
@@ -59,7 +72,7 @@ describe('signals/settings/hooks/useFetchResponseNotification', () => {
     )
 
     renderHook(() =>
-      withAppContext(useFetchResponseNotification({ isLoading: false }))
+      withAppContext(useFetchResponseNotification({ ...defaultProps }))
     )
 
     expect(dispatch).not.toHaveBeenCalled()
@@ -69,10 +82,15 @@ describe('signals/settings/hooks/useFetchResponseNotification', () => {
   it('should dispatch error', () => {
     const title = 'Keyboard not found. Press F1 to continue.'
     const variant = VARIANT_ERROR
-    const type = TYPE_LOCAL
+    const type = TYPE_GLOBAL
 
     renderHook(() =>
-      withAppContext(useFetchResponseNotification({ error: new Error(title) }))
+      withAppContext(
+        useFetchResponseNotification({
+          ...defaultProps,
+          error: new Error(title),
+        })
+      )
     )
 
     expect(dispatch).toHaveBeenCalledWith(
@@ -83,24 +101,24 @@ describe('signals/settings/hooks/useFetchResponseNotification', () => {
   })
 
   it('should dispatch success', () => {
-    const type = TYPE_LOCAL
+    const type = TYPE_GLOBAL
     const variant = VARIANT_SUCCESS
 
     renderHook(() =>
       withAppContext(
-        useFetchResponseNotification({ isSuccess: true, isExisting: true })
+        useFetchResponseNotification({ ...defaultProps, isSuccess: true })
       )
     )
 
     expect(dispatch).toHaveBeenLastCalledWith(
-      showGlobalNotification({ title: 'Gegevens bijgewerkt', variant, type })
+      showGlobalNotification({ title: 'Categorie bijgewerkt', variant, type })
     )
 
     renderHook(() =>
       withAppContext(
         useFetchResponseNotification({
+          ...defaultProps,
           isSuccess: true,
-          isExisting: true,
           entityName: 'Gebruiker',
         })
       )
@@ -109,8 +127,6 @@ describe('signals/settings/hooks/useFetchResponseNotification', () => {
     expect(dispatch).toHaveBeenCalledWith(
       showGlobalNotification({ title: 'Gebruiker bijgewerkt', variant, type })
     )
-
-    expect(navigateSpy).not.toHaveBeenCalled()
   })
 
   it('should redirect', () => {
@@ -118,7 +134,11 @@ describe('signals/settings/hooks/useFetchResponseNotification', () => {
 
     renderHook(() =>
       withAppContext(
-        useFetchResponseNotification({ isSuccess: true, redirectURL })
+        useFetchResponseNotification({
+          ...defaultProps,
+          isSuccess: true,
+          redirectURL,
+        })
       )
     )
 

--- a/src/signals/settings/hooks/useFetchResponseNotification.ts
+++ b/src/signals/settings/hooks/useFetchResponseNotification.ts
@@ -7,33 +7,29 @@ import { useNavigate } from 'react-router-dom'
 
 import { showGlobalNotification } from 'containers/App/actions'
 import {
-  TYPE_LOCAL,
+  TYPE_GLOBAL,
   VARIANT_ERROR,
   VARIANT_SUCCESS,
 } from 'containers/Notification/constants'
-// eslint-disable-next-line no-unused-vars
-import { State } from 'hooks/useFetch'
+import type { FetchError } from 'hooks/useFetch'
 
-/**
- * Custom hook useConfirmedCancel
- *
- * Will take a URL and can be used as onCancel callback for forms
- *
- * @param {Object} options
- * @param {String} options.entityName - Name by which the stored/patched data should be labeled (eg. 'Afdeling')
- * @param {State['error']} options.error - Exception object
- * @param {Boolean} options.isLoading - Flag indicating if data is still loading
- * @param {State['error']} options.isSuccess - Flag indicating if data has been stored/patched successfully
- * @param {String} options.redirectURL - URL to which the push should be directed when isSuccess is truthy
- * @returns {void}
- */
+import { isFetchError } from '../../shared/type-guards'
+
+interface Props {
+  entityName: string // Name by which the stored/patched data should be labeled (eg. 'Afdeling')
+  isLoading: boolean // Flag indicating if data is still loading
+  redirectURL: string // URL to which the push should be directed when isSuccess is truthy
+  isSuccess?: boolean // Flag indicating if data has been stored/patched successfully
+  error?: boolean | FetchError // Exception object
+}
+
 const useFetchResponseNotification = ({
   entityName,
   error,
   isLoading,
   isSuccess,
   redirectURL,
-}) => {
+}: Props) => {
   const dispatch = useDispatch()
   const navigate = useNavigate()
   const showNotification = useCallback(
@@ -42,7 +38,7 @@ const useFetchResponseNotification = ({
         showGlobalNotification({
           variant,
           title,
-          type: TYPE_LOCAL,
+          type: TYPE_GLOBAL,
         })
       ),
     [dispatch]
@@ -54,7 +50,7 @@ const useFetchResponseNotification = ({
     let message
     let variant = VARIANT_SUCCESS
 
-    if (error) {
+    if (error && isFetchError(error)) {
       ;({ message } = error)
       variant = VARIANT_ERROR
     }

--- a/src/signals/shared/type-guards/index.test.ts
+++ b/src/signals/shared/type-guards/index.test.ts
@@ -1,0 +1,43 @@
+import { isFetchError } from './index'
+
+describe('isFetchError', () => {
+  it('should returns true for a FetchError with detail property', () => {
+    const fetchError = { detail: 'An error occurred' }
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    const result = isFetchError(fetchError)
+
+    expect(result).toBe(true)
+  })
+
+  it('should returns true for a FetchError with message property', () => {
+    const fetchError = { status: 404, message: 'Not Found' }
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    const result = isFetchError(fetchError)
+
+    expect(result).toBe(true)
+  })
+
+  it('should returns false for a FetchError without detail property', () => {
+    const fetchError = { status: 404, result: 'Not Found' }
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    const result = isFetchError(fetchError)
+
+    expect(result).toBe(false)
+  })
+
+  it('should returns false for a boolean value', () => {
+    const booleanValue = true
+    const result = isFetchError(booleanValue)
+
+    expect(result).toBe(false)
+  })
+
+  it('should returns false for undefined', () => {
+    const result = isFetchError(undefined)
+
+    expect(result).toBe(false)
+  })
+})

--- a/src/signals/shared/type-guards/index.test.ts
+++ b/src/signals/shared/type-guards/index.test.ts
@@ -1,7 +1,7 @@
 import { isFetchError } from './index'
 
 describe('isFetchError', () => {
-  it('should returns true for a FetchError with detail property', () => {
+  it('should return true for a FetchError with detail property', () => {
     const fetchError = { detail: 'An error occurred' }
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
@@ -10,7 +10,7 @@ describe('isFetchError', () => {
     expect(result).toBe(true)
   })
 
-  it('should returns true for a FetchError with message property', () => {
+  it('should return true for a FetchError with message property', () => {
     const fetchError = { status: 404, message: 'Not Found' }
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
@@ -19,7 +19,7 @@ describe('isFetchError', () => {
     expect(result).toBe(true)
   })
 
-  it('should returns false for a FetchError without detail property', () => {
+  it('should return false for a FetchError without detail property', () => {
     const fetchError = { status: 404, result: 'Not Found' }
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
@@ -28,14 +28,14 @@ describe('isFetchError', () => {
     expect(result).toBe(false)
   })
 
-  it('should returns false for a boolean value', () => {
+  it('should return false for a boolean value', () => {
     const booleanValue = true
     const result = isFetchError(booleanValue)
 
     expect(result).toBe(false)
   })
 
-  it('should returns false for undefined', () => {
+  it('should return false for undefined', () => {
     const result = isFetchError(undefined)
 
     expect(result).toBe(false)

--- a/src/signals/shared/type-guards/index.ts
+++ b/src/signals/shared/type-guards/index.ts
@@ -1,0 +1,10 @@
+import type { FetchError } from 'hooks/useFetch'
+
+export const isFetchError = (
+  error?: boolean | FetchError
+): error is FetchError => {
+  return (
+    ((error as FetchError)?.detail || (error as FetchError)?.message) !==
+    undefined
+  )
+}


### PR DESCRIPTION
Ticket: [SIG-5292](https://gemeente-amsterdam.atlassian.net/browse/SIG-5292)

The notification of an action was barely noticeable since it was removed very quickly. That was caused by the useFetchResponseNotification that was set to TYPE_LOCAL. 

- Changed it to TYPE_GLOBAL so that it does not disappear when navigating to another page.
- Changed the functionality of TYPE_GLOBAL slightly so that is disappears after 8 seconds, just likt a TYPE_LOCAL. Only when it has variant ERROR it needs te be closed with the close button
- Moved the isFetchError typeguard to a shared location
