### PR TITLE
[bugfix-5507]: standard texts crossed boundary of parent 

### DIFF
--- a/src/signals/settings/categories/components/StandardTextsField/StandardTextsField.tsx
+++ b/src/signals/settings/categories/components/StandardTextsField/StandardTextsField.tsx
@@ -16,6 +16,7 @@ import {
   DefaultTextBody,
   StyledButton,
   TextWrapper,
+  StyledWrapper,
   Wrapper,
 } from './styled'
 import { changeStatusOptionList } from '../../../../incident-management/definitions/statusList'
@@ -95,10 +96,10 @@ export const StandardTextsField = ({ name, onChange }: Props) => {
           <Wrapper key={standardText.id}>
             <TextWrapper>
               <span data-testid="text-title">{index + 1}</span>
-              <div>
+              <StyledWrapper>
                 <span>{standardText.title}</span>
                 <DefaultTextBody>{standardText.text}</DefaultTextBody>
-              </div>
+              </StyledWrapper>
             </TextWrapper>
             <ButtonWrapper>
               <StyledButton

--- a/src/signals/settings/categories/components/StandardTextsField/styled.ts
+++ b/src/signals/settings/categories/components/StandardTextsField/styled.ts
@@ -24,6 +24,7 @@ export const DefaultTextBody = styled.div`
 
 export const TextWrapper = styled.div`
   display: flex;
+  min-width: 0;
 
   span {
     font-weight: 700;
@@ -38,4 +39,9 @@ export const StyledButton = styled(Button)`
   & + button:not([disabled]) {
     margin-top: -1px;
   }
+`
+
+export const StyledWrapper = styled.div`
+  min-width: 0;
+  overflow: hidden;
 `


### PR DESCRIPTION
Compensating for Chrome deviations
Chrome didn't show the standard texts (for example in subcategory Duiven with status afgehandeld) correct. One of the standard text overflowed its parent boundaries. Added styling (min-width and overflow hidden) to the responsible div.

Ticket: [SIG-5507](https://gemeente-amsterdam.atlassian.net/browse/SIG-5507)

## Signalen

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
