### PR TITLE
[bugfix-5487] stop unnecessary calls to the BE from the incidentmap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "immutable": "^4.0.0-rc.12",
         "invariant": "^2.2.4",
         "keycloak-js": "^20.0.3",
-        "leaflet": "^1.9.3",
+        "leaflet": "^1.9.4",
         "leaflet-gesture-handling": "^1.2.1",
         "leaflet.markercluster": "^1.5.0",
         "lodash": "^4.17.21",
@@ -12818,9 +12818,9 @@
       }
     },
     "node_modules/leaflet": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.3.tgz",
-      "integrity": "sha512-iB2cR9vAkDOu5l3HAay2obcUHZ7xwUBBjph8+PGtmW/2lYhbLizWtG7nTeYht36WfOslixQF9D/uSIzhZgGMfQ=="
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA=="
     },
     "node_modules/leaflet-gesture-handling": {
       "version": "1.2.2",
@@ -29156,9 +29156,9 @@
       }
     },
     "leaflet": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.3.tgz",
-      "integrity": "sha512-iB2cR9vAkDOu5l3HAay2obcUHZ7xwUBBjph8+PGtmW/2lYhbLizWtG7nTeYht36WfOslixQF9D/uSIzhZgGMfQ=="
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA=="
     },
     "leaflet-gesture-handling": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "immutable": "^4.0.0-rc.12",
     "invariant": "^2.2.4",
     "keycloak-js": "^20.0.3",
-    "leaflet": "^1.9.3",
+    "leaflet": "^1.9.4",
     "leaflet-gesture-handling": "^1.2.1",
     "leaflet.markercluster": "^1.5.0",
     "lodash": "^4.17.21",

--- a/src/hooks/useDeviceMode.ts
+++ b/src/hooks/useDeviceMode.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2022 - 2023 Gemeente Amsterdam
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 
 import { sizes } from '@amsterdam/asc-ui/lib/theme/default/breakpoints'
 
@@ -22,11 +22,16 @@ interface UseDeviceModeReturn {
 export function useDeviceMode(): UseDeviceModeReturn {
   const [deviceMode, setDeviceMode] = useState(getDeviceMode(window.innerWidth))
 
-  const isMobile = (mode: DeviceMode): mode is DeviceMode.Mobile =>
-    mode === DeviceMode.Mobile
+  const isMobile = useCallback(
+    (mode: DeviceMode): mode is DeviceMode.Mobile => mode === DeviceMode.Mobile,
+    []
+  )
 
-  const isDesktop = (mode: DeviceMode): mode is DeviceMode.Desktop =>
-    mode === DeviceMode.Desktop
+  const isDesktop = useCallback(
+    (mode: DeviceMode): mode is DeviceMode.Desktop =>
+      mode === DeviceMode.Desktop,
+    []
+  )
 
   useEffect(() => {
     const resizeW = () => setDeviceMode(getDeviceMode(window.innerWidth))


### PR DESCRIPTION
On the incidentmap, when a user used either the GPSLocation or the search bar for an address, the application entered a loop of calls to the BE. This was due to a dependency on a function (isMobile) that referenced a new function with every render.

Also noticed that Leaflet has a new update and updated the package. Saw no weird stuff with the maps.

Ticket: [SIG-5487](https://gemeente-amsterdam.atlassian.net/browse/SIG-5487)

## Signalen

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
