### PR TITLE
feat/5427 text upper left-corner in attachmentviewer in my incidents dependent on creator

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/IncidentDetail.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/IncidentDetail.tsx
@@ -121,6 +121,7 @@ const IncidentDetail = () => {
 
   const subcategories = useSelector(makeSelectSubCategories)
   const closeDispatch = () => dispatch({ type: CLOSE_ALL })
+
   const stateShownImage = (isPublic: boolean, isCreatedBy: string | null) => {
     if (isCreatedBy === null) return 'melder'
     return isPublic ? 'openbaar getoond' : isCreatedBy

--- a/src/signals/my-incidents/__test__/incidents-detail.ts
+++ b/src/signals/my-incidents/__test__/incidents-detail.ts
@@ -53,3 +53,51 @@ export const incidentsDetail: MyIncidentWithLocation = {
   },
   created_at: '2022-10-10T10:45:45.967617+02:00',
 }
+
+export const incidentsDetail2: MyIncidentWithLocation = {
+  _links: {
+    curies: {
+      name: 'sia',
+      href: 'https://acc.api.meldingen.amsterdam.nl/signals/v1/relations',
+    },
+    self: {
+      href: 'https://acc.api.meldingen.amsterdam.nl/signals/v1/my/signals/a4ed990e-bb4e-4de4-bb5a-f2dd9b907fc4',
+    },
+    'sia:attachments': [
+      { created_at: '', created_by: null, href: '/', caption: '' },
+    ],
+  },
+  extra_properties: [
+    {
+      answer: 'heel erg vaak en het is heel erg stom',
+      category_url:
+        '/signals/v1/public/terms/categories/overlast-van-en-door-personen-of-groepen/sub_categories/overige-overlast-door-personen',
+      id: 'extra_personen_overig_vaker_momenten',
+      label: 'Momenten',
+    },
+  ],
+  location: {
+    address: {
+      postcode: '1012MB',
+      huisletter: '',
+      huisnummer: 63,
+      woonplaats: 'Amsterdam',
+      openbare_ruimte: 'Nieuwendijk',
+      huisnummer_toevoeging: '',
+    },
+    address_text: 'Nieuwendijk 63 1012MB Amsterdam',
+    geometrie: {
+      type: 'Point',
+      coordinates: [4.896696325124808, 52.37737136900012],
+    },
+  },
+  _display: 'SIG-11656',
+  uuid: 'a4ed990e-bb4e-4de4-bb5a-f2dd9b907fc4',
+  id_display: 'SIG-11656',
+  text: 'test',
+  status: {
+    state: 'CLOSED',
+    state_display: 'Afgesloten',
+  },
+  created_at: '2022-10-10T10:45:45.967617+02:00',
+}

--- a/src/signals/my-incidents/__test__/incidents-detail.ts
+++ b/src/signals/my-incidents/__test__/incidents-detail.ts
@@ -16,7 +16,7 @@ export const incidentsDetail: MyIncidentWithLocation = {
       href: 'https://acc.api.meldingen.amsterdam.nl/signals/v1/my/signals/a4ed990e-bb4e-4de4-bb5a-f2dd9b907fc4',
     },
     'sia:attachments': [
-      { created_at: '', created_by: '', href: '/', caption: '' },
+      { created_at: '', created_by: 'somebody', href: '/', caption: '' },
     ],
   },
   extra_properties: [

--- a/src/signals/my-incidents/components/IncidentsDetail/IncidentsDetail.test.tsx
+++ b/src/signals/my-incidents/components/IncidentsDetail/IncidentsDetail.test.tsx
@@ -5,7 +5,10 @@ import userEvent from '@testing-library/user-event'
 
 import { IncidentsDetail } from './IncidentsDetail'
 import { withAppContext } from '../../../../test/utils'
-import { incidentsDetail } from '../../__test__/incidents-detail'
+import {
+  incidentsDetail,
+  incidentsDetail2,
+} from '../../__test__/incidents-detail'
 
 const setShowMap = jest.fn()
 
@@ -91,7 +94,7 @@ describe('IncidentsDetail', () => {
     expect(container.querySelector('img')).not.toBeInTheDocument()
   })
 
-  it('renders attachment viewer', () => {
+  it('renders attachment viewer with image created by the municipal official', () => {
     const { container } = render(
       withAppContext(
         <IncidentsDetail
@@ -112,6 +115,31 @@ describe('IncidentsDetail', () => {
     userEvent.click(image)
 
     expect(screen.queryByTestId('attachment-viewer-image')).toBeInTheDocument()
+    expect(screen.getByText('foto gemeente')).toBeInTheDocument()
+  })
+
+  it('renders attachment viewer with image created by the melder', () => {
+    const { container } = render(
+      withAppContext(
+        <IncidentsDetail
+          incidentsDetail={incidentsDetail2}
+          setShowMap={setShowMap}
+          token={'123'}
+        />
+      )
+    )
+
+    const image = container.querySelector('img') as HTMLElement
+
+    expect(image).toBeInTheDocument()
+    expect(
+      screen.queryByTestId('attachment-viewer-image')
+    ).not.toBeInTheDocument()
+
+    userEvent.click(image)
+
+    expect(screen.queryByTestId('attachment-viewer-image')).toBeInTheDocument()
+    expect(screen.getByText('melder')).toBeInTheDocument()
   })
 
   it('closes previews when close button is clicked', async () => {

--- a/src/signals/my-incidents/components/IncidentsDetail/IncidentsDetail.tsx
+++ b/src/signals/my-incidents/components/IncidentsDetail/IncidentsDetail.tsx
@@ -39,12 +39,17 @@ export const IncidentsDetail = ({
   const [selectedAttachmentEntity, setSelectedAttachmentEntity] =
     useState<typeof attachments>()
 
+  const stateShownImage = (isCreatedBy: string | null) => {
+    if (isCreatedBy === null) return 'melder'
+    return 'foto gemeente'
+  }
+
   const formattedAttachments =
     selectedAttachmentEntity?.map((attachment) => ({
       createdAt: attachment.created_at,
       createdBy: attachment.created_by,
       location: attachment.href,
-      stateShown: 'foto gemeente',
+      stateShown: stateShownImage(attachment.created_by),
       caption: attachment.caption,
     })) || []
 

--- a/src/signals/my-incidents/components/IncidentsDetail/IncidentsDetail.tsx
+++ b/src/signals/my-incidents/components/IncidentsDetail/IncidentsDetail.tsx
@@ -2,6 +2,7 @@
 // Copyright (C) 2022 - 2023 Gemeente Amsterdam
 import { useState } from 'react'
 
+import type { FormattedAttachment } from 'components/AttachmentViewer'
 import AttachmentViewer from 'components/AttachmentViewer'
 
 import { ExtraProperties } from './ExtraProperties'
@@ -39,17 +40,12 @@ export const IncidentsDetail = ({
   const [selectedAttachmentEntity, setSelectedAttachmentEntity] =
     useState<typeof attachments>()
 
-  const stateShownImage = (isCreatedBy: string | null) => {
-    if (isCreatedBy === null) return 'melder'
-    return 'foto gemeente'
-  }
-
-  const formattedAttachments =
+  const formattedAttachments: FormattedAttachment[] =
     selectedAttachmentEntity?.map((attachment) => ({
       createdAt: attachment.created_at,
       createdBy: attachment.created_by,
       location: attachment.href,
-      stateShown: stateShownImage(attachment.created_by),
+      stateShown: attachment.created_by ? 'foto gemeente' : 'melder',
       caption: attachment.caption,
     })) || []
 


### PR DESCRIPTION
Resolved feedback from Jelle. Now in my-incidents the text in the upperleft corner will show either melder or foto gemeente depending on the creator.

Ticket: [SIG-5427](https://gemeente-amsterdam.atlassian.net/browse/SIG-5427)

## Signalen

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
