### PR TITLE
 bugfix/5557-outlining-name-filter-in-Overview 

### DIFF
--- a/src/signals/incident-management/containers/IncidentOverviewPage/components/IncidentOverviewTitle/index.js
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/components/IncidentOverviewTitle/index.js
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2019 - 2021 Gemeente Amsterdam
-import { Fragment, useMemo } from 'react'
+import { useMemo } from 'react'
 
 import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
@@ -34,14 +34,14 @@ export const IncidentOverviewTitle = ({ filter, incidentsCount, query }) => {
     title += hasCount ? ` (${incidentsCount.toLocaleString('nl-NL')})` : ''
 
     return filter.refresh ? (
-      <Fragment>
+      <div>
         <RefreshIcon
           data-testid="refresh-icon"
           role="img"
           aria-label="Ververst automatisch"
         />{' '}
         {title}
-      </Fragment>
+      </div>
     ) : (
       title
     )


### PR DESCRIPTION
Changed <Fragment> to <div> so that title is immediately behind the refresh icon.

Since this is a bug in prod, transforming IncidentOverviewTitle to tsx will have a separate PR.

Ticket: [SIG-5557](https://gemeente-amsterdam.atlassian.net/browse/SIG-5557)

## Signalen

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)


[SIG-5557]: https://gemeente-amsterdam.atlassian.net/browse/SIG-5557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ