### PR TITLE
[bugfix-5506]: status in Instelling -> subcategory doesn't effect texts

### DIFF
--- a/src/signals/settings/categories/components/CategoryForm.test.tsx
+++ b/src/signals/settings/categories/components/CategoryForm.test.tsx
@@ -29,7 +29,6 @@ const mockFormValues = {
 }
 
 const defaultProps: Omit<Props, 'formMethods'> = {
-  formValues: mockFormValues,
   history: [
     {
       identifier: 'UPDATED_CATEGORY_217043',
@@ -57,8 +56,13 @@ const defaultProps: Omit<Props, 'formMethods'> = {
     'Toon meldingen van deze subcategorie op openbare kaarten en op de kaart in het meldformulier.',
 }
 
-const Wrapper = (props: Partial<Props>) => {
-  const methods = useForm<CategoryFormValues>()
+const Wrapper = ({
+  formValues = mockFormValues,
+  ...props
+}: Partial<Props> & { formValues?: CategoryFormValues }) => {
+  const methods = useForm<CategoryFormValues>({
+    defaultValues: formValues,
+  })
   return withAppContext(
     <CategoryForm {...defaultProps} formMethods={methods} {...props} />
   )

--- a/src/signals/settings/categories/components/CategoryForm.tsx
+++ b/src/signals/settings/categories/components/CategoryForm.tsx
@@ -3,7 +3,7 @@
 import type { FormEventHandler } from 'react'
 
 import { Row, Column } from '@amsterdam/asc-ui'
-import { Controller, FormProvider } from 'react-hook-form'
+import { Controller, FormProvider, useWatch } from 'react-hook-form'
 import type { UseFormReturn } from 'react-hook-form'
 
 import Checkbox from 'components/Checkbox'
@@ -12,7 +12,6 @@ import RadioButtonList from 'components/RadioButtonList'
 import TextArea from 'components/TextArea'
 import type { History as HistoryType } from 'types/history'
 
-import { IconInput } from './IconInput'
 import StandardTextsField from './StandardTextsField'
 import {
   FieldGroup,
@@ -31,7 +30,7 @@ import {
 import configuration from '../../../../shared/services/configuration/configuration'
 import type { CategoryFormValues } from '../types'
 
-interface StatusOption {
+export interface StatusOption {
   key: string
   value: string
 }
@@ -43,7 +42,6 @@ export const statusOptions: StatusOption[] = [
 
 export interface Props {
   formMethods: UseFormReturn<CategoryFormValues>
-  formValues: CategoryFormValues
   history: HistoryType[]
   onCancel: () => void
   onSubmit: FormEventHandler<HTMLFormElement>
@@ -55,7 +53,6 @@ export interface Props {
 
 export const CategoryForm = ({
   formMethods,
-  formValues,
   history,
   onCancel,
   onSubmit,
@@ -63,168 +60,58 @@ export const CategoryForm = ({
   responsibleDepartments,
   isMainCategory,
   isPublicAccessibleLabel,
-}: Props) => (
-  <FormProvider {...formMethods}>
-    <FormContainer>
-      <Form onSubmit={onSubmit} data-testid="detail-category-form">
-        <Row>
-          <StyledColumn
-            span={{ small: 1, medium: 2, big: 4, large: 5, xLarge: 5 }}
-          >
-            <div>
-              <FieldGroup>
-                {!isMainCategory ? (
-                  <Input
-                    {...formMethods.register('name')}
-                    disabled={readOnly}
-                    hint="Het wijzigen van de naam heeft geen invloed op het type melding"
-                    id="name"
-                    label="Naam"
-                    name="name"
-                    readOnly={readOnly}
-                    type="text"
-                  />
-                ) : (
-                  <>
-                    <StyledDefinitionTerm>
-                      <strong>Naam</strong>
-                    </StyledDefinitionTerm>
-                    <dd data-testid="name">{formValues.name}</dd>
-                  </>
-                )}
-              </FieldGroup>
-              {!isMainCategory && (
-                <Controller
-                  name="description"
-                  render={({ field: { name, value, onChange } }) => (
-                    <FieldGroup>
-                      <TextArea
-                        disabled={readOnly}
-                        id={name}
-                        label={<strong>Omschrijving</strong>}
-                        name={name}
-                        onChange={onChange}
-                        readOnly={readOnly}
-                        rows={6}
-                        value={value}
-                      />
-                    </FieldGroup>
-                  )}
-                />
-              )}
-              {responsibleDepartments.length > 0 && (
-                <FieldGroup as="dl">
-                  <StyledDefinitionTerm>
-                    <strong>Verantwoordelijke afdeling</strong>
-                  </StyledDefinitionTerm>
-                  <dd data-testid="responsible_departments">
-                    {responsibleDepartments.join(', ')}
-                  </dd>
-                </FieldGroup>
-              )}
+}: Props) => {
+  const watchIsActive = useWatch({
+    name: 'is_active',
+    control: formMethods.control,
+  })
 
-              <FieldGroup>
-                {!isMainCategory && (
-                  <>
-                    <StyledHeading>Openbaar tonen</StyledHeading>
-                    <Controller
-                      name="is_public_accessible"
-                      control={formMethods.control}
-                      render={({ field: { name, value, onChange } }) => (
-                        <FieldGroup>
-                          <StyledLabel
-                            htmlFor={name}
-                            label={isPublicAccessibleLabel}
-                            data-testid="category-is-public-accessible"
-                            disabled={readOnly}
-                          >
-                            <Checkbox
-                              checked={value}
-                              name={name}
-                              id={name}
-                              onChange={onChange}
-                            />
-                          </StyledLabel>
-                        </FieldGroup>
-                      )}
-                    />
-                  </>
-                )}
+  const watchIsPublicAccessible = useWatch({
+    name: 'is_public_accessible',
+    control: formMethods.control,
+  })
 
-                {isMainCategory && (
-                  <>
-                    <StyledHeading>Meldingenkaartfilter</StyledHeading>
-                    <Controller
-                      name="show_children_in_filter"
-                      control={formMethods.control}
-                      render={({ field: { name, value, onChange } }) => (
-                        <StyledLabel
-                          htmlFor={name}
-                          label="Toon alle subcategorieën in het filter op de meldingenkaart die openbaar getoond mogen worden"
-                          data-testid="show_children_in_filter"
-                          disabled={readOnly}
-                        >
-                          <Checkbox
-                            checked={value}
-                            name={name}
-                            id={name}
-                            onChange={onChange}
-                          />
-                        </StyledLabel>
-                      )}
-                    />
-                  </>
-                )}
-              </FieldGroup>
-
-              <IconInput formMethods={formMethods} icon={formValues.icon} />
-
-              {formValues.is_public_accessible && (
+  return (
+    <FormProvider {...formMethods}>
+      <FormContainer>
+        <Form onSubmit={onSubmit} data-testid="detail-category-form">
+          <Row>
+            <StyledColumn
+              span={{ small: 1, medium: 2, big: 4, large: 5, xLarge: 5 }}
+            >
+              <div>
                 <FieldGroup>
-                  <Input
-                    {...formMethods.register('public_name')}
-                    id="public_name"
-                    label="Naam openbaar"
-                    name="public_name"
-                    type="text"
-                    readOnly={readOnly}
-                  />
+                  {!isMainCategory ? (
+                    <Input
+                      {...formMethods.register('name')}
+                      disabled={readOnly}
+                      hint="Het wijzigen van de naam heeft geen invloed op het type melding"
+                      id="name"
+                      label="Naam"
+                      name="name"
+                      readOnly={readOnly}
+                      type="text"
+                    />
+                  ) : (
+                    <>
+                      <StyledDefinitionTerm>
+                        <strong>Naam</strong>
+                      </StyledDefinitionTerm>
+                      <dd data-testid="name">
+                        {formMethods.getValues('name')}
+                      </dd>
+                    </>
+                  )}
                 </FieldGroup>
-              )}
-              {!isMainCategory && (
-                <>
-                  <FieldGroup>
-                    <StyledHeading>Afhandeltermijn</StyledHeading>
-                    <CombinedFields>
-                      <Input
-                        {...formMethods.register('n_days')}
-                        disabled={readOnly}
-                        id="n_days"
-                        name="n_days"
-                        readOnly={readOnly}
-                        type="number"
-                        size={50}
-                      />
-
-                      <StyledSelect
-                        {...formMethods.register('use_calendar_days')}
-                        disabled={readOnly}
-                        id="use_calendar_days"
-                      >
-                        <option value="1">Dagen</option>
-                        <option value="0">Werkdagen</option>
-                      </StyledSelect>
-                    </CombinedFields>
-                  </FieldGroup>
-
+                {!isMainCategory && (
                   <Controller
-                    name="handling_message"
+                    name="description"
                     render={({ field: { name, value, onChange } }) => (
                       <FieldGroup>
                         <TextArea
                           disabled={readOnly}
                           id={name}
-                          label={<strong>Servicebelofte</strong>}
+                          label={<strong>Omschrijving</strong>}
                           name={name}
                           onChange={onChange}
                           readOnly={readOnly}
@@ -234,89 +121,217 @@ export const CategoryForm = ({
                       </FieldGroup>
                     )}
                   />
+                )}
+                {responsibleDepartments.length > 0 && (
+                  <FieldGroup as="dl">
+                    <StyledDefinitionTerm>
+                      <strong>Verantwoordelijke afdeling</strong>
+                    </StyledDefinitionTerm>
+                    <dd data-testid="responsible_departments">
+                      {responsibleDepartments.join(', ')}
+                    </dd>
+                  </FieldGroup>
+                )}
 
-                  <Controller
-                    name="is_active"
-                    control={formMethods.control}
-                    render={({ field: { name, value, onChange } }) => {
-                      /* istanbul ignore next */
-                      const handleOnChange = (
-                        _groupName: string,
-                        option: StatusOption
-                      ) => {
-                        const value = statusOptions.find(
-                          (status) => status.value === option.value
-                        )?.key
-                        onChange(value)
-                      }
+                <FieldGroup>
+                  {!isMainCategory && (
+                    <>
+                      <StyledHeading>Openbaar tonen</StyledHeading>
+                      <Controller
+                        name="is_public_accessible"
+                        control={formMethods.control}
+                        render={({ field: { name, value, onChange } }) => (
+                          <FieldGroup>
+                            <StyledLabel
+                              htmlFor={name}
+                              label={isPublicAccessibleLabel}
+                              data-testid="category-is-public-accessible"
+                              disabled={readOnly}
+                            >
+                              <Checkbox
+                                checked={value}
+                                name={name}
+                                id={name}
+                                onChange={onChange}
+                              />
+                            </StyledLabel>
+                          </FieldGroup>
+                        )}
+                      />
+                    </>
+                  )}
 
-                      return (
-                        <FieldGroup>
-                          <StyledHeading>Status</StyledHeading>
-                          <RadioButtonList
-                            defaultValue={value}
+                  {isMainCategory && (
+                    <>
+                      <StyledHeading>Meldingenkaartfilter</StyledHeading>
+                      <Controller
+                        name="show_children_in_filter"
+                        control={formMethods.control}
+                        render={({ field: { name, value, onChange } }) => (
+                          <StyledLabel
+                            htmlFor={name}
+                            label="Toon alle subcategorieën in het filter op de meldingenkaart die openbaar getoond mogen worden"
+                            data-testid="show_children_in_filter"
                             disabled={readOnly}
-                            groupName={name}
-                            hasEmptySelectionButton={false}
-                            onChange={handleOnChange}
-                            options={statusOptions}
-                          />
-                        </FieldGroup>
-                      )
-                    }}
-                  />
-                  {configuration.featureFlags.showStandardTextAdminV2 && (
+                          >
+                            <Checkbox
+                              checked={value}
+                              name={name}
+                              id={name}
+                              onChange={onChange}
+                            />
+                          </StyledLabel>
+                        )}
+                      />
+                    </>
+                  )}
+                </FieldGroup>
+
+                {watchIsPublicAccessible && (
+                  <FieldGroup>
+                    <Input
+                      {...formMethods.register('public_name')}
+                      id="public_name"
+                      label="Naam openbaar"
+                      name="public_name"
+                      type="text"
+                      readOnly={readOnly}
+                    />
+                  </FieldGroup>
+                )}
+                {!isMainCategory && (
+                  <>
+                    <FieldGroup>
+                      <StyledHeading>Afhandeltermijn</StyledHeading>
+                      <CombinedFields>
+                        <Input
+                          {...formMethods.register('n_days')}
+                          disabled={readOnly}
+                          id="n_days"
+                          name="n_days"
+                          readOnly={readOnly}
+                          type="number"
+                          size={50}
+                        />
+
+                        <StyledSelect
+                          {...formMethods.register('use_calendar_days')}
+                          disabled={readOnly}
+                          id="use_calendar_days"
+                        >
+                          <option value="1">Dagen</option>
+                          <option value="0">Werkdagen</option>
+                        </StyledSelect>
+                      </CombinedFields>
+                    </FieldGroup>
+
                     <Controller
-                      name="standard_texts"
-                      control={formMethods.control}
-                      render={({ field: { onChange, name } }) => (
+                      name="handling_message"
+                      render={({ field: { name, value, onChange } }) => (
                         <FieldGroup>
-                          <StyledH2 forwardedAs="h2" styleAs="h5">
-                            Standaardteksten per status
-                          </StyledH2>
-                          <StandardTextsField onChange={onChange} name={name} />
+                          <TextArea
+                            disabled={readOnly}
+                            id={name}
+                            label={<strong>Servicebelofte</strong>}
+                            name={name}
+                            onChange={onChange}
+                            readOnly={readOnly}
+                            rows={6}
+                            value={value}
+                          />
                         </FieldGroup>
                       )}
                     />
-                  )}
-                </>
-              )}
-            </div>
-          </StyledColumn>
 
-          <StyledColumn
-            span={{ small: 1, medium: 2, big: 6, large: 7, xLarge: 6 }}
-          >
-            <Column span={{ small: 1, medium: 2, big: 4, large: 5, xLarge: 5 }}>
-              <Controller
-                name="note"
-                render={({ field: { name, value, onChange } }) => (
-                  <TextArea
-                    disabled={readOnly}
-                    id={name}
-                    label={<strong>Notitie</strong>}
-                    name={name}
-                    onChange={onChange}
-                    readOnly={readOnly}
-                    rows={6}
-                    value={value}
-                  />
+                    <Controller
+                      name="is_active"
+                      control={formMethods.control}
+                      render={({ field: { name, value, onChange } }) => {
+                        /* istanbul ignore next */
+                        const handleOnChange = (
+                          _groupName: string,
+                          option: StatusOption
+                        ) => {
+                          const value = statusOptions.find(
+                            (status) => status.value === option.value
+                          )?.key
+                          onChange(value)
+                        }
+
+                        return (
+                          <FieldGroup>
+                            <StyledHeading>Status</StyledHeading>
+                            <RadioButtonList
+                              defaultValue={value}
+                              disabled={readOnly}
+                              groupName={name}
+                              hasEmptySelectionButton={false}
+                              onChange={handleOnChange}
+                              options={statusOptions}
+                            />
+                          </FieldGroup>
+                        )
+                      }}
+                    />
+                    {configuration.featureFlags.showStandardTextAdminV2 && (
+                      <Controller
+                        name="standard_texts"
+                        control={formMethods.control}
+                        render={({ field: { onChange, name } }) => (
+                          <FieldGroup>
+                            <StyledH2 forwardedAs="h2" styleAs="h5">
+                              Standaardteksten per status
+                            </StyledH2>
+                            <StandardTextsField
+                              onChange={onChange}
+                              name={name}
+                              statusOption={watchIsActive}
+                            />
+                          </FieldGroup>
+                        )}
+                      />
+                    )}
+                  </>
                 )}
+              </div>
+            </StyledColumn>
+
+            <StyledColumn
+              span={{ small: 1, medium: 2, big: 6, large: 7, xLarge: 6 }}
+            >
+              <Column
+                span={{ small: 1, medium: 2, big: 4, large: 5, xLarge: 5 }}
+              >
+                <Controller
+                  name="note"
+                  render={({ field: { name, value, onChange } }) => (
+                    <TextArea
+                      disabled={readOnly}
+                      id={name}
+                      label={<strong>Notitie</strong>}
+                      name={name}
+                      onChange={onChange}
+                      readOnly={readOnly}
+                      rows={6}
+                      value={value}
+                    />
+                  )}
+                />
+              </Column>
+
+              {history && <StyledHistory list={history} />}
+            </StyledColumn>
+
+            {!readOnly && (
+              <StyledFormFooter
+                cancelBtnLabel="Annuleer"
+                onCancel={onCancel}
+                submitBtnLabel="Opslaan"
               />
-            </Column>
-
-            {history && <StyledHistory list={history} />}
-          </StyledColumn>
-
-          {!readOnly && (
-            <StyledFormFooter
-              cancelBtnLabel="Annuleer"
-              onCancel={onCancel}
-              submitBtnLabel="Opslaan"
-            />
-          )}
-        </Row>
-      </Form>
-    </FormContainer>
-  </FormProvider>
-)
+            )}
+          </Row>
+        </Form>
+      </FormContainer>
+    </FormProvider>
+  )
+}

--- a/src/signals/settings/categories/components/Detail.tsx
+++ b/src/signals/settings/categories/components/Detail.tsx
@@ -101,7 +101,6 @@ export const CategoryDetail = ({
     defaultValues: { ...defaultValues },
   })
   const isDirty = formMethods.formState.isDirty
-  const formValues = formMethods.getValues()
 
   const categoryURL = `${configuration.CATEGORIES_PRIVATE_ENDPOINT}${categoryId}`
 
@@ -195,7 +194,6 @@ export const CategoryDetail = ({
       <CategoryForm
         isMainCategory={isMainCategory}
         formMethods={formMethods}
-        formValues={formValues}
         history={historyData}
         onCancel={onCancel}
         onSubmit={formMethods.handleSubmit(onSubmit)}

--- a/src/signals/settings/categories/components/StandardTextsField/StandardTextsField.test.tsx
+++ b/src/signals/settings/categories/components/StandardTextsField/StandardTextsField.test.tsx
@@ -23,6 +23,43 @@ describe('StandardTextsField', () => {
     })
   })
 
+  it('should show only active texts', async () => {
+    act(() => {
+      render(
+        withAppContext(
+          <StandardTextsField
+            name="test1"
+            onChange={() => {}}
+            statusOption={'true'}
+          />
+        )
+      )
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('Titel #7')).toBeInTheDocument()
+      expect(screen.queryByText('Titel #12')).not.toBeInTheDocument()
+    })
+  })
+  it('should show only inactive texts', async () => {
+    act(() => {
+      render(
+        withAppContext(
+          <StandardTextsField
+            name="test2"
+            onChange={() => {}}
+            statusOption={'false'}
+          />
+        )
+      )
+    })
+
+    await waitFor(() => {
+      expect(screen.queryByText('Titel #7')).not.toBeInTheDocument()
+      expect(screen.getByText('Titel #12')).toBeInTheDocument()
+    })
+  })
+
   it('should move text and call onChange', async () => {
     const onchangeMock = jest.fn()
 

--- a/src/signals/settings/categories/components/StandardTextsField/StandardTextsField.tsx
+++ b/src/signals/settings/categories/components/StandardTextsField/StandardTextsField.tsx
@@ -20,14 +20,16 @@ import {
 } from './styled'
 import { changeStatusOptionList } from '../../../../incident-management/definitions/statusList'
 import { Direction } from '../../types'
+import type { StatusOption } from '../CategoryForm'
 import { orderStandardTexts } from '../utils'
 
 type Props = {
   name: string
   onChange: (standardTexts: StandardText[]) => void
+  statusOption?: StatusOption['key']
 }
 
-export const StandardTextsField = ({ name, onChange }: Props) => {
+export const StandardTextsField = ({ name, onChange, statusOption }: Props) => {
   const params = useParams<{ categoryId: string }>()
   const { get, data } = useFetch<{ results: StandardText[] }>()
   const [selectedStatus, setSelectedStatus] = useState<string>(
@@ -64,12 +66,15 @@ export const StandardTextsField = ({ name, onChange }: Props) => {
         (status) => status.value === selectedStatus
       )?.key
 
-      const orderedStandardTexts = data.results.filter(
-        (result) => result.state === state
-      )
+      const orderedStandardTexts = data.results
+        .filter((result) => result.state === state)
+        .filter(
+          (item) => !statusOption || item.active.toString() === statusOption
+        )
+
       setOrderedStandardTexts(orderedStandardTexts)
     }
-  }, [data, selectedStatus])
+  }, [data, selectedStatus, statusOption])
 
   const options = changeStatusOptionList.map((status) => ({
     name: status.value,

--- a/src/signals/settings/categories/constants.tsx
+++ b/src/signals/settings/categories/constants.tsx
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2023 Gemeente Amsterdam
-import { StyledInfo } from './components/styled'
 import { Fragment } from 'react'
+
+import { StyledInfo } from './components/styled'
 
 export const ICONEXAMPLE = [
   <Fragment key={'IconExample'}>


### PR DESCRIPTION
Added useWatch to handle dependency of component on another component in StandardTextFiled

Because the parentcomponent Detail is not always rendered, the formValues are not always updated. React Forms has useWatch to check for changing of values in the form. FormValues are therefor removed and useWatch is implemented in CategoryForm where the showing of the standardTextFields is dependent on the status and the chosen standard text.

Ticket: [SIG-5506](https://gemeente-amsterdam.atlassian.net/browse/SIG-5506)

## Signalen

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
