### PR TITLE
Additional security headers: Referrer-Policy, Permissions-Policy and Content-Security-Policy

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -10,6 +10,12 @@ server {
     add_header X-XSS-Protection "1; mode=block";
     # This will enforce HTTP browsing into HTTPS and avoid ssl stripping attack
     add_header Strict-Transport-Security "max-age=31536000; includeSubdomains;";
+    # The Referer-Policy header defines what data is made available in the Referer header, and for navigation and iframes in the destination's document
+    add_header Referrer-Policy "strict-origin-when-cross-origin";
+    # Permissions Policy is a web platform API which gives a website the ability to allow or block the use of browser features
+    add_header Permissions-Policy "geolocation=(self), camera=(self)";
+    # Control what resources the user agent is allowed to load for this app.
+    add_header Content-Security-Policy "default-src 'self'; style-src 'self' 'nonce-$request_id'; script-src 'self' 'nonce-$request_id';";
 
     # Add GZIP compression for speed optimization
     gzip on;
@@ -34,6 +40,9 @@ server {
     location / {
         alias /usr/share/nginx/html/;
         try_files $uri $uri/ @index;
+
+        sub_filter_once off;
+        sub_filter random-csp-nonce $request_id;
     }
 
     location @index {

--- a/internals/scripts/helpers/config.js
+++ b/internals/scripts/helpers/config.js
@@ -21,7 +21,7 @@ const extendedConfig = fs.existsSync(extendedConfigFile)
 const config = merge({}, baseConfig, extendedConfig)
 
 const piwik = config?.piwik?.id
-  ? `<script type="text/javascript">
+  ? `<script type="text/javascript" nonce="random-csp-nonce">
 (function(window, document, dataLayerName, id) {
   window[dataLayerName]=window[dataLayerName]||[],window[dataLayerName].push({start:(new Date).getTime(),event:"stg.start"});var scripts=document.getElementsByTagName('script')[0],tags=document.createElement('script');
 function stgCreateCookie(a,b,c){var d="";if(c){var e=new Date;e.setTime(e.getTime()+24*c*60*60*1e3),d="; expires="+e.toUTCString()}document.cookie=a+"="+b+d+"; path=/"}
@@ -34,7 +34,7 @@ tags.async=!0,tags.src="https://dap.amsterdam.nl/containers/"+id+".js"+qPString,
   : ''
 
 const additionalCodeCss = config?.additionalCode?.css
-  ? `<style>${config.additionalCode.css}</style>`
+  ? `<style nonce="random-csp-nonce">${config.additionalCode.css}</style>`
   : ''
 
 const placeholders = {

--- a/src/app.js
+++ b/src/app.js
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2018 - 2023 Gemeente Amsterdam
+
 import { ApplicationInsights } from '@microsoft/applicationinsights-web'
 import * as Sentry from '@sentry/browser'
 import ReactDOM from 'react-dom'
@@ -25,6 +26,8 @@ const environment = process.env.BUILD_ENV
 const dsn = configuration?.sentry?.dsn
 const connectionString = configuration?.azure?.connectionString
 const release = process.env.FRONTEND_TAG
+
+__webpack_nonce__ = window.__webpack_nonce__
 
 if (dsn) {
   Sentry.init({

--- a/src/index.html
+++ b/src/index.html
@@ -13,8 +13,11 @@
   <!-- webpackIgnore: true -->
   <link rel="manifest" href="/manifest.json" />
   <title>$SIGNALS_SITE_TITLE</title>
-  <script>
-    window.CONFIG = $SIGNALS_CONFIG
+  <script nonce="random-csp-nonce">
+    window.__webpack_nonce__ = "random-csp-nonce";
+  </script>
+  <script nonce="random-csp-nonce">
+    window.CONFIG = $SIGNALS_CONFIG;
   </script>
 </head>
 
@@ -34,9 +37,9 @@
       </p>
     </noscript>
   </div>
-  <script>
+  <script nonce="random-csp-nonce">
     var spinner = document.getElementById('spinner')
-    spinner.style.fill =  window.CONFIG.head.themeColor;
+    spinner.style.fill = window.CONFIG.head.themeColor;
   </script>
   $SIGNALS_ADDITIONAL_CODE_CSS
 </body>


### PR DESCRIPTION
This is work in progress to support additional security headers in the Signalen frontend.

## Todo

- [ ] Make CSP header configurable by environment variables
- [ ] Fix Amsterdam Styled Components (ASC). The portal implementation [includes a div with an inline style](https://github.com/Amsterdam/amsterdam-styled-components/blob/c8972786c4ed494c1591b3d9c528ddd428ad6579/packages/asc-ui/src/components/Portal/Portal.tsx#L15).