### PR TITLE
[fix]: Add offset to nearby incident icons

### DIFF
--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/NearbyLayer/NearbyLayer.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/NearbyLayer/NearbyLayer.tsx
@@ -174,6 +174,7 @@ export const NearbyLayer: FC<NearbyLayerProps> = ({ zoomLevel }) => {
             feature.properties.created_at
           )}`,
           keyboard: false,
+          zIndexOffset: -1,
         }
       )
 


### PR DESCRIPTION
Ticket: none
