### PR TITLE
feat/5450-remove-inconsistencies-in-styling-of-forms

### DIFF
--- a/src/components/History/index.js
+++ b/src/components/History/index.js
@@ -8,11 +8,12 @@ import HistoryList from 'components/HistoryList'
 import { historyType } from 'shared/types'
 
 const Section = styled.section`
-  contain: centent;
+  contain: content;
+  margin-top: ${themeSpacing(8)};
 `
 
 const H2 = styled(Heading)`
-  ${styles.HeaderStyles} {
+  ${styles.HeaderStyle} {
     margin: ${themeSpacing(4, 0, 2)};
   }
 `

--- a/src/signals/incident-management/containers/IncidentDetail/IncidentDetail.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/IncidentDetail.tsx
@@ -57,7 +57,7 @@ const StyledRow = styled(Row)`
 `
 
 const StyledAttachments = styled(Attachments)`
-  margin-bottom: ${themeSpacing(4)};
+  margin-bottom: ${themeSpacing(2)};
 `
 
 const DetailContainer = styled(Column)`

--- a/src/signals/incident-management/containers/IncidentDetail/components/Attachments/styled.ts
+++ b/src/signals/incident-management/containers/IncidentDetail/components/Attachments/styled.ts
@@ -17,13 +17,14 @@ export const Wrapper = styled.section`
   contain: content;
   position: relative;
   z-index: 0;
+  margin-top: ${themeSpacing(8, 0, 2)};
 `
 
 export const StyledButtonWrapper = styled.div`
   display: flex;
   flex-wrap: wrap;
-  margin-top: ${themeSpacing(8)};
   gap: ${themeSpacing(2)};
+  margin: ${themeSpacing(8, 0, 0)};
 `
 
 export const Title = styled(Heading)`

--- a/src/signals/settings/categories/components/CategoryForm.tsx
+++ b/src/signals/settings/categories/components/CategoryForm.tsx
@@ -25,6 +25,7 @@ import {
   StyledHistory,
   StyledFormFooter,
   FormContainer,
+  StyledH2,
 } from './styled'
 import configuration from '../../../../shared/services/configuration/configuration'
 import type { CategoryFormValues } from '../types'
@@ -267,9 +268,9 @@ export const CategoryForm = ({
                       control={formMethods.control}
                       render={({ field: { onChange, name } }) => (
                         <FieldGroup>
-                          <StyledHeading>
+                          <StyledH2 forwardedAs="h2" styleAs="h5">
                             Standaardteksten per status
-                          </StyledHeading>
+                          </StyledH2>
                           <StandardTextsField onChange={onChange} name={name} />
                         </FieldGroup>
                       )}

--- a/src/signals/settings/categories/components/styled.ts
+++ b/src/signals/settings/categories/components/styled.ts
@@ -58,7 +58,7 @@ export const StyledLabel = styled(Label)`
 export const StyledH2 = styled(Heading)`
   margin-bottom: ${themeSpacing(2)};
   font-weight: bold;
-  line-height: 22px;
+  line-height: 1.375rem;
   font-size: 1rem;
 `
 
@@ -75,6 +75,6 @@ export const StyledDefinitionTerm = styled.dt`
 export const StyledHeading = styled.p`
   margin-bottom: ${themeSpacing(1)};
   font-weight: bold;
-  line-height: 22px;
+  line-height: 1.375rem;
   font-size: 1rem;
 `

--- a/src/signals/settings/categories/components/styled.ts
+++ b/src/signals/settings/categories/components/styled.ts
@@ -2,7 +2,7 @@
 // Copyright (C) 2020 - 2023 Gemeente Amsterdam
 import type { ElementType } from 'react'
 
-import { themeSpacing, Column, Select, Label } from '@amsterdam/asc-ui'
+import { themeSpacing, Column, Select, Heading, Label } from '@amsterdam/asc-ui'
 import styled from 'styled-components'
 
 import FormFooter from 'components/FormFooter'
@@ -53,6 +53,13 @@ export const StyledSelect = styled(Select)`
 
 export const StyledLabel = styled(Label)`
   font-weight: 400;
+`
+
+export const StyledH2 = styled(Heading)`
+  margin-bottom: ${themeSpacing(2)};
+  font-weight: bold;
+  line-height: 22px;
+  font-size: 1rem;
 `
 
 export const StyledHistory = styled(History as ElementType)`


### PR DESCRIPTION
Made the space between geschiedenis and the inputfield for Notitie 32 px. Made sure that in incidentdetail of Incident-Management the spacing remained the same. Made the spacing between Standaardteksten per status and the select 8px. Checked the spacing of the other components. They are either 4 px or compliant with the spacing used in their component.

Ticket: [SIG-5040](https://gemeente-amsterdam.atlassian.net/browse/SIG-5040)

## Signalen

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
