### PR TITLE
[feat 5426] show-true-size-pics-in-mijnmeldingen-when-clicked

### DIFF
--- a/src/signals/my-incidents/components/IncidentsDetail/IncidentsDetail.test.tsx
+++ b/src/signals/my-incidents/components/IncidentsDetail/IncidentsDetail.test.tsx
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: MPL-2.0 */
-/* Copyright (C) 2022 Gemeente Amsterdam */
-import { render, screen } from '@testing-library/react'
+/* Copyright (C) 2022-2023 Gemeente Amsterdam */
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 
 import { IncidentsDetail } from './IncidentsDetail'
 import { withAppContext } from '../../../../test/utils'
@@ -88,5 +89,67 @@ describe('IncidentsDetail', () => {
     expect(screen.queryByText('Foto')).not.toBeInTheDocument()
 
     expect(container.querySelector('img')).not.toBeInTheDocument()
+  })
+
+  it('renders attachment viewer', () => {
+    const { container } = render(
+      withAppContext(
+        <IncidentsDetail
+          incidentsDetail={incidentsDetail}
+          setShowMap={setShowMap}
+          token={'123'}
+        />
+      )
+    )
+
+    const image = container.querySelector('img') as HTMLElement
+
+    expect(image).toBeInTheDocument()
+    expect(
+      screen.queryByTestId('attachment-viewer-image')
+    ).not.toBeInTheDocument()
+
+    userEvent.click(image)
+
+    expect(screen.queryByTestId('attachment-viewer-image')).toBeInTheDocument()
+  })
+
+  it('closes previews when close button is clicked', async () => {
+    const { container } = render(
+      withAppContext(
+        <IncidentsDetail
+          incidentsDetail={incidentsDetail}
+          setShowMap={setShowMap}
+          token={'123'}
+        />
+      )
+    )
+
+    const image = container.querySelector('img') as HTMLElement
+
+    expect(image).toBeInTheDocument()
+
+    expect(
+      screen.queryByTestId('attachment-viewer-image')
+    ).not.toBeInTheDocument()
+    expect(screen.queryByTitle(/sluiten/i)).not.toBeInTheDocument()
+
+    userEvent.click(image)
+
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId('attachment-viewer-image')
+      ).toBeInTheDocument()
+    })
+
+    const closeButton = screen.getByTitle(/sluiten/i)
+    expect(closeButton).toBeInTheDocument()
+
+    userEvent.click(closeButton)
+
+    expect(
+      screen.queryByTestId('attachment-viewer-image')
+    ).not.toBeInTheDocument()
+    expect(screen.queryByTitle(/sluiten/i)).not.toBeInTheDocument()
   })
 })

--- a/src/signals/my-incidents/components/IncidentsDetail/IncidentsDetail.tsx
+++ b/src/signals/my-incidents/components/IncidentsDetail/IncidentsDetail.tsx
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2022 - 2023 Gemeente Amsterdam
+import { useState } from 'react'
+
 import { Paragraph } from '@amsterdam/asc-ui'
+
+import AttachmentViewer from 'components/AttachmentViewer'
 
 import { ExtraProperties } from './ExtraProperties'
 import {
@@ -28,6 +32,16 @@ export const IncidentsDetail = ({
 }: Props) => {
   const { _display, text, location, extra_properties, _links } = incidentsDetail
   const attachments = _links?.['sia:attachments']
+  const [selectedAttachment, setSelectedAttachment] = useState<string | null>(
+    null
+  )
+
+  const formattedAttachments =
+    attachments?.map((attachment) => ({
+      createdAt: attachment.created_at,
+      createdBy: attachment.created_by,
+      location: attachment.href,
+    })) || []
 
   return (
     <ContentWrapper>
@@ -48,7 +62,12 @@ export const IncidentsDetail = ({
           <FormTitle>Foto{attachments.length > 1 && "'s"}</FormTitle>
 
           {attachments.map((attachment, index) => (
-            <ImageWrapper key={attachment.href + index}>
+            <ImageWrapper
+              key={attachment.href + index}
+              onClick={() => {
+                setSelectedAttachment(attachment.href)
+              }}
+            >
               <StyledImage src={attachment.href} />
             </ImageWrapper>
           ))}
@@ -68,6 +87,16 @@ export const IncidentsDetail = ({
       <Wrapper>
         <ExtraProperties items={extra_properties} />
       </Wrapper>
+
+      {selectedAttachment && (
+        <AttachmentViewer
+          attachments={formattedAttachments}
+          href={selectedAttachment}
+          onClose={() => {
+            setSelectedAttachment(null)
+          }}
+        />
+      )}
     </ContentWrapper>
   )
 }


### PR DESCRIPTION
Added AttachmentViewer to mijn-meldingen. It uses a different State but otherwise works the same as in the backoffice.

(feedback is [here](https://github.com/Amsterdam/signals-frontend/pull/2690), new PR due to misclicking on merge when I still wanted to push these last changes)

Ticket: [SIG-5426](https://gemeente-amsterdam.atlassian.net/browse/SIG-5426)

## Signalen

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
