### PR TITLE
[feat-5240]: 'instellingen' is included in url of nested pages

### DIFF
--- a/src/components/pages/BasePage/BasePage.tsx
+++ b/src/components/pages/BasePage/BasePage.tsx
@@ -12,8 +12,6 @@ const StyledHeading = styled(Heading)`
   margin: ${themeSpacing(5)} 0;
 `
 
-export const DEFAULT_MESSAGE = 'Pagina niet gevonden'
-
 interface BasePageProps {
   documentTitle?: string
   pageTitle?: string
@@ -37,27 +35,29 @@ const BasePage = ({
   pageTitle,
   children,
   ...props
-}: BasePageProps) => (
-  <Row data-testid="base-page" {...props}>
-    <ContentWrapper>
-      <Helmet
-        defaultTitle={configuration.language.siteTitle}
-        titleTemplate={`${configuration.language.siteTitle} - %s`}
-      >
-        {documentTitle && <title>{documentTitle}</title>}
-      </Helmet>
+}: BasePageProps) => {
+  return (
+    <Row data-testid="base-page" {...props}>
+      <ContentWrapper>
+        <Helmet
+          defaultTitle={configuration.language.siteTitle}
+          titleTemplate={`${configuration.language.siteTitle} - %s`}
+        >
+          {documentTitle && <title>{documentTitle}</title>}
+        </Helmet>
 
-      <article>
-        {pageTitle && (
-          <header>
-            <StyledHeading>{pageTitle}</StyledHeading>
-          </header>
-        )}
+        <article>
+          {pageTitle && (
+            <header>
+              <StyledHeading>{pageTitle}</StyledHeading>
+            </header>
+          )}
 
-        {children}
-      </article>
-    </ContentWrapper>
-  </Row>
-)
+          {children}
+        </article>
+      </ContentWrapper>
+    </Row>
+  )
+}
 
 export default BasePage

--- a/src/components/pages/BasePage/BasePage.tsx
+++ b/src/components/pages/BasePage/BasePage.tsx
@@ -35,29 +35,27 @@ const BasePage = ({
   pageTitle,
   children,
   ...props
-}: BasePageProps) => {
-  return (
-    <Row data-testid="base-page" {...props}>
-      <ContentWrapper>
-        <Helmet
-          defaultTitle={configuration.language.siteTitle}
-          titleTemplate={`${configuration.language.siteTitle} - %s`}
-        >
-          {documentTitle && <title>{documentTitle}</title>}
-        </Helmet>
+}: BasePageProps) => (
+  <Row data-testid="base-page" {...props}>
+    <ContentWrapper>
+      <Helmet
+        defaultTitle={configuration.language.siteTitle}
+        titleTemplate={`${configuration.language.siteTitle} - %s`}
+      >
+        {documentTitle && <title>{documentTitle}</title>}
+      </Helmet>
 
-        <article>
-          {pageTitle && (
-            <header>
-              <StyledHeading>{pageTitle}</StyledHeading>
-            </header>
-          )}
+      <article>
+        {pageTitle && (
+          <header>
+            <StyledHeading>{pageTitle}</StyledHeading>
+          </header>
+        )}
 
-          {children}
-        </article>
-      </ContentWrapper>
-    </Row>
-  )
-}
+        {children}
+      </article>
+    </ContentWrapper>
+  </Row>
+)
 
 export default BasePage

--- a/src/containers/App/index.tsx
+++ b/src/containers/App/index.tsx
@@ -26,6 +26,7 @@ import IncidentReplyContainer from 'signals/incident/containers/IncidentReplyCon
 import { getSources } from './actions'
 import AppContext from './context'
 import { makeSelectLoading, makeSelectSources } from './selectors'
+import NotFoundPage from '../../components/pages/NotFoundPage'
 import VerificationPage from '../../components/pages/VerificationPage'
 import useDefaultHeader from '../../hooks/useDefaultHeader'
 import useTallHeader from '../../hooks/useTallHeader'
@@ -181,7 +182,7 @@ export const AppContainer = () => {
                     path="/verify_email/:token"
                     element={<VerificationPage />}
                   />
-                  <Route path={'*'} element={<SettingsModule />} />
+                  <Route path={'*'} element={<NotFoundPage />} />
                 </Routes>
               </Suspense>
             </ContentContainer>

--- a/src/signals/settings/SettingsModule.tsx
+++ b/src/signals/settings/SettingsModule.tsx
@@ -18,13 +18,7 @@ import {
 import { getIsAuthenticated } from 'shared/services/auth/auth'
 import configuration from 'shared/services/configuration/configuration'
 
-import routes, {
-  USERS_PAGED_URL,
-  USER_URL,
-  ROLE_URL,
-  SUBCATEGORIES_PAGED_URL,
-  EXPORT_URL,
-} from './routes'
+import routes, { USER_URL, ROLE_URL, EXPORT_URL } from './routes'
 
 const OverviewContainer = lazy(() => import('./components/Overview'))
 const LoginPage = lazy(() => import('components/pages/LoginPage'))
@@ -74,13 +68,6 @@ const SettingsModule = () => {
     if (userCanAccess('settings') === false) {
       navigate('/manage/incidents')
     }
-    if (location.pathname === routes.users) {
-      navigate(`${USERS_PAGED_URL}/1`)
-    }
-
-    if (location.pathname === routes.subcategories) {
-      navigate(`${SUBCATEGORIES_PAGED_URL}/1`)
-    }
   }, [location, navigate, userCanAccess])
 
   if (!getIsAuthenticated()) {
@@ -90,6 +77,7 @@ const SettingsModule = () => {
       </Routes>
     )
   }
+
   return (
     <Suspense fallback={<LoadingIndicator />}>
       <Routes>
@@ -115,10 +103,7 @@ const SettingsModule = () => {
             <ProtectedRoute component={RoleFormContainer} role="add_group" />
           }
         />
-        <Route
-          path={routes.users}
-          element={<Navigate to={`${USERS_PAGED_URL}/1`} replace={true} />}
-        />
+        <Route path={routes.users} element={<Navigate to="page/1" replace />} />
         <Route
           path={routes.usersPaged}
           element={
@@ -161,6 +146,10 @@ const SettingsModule = () => {
               roleGroup="departmentForm"
             />
           }
+        />
+        <Route
+          path={routes.subcategories}
+          element={<Navigate to="page/1" replace />}
         />
         <Route
           path={routes.subcategoriesPaged}

--- a/src/signals/settings/categories/components/Detail.test.tsx
+++ b/src/signals/settings/categories/components/Detail.test.tsx
@@ -123,7 +123,9 @@ describe('Detail', () => {
 
     const backLink = await screen.findByTestId('backlink')
 
-    expect(backLink.getAttribute('href')).toEqual('/subcategorieen')
+    expect(backLink.getAttribute('href')).toEqual(
+      '/instellingen/subcategorieen'
+    )
   })
 
   it('should render the correct page title for an existing category', async () => {

--- a/src/signals/settings/categories/components/Detail.tsx
+++ b/src/signals/settings/categories/components/Detail.tsx
@@ -15,7 +15,7 @@ import useFetch from 'hooks/useFetch'
 import useLocationReferrer from 'hooks/useLocationReferrer'
 import { fetchCategories } from 'models/categories/actions'
 import configuration from 'shared/services/configuration/configuration'
-import routes from 'signals/settings/routes'
+import routes, { BASE_URL } from 'signals/settings/routes'
 import type { StandardText } from 'types/api/standard-texts'
 import type { StatusMessagesCategory } from 'types/api/status-messages'
 import type { Category } from 'types/category'
@@ -48,7 +48,9 @@ export const CategoryDetail = ({
 
   const redirectURL =
     location.referrer ||
-    (isMainCategory ? routes.mainCategories : routes.subcategories)
+    (isMainCategory
+      ? `${BASE_URL}/${routes.mainCategories}`
+      : `${BASE_URL}/${routes.subcategories}`)
   const confirmedCancel = useConfirmedCancel(redirectURL)
 
   const { categoryId } = useParams<{ categoryId: string }>()

--- a/src/signals/settings/categories/main-categories/Overview.test.tsx
+++ b/src/signals/settings/categories/main-categories/Overview.test.tsx
@@ -8,7 +8,7 @@ import * as reactRouterDom from 'react-router-dom'
 
 import { makeSelectUserCan } from 'containers/App/selectors'
 import { makeSelectMainCategories } from 'models/categories/selectors'
-import { MAIN_CATEGORY_URL } from 'signals/settings/routes'
+import { BASE_URL, MAIN_CATEGORY_URL } from 'signals/settings/routes'
 import { withAppContext } from 'test/utils'
 import categories from 'utils/__tests__/fixtures/categories_structured.json'
 
@@ -98,7 +98,9 @@ describe('OverviewContainer', () => {
     userEvent.click(row)
 
     expect(navigateSpy).toHaveBeenCalledTimes(1)
-    expect(navigateSpy).toHaveBeenCalledWith(`${MAIN_CATEGORY_URL}/80`)
+    expect(navigateSpy).toHaveBeenCalledWith(
+      `${BASE_URL}/${MAIN_CATEGORY_URL}/80`
+    )
   })
 
   it('should not push on list item click when permissions are insufficient', async () => {

--- a/src/signals/settings/categories/main-categories/Overview.tsx
+++ b/src/signals/settings/categories/main-categories/Overview.tsx
@@ -50,7 +50,7 @@ export const OverviewContainer = () => {
       } = e
 
       if (itemId) {
-        navigate(`${MAIN_CATEGORY_URL}/${itemId}`)
+        navigate(`${BASE_URL}/${MAIN_CATEGORY_URL}/${itemId}`)
       }
     },
     [navigate, userCan]

--- a/src/signals/settings/categories/subcategories/Overview.test.tsx
+++ b/src/signals/settings/categories/subcategories/Overview.test.tsx
@@ -12,6 +12,7 @@ import { makeSelectAllSubCategories } from 'models/categories/selectors'
 import {
   SUBCATEGORY_URL,
   SUBCATEGORIES_PAGED_URL,
+  BASE_URL,
 } from 'signals/settings/routes'
 import { withAppContext } from 'test/utils'
 import categories from 'utils/__tests__/fixtures/categories_structured.json'
@@ -157,7 +158,9 @@ describe('signals/settings/categories/containers/Overview', () => {
     userEvent.click(pageButton)
 
     expect(navigateSpy).toHaveBeenCalledTimes(1)
-    expect(navigateSpy).toHaveBeenCalledWith(`${SUBCATEGORIES_PAGED_URL}/2`)
+    expect(navigateSpy).toHaveBeenCalledWith(
+      `${BASE_URL}/${SUBCATEGORIES_PAGED_URL}/2`
+    )
     expect(scrollTo).toHaveBeenCalledWith(0, 0)
   })
 
@@ -179,7 +182,9 @@ describe('signals/settings/categories/containers/Overview', () => {
     userEvent.click(row)
 
     expect(navigateSpy).toHaveBeenCalledTimes(1)
-    expect(navigateSpy).toHaveBeenCalledWith(`${SUBCATEGORY_URL}/${itemId}`)
+    expect(navigateSpy).toHaveBeenCalledWith(
+      `${BASE_URL}/${SUBCATEGORY_URL}/${itemId}`
+    )
 
     // Remove 'itemId' and fire click event again.
     delete row.dataset.itemId

--- a/src/signals/settings/categories/subcategories/Overview.tsx
+++ b/src/signals/settings/categories/subcategories/Overview.tsx
@@ -21,7 +21,7 @@ import {
 import { StyledDataView, StyledCompactPager } from './styled'
 import filterData from '../../utils/filterData'
 
-// name mapping from API values to human readable values
+// name mapping from API values to human-readable values
 export const colMap = {
   fk: 'fk',
   id: 'id',
@@ -79,7 +79,7 @@ export const OverviewContainer = () => {
       } = e
 
       if (itemId) {
-        navigate(`${SUBCATEGORY_URL}/${itemId}`)
+        navigate(`${BASE_URL}/${SUBCATEGORY_URL}/${itemId}`)
       }
     },
     [navigate, userCan]
@@ -88,7 +88,7 @@ export const OverviewContainer = () => {
   const onPaginationClick = useCallback(
     (pageToNavigateTo) => {
       global.window.scrollTo(0, 0)
-      navigate(`${SUBCATEGORIES_PAGED_URL}/${pageToNavigateTo}`)
+      navigate(`${BASE_URL}/${SUBCATEGORIES_PAGED_URL}/${pageToNavigateTo}`)
     },
     [navigate]
   )

--- a/src/signals/settings/departments/Detail/__tests__/Detail.test.js
+++ b/src/signals/settings/departments/Detail/__tests__/Detail.test.js
@@ -5,7 +5,7 @@ import * as reactRouterDom from 'react-router-dom'
 
 import useFetch from 'hooks/useFetch'
 import CONFIGURATION from 'shared/services/configuration/configuration'
-import routes from 'signals/settings/routes'
+import routes, { BASE_URL } from 'signals/settings/routes'
 import { withAppContext } from 'test/utils'
 import categories from 'utils/__tests__/fixtures/categories_structured.json'
 import departmentJson from 'utils/__tests__/fixtures/department.json'
@@ -68,7 +68,7 @@ describe('signals/settings/departments/Detail', () => {
     await findByTestId('settings-page-header')
 
     expect(container.querySelector('a').getAttribute('href')).toEqual(
-      routes.departments
+      `${BASE_URL}/${routes.departments}`
     )
   })
 

--- a/src/signals/settings/departments/Detail/index.js
+++ b/src/signals/settings/departments/Detail/index.js
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2019 - 2022 Gemeente Amsterdam
+// Copyright (C) 2019 - 2023 Gemeente Amsterdam
 import { useEffect, useCallback, Fragment, useMemo } from 'react'
 
 import { Row, Column, Heading, Paragraph } from '@amsterdam/asc-ui'
@@ -20,7 +20,7 @@ import {
 } from 'models/categories/selectors'
 import CONFIGURATION from 'shared/services/configuration/configuration'
 import * as types from 'shared/types'
-import routes from 'signals/settings/routes'
+import routes, { BASE_URL } from 'signals/settings/routes'
 
 import CategoryLists from './components/CategoryLists'
 import DepartmentDetailContext from './context'
@@ -35,7 +35,8 @@ export const DepartmentDetailContainer = ({
   const { departmentId } = useParams()
   const isExistingDepartment = departmentId !== undefined
   const { isLoading, isSuccess, data, error, get, patch, type } = useFetch()
-  const confirmedCancel = useConfirmedCancel(routes.departments)
+  const redirectURL = location.referrer || `${BASE_URL}/${routes.departments}`
+  const confirmedCancel = useConfirmedCancel(redirectURL)
   const entityName = `Afdeling${data ? ` '${data.name}'` : ''}`
   const title = `${entityName} ${
     isExistingDepartment ? 'wijzigen' : 'toevoegen'
@@ -47,7 +48,7 @@ export const DepartmentDetailContainer = ({
     requestType: type,
     isLoading,
     isSuccess,
-    redirectURL: routes.departments,
+    redirectURL: redirectURL,
   })
 
   const onSubmit = useCallback(
@@ -73,7 +74,9 @@ export const DepartmentDetailContainer = ({
           dataTestId={'settings-page-header'}
           title={title}
           BackLink={
-            <BackLink to={routes.departments}>Terug naar overzicht</BackLink>
+            <BackLink to={`${BASE_URL}/${routes.departments}`}>
+              Terug naar overzicht
+            </BackLink>
           }
         />
       </Row>

--- a/src/signals/settings/departments/Overview/__tests__/Overview.test.js
+++ b/src/signals/settings/departments/Overview/__tests__/Overview.test.js
@@ -5,7 +5,7 @@ import * as reactRouterDom from 'react-router-dom'
 
 import * as appSelectors from 'containers/App/selectors'
 import * as modelSelectors from 'models/departments/selectors'
-import { DEPARTMENT_URL } from 'signals/settings/routes'
+import { BASE_URL, DEPARTMENT_URL } from 'signals/settings/routes'
 import { withAppContext } from 'test/utils'
 import { departments } from 'utils/__tests__/fixtures'
 
@@ -109,7 +109,9 @@ describe('signals/settings/departments/Overview', () => {
     })
 
     expect(navigateMock).toHaveBeenCalledTimes(1)
-    expect(navigateMock).toHaveBeenCalledWith(`${DEPARTMENT_URL}/${id}`)
+    expect(navigateMock).toHaveBeenCalledWith(
+      `${BASE_URL}/${DEPARTMENT_URL}/${id}`
+    )
 
     // Remove 'itemId' and fire click event again.
     delete row.dataset.itemId

--- a/src/signals/settings/departments/Overview/index.js
+++ b/src/signals/settings/departments/Overview/index.js
@@ -52,7 +52,7 @@ const DepartmentOverview = () => {
       } = event
 
       if (itemId) {
-        navigate(`${DEPARTMENT_URL}/${itemId}`)
+        navigate(`${BASE_URL}/${DEPARTMENT_URL}/${itemId}`)
       }
     },
     [navigate, userCan]

--- a/src/signals/settings/roles/containers/RoleFormContainer/__test__/RoleFormContainer.test.js
+++ b/src/signals/settings/roles/containers/RoleFormContainer/__test__/RoleFormContainer.test.js
@@ -4,7 +4,7 @@ import { render } from '@testing-library/react'
 import * as reactRouterDom from 'react-router-dom'
 
 import { VARIANT_SUCCESS, TYPE_LOCAL } from 'containers/Notification/constants'
-import routes from 'signals/settings/routes'
+import routes, { BASE_URL } from 'signals/settings/routes'
 import { withAppContext } from 'test/utils'
 import rolesJson from 'utils/__tests__/fixtures/roles.json'
 
@@ -131,7 +131,7 @@ describe('signals/settings/roles/containers/RoleFormContainer', () => {
       variant: VARIANT_SUCCESS,
     })
     expect(props.onResetResponse).toHaveBeenCalled()
-    expect(navigateMock).toHaveBeenCalledWith(routes.roles)
+    expect(navigateMock).toHaveBeenCalledWith(`${BASE_URL}/${routes.roles}`)
   })
 
   it('should show success notication and navigate to role list page with existing role', () => {
@@ -158,7 +158,7 @@ describe('signals/settings/roles/containers/RoleFormContainer', () => {
       variant: VARIANT_SUCCESS,
     })
     expect(props.onResetResponse).toHaveBeenCalled()
-    expect(navigateMock).toHaveBeenCalledWith(routes.roles)
+    expect(navigateMock).toHaveBeenCalledWith(`${BASE_URL}/${routes.roles}`)
   })
 
   it('should show error notication and not navigate to role list page', () => {

--- a/src/signals/settings/roles/containers/RoleFormContainer/components/RoleForm/__test__/RoleForm.test.js
+++ b/src/signals/settings/roles/containers/RoleFormContainer/components/RoleForm/__test__/RoleForm.test.js
@@ -3,7 +3,7 @@
 import { render, fireEvent, act } from '@testing-library/react'
 import * as reactRouterDom from 'react-router-dom'
 
-import { ROLES_URL } from 'signals/settings/routes'
+import { BASE_URL, ROLES_URL } from 'signals/settings/routes'
 import { withAppContext } from 'test/utils'
 import permissionsJson from 'utils/__tests__/fixtures/permissions.json'
 import rolesJson from 'utils/__tests__/fixtures/roles.json'
@@ -247,6 +247,6 @@ describe('/signals/settings/roles/components/RoleForm', () => {
     })
 
     expect(props.onPatchRole).not.toHaveBeenCalled()
-    expect(navigateMock).toHaveBeenCalledWith(ROLES_URL)
+    expect(navigateMock).toHaveBeenCalledWith(`${BASE_URL}/${ROLES_URL}`)
   })
 })

--- a/src/signals/settings/roles/containers/RoleFormContainer/components/RoleForm/index.js
+++ b/src/signals/settings/roles/containers/RoleFormContainer/components/RoleForm/index.js
@@ -11,7 +11,7 @@ import Checkbox from 'components/Checkbox'
 import FormFooter, { FORM_FOOTER_HEIGHT } from 'components/FormFooter'
 import Input from 'components/Input'
 import useFormValidation from 'hooks/useFormValidation'
-import { ROLES_URL } from 'signals/settings/routes'
+import { BASE_URL, ROLES_URL } from 'signals/settings/routes'
 
 const StyledForm = styled.form`
   margin-bottom: ${FORM_FOOTER_HEIGHT}px;
@@ -93,7 +93,7 @@ export const RoleForm = ({
   }, [event, isValid, handleSubmit, errors, readOnly])
 
   const handleCancel = useCallback(() => {
-    navigate(ROLES_URL)
+    navigate(`${BASE_URL}/${ROLES_URL}`)
   }, [navigate])
 
   return (

--- a/src/signals/settings/roles/containers/RoleFormContainer/index.js
+++ b/src/signals/settings/roles/containers/RoleFormContainer/index.js
@@ -17,7 +17,7 @@ import { makeSelectUserCan } from 'containers/App/selectors'
 import { VARIANT_SUCCESS, TYPE_LOCAL } from 'containers/Notification/constants'
 import { patchRole, saveRole, resetResponse } from 'models/roles/actions'
 import { rolesModelSelector } from 'models/roles/selectors'
-import routes from 'signals/settings/routes'
+import routes, { BASE_URL } from 'signals/settings/routes'
 
 import RoleForm from './components/RoleForm'
 
@@ -41,7 +41,7 @@ export const RoleFormContainer = ({
   const location = useLocation()
   const role = list.find((item) => item.id === roleId * 1)
   const title = `Rol ${roleId ? 'wijzigen' : 'toevoegen'}`
-  const redirectURL = location.referrer || routes.roles
+  const redirectURL = location.referrer || `${BASE_URL}/${routes.roles}`
   useEffect(() => {
     let message
 

--- a/src/signals/settings/roles/containers/RolesListContainer/components/RolesList/__test__/RolesList.test.js
+++ b/src/signals/settings/roles/containers/RolesListContainer/components/RolesList/__test__/RolesList.test.js
@@ -3,7 +3,7 @@
 import { render, fireEvent } from '@testing-library/react'
 import * as reactRouterDom from 'react-router-dom'
 
-import { ROLE_URL } from 'signals/settings/routes'
+import { BASE_URL, ROLE_URL } from 'signals/settings/routes'
 import { withAppContext } from 'test/utils'
 import rolesJson from 'utils/__tests__/fixtures/roles.json'
 
@@ -66,7 +66,7 @@ describe('signals/settings/roles/containers/RolesListContainer/components/RolesL
       event
     )
 
-    expect(navigateMock).toHaveBeenCalledWith(`${ROLE_URL}/2`)
+    expect(navigateMock).toHaveBeenCalledWith(`${BASE_URL}/${ROLE_URL}/2`)
   })
 
   it('should have disabled links', () => {

--- a/src/signals/settings/roles/containers/RolesListContainer/components/RolesList/index.js
+++ b/src/signals/settings/roles/containers/RolesListContainer/components/RolesList/index.js
@@ -8,7 +8,7 @@ import styled from 'styled-components'
 
 import ListComponent from 'components/List'
 import formatRoles from 'signals/settings/roles/services/formatRoles'
-import { ROLE_URL } from 'signals/settings/routes'
+import { BASE_URL, ROLE_URL } from 'signals/settings/routes'
 
 const StyledListComponent = styled(ListComponent)`
   th:nth-child(1),
@@ -30,7 +30,7 @@ export const RolesList = ({ linksEnabled, list }) => {
       const roleId = e.currentTarget.getAttribute('data-item-id')
       /* istanbul ignore else */
       if (roleId > -1) {
-        navigate(`${ROLE_URL}/${roleId}`)
+        navigate(`${BASE_URL}/${ROLE_URL}/${roleId}`)
       }
     },
     [navigate, linksEnabled]

--- a/src/signals/settings/roles/containers/RolesListContainer/index.js
+++ b/src/signals/settings/roles/containers/RolesListContainer/index.js
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2019 - 2021 Gemeente Amsterdam
+// Copyright (C) 2019 - 2023 Gemeente Amsterdam
 import { Fragment } from 'react'
 
 import { Row, Column, Button } from '@amsterdam/asc-ui'
@@ -27,34 +27,40 @@ const HeaderButton = styled(Button)`
 export const RolesListContainer = ({
   roles: { list, loading, loadingPermissions },
   userCan,
-}) => (
-  <Fragment>
-    <Row>
-      <PageHeader
-        title="Rollen"
-        BackLink={<BackLink to={BASE_URL}>Terug naar instellingen</BackLink>}
-      >
-        {userCan('add_group') && (
-          <HeaderButton variant="primary" forwardedAs={Link} to={ROLE_URL}>
-            Rol toevoegen
-          </HeaderButton>
-        )}
-      </PageHeader>
-    </Row>
-    <Row>
-      <Column span={12}>
-        {loading || loadingPermissions ? (
-          <LoadingIndicator />
-        ) : (
-          <RolesList
-            list={list}
-            linksEnabled={Boolean(userCan('change_group'))}
-          />
-        )}
-      </Column>
-    </Row>
-  </Fragment>
-)
+}) => {
+  return (
+    <Fragment>
+      <Row>
+        <PageHeader
+          title="Rollen"
+          BackLink={<BackLink to={BASE_URL}>Terug naar instellingen</BackLink>}
+        >
+          {userCan('add_group') && (
+            <HeaderButton
+              variant="primary"
+              forwardedAs={Link}
+              to={`${BASE_URL}/${ROLE_URL}`}
+            >
+              Rol toevoegen
+            </HeaderButton>
+          )}
+        </PageHeader>
+      </Row>
+      <Row>
+        <Column span={12}>
+          {loading || loadingPermissions ? (
+            <LoadingIndicator />
+          ) : (
+            <RolesList
+              list={list}
+              linksEnabled={Boolean(userCan('change_group'))}
+            />
+          )}
+        </Column>
+      </Row>
+    </Fragment>
+  )
+}
 
 RolesListContainer.defaultProps = {
   roles: {

--- a/src/signals/settings/roles/containers/RolesListContainer/index.js
+++ b/src/signals/settings/roles/containers/RolesListContainer/index.js
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2019 - 2023 Gemeente Amsterdam
-import { Fragment } from 'react'
 
 import { Row, Column, Button } from '@amsterdam/asc-ui'
 import PropTypes from 'prop-types'
@@ -29,7 +28,7 @@ export const RolesListContainer = ({
   userCan,
 }) => {
   return (
-    <Fragment>
+    <>
       <Row>
         <PageHeader
           title="Rollen"
@@ -58,7 +57,7 @@ export const RolesListContainer = ({
           )}
         </Column>
       </Row>
-    </Fragment>
+    </>
   )
 }
 

--- a/src/signals/settings/routes.ts
+++ b/src/signals/settings/routes.ts
@@ -1,10 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2019 - 2023 Gemeente Amsterdam
 
-/*
- * These string are the matches for the different setting pages. You can use these in <Route> as paths. If you want to
- * navigate there, you have to prefix with BASE_URL.
- */
 export const BASE_URL = `/instellingen`
 export const OVERVIEW_URL = `${BASE_URL}`
 export const USERS_URL = `gebruikers`

--- a/src/signals/settings/routes.ts
+++ b/src/signals/settings/routes.ts
@@ -1,21 +1,25 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2019 - 2023 Gemeente Amsterdam
 
+/*
+ * These string are the matches for the different setting pages. You can use these in <Route> as paths. If you want to
+ * navigate there, you have to prefix with BASE_URL.
+ */
 export const BASE_URL = `/instellingen`
 export const OVERVIEW_URL = `${BASE_URL}`
-export const USERS_URL = `/gebruikers`
+export const USERS_URL = `gebruikers`
 export const USERS_PAGED_URL = `${USERS_URL}/page`
-export const USER_URL = `/gebruiker`
-export const ROLES_URL = `/rollen`
-export const ROLE_URL = `/rol`
-export const DEPARTMENTS_URL = `/afdelingen`
-export const DEPARTMENT_URL = `/afdeling`
-export const MAIN_CATEGORY_URL = `/hoofdcategorie`
-export const MAIN_CATEGORIES_URL = `/hoofdcategorieen`
-export const SUBCATEGORY_URL = `/subcategorie`
-export const SUBCATEGORIES_URL = `/subcategorieen`
+export const USER_URL = `gebruiker`
+export const ROLES_URL = `rollen`
+export const ROLE_URL = `rol`
+export const DEPARTMENTS_URL = `afdelingen`
+export const DEPARTMENT_URL = `afdeling`
+export const MAIN_CATEGORY_URL = `hoofdcategorie`
+export const MAIN_CATEGORIES_URL = `hoofdcategorieen`
+export const SUBCATEGORY_URL = `subcategorie`
+export const SUBCATEGORIES_URL = `subcategorieen`
 export const SUBCATEGORIES_PAGED_URL = `${SUBCATEGORIES_URL}/page`
-export const EXPORT_URL = `/export`
+export const EXPORT_URL = `export`
 
 const routes = {
   overview: OVERVIEW_URL,

--- a/src/signals/settings/users/Detail/__tests__/Detail.test.js
+++ b/src/signals/settings/users/Detail/__tests__/Detail.test.js
@@ -10,7 +10,7 @@ import * as useConfirm from 'hooks/useConfirm'
 import * as modelSelectors from 'models/departments/selectors'
 import * as rolesSelectors from 'models/roles/selectors'
 import configuration from 'shared/services/configuration/configuration'
-import routes from 'signals/settings/routes'
+import routes, { BASE_URL } from 'signals/settings/routes'
 import { withAppContext } from 'test/utils'
 import { departments } from 'utils/__tests__/fixtures'
 import historyFixture from 'utils/__tests__/fixtures/history.json'
@@ -93,7 +93,7 @@ describe('signals/settings/users/containers/Detail', () => {
 
     const backlink = await findByTestId('backlink')
 
-    expect(backlink.getAttribute('href')).toEqual(routes.users)
+    expect(backlink.getAttribute('href')).toEqual(`${BASE_URL}/${routes.users}`)
 
     jest
       .spyOn(reactRouterDom, 'useLocation')

--- a/src/signals/settings/users/Detail/index.js
+++ b/src/signals/settings/users/Detail/index.js
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2019 - 2021 Gemeente Amsterdam
+// Copyright (C) 2019 - 2023 Gemeente Amsterdam
 import { Fragment, useCallback, useEffect } from 'react'
 
 import { Row } from '@amsterdam/asc-ui'
@@ -16,7 +16,7 @@ import useFetch from 'hooks/useFetch'
 import configuration from 'shared/services/configuration/configuration'
 import useConfirmedCancel from 'signals/settings/hooks/useConfirmedCancel'
 import useFetchResponseNotification from 'signals/settings/hooks/useFetchResponseNotification'
-import routes from 'signals/settings/routes'
+import routes, { BASE_URL } from 'signals/settings/routes'
 
 import UserForm from './components/UserForm'
 
@@ -44,7 +44,7 @@ const UserDetail = () => {
   } = useFetch()
   const { get: historyGet, data: historyData } = useFetch()
   const shouldRenderForm = !isExistingUser || (isExistingUser && Boolean(data))
-  const redirectURL = location.referrer || routes.users
+  const redirectURL = location.referrer || `${BASE_URL}/${routes.users}`
   const userCanSubmitForm =
     (isExistingUser && userCan('change_user')) ||
     (!isExistingUser && userCan('add_user'))

--- a/src/signals/settings/users/Overview/Overview.tsx
+++ b/src/signals/settings/users/Overview/Overview.tsx
@@ -109,7 +109,7 @@ const UsersOverviewContainer = () => {
   const setUsernameFilter = useCallback(
     (value: string) => {
       filters.set('username', value)
-      navigate(`${USERS_PAGED_URL}/1?${filters.toString()}`)
+      navigate(`${BASE_URL}/${USERS_PAGED_URL}/1?${filters.toString()}`)
     },
     [filters, navigate]
   )
@@ -132,7 +132,7 @@ const UsersOverviewContainer = () => {
       event.preventDefault()
       const { name, value } = event.currentTarget
       filters.set(name, value)
-      navigate(`${USERS_PAGED_URL}/1?${filters.toString()}`)
+      navigate(`${BASE_URL}/${USERS_PAGED_URL}/1?${filters.toString()}`)
     },
     [filters, navigate]
   )
@@ -151,7 +151,7 @@ const UsersOverviewContainer = () => {
       } = event
 
       if (itemId) {
-        navigate(`${USER_URL}/${itemId}`)
+        navigate(`${BASE_URL}/${USER_URL}/${itemId}`)
       }
     },
     [navigate, userCan]
@@ -160,7 +160,9 @@ const UsersOverviewContainer = () => {
   const onPaginationClick = useCallback(
     (pageToNavigateTo: number) => {
       global.window.scrollTo(0, 0)
-      navigate(`${USERS_PAGED_URL}/${pageToNavigateTo}?${filters.toString()}`)
+      navigate(
+        `${BASE_URL}/${USERS_PAGED_URL}/${pageToNavigateTo}?${filters.toString()}`
+      )
     },
     [filters, navigate]
   )
@@ -174,7 +176,11 @@ const UsersOverviewContainer = () => {
           BackLink={<BackLink to={BASE_URL}>Terug naar instellingen</BackLink>}
         >
           {userCan('add_user') && (
-            <HeaderButton variant="primary" forwardedAs={Link} to={USER_URL}>
+            <HeaderButton
+              variant="primary"
+              forwardedAs={Link}
+              to={`${BASE_URL}/${USER_URL}`}
+            >
               Gebruiker toevoegen
             </HeaderButton>
           )}

--- a/src/signals/settings/users/Overview/__tests__/Overview.test.tsx
+++ b/src/signals/settings/users/Overview/__tests__/Overview.test.tsx
@@ -14,7 +14,7 @@ import * as constants from 'containers/App/constants'
 import * as appSelectors from 'containers/App/selectors'
 import * as departmenstSelectors from 'models/departments/selectors'
 import * as rolesSelectors from 'models/roles/selectors'
-import { USER_URL, USERS_PAGED_URL } from 'signals/settings/routes'
+import { BASE_URL, USER_URL, USERS_PAGED_URL } from 'signals/settings/routes'
 import { history as memoryHistory, withAppContext } from 'test/utils'
 import inputSelectDepartmentsSelectorFixture from 'utils/__tests__/fixtures/inputSelectDepartmentsSelector.json'
 import inputSelectRolesSelectorFixture from 'utils/__tests__/fixtures/inputSelectRolesSelector.json'
@@ -306,7 +306,9 @@ describe('signals/settings/users/containers/Overview', () => {
 
     userEvent.click(username)
 
-    expect(mockNavigate).toHaveBeenLastCalledWith(`${USER_URL}/${itemId}`)
+    expect(mockNavigate).toHaveBeenLastCalledWith(
+      `${BASE_URL}/${USER_URL}/${itemId}`
+    )
 
     // Remove 'itemId' and fire click event again.
     delete row.dataset.itemId


### PR DESCRIPTION
**Context**
In the backoffice in Instellingen you can click on several links. When clicked the url was directly appended to the main url and not appended to main url/instellingen/. We want the url to reflect the nesting. Instellingen and not Settings was chosen, because the website is in Dutch.

**Changes**
- In App/index at the highest level, there were two directs to the Settingsmodule, one with the wildcard instellingen/* and one as a catch all *. The catch all directs now to the not-found page.
- In order to append to 'instellingen/', the strings in route.js in the setting directory are now all without /.
- All navigate to's now navigate to base_url + / + whatever the rest of the url is 

Ticket: [SIG-5240](https://gemeente-amsterdam.atlassian.net/browse/SIG-5240)

## Signalen

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
