### PR TITLE
[feat-5047]: Add highlight to search results

### DIFF
--- a/src/signals/incident-management/containers/StandardTextsAdmin/components/Summary/Summary.tsx
+++ b/src/signals/incident-management/containers/StandardTextsAdmin/components/Summary/Summary.tsx
@@ -21,9 +21,18 @@ export interface Props {
 }
 
 export const Summary = ({ standardText, onClick }: Props) => {
-  const { state, title, text, id } = standardText
+  const {
+    state,
+    title: originalTitle,
+    text,
+    id,
+    meta: { highlight },
+  } = standardText
 
   const status = statusList.find(({ key }) => key === state) as StatusType
+
+  const title = highlight?.title ? highlight.title : originalTitle
+  const description = highlight?.text ? highlight.text.join('...') : text
 
   return (
     <Wrapper
@@ -44,8 +53,11 @@ export const Summary = ({ standardText, onClick }: Props) => {
       </ColumnStatus>
 
       <ColumnDescription>
-        <Title>{title}</Title>
-        <Text>{text}</Text>
+        <Title dangerouslySetInnerHTML={{ __html: title }} />
+        <Text
+          dangerouslySetInnerHTML={{ __html: description }}
+          $isHighlighted={highlight?.text}
+        />
       </ColumnDescription>
     </Wrapper>
   )

--- a/src/signals/incident-management/containers/StandardTextsAdmin/components/Summary/styled.ts
+++ b/src/signals/incident-management/containers/StandardTextsAdmin/components/Summary/styled.ts
@@ -37,7 +37,6 @@ export const Title = styled.div`
 
 export const Text = styled.div<{ $isHighlighted: boolean }>`
   font-weight: 400;
-  line-height: 16px;
   line-height: 24px;
   overflow: hidden;
 

--- a/src/signals/incident-management/containers/StandardTextsAdmin/components/Summary/styled.ts
+++ b/src/signals/incident-management/containers/StandardTextsAdmin/components/Summary/styled.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2023 Gemeente Amsterdam
-import { themeColor, Icon } from '@amsterdam/asc-ui'
-import styled from 'styled-components'
+import { themeColor, Icon, themeSpacing } from '@amsterdam/asc-ui'
+import styled, { css } from 'styled-components'
 
 export const ColumnDescription = styled.div`
   margin-left: 26px;
@@ -27,14 +27,38 @@ export const Title = styled.div`
   font-weight: 700;
   line-height: 24px;
   margin-bottom: 8px;
+
+  em {
+    background-color: ${themeColor('tint', 'level3')};
+    font-style: normal;
+    padding: ${themeSpacing(0, 1)};
+  }
 `
 
-export const Text = styled.div`
+export const Text = styled.div<{ $isHighlighted: boolean }>`
   font-weight: 400;
   line-height: 16px;
+  line-height: 24px;
   overflow: hidden;
+
   text-overflow: ellipsis;
   white-space: nowrap;
+
+  ${({ $isHighlighted }) =>
+    $isHighlighted &&
+    css`
+      white-space: wrap;
+      display: -webkit-box;
+      -webkit-line-clamp: 3;
+      -webkit-box-orient: vertical;
+
+      em {
+        background-color: ${themeColor('tint', 'level3')};
+        font-style: normal;
+        font-weight: 700;
+        padding: ${themeSpacing(0, 1)};
+      }
+    `}
 `
 
 export const Wrapper = styled.div`

--- a/src/signals/incident-management/containers/StandardTextsAdmin/components/Summary/styled.ts
+++ b/src/signals/incident-management/containers/StandardTextsAdmin/components/Summary/styled.ts
@@ -37,7 +37,7 @@ export const Title = styled.div`
 
 export const Text = styled.div<{ $isHighlighted: boolean }>`
   font-weight: 400;
-  line-height: 24px;
+  line-height: ${themeSpacing(6)};
   overflow: hidden;
 
   text-overflow: ellipsis;


### PR DESCRIPTION
Ticket: [SIG-5047](https://gemeente-amsterdam.atlassian.net/browse/SIG-5047)

Shows the highlighted search results for the Standard Texts. 

