### PR TITLE
Fix additional CSS code feature during runtime

### DIFF
--- a/internals/scripts/helpers/config.js
+++ b/internals/scripts/helpers/config.js
@@ -22,7 +22,7 @@ const config = merge({}, baseConfig, extendedConfig)
 
 const piwik = config?.piwik?.id
   ? `<script type="text/javascript">
-(function(window, document, dataLayerName, id) { 
+(function(window, document, dataLayerName, id) {
   window[dataLayerName]=window[dataLayerName]||[],window[dataLayerName].push({start:(new Date).getTime(),event:"stg.start"});var scripts=document.getElementsByTagName('script')[0],tags=document.createElement('script');
 function stgCreateCookie(a,b,c){var d="";if(c){var e=new Date;e.setTime(e.getTime()+24*c*60*60*1e3),d="; expires="+e.toUTCString()}document.cookie=a+"="+b+d+"; path=/"}
 var isStgDebug=(window.location.href.match("stg_debug")||document.cookie.match("stg_debug"))&&!window.location.href.match("stg_disable_debug");stgCreateCookie("stg_debug",isStgDebug?1:"",isStgDebug?14:-1);
@@ -31,6 +31,10 @@ tags.async=!0,tags.src="https://dap.amsterdam.nl/containers/"+id+".js"+qPString,
 !function(a,n,i){a[n]=a[n]||{};for(var c=0;c<i.length;c++)!function(i){a[n][i]=a[n][i]||{},a[n][i].api=a[n][i].api||function(){var a=[].slice.call(arguments,0);"string"==typeof a[0]&&window[dataLayerName].push({event:n+"."+i+":"+a[0],parameters:[].slice.call(arguments,1)})}}(i[c])}(window,"ppms",["tm","cm"]);
 })(window, document, 'dataLayer', '${config.piwik.id}');
 </script>`
+  : ''
+
+const additionalCodeCss = config?.additionalCode?.css
+  ? `<style>${config.additionalCode.css}</style>`
   : ''
 
 const placeholders = {
@@ -45,7 +49,7 @@ const placeholders = {
   $SIGNALS_PWA_TITLE: config.language.title,
   $SIGNALS_STATUS_BAR_STYLE: config.head.statusBarStyle,
   $SIGNALS_THEME_COLOR: config.head.themeColor,
-  $SIGNALS_ADDITIONAL_CODE_CSS: config.additionalCode.css,
+  $SIGNALS_ADDITIONAL_CODE_CSS: additionalCodeCss,
 }
 
 const inject = (files) =>

--- a/src/index.html
+++ b/src/index.html
@@ -34,13 +34,11 @@
       </p>
     </noscript>
   </div>
-<script>
-  var spinner = document.getElementById('spinner')
-  spinner.style.fill =  window.CONFIG.head.themeColor;
-</script>
-<style>
+  <script>
+    var spinner = document.getElementById('spinner')
+    spinner.style.fill =  window.CONFIG.head.themeColor;
+  </script>
   $SIGNALS_ADDITIONAL_CODE_CSS
-</style>
 </body>
 
 </html>


### PR DESCRIPTION
The recently merged feature to add additional CSS code (#2709) seems to only work during development, not during run-time. This is due to Webpack that removes `$SIGNALS_ADDITIONAL_CODE_CSS` wrapped within the style tags.

This PR fixes this and solves this analog to the Piwik configuration.
