### PR TITLE
[chore 5542]: remove standard texts v1 from Amsterdam Sia

### DIFF
--- a/app.amsterdam.json
+++ b/app.amsterdam.json
@@ -23,7 +23,8 @@
     "showVulaanControls": true,
     "useProjectenSignalType": false,
     "showContactEdit": true,
-    "showSelectorV2removeafterfinishepic5440": true
+    "showSelectorV2removeafterfinishepic5440": true,
+    "showStandardTextAdminV1": false
   },
   "head": {
     "androidIcon": "/icon_192x192.png",


### PR DESCRIPTION
Set showStandardTextAdminV1 in app.amsterdam.json to false

Ticket: [SIG-5542]https://gemeente-amsterdam.atlassian.net/browse/SIG-5542)

## Signalen

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)


[SIG-5542]: https://gemeente-amsterdam.atlassian.net/browse/SIG-5542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ