### PR TITLE
[chore]: Make FileInput optional

### DIFF
--- a/src/components/FileInput/FileInput.tsx
+++ b/src/components/FileInput/FileInput.tsx
@@ -25,7 +25,7 @@ interface FileInputProps {
   maxFileSize?: number
   allowedFileTypes?: string[]
   name: string
-  label: string
+  label?: string
   helpText?: string
   required?: boolean
   errorMessages?: string[]

--- a/src/signals/incident/components/form/FileInput/FileInput.tsx
+++ b/src/signals/incident/components/form/FileInput/FileInput.tsx
@@ -124,7 +124,6 @@ const FileInput = ({ handler, parent, meta }: Props) => {
       allowedFileTypes={meta.allowedFileTypes}
       errorMessages={errors}
       files={files}
-      label=""
       maxFileSize={meta.maxFileSize}
       maxNumberOfFiles={maxNumberOfFiles}
       minFileSize={meta.minFileSize}


### PR DESCRIPTION
Ticket: none

Make label optional because when the FileInput is rendered in FormField the FormField has already a label.