### PR TITLE
[feat-5019]: Add Icon input to category form

### DIFF
--- a/internals/testing/api.ts
+++ b/internals/testing/api.ts
@@ -26,6 +26,7 @@ export const INCIDENT_CONTEXT = `${INCIDENT}/context`
 export const INCIDENT_CONTEXT_GEOGRAPHY = `${INCIDENT}/context/near/geography`
 export const INCIDENT_CONTEXT_REPORTER = `${INCIDENT}/context/reporter`
 export const CATEGORIES_PRIVATE_ENDPOINT = `${API_BASE_URL}/private/categories/:categoryId`
+export const CATEGORIES_PRIVATE_ENDPOINT_ICON = `${API_BASE_URL}/private/categories/:categoryId/icon`
 export const CATEGORIES_PRIVATE_ENDPOINT_HISTORY = `${API_BASE_URL}/private/categories/:categoryId/history`
 export const EMAIL_VERIFICATION_ENDPOINT = `${API_BASE_URL}/public/reporter/verify-email`
 export const SIGNAL_REPORTER = `${INCIDENT}/reporters`

--- a/internals/testing/msw-server.ts
+++ b/internals/testing/msw-server.ts
@@ -315,8 +315,14 @@ const handlers = [
     res(ctx.status(200))
   ),
 
+  // DELETE
+
   rest.delete(API.STANDARD_TEXTS_DETAIL_ENDPOINT, (_req, res, ctx) =>
     res(ctx.status(204), ctx.json(null))
+  ),
+
+  rest.delete(API.CATEGORIES_PRIVATE_ENDPOINT_ICON, (_req, res, ctx) =>
+    res(ctx.status(204))
   ),
 
   // FALLBACK

--- a/src/components/DataView/components/DataViewBody/DataViewBody.tsx
+++ b/src/components/DataView/components/DataViewBody/DataViewBody.tsx
@@ -53,7 +53,12 @@ const DataViewBody = ({
                   key={`${JSON.stringify(column)}${idx}`}
                   data-testid="data-view-body-row-value"
                 >
-                  <StyledImg alt="Icoon" src={row[column]} />
+                  <StyledImg
+                    alt="Icoon"
+                    src={row[column]}
+                    height={32}
+                    width={32}
+                  />
                 </StyledImageTD>
               )
             }

--- a/src/shared/services/file-upload-channel/index.js
+++ b/src/shared/services/file-upload-channel/index.js
@@ -33,7 +33,7 @@ export default (endpoint, file, id, field = 'file', requestType = 'POST') =>
     /* istanbul ignore next */
     xhr.onload = () => {
       // upload success
-      if (xhr.readyState === 4 && xhr.status > 200 && xhr.status < 400) {
+      if (xhr.readyState === 4 && xhr.status >= 200 && xhr.status < 400) {
         emitter({ success: true })
         emitter(END)
       } else {

--- a/src/shared/services/file-upload-channel/index.js
+++ b/src/shared/services/file-upload-channel/index.js
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2018 - 2022 Vereniging van Nederlandse Gemeenten, Gemeente Amsterdam
+// Copyright (C) 2018 - 2023 Vereniging van Nederlandse Gemeenten, Gemeente Amsterdam
 import { buffers, eventChannel, END } from 'redux-saga'
 
 import { getAuthHeaders } from '../auth/auth'
 
-export default (endpoint, file, id) =>
+export default (endpoint, file, id, field = 'file', requestType = 'POST') =>
   eventChannel((emitter) => {
     const formData = new window.FormData()
     formData.append('signal_id', id)
-    formData.append('file', file)
+    formData.append(field, file)
 
     const xhr = new window.XMLHttpRequest()
 
@@ -41,7 +41,7 @@ export default (endpoint, file, id) =>
       }
     }
 
-    xhr.open('POST', endpoint, true)
+    xhr.open(requestType, endpoint, true)
     const authHeaders = getAuthHeaders()
     Object.entries(authHeaders).forEach(([header, value]) => {
       xhr.setRequestHeader(header, value)

--- a/src/shared/services/file-upload-channel/index.js
+++ b/src/shared/services/file-upload-channel/index.js
@@ -2,9 +2,17 @@
 // Copyright (C) 2018 - 2023 Vereniging van Nederlandse Gemeenten, Gemeente Amsterdam
 import { buffers, eventChannel, END } from 'redux-saga'
 
+import { RequestType } from 'hooks/useFetch'
+
 import { getAuthHeaders } from '../auth/auth'
 
-export default (endpoint, file, id, field = 'file', requestType = 'POST') =>
+export default (
+  endpoint,
+  file,
+  id,
+  field = 'file',
+  requestType = RequestType.POST
+) =>
   eventChannel((emitter) => {
     const formData = new window.FormData()
     formData.append('signal_id', id)

--- a/src/signals/incident-management/containers/IncidentDetail/IncidentDetail.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/IncidentDetail.test.js
@@ -392,7 +392,11 @@ describe('signals/incident-management/containers/IncidentDetail', () => {
     fireEvent.change(fileInputElement, {
       target: { files },
     })
-    expect(mockUseUpload.upload).toHaveBeenCalledWith(files, 4440)
+    expect(mockUseUpload.upload).toHaveBeenCalledWith(
+      files,
+      4440,
+      'http://localhost:8000/signals/v1/private/signals/4440/attachments/'
+    )
   })
 
   it('should handle attachment deletion', async () => {

--- a/src/signals/incident-management/containers/IncidentDetail/IncidentDetail.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/IncidentDetail.tsx
@@ -347,10 +347,14 @@ const IncidentDetail = () => {
   const addAttachment = useCallback(
     (files) => {
       if (incident) {
-        upload(files, incident.id)
+        upload(
+          files,
+          incident.id,
+          `${configuration.INCIDENT_PRIVATE_ENDPOINT}${id}/attachments/`
+        )
       }
     },
-    [incident, upload]
+    [id, incident, upload]
   )
 
   const removeAttachment = useCallback(

--- a/src/signals/incident-management/containers/IncidentDetail/IncidentDetail.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/IncidentDetail.tsx
@@ -350,11 +350,11 @@ const IncidentDetail = () => {
         upload(
           files,
           incident.id,
-          `${configuration.INCIDENT_PRIVATE_ENDPOINT}${id}/attachments/`
+          `${configuration.INCIDENT_PRIVATE_ENDPOINT}${incident.id}/attachments/`
         )
       }
     },
-    [id, incident, upload]
+    [incident, upload]
   )
 
   const removeAttachment = useCallback(

--- a/src/signals/incident-management/containers/IncidentDetail/hooks/useUpload.test.ts
+++ b/src/signals/incident-management/containers/IncidentDetail/hooks/useUpload.test.ts
@@ -5,7 +5,11 @@ import {
   END as mockEnd,
 } from 'redux-saga'
 
+import configuration from 'shared/services/configuration/configuration'
+
 import useUpload from './useUpload'
+
+const id = 3
 
 const mockChannel = {
   fn: (emitter: (input: any) => void) => {
@@ -63,7 +67,8 @@ describe('hooks/useUpload', () => {
               text: (() => {}) as any,
             },
           ],
-          1
+          1,
+          `${configuration.INCIDENT_PRIVATE_ENDPOINT}${id}/attachments/`
         )
       })
 
@@ -97,7 +102,8 @@ describe('hooks/useUpload', () => {
               text: (() => {}) as any,
             },
           ],
-          1
+          1,
+          `${configuration.INCIDENT_PRIVATE_ENDPOINT}${id}/attachments/`
         )
       })
 
@@ -131,7 +137,8 @@ describe('hooks/useUpload', () => {
               text: (() => {}) as any,
             },
           ],
-          1
+          1,
+          `${configuration.INCIDENT_PRIVATE_ENDPOINT}${id}/attachments/`
         )
       })
 

--- a/src/signals/incident-management/containers/IncidentDetail/hooks/useUpload.ts
+++ b/src/signals/incident-management/containers/IncidentDetail/hooks/useUpload.ts
@@ -4,6 +4,7 @@ import type { EventChannel } from 'redux-saga'
 import { runSaga, stdChannel } from 'redux-saga'
 import { all, call, put, take, takeLatest } from 'redux-saga/effects'
 
+import type { RequestType } from 'hooks/useFetch'
 import fileUploadChannel from 'shared/services/file-upload-channel'
 
 export type Files = Array<{
@@ -18,7 +19,7 @@ interface UploadAttachmentsAction {
     id: number
     endpoint: string
     field?: string
-    requestType?: string
+    requestType?: RequestType
   }
 }
 
@@ -44,7 +45,7 @@ interface UploadFileAction {
     file?: { name: string }
     endpoint: string
     field?: string
-    requestType?: string
+    requestType?: RequestType
   }
 }
 

--- a/src/signals/incident-management/containers/IncidentDetail/hooks/useUpload.ts
+++ b/src/signals/incident-management/containers/IncidentDetail/hooks/useUpload.ts
@@ -4,7 +4,6 @@ import type { EventChannel } from 'redux-saga'
 import { runSaga, stdChannel } from 'redux-saga'
 import { all, call, put, take, takeLatest } from 'redux-saga/effects'
 
-import configuration from 'shared/services/configuration/configuration'
 import fileUploadChannel from 'shared/services/file-upload-channel'
 
 export type Files = Array<{
@@ -17,6 +16,9 @@ interface UploadAttachmentsAction {
   payload: {
     files: Files
     id: number
+    endpoint: string
+    field?: string
+    requestType?: string
   }
 }
 
@@ -27,6 +29,9 @@ function* uploadAttachments(action: UploadAttachmentsAction) {
         payload: {
           file,
           id: action.payload.id,
+          endpoint: action.payload.endpoint,
+          field: action.payload?.field,
+          requestType: action.payload?.requestType,
         },
       })
     ),
@@ -37,18 +42,22 @@ interface UploadFileAction {
   payload: {
     id?: number
     file?: { name: string }
+    endpoint: string
+    field?: string
+    requestType?: string
   }
 }
 
 function* uploadFile(action: UploadFileAction): any {
-  const id = action.payload.id
+  const { id, file, endpoint, field, requestType } = action.payload
 
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const channel: EventChannel<any> = yield call(
     fileUploadChannel,
-    `${configuration.INCIDENT_PRIVATE_ENDPOINT}${id}/attachments/`,
-    action.payload?.file,
-    id
+    endpoint,
+    file,
+    id,
+    field,
+    requestType
   )
 
   while (true) {
@@ -117,11 +126,17 @@ const useUpload = () => {
     }
   }, [])
 
-  const upload = (files: File[], id: number) => {
+  const upload = (
+    files: File[],
+    id: number,
+    endpoint: string,
+    field?: string,
+    requestType?: string
+  ) => {
     setSuccess(false)
     channel.put({
       type: 'upload',
-      payload: { files, id },
+      payload: { files, id, endpoint, field, requestType },
     })
   }
 

--- a/src/signals/settings/categories/components/CategoryForm.test.tsx
+++ b/src/signals/settings/categories/components/CategoryForm.test.tsx
@@ -25,6 +25,7 @@ const mockFormValues = {
   n_days: 3,
   use_calendar_days: 1,
   show_children_in_filter: true,
+  icon: null,
 }
 
 const defaultProps: Omit<Props, 'formMethods'> = {

--- a/src/signals/settings/categories/components/CategoryForm.tsx
+++ b/src/signals/settings/categories/components/CategoryForm.tsx
@@ -12,6 +12,7 @@ import RadioButtonList from 'components/RadioButtonList'
 import TextArea from 'components/TextArea'
 import type { History as HistoryType } from 'types/history'
 
+import { IconInput } from './IconInput'
 import StandardTextsField from './StandardTextsField'
 import {
   FieldGroup,
@@ -175,6 +176,8 @@ export const CategoryForm = ({
                   </>
                 )}
               </FieldGroup>
+
+              <IconInput formMethods={formMethods} icon={formValues.icon} />
 
               {formValues.is_public_accessible && (
                 <FieldGroup>

--- a/src/signals/settings/categories/components/Detail.tsx
+++ b/src/signals/settings/categories/components/Detail.tsx
@@ -81,6 +81,7 @@ export const CategoryDetail = ({
           ? DEFAULT_STATUS_OPTION
           : `${data.is_active}`,
       is_public_accessible: data.is_public_accessible ?? true,
+      icon: data.icon,
       name: data.name,
       public_name: data.public_name ?? data.name,
       note: data.note,

--- a/src/signals/settings/categories/components/IconInput/IconInput.test.tsx
+++ b/src/signals/settings/categories/components/IconInput/IconInput.test.tsx
@@ -63,7 +63,7 @@ describe('IconInput', () => {
     ).toBeInTheDocument()
   })
 
-  it('should allow uploading a new icon', () => {
+  it('should allow uploading a new icon', async () => {
     const icon =
       'https://siaweuaaks.blob.core.windows.net/files/icons/categories/0-hoofdcategorie-test/glas-icon.svg?se=2023-04-25T15%3A16%3A27Z&sp=r&sv=2021-08-06&sr=b&sig=GtCGkYzJhlkzlRrVAShohBuCQ0mq%2BojItkjJvPRWFBY%3D'
 
@@ -86,6 +86,14 @@ describe('IconInput', () => {
     const inputTwo = screen.getByLabelText('Icoon wijzigen') as HTMLInputElement
 
     expect(inputTwo.files?.[0]?.name).toBe('test.svg')
+
+    const confirmButton = screen.getByText('Bevestig')
+
+    await waitFor(() => {
+      userEvent.click(confirmButton)
+    })
+
+    expect(mockUseUpload.upload).toHaveBeenCalled()
   })
 
   it('should allow deleting an icon', async () => {

--- a/src/signals/settings/categories/components/IconInput/IconInput.test.tsx
+++ b/src/signals/settings/categories/components/IconInput/IconInput.test.tsx
@@ -86,8 +86,6 @@ describe('IconInput', () => {
     })
     expect(screen.queryByText('Bevestig')).not.toBeInTheDocument()
     expect(mockUseUpload.upload).toHaveBeenCalled()
-
-    screen.debug()
   })
 
   it('should allow changing an icon', async () => {

--- a/src/signals/settings/categories/components/IconInput/IconInput.test.tsx
+++ b/src/signals/settings/categories/components/IconInput/IconInput.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useForm } from 'react-hook-form'
+
+import { withAppContext } from 'test/utils'
+
+import { IconInput } from './IconInput'
+import type { Props } from './IconInput'
+import * as API from '../../../../../../internals/testing/api'
+import {
+  mockRequestHandler,
+  fetchMock,
+} from '../../../../../../internals/testing/msw-server'
+
+fetchMock.disableMocks()
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => ({ categoryId: '145' }),
+}))
+
+const mockUseUpload = {
+  upload: jest.fn(),
+  uploadSuccess: jest.fn(),
+  uploadProgress: jest.fn(),
+  uploadError: jest.fn(),
+}
+
+jest.mock(
+  'signals/incident-management/containers/IncidentDetail/hooks/useUpload',
+  () => () => mockUseUpload
+)
+
+const defaultProps: Omit<Props, 'formMethods'> = {
+  icon: null,
+}
+
+const Wrapper = (props: Partial<Props>) => {
+  const methods = useForm<any>()
+  return withAppContext(
+    <IconInput {...defaultProps} formMethods={methods} {...props} />
+  )
+}
+
+describe('IconInput', () => {
+  it('should render without icon', () => {
+    render(<Wrapper icon={null} />)
+
+    expect(screen.getByText('Icoon')).toBeVisible()
+    expect(screen.getByText('Niet ingesteld')).toBeVisible()
+    expect(screen.getByText('Icoon toevoegen')).toBeVisible()
+  })
+
+  it('should render with an icon', () => {
+    const icon =
+      'https://siaweuaaks.blob.core.windows.net/files/icons/categories/0-hoofdcategorie-test/glas-icon.svg?se=2023-04-25T15%3A16%3A27Z&sp=r&sv=2021-08-06&sr=b&sig=GtCGkYzJhlkzlRrVAShohBuCQ0mq%2BojItkjJvPRWFBY%3D'
+    render(<Wrapper icon={icon} />)
+
+    expect(screen.getByRole('img', { name: '' })).toBeInTheDocument()
+    expect(screen.getByText('Icoon wijzigen')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Icoon verwijderen' })
+    ).toBeInTheDocument()
+  })
+
+  it('should allow uploading a new icon', () => {
+    const icon =
+      'https://siaweuaaks.blob.core.windows.net/files/icons/categories/0-hoofdcategorie-test/glas-icon.svg?se=2023-04-25T15%3A16%3A27Z&sp=r&sv=2021-08-06&sr=b&sig=GtCGkYzJhlkzlRrVAShohBuCQ0mq%2BojItkjJvPRWFBY%3D'
+
+    render(<Wrapper icon={icon} />)
+
+    const input = screen.getByLabelText('Icoon wijzigen') as HTMLInputElement
+
+    expect(input.files?.[0]?.name).not.toBe('test.svg')
+
+    fireEvent.change(input, {
+      target: {
+        files: [
+          new File(['(⌐□_□)'], 'test.svg', {
+            type: 'image/svg+xml',
+          }),
+        ],
+      },
+    })
+
+    const inputTwo = screen.getByLabelText('Icoon wijzigen') as HTMLInputElement
+
+    expect(inputTwo.files?.[0]?.name).toBe('test.svg')
+  })
+
+  it('should allow deleting an icon', async () => {
+    mockRequestHandler({
+      url: API.CATEGORIES_PRIVATE_ENDPOINT_ICON,
+      status: 204,
+      body: {},
+    })
+
+    const icon =
+      'https://siaweuaaks.blob.core.windows.net/files/icons/categories/0-hoofdcategorie-test/glas-icon.svg?se=2023-04-25T15%3A16%3A27Z&sp=r&sv=2021-08-06&sr=b&sig=GtCGkYzJhlkzlRrVAShohBuCQ0mq%2BojItkjJvPRWFBY%3D'
+
+    render(<Wrapper icon={icon} />)
+
+    const deleteButton = screen.getByTitle('Icoon verwijderen')
+    userEvent.click(deleteButton)
+
+    const confirmButton = screen.getByText('Bevestig')
+
+    await waitFor(() => {
+      userEvent.click(confirmButton)
+    })
+
+    const deleteButtonAfterDelete = screen.queryByTitle('Icoon verwijderen')
+
+    expect(deleteButtonAfterDelete).not.toBeInTheDocument()
+  })
+})

--- a/src/signals/settings/categories/components/IconInput/IconInput.tsx
+++ b/src/signals/settings/categories/components/IconInput/IconInput.tsx
@@ -9,6 +9,7 @@ import { useParams } from 'react-router-dom'
 import Button from 'components/Button'
 import { useConfirm } from 'hooks/useConfirm'
 import useFetch from 'hooks/useFetch'
+import { RequestType } from 'hooks/useFetch'
 import configuration from 'shared/services/configuration/configuration'
 import FileInput from 'signals/incident-management/containers/IncidentDetail/components/FileInput'
 import useUpload from 'signals/incident-management/containers/IncidentDetail/hooks/useUpload'
@@ -47,13 +48,13 @@ export const IconInput = ({ formMethods, icon }: Props) => {
     error: error || uploadError,
     isLoading,
     isSuccess: isSuccess || uploadSuccess,
-    requestType: type || 'PUT',
+    requestType: type || RequestType.PUT,
   })
 
   const handleOnChange = useCallback(
     async (files: File[]) => {
       const confirmed = await isConfirmed(
-        'Let op! Je veranderd een icoon. ',
+        'Let op! Je verander een icoon. ',
         'Er wordt geen back-up van het icoon gemaakt.'
       )
 
@@ -65,7 +66,7 @@ export const IconInput = ({ formMethods, icon }: Props) => {
             Number(categoryId),
             `${configuration.CATEGORIES_PRIVATE_ENDPOINT}${categoryId}/icon`,
             'icon',
-            'PUT'
+            RequestType.PUT
           )
       }
 

--- a/src/signals/settings/categories/components/IconInput/IconInput.tsx
+++ b/src/signals/settings/categories/components/IconInput/IconInput.tsx
@@ -1,0 +1,112 @@
+import { useEffect, useState } from 'react'
+
+import { Controller } from 'react-hook-form'
+import { useParams } from 'react-router-dom'
+
+import Button from 'components/Button'
+import { useConfirm } from 'hooks/useConfirm'
+import configuration from 'shared/services/configuration/configuration'
+import FileInput from 'signals/incident-management/containers/IncidentDetail/components/FileInput'
+
+import {
+  StyeldAlert as Alert,
+  FieldGroup,
+  StyledHeading,
+  StyledIcon,
+} from '../styled'
+import { StyledDiv } from '../styled'
+
+interface Props {
+  icon: string | null
+  formMethods: any
+}
+
+export const IconInput = ({ formMethods, icon }: Props) => {
+  const [file, setFile] = useState<File | null>(null)
+  const [fileDataURL, setFileDataURL] = useState<string | null>(icon)
+  const { isConfirmed } = useConfirm()
+  const { categoryId } = useParams<{ categoryId: string }>()
+  const categoryURL = `${configuration.CATEGORIES_PRIVATE_ENDPOINT}${categoryId}/icon`
+  const label = icon ? 'Icoon wijzigen' : 'Icoon toevoegen'
+  const handleOnChange = async (e: File[]) => {
+    setFile(e[0])
+
+    const confirmed = await isConfirmed(
+      'Let op! Je veranderd een icoon. ',
+      'Er wordt geen back-up van het icoon gemaakt.'
+    )
+
+    if (confirmed) {
+      categoryURL
+      // TODO: patch to categoryURL
+    }
+  }
+
+  useEffect(() => {
+    let fileReader: any
+    let isCancel = false
+
+    if (file) {
+      fileReader = new FileReader()
+      fileReader.onload = (e: { target: { result: string } }) => {
+        const { result } = e.target
+        if (result && !isCancel) {
+          setFileDataURL(result)
+        }
+      }
+      fileReader.readAsDataURL(file)
+    }
+    return () => {
+      isCancel = true
+      if (fileReader && fileReader.readyState === 1) {
+        fileReader.abort()
+      }
+    }
+  }, [file])
+
+  return (
+    <FieldGroup>
+      <StyledHeading>Icoon</StyledHeading>
+
+      {/* Informatie */}
+
+      <Controller
+        name="icon"
+        control={formMethods.control}
+        render={({ field: { name } }) => (
+          <StyledDiv>
+            {fileDataURL && (
+              <StyledIcon size={32}>
+                <img alt="Icoon" src={fileDataURL} />
+              </StyledIcon>
+            )}
+
+            {file && (
+              <Alert
+                level="info"
+                heading="Let op! Er wordt geen back-up van het icoon gemaakt."
+                content="Om te annuleren gebruik de knop onderaan de pagina."
+              />
+            )}
+
+            <FileInput
+              allowedFileTypes={['image/svg']}
+              name={name}
+              onChange={(event) => handleOnChange(event)}
+              multiple={false}
+            >
+              <Button
+                forwardedAs={'span'}
+                tabIndex={0}
+                variant="primaryInverted"
+                type="button"
+              >
+                {label}
+              </Button>
+            </FileInput>
+          </StyledDiv>
+        )}
+      />
+    </FieldGroup>
+  )
+}

--- a/src/signals/settings/categories/components/IconInput/IconInput.tsx
+++ b/src/signals/settings/categories/components/IconInput/IconInput.tsx
@@ -130,7 +130,7 @@ export const IconInput = ({ formMethods, icon }: Props) => {
       <StyledHeading>Icoon</StyledHeading>
       <Detail
         header={'Het icoon wordt getoond op de openbare meldingenkaart.'}
-        content={'Zorg voor een circel en exporteer als SVG.'}
+        content={'Zorg voor een cirkel en exporteer als SVG.'}
       >
         {ICONEXAMPLE}
       </Detail>

--- a/src/signals/settings/categories/components/IconInput/IconInput.tsx
+++ b/src/signals/settings/categories/components/IconInput/IconInput.tsx
@@ -96,6 +96,7 @@ export const IconInput = ({ formMethods, icon }: Props) => {
     [categoryId, deleteIcon, isConfirmed]
   )
 
+  // istanbul ignore next
   useEffect(() => {
     let fileReader: FileReader
     let isCancel = false

--- a/src/signals/settings/categories/components/IconInput/IconInput.tsx
+++ b/src/signals/settings/categories/components/IconInput/IconInput.tsx
@@ -14,6 +14,7 @@ import FileInput from 'signals/incident-management/containers/IncidentDetail/com
 import useUpload from 'signals/incident-management/containers/IncidentDetail/hooks/useUpload'
 
 import useFetchResponseNotification from '../../../hooks/useFetchResponseNotification'
+import type { Props as CategoryFormProps } from '../CategoryForm'
 import {
   DeleteButton,
   FieldGroup,
@@ -26,7 +27,7 @@ import { StyledDiv } from '../styled'
 
 interface Props {
   icon: string | null
-  formMethods: any
+  formMethods: CategoryFormProps['formMethods']
 }
 
 export const IconInput = ({ formMethods, icon }: Props) => {
@@ -49,28 +50,31 @@ export const IconInput = ({ formMethods, icon }: Props) => {
     requestType: type || 'PUT',
   })
 
-  const handleOnChange = async (files: File[]) => {
-    const confirmed = await isConfirmed(
-      'Let op! Je veranderd een icoon. ',
-      'Er wordt geen back-up van het icoon gemaakt.'
-    )
+  const handleOnChange = useCallback(
+    async (files: File[]) => {
+      const confirmed = await isConfirmed(
+        'Let op! Je veranderd een icoon. ',
+        'Er wordt geen back-up van het icoon gemaakt.'
+      )
 
-    if (confirmed) {
-      setFile(files[0])
-      categoryId &&
-        upload(
-          files,
-          Number(categoryId),
-          `${configuration.CATEGORIES_PRIVATE_ENDPOINT}${categoryId}/icon`,
-          'icon',
-          'PUT'
-        )
-    }
+      if (confirmed) {
+        setFile(files[0])
+        categoryId &&
+          upload(
+            files,
+            Number(categoryId),
+            `${configuration.CATEGORIES_PRIVATE_ENDPOINT}${categoryId}/icon`,
+            'icon',
+            'PUT'
+          )
+      }
 
-    if (!confirmed) {
-      setFile(null)
-    }
-  }
+      if (!confirmed) {
+        setFile(null)
+      }
+    },
+    [categoryId, isConfirmed, upload]
+  )
 
   const handleOnDelete = useCallback(
     async (event) => {
@@ -93,13 +97,13 @@ export const IconInput = ({ formMethods, icon }: Props) => {
   )
 
   useEffect(() => {
-    let fileReader: any
+    let fileReader: FileReader
     let isCancel = false
 
     if (file) {
       fileReader = new FileReader()
-      fileReader.onload = (e: { target: { result: string } }) => {
-        const { result } = e.target
+      fileReader.onload = (e) => {
+        const result = e?.target?.result as string
         if (result && !isCancel) {
           setFileDataURL(result)
         }
@@ -127,7 +131,7 @@ export const IconInput = ({ formMethods, icon }: Props) => {
           <StyledDiv>
             {fileDataURL ? (
               <StyledIcon size={32}>
-                <img alt="Icoon" src={fileDataURL} />
+                <img width={32} height={32} alt="Icoon" src={fileDataURL} />
               </StyledIcon>
             ) : (
               <StyledSpan>Niet ingesteld</StyledSpan>

--- a/src/signals/settings/categories/components/IconInput/IconInput.tsx
+++ b/src/signals/settings/categories/components/IconInput/IconInput.tsx
@@ -7,6 +7,7 @@ import Button from 'components/Button'
 import { useConfirm } from 'hooks/useConfirm'
 import configuration from 'shared/services/configuration/configuration'
 import FileInput from 'signals/incident-management/containers/IncidentDetail/components/FileInput'
+import useUpload from 'signals/incident-management/containers/IncidentDetail/hooks/useUpload'
 
 import {
   StyeldAlert as Alert,
@@ -25,8 +26,8 @@ export const IconInput = ({ formMethods, icon }: Props) => {
   const [file, setFile] = useState<File | null>(null)
   const [fileDataURL, setFileDataURL] = useState<string | null>(icon)
   const { isConfirmed } = useConfirm()
+  const { upload } = useUpload()
   const { categoryId } = useParams<{ categoryId: string }>()
-  const categoryURL = `${configuration.CATEGORIES_PRIVATE_ENDPOINT}${categoryId}/icon`
   const label = icon ? 'Icoon wijzigen' : 'Icoon toevoegen'
   const handleOnChange = async (e: File[]) => {
     setFile(e[0])
@@ -37,8 +38,14 @@ export const IconInput = ({ formMethods, icon }: Props) => {
     )
 
     if (confirmed) {
-      categoryURL
-      // TODO: patch to categoryURL
+      categoryId &&
+        upload(
+          e,
+          Number(categoryId),
+          `${configuration.CATEGORIES_PRIVATE_ENDPOINT}${categoryId}/icon`,
+          'icon',
+          'PUT'
+        )
     }
   }
 

--- a/src/signals/settings/categories/components/IconInput/IconInput.tsx
+++ b/src/signals/settings/categories/components/IconInput/IconInput.tsx
@@ -14,14 +14,15 @@ import configuration from 'shared/services/configuration/configuration'
 import FileInput from 'signals/incident-management/containers/IncidentDetail/components/FileInput'
 import useUpload from 'signals/incident-management/containers/IncidentDetail/hooks/useUpload'
 
+import { Detail } from '../../../../../components/Detail'
 import useFetchResponseNotification from '../../../hooks/useFetchResponseNotification'
+import { ICONEXAMPLE } from '../../constants'
 import type { Props as CategoryFormProps } from '../CategoryForm'
 import {
   DeleteButton,
   FieldGroup,
   StyledHeading,
   StyledIcon,
-  StyledSpan,
   Wrapper,
 } from '../styled'
 import { StyledDiv } from '../styled'
@@ -53,10 +54,14 @@ export const IconInput = ({ formMethods, icon }: Props) => {
 
   const handleOnChange = useCallback(
     async (files: File[]) => {
-      const confirmed = await isConfirmed(
-        'Let op! Je verander een icoon. ',
-        'Er wordt geen back-up van het icoon gemaakt.'
-      )
+      let confirmed
+      if (!fileDataURL) confirmed = true
+      if (fileDataURL) {
+        confirmed = await isConfirmed(
+          'Let op, je verandert het icoon. ',
+          'Er wordt geen back-up van het icoon gemaakt.'
+        )
+      }
 
       if (confirmed) {
         setFile(files[0])
@@ -74,7 +79,7 @@ export const IconInput = ({ formMethods, icon }: Props) => {
         setFile(null)
       }
     },
-    [categoryId, isConfirmed, upload]
+    [categoryId, fileDataURL, isConfirmed, upload]
   )
 
   const handleOnDelete = useCallback(
@@ -82,7 +87,7 @@ export const IconInput = ({ formMethods, icon }: Props) => {
       event.preventDefault()
 
       const confirmed = await isConfirmed(
-        'Let op! Je verwijderd een icoon. ',
+        'Let op, je verwijdert het icoon. ',
         'Er wordt geen back-up van het icoon gemaakt.'
       )
 
@@ -123,20 +128,21 @@ export const IconInput = ({ formMethods, icon }: Props) => {
   return (
     <FieldGroup>
       <StyledHeading>Icoon</StyledHeading>
-
-      {/* Informatie */}
-
+      <Detail
+        header={'Het icoon wordt getoond op de openbare meldingenkaart.'}
+        content={'Zorg voor een circel en exporteer als SVG.'}
+      >
+        {ICONEXAMPLE}
+      </Detail>
       <Controller
         name="icon"
         control={formMethods.control}
         render={({ field: { name } }) => (
           <StyledDiv>
-            {fileDataURL ? (
+            {fileDataURL && (
               <StyledIcon size={32}>
                 <img width={32} height={32} alt="Icoon" src={fileDataURL} />
               </StyledIcon>
-            ) : (
-              <StyledSpan>Niet ingesteld</StyledSpan>
             )}
 
             <Wrapper>

--- a/src/signals/settings/categories/components/IconInput/IconInput.tsx
+++ b/src/signals/settings/categories/components/IconInput/IconInput.tsx
@@ -25,7 +25,7 @@ import {
 } from '../styled'
 import { StyledDiv } from '../styled'
 
-interface Props {
+export interface Props {
   icon: string | null
   formMethods: CategoryFormProps['formMethods']
 }

--- a/src/signals/settings/categories/components/IconInput/index.ts
+++ b/src/signals/settings/categories/components/IconInput/index.ts
@@ -1,0 +1,1 @@
+export { IconInput } from './IconInput'

--- a/src/signals/settings/categories/components/styled.ts
+++ b/src/signals/settings/categories/components/styled.ts
@@ -11,7 +11,7 @@ import {
   Select,
   themeSpacing,
 } from '@amsterdam/asc-ui'
-import styled, { css } from 'styled-components'
+import styled from 'styled-components'
 
 import FormFooter from 'components/FormFooter'
 import History from 'components/History'
@@ -106,28 +106,6 @@ export const DeleteButton = styled(Button)`
 export const StyledInfo = styled.p`
   margin-top: ${themeSpacing(0)};
   margin-bottom: ${themeSpacing(1)};
-`
-
-export const InvisibleButton = styled.button<{ toggle: boolean }>`
-  text-decoration: none;
-  background-color: unset;
-  color: inherit;
-  border: none;
-  padding: 0;
-
-  > * {
-    transition: transform 0.25s;
-    ${({ toggle }) =>
-      toggle &&
-      css`
-        transform: rotate(180deg);
-      `}
-  }
-`
-export const StyledImg = styled.img`
-  max-height: ${themeSpacing(8)};
-  align-self: flex-start;
-  margin-top: ${themeSpacing(2.5)};
 `
 
 export const Wrapper = styled.div`

--- a/src/signals/settings/categories/components/styled.ts
+++ b/src/signals/settings/categories/components/styled.ts
@@ -11,7 +11,7 @@ import {
   Select,
   themeSpacing,
 } from '@amsterdam/asc-ui'
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
 
 import FormFooter from 'components/FormFooter'
 import History from 'components/History'
@@ -103,6 +103,32 @@ export const DeleteButton = styled(Button)`
   height: 44px;
   width: 44px;
 `
+export const StyledInfo = styled.p`
+  margin-top: ${themeSpacing(0)};
+  margin-bottom: ${themeSpacing(1)};
+`
+
+export const InvisibleButton = styled.button<{ toggle: boolean }>`
+  text-decoration: none;
+  background-color: unset;
+  color: inherit;
+  border: none;
+  padding: 0;
+
+  > * {
+    transition: transform 0.25s;
+    ${({ toggle }) =>
+      toggle &&
+      css`
+        transform: rotate(180deg);
+      `}
+  }
+`
+export const StyledImg = styled.img`
+  max-height: ${themeSpacing(8)};
+  align-self: flex-start;
+  margin-top: ${themeSpacing(2.5)};
+`
 
 export const Wrapper = styled.div`
   display: flex;
@@ -110,8 +136,4 @@ export const Wrapper = styled.div`
   & > *:not(:first-child) {
     margin-left: ${themeSpacing(2)};
   }
-`
-
-export const StyledSpan = styled.span`
-  margin-bottom: ${themeSpacing(2)};
 `

--- a/src/signals/settings/categories/components/styled.ts
+++ b/src/signals/settings/categories/components/styled.ts
@@ -3,7 +3,7 @@
 import type { ElementType } from 'react'
 
 import {
-  Alert,
+  Button,
   Column,
   Heading,
   Icon,
@@ -90,12 +90,28 @@ export const StyledHeading = styled.label`
 export const StyledDiv = styled.div`
   display: flex;
   flex-direction: column;
+  margin-top: ${themeSpacing(2)};
 `
 
 export const StyledIcon = styled(Icon)`
-  margin: ${themeSpacing(2, 0)};
+  margin-bottom: ${themeSpacing(2)};
 `
 
-export const StyeldAlert = styled(Alert)`
+export const DeleteButton = styled(Button)`
+  margin-left: ${themeSpacing(2)};
+  justify-content: center;
+  height: 44px;
+  width: 44px;
+`
+
+export const Wrapper = styled.div`
+  display: flex;
+
+  & > *:not(:first-child) {
+    margin-left: ${themeSpacing(2)};
+  }
+`
+
+export const StyledSpan = styled.span`
   margin-bottom: ${themeSpacing(2)};
 `

--- a/src/signals/settings/categories/components/styled.ts
+++ b/src/signals/settings/categories/components/styled.ts
@@ -2,7 +2,15 @@
 // Copyright (C) 2020 - 2023 Gemeente Amsterdam
 import type { ElementType } from 'react'
 
-import { themeSpacing, Column, Select, Heading, Label } from '@amsterdam/asc-ui'
+import {
+  Alert,
+  Column,
+  Heading,
+  Icon,
+  Label,
+  Select,
+  themeSpacing,
+} from '@amsterdam/asc-ui'
 import styled from 'styled-components'
 
 import FormFooter from 'components/FormFooter'
@@ -72,9 +80,22 @@ export const StyledDefinitionTerm = styled.dt`
   margin-bottom: ${themeSpacing(1)};
 `
 
-export const StyledHeading = styled.p`
+export const StyledHeading = styled.label`
   margin-bottom: ${themeSpacing(1)};
   font-weight: bold;
   line-height: 1.375rem;
   font-size: 1rem;
+`
+
+export const StyledDiv = styled.div`
+  display: flex;
+  flex-direction: column;
+`
+
+export const StyledIcon = styled(Icon)`
+  margin: ${themeSpacing(2, 0)};
+`
+
+export const StyeldAlert = styled(Alert)`
+  margin-bottom: ${themeSpacing(2)};
 `

--- a/src/signals/settings/categories/components/utils.test.ts
+++ b/src/signals/settings/categories/components/utils.test.ts
@@ -13,12 +13,12 @@ const mockFormData: CategoryFormValues = {
     'We laten u binnen 5 dagen weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail.',
   is_active: 'true',
   is_public_accessible: false,
-  name: 'Bedrijfsafval',
-  public_name: 'Bedrijfsafval',
-  note: 'Test notitie',
   n_days: 5,
-  use_calendar_days: 1,
+  name: 'Bedrijfsafval',
   icon: null,
+  note: 'Test notitie',
+  public_name: 'Bedrijfsafval',
+  use_calendar_days: 1,
 }
 
 const mockDirtyFields = {

--- a/src/signals/settings/categories/components/utils.test.ts
+++ b/src/signals/settings/categories/components/utils.test.ts
@@ -18,6 +18,7 @@ const mockFormData: CategoryFormValues = {
   note: 'Test notitie',
   n_days: 5,
   use_calendar_days: 1,
+  icon: null,
 }
 
 const mockDirtyFields = {

--- a/src/signals/settings/categories/constants.tsx
+++ b/src/signals/settings/categories/constants.tsx
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (C) 2023 Gemeente Amsterdam
+import { StyledInfo } from './components/styled'
+import { Fragment } from 'react'
+
+export const ICONEXAMPLE = [
+  <Fragment key={'IconExample'}>
+    <StyledInfo>Voorbeeld van een icoon:</StyledInfo>
+    <img alt={'example-of-an-icon'} src={'/assets/images/afval/rest.svg'} />
+  </Fragment>,
+]

--- a/src/signals/settings/categories/types.ts
+++ b/src/signals/settings/categories/types.ts
@@ -9,6 +9,7 @@ export interface CategoryFormValues {
   is_public_accessible: boolean
   n_days: number | null
   name: string
+  icon: string | null
   note: string | null
   public_name: string
   use_calendar_days: number

--- a/src/types/category.ts
+++ b/src/types/category.ts
@@ -25,6 +25,7 @@ export interface Category {
   }
   id: number | string
   name: string
+  icon: string | null
   slug: string
   is_active: boolean
   description: string | null

--- a/src/utils/__tests__/fixtures/categories_private.json
+++ b/src/utils/__tests__/fixtures/categories_private.json
@@ -29,6 +29,7 @@
           "href": "https://acc.api.data.amsterdam.nl/signals/v1/private/terms/categories/afval/status-message-templates"
         }
       },
+      "icon": null,
       "_display": "Afval",
       "id": 79,
       "name": "Afval",
@@ -66,6 +67,7 @@
           "public": "https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/civiele-constructies"
         }
       },
+      "icon": null,
       "_display": "Afwatering brug (Civiele Constructies)",
       "id": 145,
       "name": "Afwatering brug",
@@ -171,6 +173,7 @@
           "public": "https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/afval"
         }
       },
+      "icon": null,
       "_display": "Asbest / accu (Afval)",
       "id": 10,
       "name": "Asbest / accu",
@@ -289,6 +292,7 @@
           "public": "https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/overlast-in-de-openbare-ruimte"
         }
       },
+      "icon": null,
       "_display": "Auto- / scooter- / bromfiets(wrak) (Overlast in de openbare ruimte)",
       "id": 34,
       "name": "Auto- / scooter- / bromfiets(wrak)",
@@ -407,6 +411,7 @@
           "public": "https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair"
         }
       },
+      "icon": null,
       "_display": "Autom. Verzinkbare palen (Wegen, verkeer, straatmeubilair)",
       "id": 92,
       "name": "Autom. Verzinkbare palen",
@@ -517,6 +522,7 @@
           "public": "https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/afval"
         }
       },
+      "icon": null,
       "_display": "Bedrijfsafval (Afval)",
       "id": 4,
       "name": "Bedrijfsafval",
@@ -563,6 +569,7 @@
           "public": "https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/openbaar-groen-en-water"
         }
       },
+      "icon": null,
       "_display": "Beplanting (Openbaar groen en water)",
       "id": 152,
       "name": "Beplanting",
@@ -785,6 +792,7 @@
           "public": "https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/wegen-verkeer-straatmeubilair"
         }
       },
+      "icon": null,
       "_display": "Bewegwijzering (Wegen, verkeer, straatmeubilair)",
       "id": 93,
       "name": "Bewegwijzering",
@@ -895,6 +903,7 @@
           "public": "https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/overlast-op-het-water"
         }
       },
+      "icon": null,
       "_display": "Blokkade van de vaarweg (Overlast op het water)",
       "id": 134,
       "name": "Blokkade van de vaarweg",
@@ -1093,6 +1102,7 @@
           "public": "https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/openbaar-groen-en-water"
         }
       },
+      "icon": null,
       "_display": "Boom - aanvraag plaatsing (Openbaar groen en water)",
       "id": 113,
       "name": "Boom - aanvraag plaatsing",

--- a/src/utils/__tests__/fixtures/categories_structured.json
+++ b/src/utils/__tests__/fixtures/categories_structured.json
@@ -24,6 +24,7 @@
         "href": "https://acc.api.data.amsterdam.nl/signals/v1/private/terms/categories/openbaar-groen-en-water/status-message-templates"
       }
     },
+    "icon": null,
     "id": "https://acc.api.data.amsterdam.nl/signals/v1/public/terms/categories/openbaar-groen-en-water",
     "is_active": true,
     "description": null,
@@ -38,6 +39,7 @@
           "n_days": 5,
           "use_calendar_days": false
         },
+        "icon": null,
         "name": "Boom - boomstob",
         "slug": "boom-boomstob",
         "handling_message": "\nUw melding wordt ingepland: wij laten u binnen 5 werkdagen weten hoe en wanneer uw melding wordt afgehandeld. Dat doen we via e-mail.",
@@ -77,6 +79,7 @@
       "n_days": null,
       "use_calendar_days": null
     },
+    "icon": null,
     "name": "Afval",
     "slug": "afval",
     "handling_message": "\nWij bekijken uw melding en zorgen dat het juiste onderdeel van de gemeente deze gaat behandelen. Heeft u contactgegevens achtergelaten? Dan nemen wij bij onduidelijkheid contact met u op.",
@@ -107,6 +110,7 @@
           "n_days": 3,
           "use_calendar_days": false
         },
+        "icon": null,
         "name": "Container glas kapot",
         "slug": "container-glas-kapot",
         "handling_message": "\nWe laten u binnen 3 weken weten wat we hebben gedaan. En anders hoort u wanneer wij uw melding kunnen oppakken.\nWe houden u op de hoogte via e-mail.",
@@ -178,6 +182,7 @@
       "n_days": null,
       "use_calendar_days": null
     },
+    "icon": null,
     "name": "Wegen, verkeer, straatmeubilair",
     "slug": "wegen-verkeer-straatmeubilair",
     "handling_message": "\nWij bekijken uw melding en zorgen dat het juiste onderdeel van de gemeente deze gaat behandelen. Heeft u contactgegevens achtergelaten? Dan nemen wij bij onduidelijkheid contact met u op.",
@@ -211,6 +216,7 @@
           "n_days": 21,
           "use_calendar_days": true
         },
+        "icon": null,
         "name": "Autom. Verzinkbare palen",
         "slug": "autom-verzinkbare-palen",
         "handling_message": "\nWij handelen uw melding binnen drie weken af. U ontvangt dan geen apart bericht meer.\nEn anders hoort u - via e-mail - wanneer wij uw melding kunnen oppakken.",


### PR DESCRIPTION
Ticket: [SIG-5019](https://gemeente-amsterdam.atlassian.net/browse/SIG-5019)

Chose a slightly different approach then designed. The design assume the icon is saved when the whole page is saved. But the icon is posted to a different endpoint, therefor I thought it'd be nicer to use the confirmation modal.

Notes:
- Flow is slightly different then designed. Instead of savind on page save I chose to save with the confirmation modal. This way all logic stays in one place. 
- A warning for pixels is not necessary since they are svg's

Todo:

- [x] Add information dropdown (will do in another PR)
- [x] Detail component should be implemented. See [this PR](https://github.com/Amsterdam/signals-frontend/pull/2719)
- [x] Feedback point 3 from Siree 

Previous [draft PR](https://github.com/Amsterdam/signals-frontend/pull/2612/files#diff-6d4d8e6cb1ea85996fe6f4084193e7e076e8c40ba681f7f7a66e093d61a0130b) 