### PR TITLE
[fix-5266]: Fix open answer validation

### DIFF
--- a/src/components/CheckboxList/CheckboxList.test.tsx
+++ b/src/components/CheckboxList/CheckboxList.test.tsx
@@ -671,6 +671,7 @@ describe('signals/incident-management/components/CheckboxList', () => {
       trigger: jest.fn(),
       setValue: jest.fn(),
       register: jest.fn(),
+      unregister: jest.fn(),
     }
 
     render(

--- a/src/components/CheckboxList/CheckboxList.tsx
+++ b/src/components/CheckboxList/CheckboxList.tsx
@@ -9,6 +9,7 @@ import type {
   UseFormRegister,
   UseFormSetValue,
   UseFormTrigger,
+  UseFormUnregister,
 } from 'react-hook-form'
 import styled, { css } from 'styled-components'
 
@@ -121,6 +122,7 @@ export type CheckboxListProps<T = Option> = {
     trigger: UseFormTrigger<any>
     setValue: UseFormSetValue<any>
     register: UseFormRegister<any>
+    unregister: UseFormUnregister<any>
   }
 }
 
@@ -260,6 +262,9 @@ const CheckboxList = <T extends Option>({
         } else {
           const option = getChecked(target.dataset.id)
 
+          option?.open_answer &&
+            formValidation?.unregister(`open_answer-${option?.value}`)
+
           option && modifiedState.delete(option)
         }
 
@@ -281,7 +286,16 @@ const CheckboxList = <T extends Option>({
         return modifiedState
       })
     },
-    [getChecked, getOption, groupValue, name, numOptions, onChange, onToggle]
+    [
+      formValidation,
+      getChecked,
+      getOption,
+      groupValue,
+      name,
+      numOptions,
+      onChange,
+      onToggle,
+    ]
   )
 
   /**

--- a/src/signals/incident/containers/KtoContainer/components/KtoForm/KtoForm.tsx
+++ b/src/signals/incident/containers/KtoContainer/components/KtoForm/KtoForm.tsx
@@ -116,6 +116,7 @@ const KtoForm = ({
     trigger,
     getValues,
     register,
+    unregister,
     formState: { errors },
   } = formMethods
 
@@ -181,6 +182,7 @@ const KtoForm = ({
                     trigger: trigger,
                     setValue: setValue,
                     register: register,
+                    unregister: unregister,
                   }}
                 />
               ) : (
@@ -190,6 +192,13 @@ const KtoForm = ({
                   groupName="kto"
                   hasEmptySelectionButton={false}
                   onChange={(_groupName, option: OptionMapped) => {
+                    options.forEach((option) => {
+                      // Clear all open answers when changing options
+                      if (option.open_answer) {
+                        unregister(`open_answer-${option.value}`)
+                      }
+                    })
+
                     setValue('text_list', [option.value])
                     trigger('text_list')
                   }}


### PR DESCRIPTION
Ticket: [SIG-5266](https://gemeente-amsterdam.atlassian.net/browse/SIG-5266)

Fixes an issue with the validation of the open answers.

- Select an option with open answer
- type something.
- undo the selection
- chose a "closed" answer
- try to save
- You used to get an error saying you didn't fill in the required fields.
- This PR unregisters the open_answer field when unselected. 