### PR TITLE
[feat-5485]: street name only search filterform 

### DIFF
--- a/src/components/AutoSuggest/AutoSuggest.tsx
+++ b/src/components/AutoSuggest/AutoSuggest.tsx
@@ -362,7 +362,6 @@ const AutoSuggest = ({
           aria-activedescendant={activeId.toString()}
           aria-autocomplete="list"
           autoComplete="off"
-          defaultValue={defaultValue}
           disabled={disabled}
           id={id}
           onChange={onChange}

--- a/src/components/PDOKAutoSuggest/PDOKAutoSuggest.test.tsx
+++ b/src/components/PDOKAutoSuggest/PDOKAutoSuggest.test.tsx
@@ -43,6 +43,28 @@ const renderAndSearch = async (value = 'Dam', props = {}) => {
   await screen.findByTestId('auto-suggest')
 }
 
+const renderAndSearchWithStreetNameOnlyAsTrue = async (
+  value = 'dor',
+  props = {}
+) => {
+  render(
+    withAppContext(
+      <PDOKAutoSuggest onSelect={onSelect} streetNameOnly={true} {...props} />
+    )
+  )
+  const input = screen.getByRole('textbox') as HTMLInputElement
+
+  input.focus()
+
+  fireEvent.change(input, { target: { value } })
+
+  act(() => {
+    jest.advanceTimersByTime(INPUT_DELAY)
+  })
+
+  await screen.findByTestId('auto-suggest')
+}
+
 describe('components/PDOKAutoSuggest', () => {
   beforeEach(() => {
     fetch.mockResponse(mockResponse)
@@ -93,6 +115,24 @@ describe('components/PDOKAutoSuggest', () => {
           variant: VARIANT_ERROR,
           type: TYPE_LOCAL,
         })
+      )
+    })
+  })
+
+  describe('serviceParams', () => {
+    it('should fetch with type:weg when streetNameOnly is true', async () => {
+      await renderAndSearchWithStreetNameOnlyAsTrue()
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining('type:weg'),
+        expect.anything()
+      )
+    })
+
+    it('should fetch with type:address when streetNameOnly is false', async () => {
+      await renderAndSearch()
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining('type:adres'),
+        expect.anything()
       )
     })
   })

--- a/src/components/PDOKAutoSuggest/PDOKAutoSuggest.test.tsx
+++ b/src/components/PDOKAutoSuggest/PDOKAutoSuggest.test.tsx
@@ -49,7 +49,7 @@ const renderAndSearchWithStreetNameOnlyAsTrue = async (
 ) => {
   render(
     withAppContext(
-      <PDOKAutoSuggest onSelect={onSelect} streetNameOnly={true} {...props} />
+      <PDOKAutoSuggest onSelect={onSelect} streetNameOnly {...props} />
     )
   )
   const input = screen.getByRole('textbox') as HTMLInputElement

--- a/src/components/PDOKAutoSuggest/PDOKAutoSuggest.tsx
+++ b/src/components/PDOKAutoSuggest/PDOKAutoSuggest.tsx
@@ -20,7 +20,7 @@ export interface PDOKAutoSuggestProps
     AutoSuggestProps,
     'url' | 'formatResponse' | 'numOptionsDeterminer'
   > {
-  serviceParams?: string[][]
+  streetNameOnly?: boolean
   fieldList?: Array<string>
   municipality?: string
 }
@@ -32,12 +32,8 @@ export interface PDOKAutoSuggestProps
  */
 const PDOKAutoSuggest: FC<PDOKAutoSuggestProps> = ({
   fieldList = [],
+  streetNameOnly = false,
   municipality = configuration.map.municipality,
-  serviceParams = [
-    ['fq', 'bron:BAG'],
-    ['fq', 'type:adres'],
-    ['q', ''],
-  ],
   ...rest
 }) => {
   const fq = municipality
@@ -47,6 +43,12 @@ const PDOKAutoSuggest: FC<PDOKAutoSuggestProps> = ({
   const fl = [
     ['fl', [...pdokResponseFieldList, ...(fieldList || [])].join(',')],
   ]
+
+  const serviceParams = [
+    ['fq', 'bron:BAG'],
+    ['fq', streetNameOnly ? 'type:weg' : 'type:adres'],
+    ['q', ''],
+  ]
   const params = [...fq, ...fl, ...serviceParams]
   const queryParams = params.map(([key, val]) => `${key}=${val}`).join('&')
   const url = `${configuration.map.pdok.suggest}?${queryParams}`
@@ -55,7 +57,7 @@ const PDOKAutoSuggest: FC<PDOKAutoSuggestProps> = ({
     <AutoSuggest
       {...rest}
       url={url}
-      formatResponse={formatPDOKResponse}
+      formatResponse={(request) => formatPDOKResponse(request, streetNameOnly)}
       numOptionsDeterminer={numOptionsDeterminer}
       tabIndex={0}
     />

--- a/src/shared/services/map-location/map-location.test.ts
+++ b/src/shared/services/map-location/map-location.test.ts
@@ -246,6 +246,26 @@ describe('formatPDOKResponse', () => {
     expect(formatPDOKResponse(undefined)).toEqual([])
     expect(formatPDOKResponse(null)).toEqual([])
   })
+
+  it('returns an list with unique streetNames when streetNameOnly is true', () => {
+    const data = PDOKResponseJson
+    const streetNameOnly = true
+    expect(formatPDOKResponse(data, streetNameOnly)).toEqual([
+      {
+        id: 'adr-e26dbf16d329474aa79276d93db9bebd',
+        value: 'Achtergracht',
+        data: {
+          location: { lat: 52.36150435, lng: 4.90225668 },
+          address: {
+            openbare_ruimte: 'Achtergracht',
+            huisnummer: '43G',
+            postcode: '1017WN',
+            woonplaats: 'Amsterdam',
+          },
+        },
+      },
+    ])
+  })
 })
 
 describe('pointWithinBounds', () => {

--- a/src/shared/services/map-location/map-location.ts
+++ b/src/shared/services/map-location/map-location.ts
@@ -114,19 +114,31 @@ export type PdokResponse = {
 }
 
 export const formatPDOKResponse = (
-  request?: RevGeo | null
-): Array<PdokResponse> =>
-  request?.response?.docs.map((result) => {
-    const { id, weergavenaam, centroide_ll } = result
-    return {
-      id,
-      value: weergavenaam,
-      data: {
-        location: wktPointToLocation(centroide_ll),
-        address: serviceResultToAddress(result),
-      },
-    }
-  }) || []
+  request?: RevGeo | null,
+  streetNameOnly?: boolean
+): Array<PdokResponse> => {
+  const uniqueAddressesList = new Map<string, PdokResponse>(
+    request?.response?.docs.map((result) => {
+      const { id, weergavenaam, centroide_ll, straatnaam } = result
+
+      const value = streetNameOnly ? straatnaam : weergavenaam
+
+      return [
+        value,
+        {
+          id,
+          value,
+          data: {
+            location: wktPointToLocation(centroide_ll),
+            address: serviceResultToAddress(result),
+          },
+        },
+      ]
+    }) || []
+  )
+
+  return [...uniqueAddressesList.values()]
+}
 
 export const pointWithinBounds = (
   coordinates: LatLngTuple,

--- a/src/signals/incident-management/components/FilterForm/FilterForm.tsx
+++ b/src/signals/incident-management/components/FilterForm/FilterForm.tsx
@@ -641,7 +641,7 @@ const FilterForm = ({
               onSelect={onAddressSelect}
               placeholder="Zoek op straatnaam"
               value={state.options.address_text}
-              streetNameOnly={true}
+              streetNameOnly
             />
           </FilterGroup>
 

--- a/src/signals/incident-management/components/FilterForm/FilterForm.tsx
+++ b/src/signals/incident-management/components/FilterForm/FilterForm.tsx
@@ -80,12 +80,6 @@ const getUserOptions = (data: UserOptions) =>
     value: user.username,
   }))
 
-const serviceParams = [
-  ['fq', 'bron:BAG'],
-  ['fq', 'type:weg'],
-  ['q', ''],
-]
-
 const getUserCount = (data: UserOptions) => data.count
 
 interface Props {
@@ -313,7 +307,7 @@ const FilterForm = ({
 
   const onAddressSelect = useCallback(
     (response: PdokResponse) => {
-      dispatch(setAddress(response.data.address.openbare_ruimte))
+      dispatch(setAddress(response.value))
     },
     [dispatch]
   )
@@ -644,10 +638,10 @@ const FilterForm = ({
             <PDOKAutoSuggest
               id="filter_address"
               municipality={configuration.map?.municipality}
-              serviceParams={serviceParams}
               onSelect={onAddressSelect}
               placeholder="Zoek op straatnaam"
               value={state.options.address_text}
+              streetNameOnly={true}
             />
           </FilterGroup>
 

--- a/src/signals/incident-management/components/FilterForm/__tests__/FilterForm.test.tsx
+++ b/src/signals/incident-management/components/FilterForm/__tests__/FilterForm.test.tsx
@@ -148,6 +148,19 @@ describe('signals/incident-management/components/FilterForm', () => {
     expect(getByTestId('filter-name')).toHaveValue('FooBar')
   })
 
+  it('should render a PDOKAutoSuggest', () => {
+    const { getByTestId } = render(
+      withContext(
+        <FilterForm
+          {...formProps}
+          filter={{ id: 1234, name: 'FooBar', options: {} }}
+        />
+      )
+    )
+
+    expect(getByTestId('auto-suggest')).toBeInTheDocument()
+  })
+
   it('should render filter fields', async () => {
     const { container, findAllByPlaceholderText } = render(
       withContext(<FilterForm {...formProps} />)


### PR DESCRIPTION
Context
Feedback from testers was that beaviour of showing address in inputfield inconsistent was. Sometimes it showed just the streetname, sometimes it showed the streetname and the municipality. Also discovered that clicking Nieuw Filter didn't clear the value of the inputfield.
Now only unique streetnames are shown

Changes
dependent on prop streetNameOnly will serviceParams and formatPdokResponse change their behaviour.
Filtering for unique streetnames
removed defaultvalue from Autosuggest. -> Autosuggest seems to be a mix of uncontrolled and controlled feautures (with a useState to set the defaultvalue and an inPutRef). Story has been created (https://gemeente-amsterdam.atlassian.net/browse/SIG-5574) in Jira for refactoring.
tests for meeting threshold added

For testers
PDOK sends back all matches, so also the matches with the municipality. This shows most when searching for Ams. Can't do nothing about that.

Ticket: [SIG-5485](https://gemeente-amsterdam.atlassian.net/browse/SIG-5485)


[SIG-5485]: https://gemeente-amsterdam.atlassian.net/browse/SIG-5485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ