### PR TITLE
[feat-5485]: search suggestions for streetname in filter

### DIFF
--- a/src/components/AutoSuggest/AutoSuggest.tsx
+++ b/src/components/AutoSuggest/AutoSuggest.tsx
@@ -392,6 +392,7 @@ const AutoSuggest = ({
             onClick={() => inputRef.current?.focus()}
             size={24}
             variant="blank"
+            type="button"
           />
         )}
       </div>

--- a/src/components/PDOKAutoSuggest/PDOKAutoSuggest.tsx
+++ b/src/components/PDOKAutoSuggest/PDOKAutoSuggest.tsx
@@ -12,12 +12,6 @@ import {
 import type { RevGeo } from 'types/pdok/revgeo'
 
 const municipalityFilterName = 'gemeentenaam'
-const serviceParams = [
-  ['fq', 'bron:BAG'],
-  ['fq', 'type:adres'],
-  ['q', ''],
-]
-
 const numOptionsDeterminer = (data?: RevGeo) =>
   data?.response?.docs?.length || 0
 
@@ -26,6 +20,7 @@ export interface PDOKAutoSuggestProps
     AutoSuggestProps,
     'url' | 'formatResponse' | 'numOptionsDeterminer'
   > {
+  serviceParams?: string[][]
   fieldList?: Array<string>
   municipality?: string
 }
@@ -38,6 +33,11 @@ export interface PDOKAutoSuggestProps
 const PDOKAutoSuggest: FC<PDOKAutoSuggestProps> = ({
   fieldList = [],
   municipality = configuration.map.municipality,
+  serviceParams = [
+    ['fq', 'bron:BAG'],
+    ['fq', 'type:adres'],
+    ['q', ''],
+  ],
   ...rest
 }) => {
   const fq = municipality


### PR DESCRIPTION
**Context**
Users wanted to have search suggestions for street names in the filter. 

**Changes**
- Instead of an Inputfield for the search bar, now PDOKAutosuggest is implemented. The serverparams are giving as a prop so that only on streetnames will be queried.
- The onAddressSelect is not covered by a test since PDOKAutosuggest is sufficiently tested by itself and testing it in the FilterForm would require mocking Filter, FilterForm and PDOKAutosuggest.
- 


Ticket: [SIG-5485](https://gemeente-amsterdam.atlassian.net/browse/SIG-5485)

## Signalen

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)


[SIG-5485]: https://gemeente-amsterdam.atlassian.net/browse/SIG-5485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ