### PR TITLE
[fix-5534]: Dont show error when permission is missing

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/components/Detail/components/Contact/Contact.test.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/Detail/components/Contact/Contact.test.tsx
@@ -14,6 +14,7 @@ import {
   fetchMock,
   mockRequestHandler,
 } from '../../../../../../../../../internals/testing/msw-server'
+import * as appSelectors from '../../../../../../../../containers/App/selectors'
 jest.mock('shared/services/configuration/configuration')
 const incidentFixture = incidentJSON as unknown as any
 
@@ -29,6 +30,9 @@ describe('Contact', () => {
     jest
       .spyOn(reactRouterDom, 'useParams')
       .mockImplementation(() => ({ id: '7740' }))
+    jest
+      .spyOn(appSelectors, 'makeSelectUserCan')
+      .mockImplementation(() => () => true)
   })
 
   it('should render the component', async () => {
@@ -230,5 +234,16 @@ describe('Contact', () => {
         screen.queryByText(/Verificatie annuleren/)
       ).not.toBeInTheDocument()
     })
+  })
+  it('should not show the edit contact button when user does not have permission', async () => {
+    jest
+      .spyOn(appSelectors, 'makeSelectUserCan')
+      .mockImplementation(() => () => false)
+
+    await act(async () => {
+      render(withAppContext(<Contact showPhone incident={incidentFixture} />))
+    })
+
+    expect(screen.queryByTestId('edit-contact-button')).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
when missing permission sia_can_view_contact_details. Also stop error from showing by default.

Ticket: [SIG-5534](https://gemeente-amsterdam.atlassian.net/browse/SIG-5534)

## Signalen

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
