### PR TITLE
[Chore] move DataViewBody from js to tsx

### DIFF
--- a/src/components/DataView/components/DataViewBody/DataViewBody.tsx
+++ b/src/components/DataView/components/DataViewBody/DataViewBody.tsx
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2020 - 2023 Gemeente Amsterdam
+import type { UIEvent } from 'react'
 import { useMemo } from 'react'
-
-import PropTypes from 'prop-types'
 
 import {
   StyledTR,
@@ -12,13 +11,21 @@ import {
 } from 'components/DataView/styled'
 import onButtonPress from 'utils/on-button-press'
 
+export interface DataViewBodyProps {
+  data: []
+  visibleColumns: string[]
+  onItemClick: (e: UIEvent) => void
+  primaryKeyColumn: number | undefined
+  numberOfColumns: number
+}
+
 const DataViewBody = ({
   data,
   visibleColumns,
   onItemClick,
   primaryKeyColumn,
   numberOfColumns,
-}) => {
+}: DataViewBodyProps) => {
   const dataColumnsMissing = useMemo(
     () => numberOfColumns - visibleColumns.length,
     [numberOfColumns, visibleColumns.length]
@@ -26,7 +33,7 @@ const DataViewBody = ({
 
   return (
     <tbody data-testid="data-view-body">
-      {data.map((row, index) => (
+      {data.map((row: any, index: number) => (
         <StyledTR
           key={JSON.stringify(row) + index}
           data-item-id={primaryKeyColumn && row[primaryKeyColumn]}
@@ -38,7 +45,7 @@ const DataViewBody = ({
           role={'button'}
           data-testid="data-view-body-row"
         >
-          {visibleColumns.map((column, idx) => {
+          {visibleColumns.map((column: string, idx: number) => {
             if (column === 'Icoon' && row[column] !== 'Niet ingesteld') {
               return (
                 <StyledImageTD
@@ -70,24 +77,6 @@ const DataViewBody = ({
       ))}
     </tbody>
   )
-}
-
-DataViewBody.defaultProps = {
-  onItemClick: null,
-  primaryKeyColumn: undefined,
-}
-
-DataViewBody.propTypes = {
-  /** Array of data to be displayed */
-  data: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
-  /** Total number of columns in current view */
-  numberOfColumns: PropTypes.number.isRequired,
-  /** List of column names that should be displayed and in the order they should be displayed in */
-  visibleColumns: PropTypes.arrayOf(PropTypes.string).isRequired,
-  /** Name of the column that contains the value that is used to build the URL to navigate to on item click */
-  primaryKeyColumn: PropTypes.string,
-  /** Row click callback handler */
-  onItemClick: PropTypes.func,
 }
 
 export default DataViewBody

--- a/src/components/DataView/components/DataViewBody/DataViewBody.tsx
+++ b/src/components/DataView/components/DataViewBody/DataViewBody.tsx
@@ -14,7 +14,7 @@ import onButtonPress from 'utils/on-button-press'
 export interface Props {
   data: Record<string, any>[]
   visibleColumns: string[]
-  primaryKeyColumn: number | undefined
+  primaryKeyColumn?: number
   numberOfColumns: number
   onItemClick?: (e: UIEvent) => void
 }

--- a/src/components/DataView/components/DataViewBody/DataViewBody.tsx
+++ b/src/components/DataView/components/DataViewBody/DataViewBody.tsx
@@ -11,12 +11,12 @@ import {
 } from 'components/DataView/styled'
 import onButtonPress from 'utils/on-button-press'
 
-export interface DataViewBodyProps {
-  data: []
+export interface Props {
+  data: Record<string, any>[]
   visibleColumns: string[]
-  onItemClick: (e: UIEvent) => void
   primaryKeyColumn: number | undefined
   numberOfColumns: number
+  onItemClick?: (e: UIEvent) => void
 }
 
 const DataViewBody = ({
@@ -25,7 +25,7 @@ const DataViewBody = ({
   onItemClick,
   primaryKeyColumn,
   numberOfColumns,
-}: DataViewBodyProps) => {
+}: Props) => {
   const dataColumnsMissing = useMemo(
     () => numberOfColumns - visibleColumns.length,
     [numberOfColumns, visibleColumns.length]
@@ -33,19 +33,19 @@ const DataViewBody = ({
 
   return (
     <tbody data-testid="data-view-body">
-      {data.map((row: any, index: number) => (
+      {data.map((row, index) => (
         <StyledTR
           key={JSON.stringify(row) + index}
           data-item-id={primaryKeyColumn && row[primaryKeyColumn]}
           onClick={onItemClick}
           onKeyDown={(e) => {
-            onButtonPress(e, () => onItemClick(e))
+            onItemClick && onButtonPress(e, () => onItemClick(e))
           }}
           tabIndex={0}
           role={'button'}
           data-testid="data-view-body-row"
         >
-          {visibleColumns.map((column: string, idx: number) => {
+          {visibleColumns.map((column, idx) => {
             if (column === 'Icoon' && row[column] !== 'Niet ingesteld') {
               return (
                 <StyledImageTD

--- a/src/components/DataView/components/DataViewBody/index.ts
+++ b/src/components/DataView/components/DataViewBody/index.ts
@@ -1,0 +1,1 @@
+export { default } from './DataViewBody'


### PR DESCRIPTION
- Transformed file to .tsx file. Data is an [ ], because DataViewBody is used as a generic way to showcase data.
- No tests are transformed since 100% coverage is achieved by tests of DataView (which still needs to be transformed)
- Discovered bug; primary key of departments VTH  are the same in the backend. Jelle has been informed.

## Signalen

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
