### PR TITLE
[fix]: Set zIndexOffset on nearby layer marker

### DIFF
--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/NearbyLayer/NearbyLayer.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/NearbyLayer/NearbyLayer.tsx
@@ -174,6 +174,7 @@ export const NearbyLayer: FC<NearbyLayerProps> = ({ zoomLevel }) => {
             feature.properties.created_at
           )}`,
           keyboard: false,
+          zIndexOffset: -1,
         }
       )
 


### PR DESCRIPTION
Ticket: none

The icons of already known incidents on the same spot as for example a container were placed on top of the container. Making the container unreachable. This change sets the marker underneath the container.
