### PR TITLE
[feat 5485]: show only streetnames in filter

### DIFF
--- a/internals/testing/api.ts
+++ b/internals/testing/api.ts
@@ -34,3 +34,5 @@ export const CANCEL_SIGNAL_REPORTER = `${SIGNAL_REPORTER}/:reporterId/cancel`
 export const STANDARD_TEXTS_SEARCH_ENDPOINT = `${API_BASE_URL}/private/status-messages/search`
 export const STANDARD_TEXTS_DETAIL_ENDPOINT = `${API_BASE_URL}/private/status-messages/:standardTextId`
 export const STANDARD_TEXTS_ENDPOINT = `${API_BASE_URL}/private/status-messages/`
+
+export const PDOK_RESPONSE = `https://some-service.com/`

--- a/internals/testing/msw-server.ts
+++ b/internals/testing/msw-server.ts
@@ -265,6 +265,10 @@ const handlers = [
     res(ctx.status(200), ctx.json(detail))
   ),
 
+  rest.get(API.PDOK_RESPONSE, (_req, res, ctx) =>
+    res(ctx.status(200), ctx.json({}))
+  ),
+
   // PATCH
 
   rest.patch(API.INCIDENT, (_req, res, ctx) =>

--- a/src/components/AutoSuggest/AutoSuggest.test.tsx
+++ b/src/components/AutoSuggest/AutoSuggest.test.tsx
@@ -766,8 +766,9 @@ describe('src/components/AutoSuggest errorhandling', () => {
 
     render(withAppContext(<AutoSuggest {...props} />))
     const input = screen.getByRole('textbox')
-    userEvent.type(input, 'Ams')
-
+    await act(async () => {
+      userEvent.type(input, 'Ams')
+    })
     await act(async () => {
       jest.advanceTimersByTime(INPUT_DELAY)
     })

--- a/src/components/AutoSuggest/AutoSuggest.tsx
+++ b/src/components/AutoSuggest/AutoSuggest.tsx
@@ -14,6 +14,7 @@ import type { PdokResponse } from 'shared/services/map-location'
 import type { RevGeo } from 'types/pdok/revgeo'
 
 import { Wrapper, Input, List, ClearInput } from './styled'
+import type { PdokResponseStreetName } from '../../shared/services/map-location/map-location'
 
 export const INPUT_DELAY = 350
 
@@ -33,7 +34,7 @@ export interface AutoSuggestProps {
   onClear?: () => void
   onData?: (optionsList: any) => void
   onFocus?: () => void
-  onSelect: (option: PdokResponse) => void
+  onSelect: (option: PdokResponse | PdokResponseStreetName) => void
   placeholder?: string
   showInlineList?: boolean
   tabIndex?: number
@@ -214,9 +215,12 @@ const AutoSuggest = ({
           )
 
           const responseData = await response.json()
-
           if (response.ok) {
             setData(responseData)
+          } else {
+            //see https://stackoverflow.com/questions/47015693/how-to-fix-throw-of-exception-caught-locally
+            // noinspection ExceptionCaughtLocallyJS
+            throw response
           }
         } catch (error) {
           dispatch(
@@ -362,7 +366,6 @@ const AutoSuggest = ({
           aria-activedescendant={activeId.toString()}
           aria-autocomplete="list"
           autoComplete="off"
-          defaultValue={defaultValue}
           disabled={disabled}
           id={id}
           onChange={onChange}

--- a/src/components/OverviewMap/OverviewMap.tsx
+++ b/src/components/OverviewMap/OverviewMap.tsx
@@ -251,7 +251,6 @@ const OverviewMap: FC<OverviewMapProps> = ({
         <StyledViewerContainer
           topLeft={
             <Autosuggest
-              fieldList={['centroide_ll']}
               municipality={configuration.map?.municipality}
               onSelect={onSelect}
               placeholder="Zoom naar adres"

--- a/src/components/PDOKAutoSuggest/PDOKAutoSuggest.test.tsx
+++ b/src/components/PDOKAutoSuggest/PDOKAutoSuggest.test.tsx
@@ -7,11 +7,11 @@ import * as reactRedux from 'react-redux'
 import { INPUT_DELAY } from 'components/AutoSuggest'
 import { showGlobalNotification } from 'containers/App/actions'
 import { VARIANT_ERROR, TYPE_LOCAL } from 'containers/Notification/constants'
-import { pdokResponseFieldList } from 'shared/services/map-location'
 import { withAppContext } from 'test/utils'
 import JSONResponse from 'utils/__tests__/fixtures/PDOKResponseData.json'
 
 import PDOKAutoSuggest from '.'
+import { addressPDOKDetails } from '../../shared/services/map-location'
 
 const dispatch = jest.fn()
 jest.spyOn(reactRedux, 'useDispatch').mockImplementation(() => dispatch)
@@ -139,17 +139,7 @@ describe('components/PDOKAutoSuggest', () => {
     it('should call fetch with default field list', async () => {
       await renderAndSearch()
       expect(fetch).toHaveBeenCalledWith(
-        expect.stringContaining(`${fieldListQs}${pdokResponseFieldList}`),
-        expect.objectContaining(headers)
-      )
-    })
-
-    it('should call fetch with extra fields', async () => {
-      await renderAndSearch('Dam', { fieldList: ['name', 'type'] })
-      expect(fetch).toHaveBeenCalledWith(
-        expect.stringContaining(
-          `${fieldListQs}${pdokResponseFieldList},name,type`
-        ),
+        expect.stringContaining(`${fieldListQs}${addressPDOKDetails.fields}`),
         expect.objectContaining(headers)
       )
     })

--- a/src/shared/services/map-location/index.ts
+++ b/src/shared/services/map-location/index.ts
@@ -3,14 +3,15 @@ export {
   coordinatesToFeature,
   featureToCoordinates,
   formatMapLocation,
-  formatPDOKResponse,
-  pdokResponseFieldList,
   pointWithinBounds,
   serviceResultToAddress,
   wktPointToLocation,
+  streetNamePDOKDetails,
+  addressPDOKDetails,
 } from './map-location'
 export type {
   PdokResponse,
   PdokAddress,
   FormatMapLocation,
+  PDOKDetails,
 } from './map-location'

--- a/src/shared/services/map-location/map-location.test.ts
+++ b/src/shared/services/map-location/map-location.test.ts
@@ -3,16 +3,18 @@
 import type { LatLngTuple } from 'leaflet'
 
 import PDOKResponseJson from 'utils/__tests__/fixtures/PDOKResponseData.json'
+import PDOKResponseStreetNameDataJson from 'utils/__tests__/fixtures/PDOKResponseStreetNameData.json'
 
 import {
   featureToCoordinates,
   formatMapLocation,
-  formatPDOKResponse,
   coordinatesToAPIFeature,
   coordinatesToFeature,
   pointWithinBounds,
   serviceResultToAddress,
   wktPointToLocation,
+  addressPDOKDetails,
+  streetNamePDOKDetails,
 } from '.'
 
 const testAddress = {
@@ -212,7 +214,7 @@ describe('serviceResultToAddress', () => {
 describe('formatPDOKResponse', () => {
   it('should convert PDOK response to address list ', () => {
     const data = PDOKResponseJson
-    expect(formatPDOKResponse(data)).toEqual([
+    expect(addressPDOKDetails.formatter(data)).toEqual([
       {
         id: 'adr-7e22b4ee3640202eff3203e63610c76e',
         value: 'Achtergracht 43, 1017WN Amsterdam',
@@ -241,10 +243,19 @@ describe('formatPDOKResponse', () => {
       },
     ])
   })
+  it('should convert PDOK response to street name list ', () => {
+    const data = PDOKResponseStreetNameDataJson
+    expect(streetNamePDOKDetails.formatter(data)).toEqual([
+      {
+        id: 0,
+        value: 'Achtergracht',
+      },
+    ])
+  })
 
   it('return an empty array', () => {
-    expect(formatPDOKResponse(undefined)).toEqual([])
-    expect(formatPDOKResponse(null)).toEqual([])
+    expect(addressPDOKDetails.formatter(undefined)).toEqual([])
+    expect(addressPDOKDetails.formatter(null)).toEqual([])
   })
 })
 

--- a/src/shared/services/reverse-geocoder/reverse-geocoder.ts
+++ b/src/shared/services/reverse-geocoder/reverse-geocoder.ts
@@ -4,14 +4,11 @@ import type { LatLngLiteral } from 'leaflet'
 
 import configuration from 'shared/services/configuration/configuration'
 import { wgs84ToRd } from 'shared/services/crs-converter/crs-converter'
-import {
-  pdokResponseFieldList,
-  formatPDOKResponse,
-} from 'shared/services/map-location'
 import type { PdokResponse } from 'shared/services/map-location'
+import { addressPDOKDetails } from 'shared/services/map-location'
 import type { RevGeo } from 'types/pdok/revgeo'
 
-const flParams = pdokResponseFieldList.join(',')
+const flParams = addressPDOKDetails.fields.join(',')
 export const serviceURL = `${configuration.map.pdok.reverse}?type=adres&rows=1&fl=${flParams}`
 
 export const formatRequest = (
@@ -33,7 +30,7 @@ const reverseGeocoderService = async (
     // make sure to catch any error responses from the geocoder service
     .catch(() => ({}))
 
-  const formattedResponse = formatPDOKResponse(result)
+  const formattedResponse = addressPDOKDetails.formatter(result)
 
   return formattedResponse[0]
 }

--- a/src/signals/incident-management/components/FilterForm/FilterForm.tsx
+++ b/src/signals/incident-management/components/FilterForm/FilterForm.tsx
@@ -66,7 +66,8 @@ import CheckboxList from '../../../../components/CheckboxList'
 import PDOKAutoSuggest from '../../../../components/PDOKAutoSuggest'
 import AppContext from '../../../../containers/App/context'
 import RefreshIcon from '../../../../images/icon-refresh.svg'
-import type { PdokResponse } from '../../../../shared/services/map-location'
+import { streetNamePDOKDetails } from '../../../../shared/services/map-location'
+import type { PdokResponseStreetName } from '../../../../shared/services/map-location/map-location'
 import { useIncidentManagementContext } from '../../context'
 import { makeSelectFilterParams } from '../../selectors'
 import type { SaveFilterAction, UpdateFilterAction } from '../../types'
@@ -79,12 +80,6 @@ const getUserOptions = (data: UserOptions) =>
     id: user.username,
     value: user.username,
   }))
-
-const serviceParams = [
-  ['fq', 'bron:BAG'],
-  ['fq', 'type:weg'],
-  ['q', ''],
-]
 
 const getUserCount = (data: UserOptions) => data.count
 
@@ -132,7 +127,6 @@ const FilterForm = ({
   const [routedFilterValue, setRoutedFilterValue] = useState<KeyValue[]>([])
   const [controlledTextInput, setControlledTextInput] = useState({
     name: state.filter.name,
-    address: state.options.address_text,
     note: state.options.note_keyword,
   })
 
@@ -237,7 +231,6 @@ const FilterForm = ({
     onClearFilter()
     setControlledTextInput({
       name: '',
-      address: '',
       note: '',
     })
   }, [dispatch, onClearFilter])
@@ -312,8 +305,8 @@ const FilterForm = ({
   )
 
   const onAddressSelect = useCallback(
-    (response: PdokResponse) => {
-      dispatch(setAddress(response.data.address.openbare_ruimte))
+    (response: PdokResponseStreetName) => {
+      dispatch(setAddress(response.value))
     },
     [dispatch]
   )
@@ -399,7 +392,6 @@ const FilterForm = ({
       state.options.routing_department[0].key === notRoutedOption.key,
     [notRoutedOption.key, state.options.routing_department]
   )
-
   return (
     <Fragment>
       {showNotification && <Notification reference={notificationRef} />}
@@ -644,9 +636,9 @@ const FilterForm = ({
             <PDOKAutoSuggest
               id="filter_address"
               municipality={configuration.map?.municipality}
-              serviceParams={serviceParams}
               onSelect={onAddressSelect}
               placeholder="Zoek op straatnaam"
+              pDOKDetails={streetNamePDOKDetails}
               value={state.options.address_text}
             />
           </FilterGroup>

--- a/src/types/pdok/revgeo.ts
+++ b/src/types/pdok/revgeo.ts
@@ -16,3 +16,17 @@ export type RevGeo = {
     start: number
   }
 }
+
+export type DocStreetName = {
+  id: string
+  straatnaam: string
+}
+
+export type RevGeoStreetName = {
+  response: {
+    docs: DocStreetName[]
+    maxScore: number
+    numFound: number
+    start: number
+  }
+}

--- a/src/utils/__tests__/fixtures/PDOKResponseStreetNameData.json
+++ b/src/utils/__tests__/fixtures/PDOKResponseStreetNameData.json
@@ -1,0 +1,14 @@
+{
+  "response": {
+    "numFound": 1,
+    "start": 0,
+    "maxScore": 16.013206,
+    "docs": [
+      {
+        "id": "adr-7e22b4ee3640202eff3203e63610c76e",
+        "straatnaam": "Achtergracht"
+
+       }
+    ]
+  }
+}


### PR DESCRIPTION
**Context**
Feedback from testers was that beaviour of showing address in inputfield inconsistent was. Sometimes it showed just the streetname, sometimes it showed the streetname and the municipality. Also discovered that clicking Nieuw Filter didn't clear the value of the inputfield. 
Now only unique streetnames are shown

**Changes**
Parameterised PDOKAutosuggest for streetnames and normal addresses.
Filtering for unique streetnames
removed defaultvalue from Autosuggest. -> Autosuggest seems to be a mix of uncontrolled and controlled feautures (with a useState to set the defaultvalue and an inPutRef). Story has been created (https://gemeente-amsterdam.atlassian.net/browse/SIG-5574) in Jira for refactoring. 
tests for meeting threshold added

**For testers**
PDOK sends back all matches, so also the matches with the municipality. This shows most when searching for Ams. Can't do nothing about that. 

Ticket: [SIG-5485](https://gemeente-amsterdam.atlassian.net/browse/SIG-5485)

## Signalen

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)


[SIG-5485]: https://gemeente-amsterdam.atlassian.net/browse/SIG-5485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ