### PR TITLE
[feat-5454]: Aligned Attachment types

### DIFF
--- a/src/components/AttachmentViewer/AttachmentViewer.test.tsx
+++ b/src/components/AttachmentViewer/AttachmentViewer.test.tsx
@@ -10,26 +10,32 @@ import type { FormattedAttachment } from './AttachmentViewer'
 
 const attachments: FormattedAttachment[] = [
   {
-    location: 'https://objectstore.eu/mock/image/1',
+    caption: 'text shown',
     createdAt: '2019-08-05T08:19:16.372476+02:00',
     createdBy: null,
-    caption: 'text shown',
+    location: 'https://objectstore.eu/mock/image/1',
+    stateShown: 'melder',
   },
   {
+    caption: 'text shown',
+    createdAt: '2019-08-05T08:19:17.205236+02:00',
+    createdBy: 'test@signalen.dev',
     location: 'https://objectstore.eu/mock/image/4/',
-    createdAt: '2019-08-05T08:19:17.205236+02:00',
-    createdBy: 'test@signalen.dev',
-    caption: 'text shown',
+    stateShown: 'melder',
   },
   {
+    caption: null,
+    createdAt: '2019-08-05T08:19:17.205236+02:00',
+    createdBy: 'test@signalen.dev',
     location: 'https://objectstore.eu/mock/image/2',
-    createdAt: '2019-08-05T08:19:17.205236+02:00',
-    createdBy: 'test@signalen.dev',
+    stateShown: 'melder',
   },
   {
-    location: 'https://objectstore.eu/mock/image/3',
+    caption: null,
     createdAt: '2019-08-05T08:19:18.389461+02:00',
     createdBy: 'employee@signalen.dev',
+    location: 'https://objectstore.eu/mock/image/3',
+    stateShown: 'melder',
   },
 ]
 

--- a/src/components/AttachmentViewer/AttachmentViewer.test.tsx
+++ b/src/components/AttachmentViewer/AttachmentViewer.test.tsx
@@ -6,41 +6,36 @@ import userEvent from '@testing-library/user-event'
 import { withAppContext } from 'test/utils'
 
 import AttachmentViewer from '.'
+import type { FormattedAttachment } from './AttachmentViewer'
+
+const attachments: FormattedAttachment[] = [
+  {
+    location: 'https://objectstore.eu/mock/image/1',
+    createdAt: '2019-08-05T08:19:16.372476+02:00',
+    createdBy: null,
+    caption: 'text shown',
+  },
+  {
+    location: 'https://objectstore.eu/mock/image/4/',
+    createdAt: '2019-08-05T08:19:17.205236+02:00',
+    createdBy: 'test@signalen.dev',
+    caption: 'text shown',
+  },
+  {
+    location: 'https://objectstore.eu/mock/image/2',
+    createdAt: '2019-08-05T08:19:17.205236+02:00',
+    createdBy: 'test@signalen.dev',
+  },
+  {
+    location: 'https://objectstore.eu/mock/image/3',
+    createdAt: '2019-08-05T08:19:18.389461+02:00',
+    createdBy: 'employee@signalen.dev',
+  },
+]
 
 describe('<AttachmentViewer />', () => {
   const props = {
-    attachments: [
-      {
-        _display: 'Attachment object (678)',
-        location: 'https://objectstore.eu/mock/image/1',
-        is_image: true,
-        createdAt: '2019-08-05T08:19:16.372476+02:00',
-        createdBy: '',
-        caption: 'text shown',
-      },
-      {
-        _display: 'Attachment object (681)',
-        location: 'https://objectstore.eu/mock/image/4/',
-        is_image: true,
-        createdAt: '2019-08-05T08:19:17.205236+02:00',
-        createdBy: 'test@signalen.dev',
-        caption: 'text shown',
-      },
-      {
-        _display: 'Attachment object (679)',
-        location: 'https://objectstore.eu/mock/image/2',
-        is_image: true,
-        createdAt: '2019-08-05T08:19:17.205236+02:00',
-        createdBy: 'test@signalen.dev',
-      },
-      {
-        _display: 'Attachment object (680)',
-        location: 'https://objectstore.eu/mock/image/3',
-        is_image: true,
-        createdAt: '2019-08-05T08:19:18.389461+02:00',
-        createdBy: 'employee@signalen.dev',
-      },
-    ],
+    attachments,
     onClose: () => {},
   }
 

--- a/src/components/AttachmentViewer/AttachmentViewer.tsx
+++ b/src/components/AttachmentViewer/AttachmentViewer.tsx
@@ -27,11 +27,13 @@ import {
   Title,
   Wrapper,
 } from './styles'
-// TODO: add caption?
+
 export interface FormattedAttachment {
-  location: string
+  caption: string | null
   createdAt: string | null
   createdBy: string | null
+  location: string
+  stateShown: string
 }
 
 interface Props {

--- a/src/components/AttachmentViewer/AttachmentViewer.tsx
+++ b/src/components/AttachmentViewer/AttachmentViewer.tsx
@@ -27,18 +27,16 @@ import {
   Title,
   Wrapper,
 } from './styles'
-
-export interface Attachment {
+// TODO: add caption?
+export interface FormattedAttachment {
   location: string
-  createdAt?: string
-  createdBy?: string | null
-  stateShown?: string
-  caption?: string
+  createdAt: string | null
+  createdBy: string | null
 }
 
 interface Props {
   href: string
-  attachments: Attachment[]
+  attachments: FormattedAttachment[]
   onClose: () => void
 }
 

--- a/src/components/AttachmentViewer/components/InteractiveImage/InteractiveImage.test.tsx
+++ b/src/components/AttachmentViewer/components/InteractiveImage/InteractiveImage.test.tsx
@@ -5,7 +5,7 @@ import InteractiveImage from './InteractiveImage'
 
 describe('InteractiveImage', () => {
   it('sets visibility of main image when clicked', () => {
-    render(<InteractiveImage src="foo" alt="bar" />)
+    render(<InteractiveImage src="foo" alt="bar" caption={null} />)
     const image = screen.getByTestId('interactive-image')
     const zoomedImage = screen.getByTestId('zoomed-interactive-image')
 

--- a/src/components/AttachmentViewer/components/InteractiveImage/InteractiveImage.tsx
+++ b/src/components/AttachmentViewer/components/InteractiveImage/InteractiveImage.tsx
@@ -8,7 +8,7 @@ import { ZoomedImage, Image, StyledFigCaption, Wrapper } from './styled'
 type InteractiveImageProps = {
   src: string
   alt: string
-  caption?: string
+  caption: string | null
   className?: string
 }
 

--- a/src/components/AttachmentViewer/index.ts
+++ b/src/components/AttachmentViewer/index.ts
@@ -1,1 +1,2 @@
 export { default } from './AttachmentViewer'
+export type { FormattedAttachment } from './AttachmentViewer'

--- a/src/signals/incident-management/containers/IncidentDetail/IncidentDetail.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/IncidentDetail.tsx
@@ -125,14 +125,14 @@ const IncidentDetail = () => {
     if (isCreatedBy === null) return 'melder'
     return isPublic ? 'openbaar getoond' : isCreatedBy
   }
-  // TODO: Fix this type
-  const formattedAttachments =
+
+  const formattedAttachments: FormattedAttachment[] =
     state.attachments?.results.map((attachment) => ({
+      caption: attachment.caption,
       createdAt: attachment.created_at,
       createdBy: attachment.created_by,
       location: attachment.location,
       stateShown: stateShownImage(attachment.public, attachment.created_by),
-      caption: attachment.caption,
     })) || []
 
   const handleKeyUp = useCallback((event: KeyboardEvent) => {

--- a/src/signals/incident-management/containers/IncidentDetail/IncidentDetail.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/IncidentDetail.tsx
@@ -8,6 +8,7 @@ import { useParams } from 'react-router-dom'
 import styled from 'styled-components'
 
 import AttachmentViewer from 'components/AttachmentViewer'
+import type { FormattedAttachment } from 'components/AttachmentViewer'
 import CloseButton from 'components/CloseButton'
 import History from 'components/History'
 import { showGlobalNotification } from 'containers/App/actions'
@@ -124,7 +125,7 @@ const IncidentDetail = () => {
     if (isCreatedBy === null) return 'melder'
     return isPublic ? 'openbaar getoond' : isCreatedBy
   }
-
+  // TODO: Fix this type
   const formattedAttachments =
     state.attachments?.results.map((attachment) => ({
       createdAt: attachment.created_at,

--- a/src/signals/incident-management/containers/IncidentDetail/components/Attachments/EditAttachment..tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/Attachments/EditAttachment..tsx
@@ -44,7 +44,7 @@ export default function EditAttachment({
   const { handleSubmit, formState, control, getValues } = useForm<FormValues>({
     defaultValues: {
       public: attachment.public,
-      caption: attachment.caption,
+      caption: attachment.caption ?? undefined,
     },
     resolver: yupResolver(schema),
   })

--- a/src/signals/incident-management/containers/IncidentDetail/types.ts
+++ b/src/signals/incident-management/containers/IncidentDetail/types.ts
@@ -68,7 +68,7 @@ export interface Attachment {
   created_by: string | null
   is_image: boolean
   location: string
-  caption: string
+  caption: string | null
   public: boolean
   _links: {
     self: {

--- a/src/signals/incident/containers/ExternalReplyContainer/useExternalReplyQuestionnaire.ts
+++ b/src/signals/incident/containers/ExternalReplyContainer/useExternalReplyQuestionnaire.ts
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from 'react'
 
 import { useDispatch } from 'react-redux'
 
-import type { Attachment } from 'components/AttachmentViewer/AttachmentViewer'
+import type { FormattedAttachment } from 'components/AttachmentViewer/AttachmentViewer'
 import { showGlobalNotification } from 'containers/App/actions'
 import { VARIANT_ERROR, TYPE_LOCAL } from 'containers/Notification/constants'
 import { useFetch } from 'hooks'
@@ -187,13 +187,14 @@ const useExternalReplyQuestionnaire = (id: string) => {
 
   const attachments =
     questionnaireData?.questionnaire_explanation.sections.reduce(
-      (previous, current) => [
-        ...previous,
-        ...current.files.map(({ file }) => ({
-          location: file,
-        })),
-      ],
-      [] as Attachment[]
+      (previous, current) =>
+        [
+          ...previous,
+          ...current.files.map(({ file }) => ({
+            location: file,
+          })),
+        ] as FormattedAttachment[],
+      [] as FormattedAttachment[]
     ) || []
 
   return {

--- a/src/signals/my-incidents/types.ts
+++ b/src/signals/my-incidents/types.ts
@@ -10,11 +10,11 @@ export interface MyIncidentsValue {
   email?: string
 }
 
-interface Attachment {
+interface MyIncidentAttachment {
   created_at: string
-  created_by: string
+  created_by: string | null
   href: string
-  caption?: string
+  caption: string | null
 }
 
 export interface MyIncident {
@@ -41,7 +41,7 @@ interface Links {
 }
 
 export interface MyIncidentDetail extends MyIncident {
-  _links: Links & { 'sia:attachments': Attachment[] }
+  _links: Links & { 'sia:attachments': MyIncidentAttachment[] }
   location: Location
   extra_properties?: Item[] | LegacyItems
 }


### PR DESCRIPTION
Ticket: [SIG-5454](https://gemeente-amsterdam.atlassian.net/browse/SIG-5454)

### Changes
Three different types of attachments:
-  incidentDetail management
-  then a mapped one
-  A different "public" on on my-incidents

Did align the types with what is actually passed as data. Many times undefined was used while the actual value was null. 