### PR TITLE
[feat-5019]: styling button Icoon wijzigen

### DIFF
--- a/src/signals/settings/categories/components/IconInput/IconInput.tsx
+++ b/src/signals/settings/categories/components/IconInput/IconInput.tsx
@@ -6,7 +6,6 @@ import { TrashBin } from '@amsterdam/asc-assets'
 import { Controller } from 'react-hook-form'
 import { useParams } from 'react-router-dom'
 
-import Button from 'components/Button'
 import { useConfirm } from 'hooks/useConfirm'
 import useFetch from 'hooks/useFetch'
 import { RequestType } from 'hooks/useFetch'
@@ -21,6 +20,7 @@ import type { Props as CategoryFormProps } from '../CategoryForm'
 import {
   DeleteButton,
   FieldGroup,
+  StyledButton,
   StyledHeading,
   StyledIcon,
   Wrapper,
@@ -156,14 +156,14 @@ export const IconInput = ({ formMethods, icon }: Props) => {
                 onChange={handleOnChange}
                 multiple={false}
               >
-                <Button
+                <StyledButton
                   forwardedAs={'span'}
                   tabIndex={0}
                   variant="primaryInverted"
                   type="button"
                 >
                   {label}
-                </Button>
+                </StyledButton>
               </FileInput>
 
               {fileDataURL && (

--- a/src/signals/settings/categories/components/styled.ts
+++ b/src/signals/settings/categories/components/styled.ts
@@ -115,3 +115,9 @@ export const Wrapper = styled.div`
     margin-left: ${themeSpacing(2)};
   }
 `
+
+export const StyledButton = styled(Button)`
+  &:hover {
+    border-left-width: 2px;
+  }
+`


### PR DESCRIPTION
Resolved new feedback
Now button Icoon wijzigen has on hover same border width on all sides

Ticket: [SIG-5019](https://gemeente-amsterdam.atlassian.net/browse/SIG-5019)

## Signalen

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
