### PR TITLE
[bug-5429]: Add isBlocking to input validator map

### DIFF
--- a/src/signals/incident/containers/IncidentContainer/constants.ts
+++ b/src/signals/incident/containers/IncidentContainer/constants.ts
@@ -68,4 +68,5 @@ export const INPUT_VALIDATOR_MAP = {
   pattern: 'pattern',
   required: 'required',
   required_true: 'requiredTrue',
+  isBlocking: 'isBlocking',
 }


### PR DESCRIPTION
**how to test**
- run backend and frontend with fetchQuestionsFromBackend to true (docker compose up -d in both signals and signals frontend)
- then add two questions where the alert is triggered on the first option of the first question:

<img width="1168" alt="Screenshot 2023-09-25 at 14 21 48" src="https://github.com/Amsterdam/signals-frontend/assets/7532781/986f9923-a58d-4a32-b513-a1377e6ef788">

<img width="940" alt="Screenshot 2023-09-25 at 14 22 39" src="https://github.com/Amsterdam/signals-frontend/assets/7532781/8190de3c-0fb7-4dbb-a473-43dec563db94">

- it should init the 'harde stop'


Ticket: [SIG-5429](https://gemeente-amsterdam.atlassian.net/browse/SIG-5429)

## Signalen

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
