### PR TITLE
[feature 5526]: Notification needs to fade out after a short period

### DIFF
--- a/src/containers/Notification/constants.ts
+++ b/src/containers/Notification/constants.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2019 - 2021 Gemeente Amsterdam
+// Copyright (C) 2019 - 2023 Gemeente Amsterdam
 export const VARIANT_ERROR = 'error'
 export const VARIANT_NOTICE = 'notice'
 export const VARIANT_SUCCESS = 'success'
@@ -7,5 +7,5 @@ export const VARIANT_SUCCESS = 'success'
 export const TYPE_GLOBAL = 'global'
 export const TYPE_LOCAL = 'local'
 
-export const SLIDEUP_TIMEOUT = 8000
+export const SLIDEUP_TIMEOUT = 3000
 export const ONCLOSE_TIMEOUT = 200


### PR DESCRIPTION
Changed SLIDEUP_TIMEOUT to 3 seconds in Notification
Ticket: [SIG-5526](https://gemeente-amsterdam.atlassian.net/browse/SIG-5526)

## Signalen

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)


[SIG-5526]: https://gemeente-amsterdam.atlassian.net/browse/SIG-5526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ