### PR TITLE
[feat 5575]: Change behaviour chevron of column ID to mimick that of Datum

### DIFF
--- a/src/signals/incident-management/containers/IncidentOverviewPage/components/List/index.tsx
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/components/List/index.tsx
@@ -50,9 +50,7 @@ import ThSort from '../Th'
 
 export const getDaysOpen = (incident: IncidentListItem) => {
   const statusesWithoutDaysOpen = statusList
-    .filter(
-      ({ shows_remaining_sla_days }) => shows_remaining_sla_days === false
-    )
+    .filter(({ shows_remaining_sla_days }) => !shows_remaining_sla_days)
     .map(({ key }) => key)
   const hasDaysOpen =
     incident.status && !statusesWithoutDaysOpen.includes(incident.status.state)

--- a/src/signals/incident-management/containers/IncidentOverviewPage/components/SortIcon/SortIcon.test.tsx
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/components/SortIcon/SortIcon.test.tsx
@@ -11,7 +11,7 @@ describe('SortIcon', () => {
     render(
       <SortIcon
         sortOption={SortOptions.CREATED_AT_ASC}
-        ordering={SortOptions.CREATED_AT_DESC}
+        selectedSortOption={SortOptions.CREATED_AT_DESC}
       />
     )
 
@@ -22,11 +22,33 @@ describe('SortIcon', () => {
     render(
       <SortIcon
         sortOption={SortOptions.CREATED_AT_DESC}
-        ordering={SortOptions.CREATED_AT_ASC}
+        selectedSortOption={SortOptions.CREATED_AT_ASC}
       />
     )
 
     expect(screen.getByTestId('chevron-down')).toBeInTheDocument()
+  })
+
+  it('should render a sort icon for id when its desc', () => {
+    render(
+      <SortIcon
+        sortOption={SortOptions.ID_ASC}
+        selectedSortOption={SortOptions.ID_DESC}
+      />
+    )
+
+    expect(screen.getByTestId('chevron-down')).toBeInTheDocument()
+  })
+
+  it('should render a sort icon for ID when its asc', () => {
+    render(
+      <SortIcon
+        sortOption={SortOptions.ID_DESC}
+        selectedSortOption={SortOptions.ID_ASC}
+      />
+    )
+
+    expect(screen.getByTestId('chevron-up')).toBeInTheDocument()
   })
 
   // and now for address
@@ -34,7 +56,7 @@ describe('SortIcon', () => {
     render(
       <SortIcon
         sortOption={SortOptions.ADDRESS_ASC}
-        ordering={SortOptions.ADDRESS_DESC}
+        selectedSortOption={SortOptions.ADDRESS_DESC}
       />
     )
 
@@ -45,18 +67,18 @@ describe('SortIcon', () => {
     render(
       <SortIcon
         sortOption={SortOptions.ADDRESS_DESC}
-        ordering={SortOptions.ADDRESS_ASC}
+        selectedSortOption={SortOptions.ADDRESS_ASC}
       />
     )
 
     expect(screen.getByTestId('chevron-down')).toBeInTheDocument()
   })
 
-  it('should return null when there is no match between sortOption and ordering', () => {
+  it('should return null when there is no match between sortOption and selectedSortOption', () => {
     render(
       <SortIcon
         sortOption={SortOptions.ADDRESS_ASC}
-        ordering={SortOptions.CREATED_AT_ASC}
+        selectedSortOption={SortOptions.CREATED_AT_ASC}
       />
     )
 

--- a/src/signals/incident-management/containers/IncidentOverviewPage/components/SortIcon/SortIcon.tsx
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/components/SortIcon/SortIcon.tsx
@@ -4,24 +4,48 @@ import { StyledChevronUp } from './styled'
 import { SortOptions } from '../../contants'
 import compareSortOptions from '../../utils'
 
+const sortException = (sortOption: SortOptions) => {
+  return (
+    sortOption === SortOptions.CREATED_AT_ASC ||
+    sortOption === SortOptions.CREATED_AT_DESC ||
+    sortOption === SortOptions.ID_DESC ||
+    sortOption === SortOptions.ID_ASC
+  )
+}
 export default function SortIcon({
-  ordering,
+  selectedSortOption,
   sortOption,
 }: {
   sortOption: SortOptions
-  ordering?: SortOptions
+  selectedSortOption?: SortOptions
 }) {
   /**
    * The sorting for created at differs from the other columns because the dates
-   * are sorted from newest to oldest by default. The other columns are sorted
-   * alphabetically by from A to Z by default.
+   * are sorted from newest to oldest by default. The sorting differs for ID because
+   * it chevrons behaviour needs to mimick that of the created at chevron. The
+   * other columns are sorted alphabetically by from A to Z by default.
    */
-  return ordering && compareSortOptions(ordering, sortOption) ? (
-    (ordering.startsWith('-') && ordering !== SortOptions.CREATED_AT_ASC) ||
-    ordering === SortOptions.CREATED_AT_DESC ? (
-      <StyledChevronUp data-testid={'chevron-up'} $rotated={false} />
-    ) : (
-      <StyledChevronUp data-testid={'chevron-down'} $rotated />
+  if (
+    !selectedSortOption ||
+    !compareSortOptions(selectedSortOption, sortOption)
+  )
+    return null
+
+  if (sortException(sortOption)) {
+    const rotateOne = selectedSortOption?.startsWith('-') ? true : false
+    return (
+      <StyledChevronUp
+        data-testid={rotateOne ? 'chevron-down' : 'chevron-up'}
+        $rotated={rotateOne}
+      />
     )
-  ) : null
+  }
+
+  const rotate = selectedSortOption?.startsWith('-') ? false : true
+  return (
+    <StyledChevronUp
+      data-testid={rotate ? 'chevron-down' : 'chevron-up'}
+      $rotated={rotate}
+    />
+  )
 }

--- a/src/signals/incident-management/containers/IncidentOverviewPage/components/SortIcon/SortIcon.tsx
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/components/SortIcon/SortIcon.tsx
@@ -32,16 +32,16 @@ export default function SortIcon({
     return null
 
   if (sortException(sortOption)) {
-    const rotateOne = selectedSortOption?.startsWith('-') ? true : false
+    const rotateException = selectedSortOption?.startsWith('-')
     return (
       <StyledChevronUp
-        data-testid={rotateOne ? 'chevron-down' : 'chevron-up'}
-        $rotated={rotateOne}
+        data-testid={rotateException ? 'chevron-down' : 'chevron-up'}
+        $rotated={rotateException}
       />
     )
   }
 
-  const rotate = selectedSortOption?.startsWith('-') ? false : true
+  const rotate = !selectedSortOption?.startsWith('-')
   return (
     <StyledChevronUp
       data-testid={rotate ? 'chevron-down' : 'chevron-up'}

--- a/src/signals/incident-management/containers/IncidentOverviewPage/components/Th/Th.tsx
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/components/Th/Th.tsx
@@ -26,7 +26,7 @@ const ThComponent = ({
       $isDisabled={sortingDisabled}
     >
       {headerText}
-      <SortIcon ordering={ordering} sortOption={sortOption} />
+      <SortIcon selectedSortOption={ordering} sortOption={sortOption} />
     </StyledComponent>
   )
 }


### PR DESCRIPTION
When ID's are sorted from hoog-laag than the chrevron has to point down and vice versa, exactly like Datum.

- Changed order column ID from ASC to DESC
- sortOption in List changed to ID_DESC

Ticket: [SIG-5575](https://gemeente-amsterdam.atlassian.net/browse/SIG-5575), part of ticket [SIG-5571](https://gemeente-amsterdam.atlassian.net/browse/SIG-5571)

## Signalen

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)


[SIG-5575]: https://gemeente-amsterdam.atlassian.net/browse/SIG-5575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SIG-5571]: https://gemeente-amsterdam.atlassian.net/browse/SIG-5571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ