### PR TITLE
[feat-5532]: write Attachments with permission

### DIFF
--- a/src/signals/incident-management/containers/IncidentDetail/IncidentDetail.test.js
+++ b/src/signals/incident-management/containers/IncidentDetail/IncidentDetail.test.js
@@ -31,6 +31,10 @@ jest
   .spyOn(categoriesSelectors, 'makeSelectSubCategories')
   .mockImplementation(() => subCategories)
 
+jest
+  .spyOn(appSelectors, 'makeSelectUserCan')
+  .mockImplementation(() => () => true)
+
 const mockUseUpload = {
   upload: jest.fn(),
   uploadSuccess: jest.fn(),
@@ -404,9 +408,7 @@ describe('signals/incident-management/containers/IncidentDetail', () => {
     jest.spyOn(window, 'confirm').mockImplementation(() => {
       return true
     })
-    jest
-      .spyOn(appSelectors, 'makeSelectUserCan')
-      .mockImplementation(() => () => true)
+
     server.use(
       rest.delete(
         'http://localhost:8000/signals/v1/private/signals/63/attachments/88',

--- a/src/signals/incident-management/containers/IncidentDetail/components/Attachments/Attachments.test.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/Attachments/Attachments.test.tsx
@@ -6,14 +6,15 @@ import userEvent from '@testing-library/user-event'
 import * as appSelectors from 'containers/App/selectors'
 import { withAppContext } from 'test/utils'
 
-import Attachments, {
+import Attachments from './Attachments'
+import attachments from '../../../../../../../internals/mocks/fixtures/attachments.json'
+import userFixture from '../../../../../../utils/__tests__/fixtures/user.json'
+import {
   DELETE_CHILD,
   DELETE_NORMAL,
   DELETE_OTHER,
   DELETE_PARENT,
-} from './Attachments'
-import attachments from '../../../../../../../internals/mocks/fixtures/attachments.json'
-import userFixture from '../../../../../../utils/__tests__/fixtures/user.json'
+} from '../../constants'
 import IncidentDetailContext from '../../context'
 
 jest.mock('./UploadProgress', () => ({ progress }: { progress: number }) => (
@@ -21,15 +22,22 @@ jest.mock('./UploadProgress', () => ({ progress }: { progress: number }) => (
 ))
 
 const patch = jest.fn()
+const preview = jest.fn()
+const add = jest.fn()
+const remove = jest.fn()
 
 describe('Attachments', () => {
   beforeEach(() => {
     patch.mockClear()
+    jest
+      .spyOn(appSelectors, 'makeSelectUserCan')
+      .mockImplementation(() => () => true)
+  })
+  afterEach(() => {
+    jest.resetAllMocks()
   })
 
   it('renders the Attachments component', () => {
-    const add = jest.fn()
-    const remove = jest.fn()
     const fileName = 'ae70d54aca324d0480ca01934240c78f.jpg'
 
     render(
@@ -56,9 +64,6 @@ describe('Attachments', () => {
   })
 
   it('works without location', () => {
-    const add = jest.fn()
-    const remove = jest.fn()
-
     render(
       withAppContext(
         <Attachments
@@ -79,9 +84,6 @@ describe('Attachments', () => {
   })
 
   it('works without attachments', () => {
-    const add = jest.fn()
-    const remove = jest.fn()
-
     render(
       withAppContext(
         <Attachments
@@ -103,8 +105,6 @@ describe('Attachments', () => {
   })
 
   it('shows the creator', () => {
-    const add = jest.fn()
-    const remove = jest.fn()
     const employee = 'employee@signalen.dev'
 
     const newAttachments = [
@@ -138,8 +138,6 @@ describe('Attachments', () => {
       patch.mockClear()
     })
     it('calls add and shows the file', async () => {
-      const add = jest.fn()
-      const remove = jest.fn()
       const files = [
         {
           name: 'bloem.jpeg',
@@ -181,8 +179,6 @@ describe('Attachments', () => {
     })
 
     it('shows the upload progress', async () => {
-      const add = jest.fn()
-      const remove = jest.fn()
       const files = [
         {
           name: 'bloem.jpeg',
@@ -276,8 +272,6 @@ describe('Attachments', () => {
     })
 
     it('handles upload error', async () => {
-      const add = jest.fn()
-      const remove = jest.fn()
       const files = [
         {
           name: 'bloem.jpeg',
@@ -358,8 +352,6 @@ describe('Attachments', () => {
     })
 
     it('handles too large files', () => {
-      const add = jest.fn()
-      const remove = jest.fn()
       const files = [
         {
           name: 'bloem.jpeg',
@@ -396,8 +388,6 @@ describe('Attachments', () => {
     })
 
     it('handles too small files', () => {
-      const add = jest.fn()
-      const remove = jest.fn()
       const files = [
         {
           name: 'bloem.jpeg',
@@ -435,9 +425,6 @@ describe('Attachments', () => {
   })
 
   it('can toggle the note form', () => {
-    const add = jest.fn()
-    const remove = jest.fn()
-
     render(
       withAppContext(
         <Attachments
@@ -470,8 +457,6 @@ describe('Attachments', () => {
       patch.mockClear()
     })
     it('does not show the delete button when not allowed', () => {
-      const add = jest.fn()
-      const remove = jest.fn()
       jest
         .spyOn(appSelectors, 'makeSelectUserCan')
         .mockImplementation(() => () => false)
@@ -498,8 +483,6 @@ describe('Attachments', () => {
     })
 
     it('shows the delete button when allowed', () => {
-      const add = jest.fn()
-      const remove = jest.fn()
       jest
         .spyOn(appSelectors, 'makeSelectUserCan')
         .mockImplementation(() => () => true)
@@ -524,8 +507,6 @@ describe('Attachments', () => {
     })
 
     it('shows the delete button when allowed from others and for normal incidents', () => {
-      const add = jest.fn()
-      const remove = jest.fn()
       jest
         .spyOn(appSelectors, 'makeSelectUserCan')
         .mockImplementation(
@@ -552,8 +533,6 @@ describe('Attachments', () => {
     })
 
     it('shows the delete button when allowed from others and for child incidents', () => {
-      const add = jest.fn()
-      const remove = jest.fn()
       jest
         .spyOn(appSelectors, 'makeSelectUserCan')
         .mockImplementation(
@@ -580,8 +559,6 @@ describe('Attachments', () => {
     })
 
     it('shows the delete button when allowed from others and for parent incidents', () => {
-      const add = jest.fn()
-      const remove = jest.fn()
       jest
         .spyOn(appSelectors, 'makeSelectUserCan')
         .mockImplementation(
@@ -608,8 +585,6 @@ describe('Attachments', () => {
     })
 
     it('shows the delete button when its your own attachment and allowed for normal incidents', () => {
-      const add = jest.fn()
-      const remove = jest.fn()
       const employee = 'employee@signalen.dev'
 
       const newAttachments = [
@@ -646,9 +621,6 @@ describe('Attachments', () => {
     })
 
     it('calls remove', () => {
-      const add = jest.fn()
-      const remove = jest.fn()
-
       jest
         .spyOn(appSelectors, 'makeSelectUserCan')
         .mockImplementation(() => () => true)
@@ -679,9 +651,6 @@ describe('Attachments', () => {
     })
 
     it('does not call remove without confirmation', () => {
-      const add = jest.fn()
-      const remove = jest.fn()
-
       jest
         .spyOn(appSelectors, 'makeSelectUserCan')
         .mockImplementation(() => () => true)
@@ -725,13 +694,18 @@ describe('Attachments', () => {
     })
 
     it('should open EditAttachment form and the form should be interactive', async () => {
-      const preview = jest.fn()
-      const add = jest.fn()
-      const remove = jest.fn()
+      jest
+        .spyOn(appSelectors, 'makeSelectUserCan')
+        .mockImplementation(() => () => true)
 
       render(
         withAppContext(
-          <IncidentDetailContext.Provider value={{ update: () => {}, preview }}>
+          <IncidentDetailContext.Provider
+            value={{
+              update: () => {},
+              preview,
+            }}
+          >
             <Attachments
               patch={patch}
               attachments={publicAttachmentResults}
@@ -763,12 +737,38 @@ describe('Attachments', () => {
 
       expect(screen.getByText(/Onderschrift/)).toBeInTheDocument()
     })
+    it('should not open EditAttachment form', async () => {
+      jest
+        .spyOn(appSelectors, 'makeSelectUserCan')
+        .mockImplementation(() => () => false)
+
+      render(
+        withAppContext(
+          <IncidentDetailContext.Provider
+            value={{
+              update: () => {},
+              preview,
+            }}
+          >
+            <Attachments
+              patch={patch}
+              attachments={publicAttachmentResults}
+              add={add}
+              remove={remove}
+              isChildIncident={false}
+              isParentIncident={false}
+              isRemoving={false}
+              uploadProgress={0}
+              uploadError={false}
+            />
+          </IncidentDetailContext.Provider>
+        )
+      )
+
+      expect(screen.queryByTitle('Openbaar maken')).not.toBeInTheDocument()
+    })
 
     it('should show public and non public attachments with and without edit button', async () => {
-      const preview = jest.fn()
-      const add = jest.fn()
-      const remove = jest.fn()
-
       const attachmentResultsMultiple = [
         {
           ...attachments.results[0],
@@ -783,7 +783,12 @@ describe('Attachments', () => {
 
       render(
         withAppContext(
-          <IncidentDetailContext.Provider value={{ update: () => {}, preview }}>
+          <IncidentDetailContext.Provider
+            value={{
+              update: () => {},
+              preview,
+            }}
+          >
             <Attachments
               patch={patch}
               attachments={attachmentResultsMultiple}
@@ -816,10 +821,6 @@ describe('Attachments', () => {
     })
 
     it('should not be able to make pdf public available', async () => {
-      const preview = jest.fn()
-      const add = jest.fn()
-      const remove = jest.fn()
-
       const attachmentResultsMultiple = [
         {
           ...attachments.results[0],
@@ -836,7 +837,12 @@ describe('Attachments', () => {
 
       render(
         withAppContext(
-          <IncidentDetailContext.Provider value={{ update: () => {}, preview }}>
+          <IncidentDetailContext.Provider
+            value={{
+              update: () => {},
+              preview,
+            }}
+          >
             <Attachments
               patch={patch}
               attachments={attachmentResultsMultiple}
@@ -856,13 +862,14 @@ describe('Attachments', () => {
     })
 
     it('should open EditAttachment form and it should send a PATCH request', async () => {
-      const preview = jest.fn()
-      const add = jest.fn()
-      const remove = jest.fn()
-
       render(
         withAppContext(
-          <IncidentDetailContext.Provider value={{ update: () => {}, preview }}>
+          <IncidentDetailContext.Provider
+            value={{
+              update: () => {},
+              preview,
+            }}
+          >
             <Attachments
               patch={patch}
               attachments={publicAttachmentResults}
@@ -910,10 +917,6 @@ describe('Attachments', () => {
     })
 
     it('should open EditAttachment form and it should send a PATCH request with caption null', async () => {
-      const preview = jest.fn()
-      const add = jest.fn()
-      const remove = jest.fn()
-
       const publicAttachmentResultsWithCaption = [
         {
           ...attachments.results[0],
@@ -924,7 +927,12 @@ describe('Attachments', () => {
 
       render(
         withAppContext(
-          <IncidentDetailContext.Provider value={{ update: () => {}, preview }}>
+          <IncidentDetailContext.Provider
+            value={{
+              update: () => {},
+              preview,
+            }}
+          >
             <Attachments
               patch={patch}
               attachments={publicAttachmentResultsWithCaption}
@@ -959,13 +967,14 @@ describe('Attachments', () => {
     })
 
     it('should open EditAttachment form, fill it and press cancel button', async () => {
-      const preview = jest.fn()
-      const add = jest.fn()
-      const remove = jest.fn()
-
       render(
         withAppContext(
-          <IncidentDetailContext.Provider value={{ update: () => {}, preview }}>
+          <IncidentDetailContext.Provider
+            value={{
+              update: () => {},
+              preview,
+            }}
+          >
             <Attachments
               patch={patch}
               attachments={publicAttachmentResults}
@@ -996,14 +1005,16 @@ describe('Attachments', () => {
   })
 
   it('shows the preview', () => {
-    const preview = jest.fn()
-    const add = jest.fn()
-    const remove = jest.fn()
     const fileName = 'ae70d54aca324d0480ca01934240c78f.jpg'
 
     render(
       withAppContext(
-        <IncidentDetailContext.Provider value={{ update: () => {}, preview }}>
+        <IncidentDetailContext.Provider
+          value={{
+            update: () => {},
+            preview,
+          }}
+        >
           <Attachments
             patch={patch}
             attachments={attachments.results}
@@ -1026,9 +1037,6 @@ describe('Attachments', () => {
   })
 
   it('shows a pdf in a new tab', () => {
-    const preview = jest.fn()
-    const add = jest.fn()
-    const remove = jest.fn()
     const fileName = 'ae70d54aca324d0480ca01934240c78f.pdf'
 
     const mockOpen = jest.fn()
@@ -1039,7 +1047,12 @@ describe('Attachments', () => {
 
     render(
       withAppContext(
-        <IncidentDetailContext.Provider value={{ update: () => {}, preview }}>
+        <IncidentDetailContext.Provider
+          value={{
+            update: () => {},
+            preview,
+          }}
+        >
           <Attachments
             patch={patch}
             attachments={attachments.results}

--- a/src/signals/incident-management/containers/IncidentDetail/components/Attachments/Attachments.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/Attachments/Attachments.tsx
@@ -43,16 +43,19 @@ import {
   StyledButtonsWrapper,
 } from './styled'
 import StyledUploadProgress from './UploadProgress'
+import {
+  DELETE_CHILD,
+  DELETE_NORMAL,
+  DELETE_OTHER,
+  DELETE_PARENT,
+  CHANGE_ATTACHMENT,
+  ADD_ATTACHMENT,
+} from '../../constants'
 import IncidentDetailContext from '../../context'
 import type { Files } from '../../hooks/useUpload'
 import type { Attachment } from '../../types'
 import { isPdf } from '../../utils/isPdf'
 import FileInput from '../FileInput'
-
-export const DELETE_CHILD = 'sia_delete_attachment_of_child_signal'
-export const DELETE_NORMAL = 'sia_delete_attachment_of_normal_signal'
-export const DELETE_OTHER = 'sia_delete_attachment_of_other_user'
-export const DELETE_PARENT = 'sia_delete_attachment_of_parent_signal'
 
 const MIN = 30 * 2 ** 10 // 30 KiB
 const MAX = 20 * 2 ** 20 // 20 MiB
@@ -220,24 +223,26 @@ const Attachments: FC<AttachmentsProps> = ({
                   </StyledDate>
                 </StyledDetails>
                 <StyledButtonsWrapper>
-                  {attachment.created_by && attachment.is_image && (
-                    <StyledButton
-                      icon={
-                        <img
-                          src="/assets/images/icon-edit.svg"
-                          alt="Bewerken"
-                        />
-                      }
-                      iconSize={18}
-                      onClick={(event) => {
-                        event.stopPropagation()
-                        setSelectedEditAttachment(attachment.location)
-                      }}
-                      title="Openbaar maken"
-                      variant="application"
-                      disabled={isRemoving || !!selectedEditAttachment}
-                    />
-                  )}
+                  {userCan(CHANGE_ATTACHMENT) &&
+                    attachment.created_by &&
+                    attachment.is_image && (
+                      <StyledButton
+                        icon={
+                          <img
+                            src="/assets/images/icon-edit.svg"
+                            alt="Bewerken"
+                          />
+                        }
+                        iconSize={18}
+                        onClick={(event) => {
+                          event.stopPropagation()
+                          setSelectedEditAttachment(attachment.location)
+                        }}
+                        title="Openbaar maken"
+                        variant="application"
+                        disabled={isRemoving || !!selectedEditAttachment}
+                      />
+                    )}
                   {canDeleteAttachment(attachment) && (
                     <StyledButton
                       icon={<DeleteIcon />}
@@ -304,22 +309,24 @@ const Attachments: FC<AttachmentsProps> = ({
       )}
       {error && <ErrorMessage message={error} />}
       <StyledButtonWrapper>
-        <FileInput multiple={false} name="addPhoto" onChange={handleChange}>
-          {files.length > 0 && !uploadError ? (
-            <Button variant="application" disabled={true} type="button">
-              Bestand toevoegen
-            </Button>
-          ) : (
-            <Button
-              forwardedAs={'span'}
-              tabIndex={0}
-              variant="application"
-              type="button"
-            >
-              Bestand toevoegen
-            </Button>
-          )}
-        </FileInput>
+        {userCan(ADD_ATTACHMENT) && (
+          <FileInput multiple={false} name="addPhoto" onChange={handleChange}>
+            {files.length > 0 && !uploadError ? (
+              <Button variant="application" disabled={true} type="button">
+                Bestand toevoegen
+              </Button>
+            ) : (
+              <Button
+                forwardedAs={'span'}
+                tabIndex={0}
+                variant="application"
+                type="button"
+              >
+                Bestand toevoegen
+              </Button>
+            )}
+          </FileInput>
+        )}
         <Button
           type="button"
           variant="application"

--- a/src/signals/incident-management/containers/IncidentDetail/constants.ts
+++ b/src/signals/incident-management/containers/IncidentDetail/constants.ts
@@ -38,3 +38,10 @@ export const PREVIEW =
 export const EDIT = 'sia/incidentManagement/containers/IncidentDetail/EDIT'
 export const EXTERNAL =
   'sia/incidentManagement/containers/IncidentDetail/EXTERNAL'
+
+export const DELETE_CHILD = 'sia_delete_attachment_of_child_signal'
+export const DELETE_NORMAL = 'sia_delete_attachment_of_normal_signal'
+export const DELETE_OTHER = 'sia_delete_attachment_of_other_user'
+export const DELETE_PARENT = 'sia_delete_attachment_of_parent_signal'
+export const CHANGE_ATTACHMENT = 'sia_change_attachment'
+export const ADD_ATTACHMENT = 'sia_add_attachment'

--- a/src/signals/settings/categories/constants.tsx
+++ b/src/signals/settings/categories/constants.tsx
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2023 Gemeente Amsterdam
-import { StyledInfo } from './components/styled'
 import { Fragment } from 'react'
+
+import { StyledInfo } from './components/styled'
 
 export const ICONEXAMPLE = [
   <Fragment key={'IconExample'}>


### PR DESCRIPTION
**only users with right permissions are able to see/edit/delete attachments**

- Only users with permission sia_add_attachment will see the button Bestand toevoegen
- Only users with permission sia_change_attachment will see the delete button and the edit button.
- Permissions sia_change_attachment and sia_add_attachment are added to permissions for Attachments
- Permissions are moved to constants file in IncidentDetail directory.

Ticket: [SIG-5532](https://gemeente-amsterdam.atlassian.net/browse/SIG-5532)

## Signalen

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)


[SIG-5532]: https://gemeente-amsterdam.atlassian.net/browse/SIG-5532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ