### PR TITLE
Add additional CSS code

### DIFF
--- a/app.base.json
+++ b/app.base.json
@@ -181,7 +181,6 @@
     "text":""
   },
   "additionalCode": {
-    "css": "",
-    "js": ""
+    "css": ""
   }
 }

--- a/app.base.json
+++ b/app.base.json
@@ -179,6 +179,9 @@
   },
   "frontPageAlert": {
     "text":""
+  },
+  "additionalCode": {
+    "css": "",
+    "js": ""
   }
 }
-

--- a/internals/schemas/app.schema.json
+++ b/internals/schemas/app.schema.json
@@ -833,10 +833,6 @@
         "css": {
           "type": "string",
           "description": "Additional CSS code"
-        },
-        "js": {
-          "type": "string",
-          "description": "Additional JS code"
         }
       },
       "title": "AdditionalCode"

--- a/internals/schemas/app.schema.json
+++ b/internals/schemas/app.schema.json
@@ -50,6 +50,9 @@
         },
         "piwik": {
           "$ref": "#/definitions/Piwik"
+        },
+        "additionalCode": {
+          "$ref": "#/definitions/AdditionalCode"
         }
       },
       "required": [
@@ -822,6 +825,21 @@
         }
       },
       "title": "Piwik"
+    },
+    "AdditionalCode": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "css": {
+          "type": "string",
+          "description": "Additional CSS code"
+        },
+        "js": {
+          "type": "string",
+          "description": "Additional JS code"
+        }
+      },
+      "title": "AdditionalCode"
     }
   }
 }

--- a/internals/scripts/helpers/config.js
+++ b/internals/scripts/helpers/config.js
@@ -46,7 +46,6 @@ const placeholders = {
   $SIGNALS_STATUS_BAR_STYLE: config.head.statusBarStyle,
   $SIGNALS_THEME_COLOR: config.head.themeColor,
   $SIGNALS_ADDITIONAL_CODE_CSS: config.additionalCode.css,
-  $SIGNALS_ADDITIONAL_CODE_JS: config.additionalCode.js,
 }
 
 const inject = (files) =>

--- a/internals/scripts/helpers/config.js
+++ b/internals/scripts/helpers/config.js
@@ -45,6 +45,8 @@ const placeholders = {
   $SIGNALS_PWA_TITLE: config.language.title,
   $SIGNALS_STATUS_BAR_STYLE: config.head.statusBarStyle,
   $SIGNALS_THEME_COLOR: config.head.themeColor,
+  $SIGNALS_ADDITIONAL_CODE_CSS: config.additionalCode.css,
+  $SIGNALS_ADDITIONAL_CODE_JS: config.additionalCode.js,
 }
 
 const inject = (files) =>

--- a/src/index.html
+++ b/src/index.html
@@ -38,6 +38,12 @@
   var spinner = document.getElementById('spinner')
   spinner.style.fill =  window.CONFIG.head.themeColor;
 </script>
+<script>
+  $SIGNALS_ADDITIONAL_CODE_JS
+</script>
+<style>
+  $SIGNALS_ADDITIONAL_CODE_CSS
+</style>
 </body>
 
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -38,9 +38,6 @@
   var spinner = document.getElementById('spinner')
   spinner.style.fill =  window.CONFIG.head.themeColor;
 </script>
-<script>
-  $SIGNALS_ADDITIONAL_CODE_JS
-</script>
 <style>
   $SIGNALS_ADDITIONAL_CODE_CSS
 </style>


### PR DESCRIPTION
This municipality of The Hague would like to add their own fonts to their deployment of Signalen. This PR makes it possible to configure additional CSS code. This adds the ability to load custom fonts.

*This PR is open to discussion and should be considered as an exploration of implementation option number 1 as discussed with @SireeKoolenWijkstra.*

(aanvulling Sirée) 
option number 1 was:
**1e manier**
Wijziging in de source code -> maak fontlocatie configureerbaar. Den Haag past yml aan met de locatie van de fonts. Doe dit door:
1. de locatie van fonts.css configureerbaar maken (maak app.js de import van fonts.css dynamic)
2. zet in de app.<gemeentenaam>.json de plaats voor de fonts.css die niet bij Amsterdam hoort
3. maak een fonts.css met de juiste urls naar de juiste fonts en zet die ergens waar de applicatie bij kan.
4. 
Vereist eenmalige actie van zowel Amsterdam als Den Haag