### PR TITLE
[fix]:standard texts query

### DIFF
--- a/app.amsterdam.json
+++ b/app.amsterdam.json
@@ -19,6 +19,7 @@
     "reporterMailHandledNegativeContactEnabled": true,
     "showMainCategories": true,
     "showStandardTextAdminV2": true,
+    "showStandardTextAdminV1": false,
     "showThorButton": true,
     "showVulaanControls": true,
     "useProjectenSignalType": false,

--- a/src/signals/incident-management/containers/IncidentDetail/IncidentDetail.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/IncidentDetail.tsx
@@ -211,9 +211,8 @@ const IncidentDetail = () => {
       const category = subcategories?.find(
         (cat) => cat.slug === incident.category?.sub_slug
       )
-
       getDefaultTexts(
-        `${configuration.STANDARD_TEXTS_ENDPOINT}?category_id=${category?.fk}`
+        `${configuration.STANDARD_TEXTS_ENDPOINT}?ordering=statusmessagecategory__position&category_id=${category?.fk}`
       )
     }
   }, [incident?.category, getDefaultTexts, subcategories])

--- a/src/signals/incident-management/containers/IncidentDetail/components/MetaList/MetaList.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/MetaList/MetaList.tsx
@@ -358,7 +358,7 @@ const MetaList: FC<MetaListProps> = ({ defaultTexts, childIncidents }) => {
       </Highlight>
       {showEditStatus && (
         <StatusForm
-          defaultTexts={defaultTexts || []}
+          defaultTexts={defaultTexts}
           childIncidents={childIncidents || []}
           onClose={() => setShowEditStatus(false)}
         />

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.tsx
@@ -47,7 +47,7 @@ export interface StandardTextsResponse {
   results: StandardTextType[]
 }
 export interface StatusFormProps {
-  defaultTexts: DefaultTextsType | StandardTextsResponse
+  defaultTexts?: DefaultTextsType | StandardTextsResponse
   childIncidents: IncidentChild[]
   onClose: () => void
 }

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/DefaultTexts/DefaultTextsContainer.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/DefaultTexts/DefaultTextsContainer.tsx
@@ -39,7 +39,7 @@ const DefaultTextsContainer = ({
 
   if (!defaultTexts) return null
 
-  const activeDefaultTexts = defaultTexts?.map((defaultText) => {
+  const activeDefaultTexts = defaultTexts.map((defaultText) => {
     const templates = defaultText.templates.filter(
       (template) => template.is_active
     )

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/DefaultTexts/DefaultTextsContainer.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/DefaultTexts/DefaultTextsContainer.tsx
@@ -9,7 +9,7 @@ import { StandardTextsButton } from '../../styled'
 
 export interface Props {
   closeDefaultTextModal: () => void
-  defaultTexts: DefaultTextsType
+  defaultTexts?: DefaultTextsType
   modalDefaultTextIsOpen: boolean
   openDefaultTextModal: (event: SyntheticEvent) => void
   status: StatusCode
@@ -24,16 +24,6 @@ const DefaultTextsContainer = ({
   status,
   useDefaultText,
 }: Props) => {
-  const activeDefaultTexts = defaultTexts?.map((defaultText) => {
-    const templates = defaultText.templates.filter(
-      (template) => template.is_active
-    )
-    return {
-      ...defaultText,
-      templates,
-    }
-  })
-
   const defaultTextTemplatesLength = useCallback(
     (defaultTexts: DefaultTextsType) => {
       if (!defaultTexts || defaultTexts.length === 0) {
@@ -46,6 +36,18 @@ const DefaultTextsContainer = ({
     },
     [status]
   )
+
+  if (!defaultTexts) return null
+
+  const activeDefaultTexts = defaultTexts?.map((defaultText) => {
+    const templates = defaultText.templates.filter(
+      (template) => template.is_active
+    )
+    return {
+      ...defaultText,
+      templates,
+    }
+  })
 
   return (
     <>

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/StandardTexts/StandardTextsContainer.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/components/StandardTexts/StandardTextsContainer.tsx
@@ -11,7 +11,7 @@ export interface Props {
   modalStandardTextIsOpen: boolean
   openStandardTextModal: (event: SyntheticEvent) => void
   status: StatusCode
-  standardTexts: {
+  standardTexts?: {
     results: StandardTextType[]
   }
   useStandardText: (event: SyntheticEvent, text: string) => void
@@ -25,6 +25,8 @@ const StandardTextsContainer = ({
   closeStandardTextModal,
   standardTexts,
 }: Props) => {
+  if (!standardTexts) return null
+
   const activeTexts = standardTexts.results.filter((text) => text.active)
 
   const textsByStatus = activeTexts.filter((text) => text.state === status)

--- a/src/signals/settings/categories/components/StandardTextsField/StandardTextsField.tsx
+++ b/src/signals/settings/categories/components/StandardTextsField/StandardTextsField.tsx
@@ -40,7 +40,7 @@ export const StandardTextsField = ({ name, onChange }: Props) => {
 
   useEffect(() => {
     get(
-      `${configuration.STANDARD_TEXTS_ENDPOINT}?ordering=statusmessagecategory__position&category_id=10&category_id=${params.categoryId}`
+      `${configuration.STANDARD_TEXTS_ENDPOINT}?ordering=statusmessagecategory__position&category_id=${params.categoryId}`
     )
   }, [get, params.categoryId])
 


### PR DESCRIPTION
Ticket: none

Fixes:
- order of standard texts on incidentDetail and categoryDetail
- return null when standard texts are undefined