### PR TITLE
[feature 5536]: change order of elements in CategoryForm

### DIFF
--- a/src/signals/settings/categories/components/CategoryForm.test.tsx
+++ b/src/signals/settings/categories/components/CategoryForm.test.tsx
@@ -171,9 +171,7 @@ describe('CategoryForm', () => {
     render(<Wrapper />)
 
     await waitFor(() => {
-      expect(
-        screen.getByText('Standaardteksten per status')
-      ).toBeInTheDocument()
+      expect(screen.getByText('Standaardteksten volgorde')).toBeInTheDocument()
     })
   })
 })

--- a/src/signals/settings/categories/components/CategoryForm.tsx
+++ b/src/signals/settings/categories/components/CategoryForm.tsx
@@ -197,6 +197,36 @@ export const CategoryForm = ({
                 )}
                 {!isMainCategory && (
                   <>
+                    <Controller
+                      name="is_active"
+                      control={formMethods.control}
+                      render={({ field: { name, value, onChange } }) => {
+                        /* istanbul ignore next */
+                        const handleOnChange = (
+                          _groupName: string,
+                          option: StatusOption
+                        ) => {
+                          const value = statusOptions.find(
+                            (status) => status.value === option.value
+                          )?.key
+                          onChange(value)
+                        }
+
+                        return (
+                          <FieldGroup>
+                            <StyledHeading>Status</StyledHeading>
+                            <RadioButtonList
+                              defaultValue={value}
+                              disabled={readOnly}
+                              groupName={name}
+                              hasEmptySelectionButton={false}
+                              onChange={handleOnChange}
+                              options={statusOptions}
+                            />
+                          </FieldGroup>
+                        )
+                      }}
+                    />
                     <FieldGroup>
                       <StyledHeading>Afhandeltermijn</StyledHeading>
                       <CombinedFields>
@@ -239,36 +269,6 @@ export const CategoryForm = ({
                       )}
                     />
 
-                    <Controller
-                      name="is_active"
-                      control={formMethods.control}
-                      render={({ field: { name, value, onChange } }) => {
-                        /* istanbul ignore next */
-                        const handleOnChange = (
-                          _groupName: string,
-                          option: StatusOption
-                        ) => {
-                          const value = statusOptions.find(
-                            (status) => status.value === option.value
-                          )?.key
-                          onChange(value)
-                        }
-
-                        return (
-                          <FieldGroup>
-                            <StyledHeading>Status</StyledHeading>
-                            <RadioButtonList
-                              defaultValue={value}
-                              disabled={readOnly}
-                              groupName={name}
-                              hasEmptySelectionButton={false}
-                              onChange={handleOnChange}
-                              options={statusOptions}
-                            />
-                          </FieldGroup>
-                        )
-                      }}
-                    />
                     {configuration.featureFlags.showStandardTextAdminV2 && (
                       <Controller
                         name="standard_texts"
@@ -276,7 +276,7 @@ export const CategoryForm = ({
                         render={({ field: { onChange, name } }) => (
                           <FieldGroup>
                             <StyledH2 forwardedAs="h2" styleAs="h5">
-                              Standaardteksten per status
+                              Standaardteksten volgorde
                             </StyledH2>
                             <StandardTextsField
                               onChange={onChange}


### PR DESCRIPTION
Positioned FieldGroup Status (name= is_active) above  FieldGroup Afhandeltermijn (id=n_days) in DOM.

also changed 'Standaardteksten per status' to 'Standaardteksten volgorde'.

Ticket: [SIG-5536](https://gemeente-amsterdam.atlassian.net/browse/SIG-5536)

## Signalen

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)


[SIG-5536]: https://gemeente-amsterdam.atlassian.net/browse/SIG-5536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ