### PR TITLE
[FEAT-5438]: fixes for tonen objecten lijstweergave

### DIFF
--- a/src/components/DrawerOverlay/DrawerOverlay.tsx
+++ b/src/components/DrawerOverlay/DrawerOverlay.tsx
@@ -11,7 +11,6 @@ import {
   Drawer,
   DrawerContainer,
   DrawerContent,
-  DrawerContentWrapper,
   DrawerHandleDesktop,
   DrawerHandleMiniDesktop,
   DrawerHandleMobile,
@@ -115,7 +114,7 @@ export const DrawerOverlay = ({
           )}
 
           <DrawerContent style={drawerContentStyle} data-testid="drawerContent">
-            <DrawerContentWrapper>{children}</DrawerContentWrapper>
+            {children}
           </DrawerContent>
         </Drawer>
       </DrawerContainer>

--- a/src/components/DrawerOverlay/styled.ts
+++ b/src/components/DrawerOverlay/styled.ts
@@ -183,7 +183,7 @@ export const DrawerContent = styled.div`
   flex-grow: 1;
   max-width: 100%;
   min-height: 0;
-  overflow-y: auto;
+  height: 100%;
 
   @media screen and ${breakpoint('min-width', 'tabletM')} {
     width: ${MENU_WIDTH}px;

--- a/src/components/IconList/IconList.test.tsx
+++ b/src/components/IconList/IconList.test.tsx
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2021 - 2022 Gemeente Amsterdam
-import { render, screen } from '@testing-library/react'
+import { act, render, screen } from '@testing-library/react'
 
 import type configurationType from 'shared/services/configuration/__mocks__/configuration'
 import configuration from 'shared/services/configuration/configuration'
@@ -13,9 +13,14 @@ jest.mock('shared/services/configuration/configuration')
 const mockConfiguration = configuration as typeof configurationType
 
 describe('IconList', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
   afterEach(() => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
     mockConfiguration.__reset()
+
+    jest.useRealTimers()
   })
 
   it('renders correctly', () => {
@@ -39,5 +44,34 @@ describe('IconList', () => {
 
     expect(screen.getByRole('list')).toBeInTheDocument()
     expect(screen.queryAllByRole('listitem').length).toBe(0)
+  })
+
+  it('click checkbox', () => {
+    const onClickMock = jest.fn()
+    render(
+      withAppContext(
+        <IconList>
+          <IconListItem
+            iconUrl=""
+            item={{
+              id: '1',
+              name: 'test',
+              featureStatusType: 'test',
+            }}
+            onClick={onClickMock}
+          >
+            Icon
+          </IconListItem>
+        </IconList>
+      )
+    )
+
+    screen.getByRole('checkbox').click()
+
+    act(() => {
+      jest.runAllTimers()
+    })
+
+    expect(onClickMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/components/IconList/IconList.tsx
+++ b/src/components/IconList/IconList.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2021-2023 Gemeente Amsterdam
 import type { ReactNode } from 'react'
+import { useCallback, useState } from 'react'
 
 import { List } from '@amsterdam/asc-ui'
 import styled from 'styled-components'
@@ -20,10 +21,10 @@ export interface IconListItemProps {
   iconSize?: number
   featureStatusType?: FeatureStatusType
   children: ReactNode
-  remove?: (item: Item) => void
+  onClick?: (item: Item) => void
   item?: Item
-  checked?: boolean
   checkboxDisabled?: boolean
+  checked?: boolean
 }
 
 export const IconListItem = ({
@@ -33,32 +34,54 @@ export const IconListItem = ({
   iconSize = 40,
   id,
   featureStatusType,
-  remove,
+  onClick,
   item,
-  checked,
   checkboxDisabled,
-}: IconListItemProps) => (
-  <StyledListItem data-testid={id} className={className}>
-    {!checkboxDisabled && (
-      <Checkbox
-        onClick={() => remove && item && remove(item)}
-        checked={checked}
-      />
-    )}
-    {iconUrl && (
-      <StyledImg alt="" height={iconSize} src={iconUrl} width={iconSize} />
-    )}
-    {featureStatusType && (
-      <StatusIcon
-        alt=""
-        height={20}
-        src={featureStatusType.icon.iconUrl}
-        width={20}
-      />
-    )}
-    {children}
-  </StyledListItem>
-)
+  checked,
+}: IconListItemProps) => {
+  const [checkedState, setCheckedState] = useState<boolean | undefined>(
+    undefined
+  )
+  const [disabled, setDisabled] = useState<boolean>(false)
+
+  const onClickWithDelay = useCallback(
+    (item) => {
+      if (onClick && !disabled) {
+        setDisabled(true)
+        setCheckedState(!checked)
+        const timeout = setTimeout(() => {
+          onClick(item)
+          setDisabled(false)
+        }, 600)
+        return () => clearTimeout(timeout)
+      }
+    },
+    [checked, disabled, onClick]
+  )
+
+  return (
+    <StyledListItem data-testid={id} className={className}>
+      {!checkboxDisabled && (
+        <Checkbox
+          onClick={() => onClickWithDelay(item)}
+          checked={checkedState === undefined ? checked : checkedState}
+        />
+      )}
+      {iconUrl && (
+        <StyledImg alt="" height={iconSize} src={iconUrl} width={iconSize} />
+      )}
+      {featureStatusType && (
+        <StatusIcon
+          alt=""
+          height={20}
+          src={featureStatusType.icon.iconUrl}
+          width={20}
+        />
+      )}
+      {children}
+    </StyledListItem>
+  )
+}
 
 const StyledList = styled(List)`
   margin: 0;

--- a/src/components/IconList/styled.tsx
+++ b/src/components/IconList/styled.tsx
@@ -14,12 +14,12 @@ export const StyledListItem = styled(ListItem)`
   padding: 0;
 
   ${Checkbox} {
+    margin-right: ${themeSpacing(0.5)};
     cursor: pointer;
   }
 `
 
 export const StyledImg = styled.img`
-  margin-right: ${themeSpacing(2)};
   flex-shrink: 0;
 `
 

--- a/src/signals/IncidentMap/components/IncidentMap/IncidentMap.tsx
+++ b/src/signals/IncidentMap/components/IncidentMap/IncidentMap.tsx
@@ -22,6 +22,7 @@ import {
   StyledViewerContainer,
   TopLeftWrapper,
   Wrapper,
+  DrawerContentWrapper,
 } from './styled'
 import usePaginatedIncidents from './usePaginatedIncidents'
 import { getFlyToZoom } from './utils'
@@ -227,24 +228,26 @@ export const IncidentMap = () => {
           incident={selectedIncident}
           DetailPanel={DetailPanel}
         >
-          <StyledParagraph>
-            Op deze kaart staan meldingen in de openbare ruimte waarmee we aan
-            het werk zijn. Vanwege privacy staat een klein deel van de meldingen
-            niet op de kaart.
-          </StyledParagraph>
+          <DrawerContentWrapper>
+            <StyledParagraph>
+              Op deze kaart staan meldingen in de openbare ruimte waarmee we aan
+              het werk zijn. Vanwege privacy staat een klein deel van de
+              meldingen niet op de kaart.
+            </StyledParagraph>
 
-          {!isMobile(deviceMode) && (
-            <AddressLocation
-              setCoordinates={setCoordinates}
-              address={address}
+            {!isMobile(deviceMode) && (
+              <AddressLocation
+                setCoordinates={setCoordinates}
+                address={address}
+              />
+            )}
+
+            <FilterPanel
+              filters={filters}
+              setFilters={setFilters}
+              setMapMessage={setMapMessage}
             />
-          )}
-
-          <FilterPanel
-            filters={filters}
-            setFilters={setFilters}
-            setMapMessage={setMapMessage}
-          />
+          </DrawerContentWrapper>
         </DrawerOverlay>
 
         <StyledViewerContainer

--- a/src/signals/IncidentMap/components/IncidentMap/styled.ts
+++ b/src/signals/IncidentMap/components/IncidentMap/styled.ts
@@ -65,3 +65,14 @@ export const StyledViewerContainer = styled(ViewerContainer)<{
     margin-left: ${themeSpacing(4)};
   }
 `
+
+export const DrawerContentWrapper = styled('div')`
+  width: 100%;
+  height: 100%;
+  padding: ${themeSpacing(5)};
+  overflow-y: auto;
+
+  @media screen and ${breakpoint('max-width', 'tabletM')} {
+    padding-top: 0;
+  }
+`

--- a/src/signals/incident/components/form/MapSelectors/Asset/AssetList/AssetList.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/AssetList/AssetList.test.tsx
@@ -54,6 +54,7 @@ jest.mock('components/IconList/IconList', () => ({
     iconUrl,
     featureStatusType,
     id,
+    onClick,
     ...props
   }: PropsWithChildren<IconListItemProps>) => {
     return (

--- a/src/signals/incident/components/form/MapSelectors/Asset/AssetList/AssetList.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/AssetList/AssetList.tsx
@@ -5,6 +5,7 @@ import type { FunctionComponent } from 'react'
 import type { FeatureCollection } from 'geojson'
 
 import IconList from 'components/IconList/IconList'
+import { capitalize } from 'shared/services/date-utils'
 
 import { AssetListItem } from './AssetListItem'
 import { AssetListItemSelectable } from './AssetListItemSelectable'
@@ -51,10 +52,12 @@ const AssetList: FunctionComponent<AssetListProps> = ({
     (zoomLevel && zoomLevel >= 13) || (selection && selection.length > 0)
 
   return (
-    <div>
+    <>
       {renderAssetListHeading && (
         <>
-          <ListHeading>{objectTypePlural || 'Objecten'}</ListHeading>
+          <ListHeading>
+            {(objectTypePlural && capitalize(objectTypePlural)) || 'Objecten'}
+          </ListHeading>
           {featureTypes.length > 0 &&
             !(
               (selectableComponents && selectableComponents?.length > 0) ||
@@ -75,20 +78,20 @@ const AssetList: FunctionComponent<AssetListProps> = ({
           selection.length > 0 &&
           selection
             .filter(({ id }) => id)
-            .map((item, index) => (
+            .map((item) => (
               <AssetListItem
-                key={index}
+                key={item.id}
                 item={item}
                 featureTypes={featureTypes}
                 featureStatusTypes={featureStatusTypes}
-                remove={() => remove && remove(item)}
+                remove={remove}
               />
             ))}
         {Array.isArray(selectableComponents) &&
           selectableComponents.length > 0 &&
           selectableComponents}
       </IconList>
-    </div>
+    </>
   )
 }
 

--- a/src/signals/incident/components/form/MapSelectors/Asset/AssetList/AssetListItem.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/AssetList/AssetListItem.tsx
@@ -91,7 +91,7 @@ export const AssetListItem: FunctionComponent<ItemType> = ({
           id={extendedId}
           iconUrl={icon?.iconUrl}
           featureStatusType={featureStatusType}
-          remove={remove}
+          onClick={remove}
           item={item}
           checked
         >

--- a/src/signals/incident/components/form/MapSelectors/Asset/AssetList/AssetListItemSelectable.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/AssetList/AssetListItemSelectable.tsx
@@ -33,7 +33,7 @@ export const AssetListItemSelectable = ({
         id={`${id}`}
         iconUrl={icon?.iconUrl}
         featureStatusType={featureStatusType}
-        remove={onClick}
+        onClick={onClick}
         item={item}
         checked={false}
       >

--- a/src/signals/incident/components/form/MapSelectors/Asset/AssetList/styled.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/AssetList/styled.tsx
@@ -35,6 +35,7 @@ export const SelectionNearby = styled.div`
 
 export const ListHeading = styled.p`
   font-weight: 700;
+  margin-top: 0;
   margin-bottom: ${themeSpacing(2)};
 `
 

--- a/src/signals/incident/components/form/MapSelectors/Asset/AssetList/styled.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/AssetList/styled.tsx
@@ -1,4 +1,4 @@
-import { Button, themeColor, themeSpacing } from '@amsterdam/asc-ui'
+import { breakpoint, Button, themeColor, themeSpacing } from '@amsterdam/asc-ui'
 import styled from 'styled-components'
 
 import { FeatureStatus } from '../../types'
@@ -37,6 +37,10 @@ export const ListHeading = styled.p`
   font-weight: 700;
   margin-top: 0;
   margin-bottom: ${themeSpacing(2)};
+
+  @media only screen and ${breakpoint('min-width', 'tabletM')} {
+    margin-top: ${themeSpacing(4)};
+  }
 `
 
 export const ListDescription = styled.p`

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector_v2_removeafterfinishepic5440/DetailPanel/DetailPanel.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector_v2_removeafterfinishepic5440/DetailPanel/DetailPanel.test.tsx
@@ -5,6 +5,7 @@ import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import * as reactRedux from 'react-redux'
 import * as reactResponsive from 'react-responsive'
+import { act } from 'react-test-renderer'
 
 import type { Item } from 'signals/incident/components/form/MapSelectors/types'
 import { closeMap } from 'signals/incident/containers/IncidentContainer/actions'
@@ -112,9 +113,11 @@ describe('DetailPanel', () => {
     )
     dispatch.mockReset()
     dispatchEventSpy.mockReset()
+    jest.useFakeTimers()
   })
 
   afterEach(() => {
+    jest.useRealTimers()
     jest.resetAllMocks()
   })
 
@@ -125,6 +128,10 @@ describe('DetailPanel', () => {
         selection: undefined,
       })
     )
+
+    act(() => {
+      jest.runAllTimers()
+    })
 
     expect(screen.getByText('Selecteer de locatie')).toBeInTheDocument()
 
@@ -156,6 +163,10 @@ describe('DetailPanel', () => {
         selection,
       })
     )
+
+    act(() => {
+      jest.runAllTimers()
+    })
 
     expect(screen.getByTestId('asset-select-submit-button')).toBeInTheDocument()
     expect(screen.getByTestId('mock-asset-list')).toBeInTheDocument()
@@ -193,6 +204,10 @@ describe('DetailPanel', () => {
 
     expect(dispatch).not.toHaveBeenCalledWith(closeMap())
 
+    act(() => {
+      jest.runAllTimers()
+    })
+
     userEvent.click(screen.getByTestId('asset-select-submit-button'))
 
     expect(dispatch).toHaveBeenCalledWith(closeMap())
@@ -207,6 +222,10 @@ describe('DetailPanel', () => {
         selection: undefined,
       })
     )
+
+    act(() => {
+      jest.runAllTimers()
+    })
 
     expect(screen.getByTestId('asset-select-submit-button')).toBeInTheDocument()
 
@@ -224,6 +243,10 @@ describe('DetailPanel', () => {
         selection: undefined,
       })
     )
+
+    act(() => {
+      jest.runAllTimers()
+    })
 
     expect(screen.getByText('Ga verder zonder object')).toBeInTheDocument()
   })
@@ -245,6 +268,10 @@ describe('DetailPanel', () => {
         selection: undefined,
       })
     )
+
+    act(() => {
+      jest.runAllTimers()
+    })
 
     expect(screen.getByText('Ga verder zonder container')).toBeInTheDocument()
   })

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector_v2_removeafterfinishepic5440/DetailPanel/DetailPanel.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector_v2_removeafterfinishepic5440/DetailPanel/DetailPanel.tsx
@@ -1,7 +1,14 @@
 // SPDX-License-Identifier: MPL-2.0
 import type { FC } from 'react'
 // Copyright (C) 2021 - 2023 Gemeente Amsterdam, Vereniging van Nederlandse Gemeenten
-import { useCallback, useContext, useState } from 'react'
+import {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 
 import { ChevronLeft } from '@amsterdam/asc-assets'
 import { ascDefaultTheme, breakpoint, Button } from '@amsterdam/asc-ui'
@@ -27,6 +34,7 @@ import {
   DrawerOverlay,
   DrawerState,
 } from '../../../../../../../../components/DrawerOverlay'
+import type { Address } from '../../../../../../../../types/address'
 import AssetSelectContext from '../../context'
 import Legend from '../Legend'
 import { ScrollWrapper, StyledPDOKAutoSuggest } from '../styled'
@@ -55,6 +63,10 @@ const DetailPanel: FC<DetailPanelProps> = ({ language, zoomLevel }) => {
   const { featureTypes } = meta
   const featureStatusTypes = meta.featureStatusTypes || []
   const addressValue = address ? formatAddress(address) : ''
+  const [currentAddress, setCurrentAddress] = useState<Address | undefined>(
+    undefined
+  )
+  const newAddressRef = useRef<Address | undefined>(address)
 
   const selectionOnMap =
     selection && selectionIsObject(selection[0]) ? selection : undefined
@@ -70,16 +82,40 @@ const DetailPanel: FC<DetailPanelProps> = ({ language, zoomLevel }) => {
 
   useResetDrawerState(drawerState, setDrawerState, zoomLevel)
 
-  const topPositionDrawerMobile =
-    selection || (zoomLevel && zoomLevel >= 13) || legendOpen ? 60 : 100
+  const submitButtonText = useMemo(() => {
+    return selection
+      ? language?.submit || 'Meld dit object'
+      : featureTypes.length > 0
+      ? 'Ga verder zonder ' + (language?.objectTypeSingular || 'object')
+      : language?.submit
+  }, [selection, featureTypes, language])
 
+  const topPositionDrawerMobile = useMemo(() => {
+    return selection ||
+      (zoomLevel && zoomLevel >= 13 && featureTypes.length > 0) ||
+      legendOpen
+      ? 60
+      : 100
+  }, [selection, zoomLevel, featureTypes, legendOpen])
+
+  useEffect(() => {
+    newAddressRef.current = address
+
+    const timeoutId = setTimeout(() => {
+      setCurrentAddress(newAddressRef.current)
+    }, 100)
+
+    return () => {
+      clearTimeout(timeoutId)
+    }
+  }, [address])
   return (
     <DrawerOverlay
       state={drawerState}
       onStateChange={setDrawerState}
       disableDrawerHandleDesktop
       topPositionDrawerMobile={topPositionDrawerMobile}
-      address={address}
+      address={currentAddress}
     >
       <PanelContent data-testid="detail-panel">
         {!shouldRenderMobileVersion && (
@@ -127,17 +163,14 @@ const DetailPanel: FC<DetailPanelProps> = ({ language, zoomLevel }) => {
               zoomLevel={zoomLevel}
             />
           )}
-          {address && !shouldRenderMobileVersion && (
+          {currentAddress && !shouldRenderMobileVersion && (
             <StyledButton
               onClick={() => dispatch(closeMap())}
               variant="primary"
               data-testid="asset-select-submit-button"
               tabIndex={0}
             >
-              {selection
-                ? language?.submit || 'Meld dit object'
-                : 'Ga verder zonder ' +
-                  (language?.objectTypeSingular || 'object')}
+              {submitButtonText}
             </StyledButton>
           )}
         </ScrollWrapper>
@@ -148,7 +181,7 @@ const DetailPanel: FC<DetailPanelProps> = ({ language, zoomLevel }) => {
           setLegendOpen(!legendOpen)
         }}
       />
-      {shouldRenderMobileVersion && address && (
+      {shouldRenderMobileVersion && currentAddress && (
         <StyledButtonWrapper>
           <StyledButton
             onClick={() => dispatch(closeMap())}
@@ -156,10 +189,7 @@ const DetailPanel: FC<DetailPanelProps> = ({ language, zoomLevel }) => {
             data-testid="asset-select-submit-button"
             tabIndex={0}
           >
-            {selection
-              ? language?.submit || 'Meld dit object'
-              : 'Ga verder zonder ' +
-                (language?.objectTypeSingular || 'object')}
+            {submitButtonText}
           </StyledButton>
         </StyledButtonWrapper>
       )}

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector_v2_removeafterfinishepic5440/DetailPanel/DetailPanel.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector_v2_removeafterfinishepic5440/DetailPanel/DetailPanel.tsx
@@ -11,7 +11,7 @@ import {
 } from 'react'
 
 import { ChevronLeft } from '@amsterdam/asc-assets'
-import { ascDefaultTheme, breakpoint, Button } from '@amsterdam/asc-ui'
+import { ascDefaultTheme, breakpoint } from '@amsterdam/asc-ui'
 import { useDispatch } from 'react-redux'
 import { useMediaQuery } from 'react-responsive'
 
@@ -24,6 +24,7 @@ import {
   Description,
   PanelContent,
   StyledAssetList,
+  StyledBackButton,
   StyledButton,
   StyledButtonWrapper,
   StyledLabelPDOkAutoSuggest,
@@ -119,7 +120,7 @@ const DetailPanel: FC<DetailPanelProps> = ({ language, zoomLevel }) => {
     >
       <PanelContent data-testid="detail-panel">
         {!shouldRenderMobileVersion && (
-          <Button
+          <StyledBackButton
             aria-label="Terug"
             aria-controls="addressPanel"
             icon={<ChevronLeft />}

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector_v2_removeafterfinishepic5440/DetailPanel/styled.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector_v2_removeafterfinishepic5440/DetailPanel/styled.tsx
@@ -10,6 +10,11 @@ import LegendToggle from '../LegendToggleButton'
 
 export const StyledAssetList = styled(AssetList)`
   margin: ${themeSpacing(2)} 0 ${themeSpacing(16)} 0;
+
+  img {
+    width: ${themeSpacing(8)};
+    height: ${themeSpacing(8)};
+  }
   @media only screen and ${breakpoint('min-width', 'tabletM')} {
     margin: ${themeSpacing(2)} 0 0 0;
   }
@@ -54,6 +59,7 @@ export const PanelContent = styled.div`
   background-color: white;
   z-index: 1;
   position: relative;
+  height: 100%;
 `
 
 export const StyledLegendPanel = styled(LegendPanel)`

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector_v2_removeafterfinishepic5440/DetailPanel/styled.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector_v2_removeafterfinishepic5440/DetailPanel/styled.tsx
@@ -8,6 +8,12 @@ import AssetList from '../../AssetList'
 import LegendPanel from '../LegendPanel'
 import LegendToggle from '../LegendToggleButton'
 
+export const StyledBackButton = styled(Button)`
+  @media only screen and ${breakpoint('min-width', 'tabletM')} {
+    margin: ${themeSpacing(5, 0, 0, 5)};
+  }
+`
+
 export const StyledAssetList = styled(AssetList)`
   margin: ${themeSpacing(2)} 0 ${themeSpacing(16)} 0;
 
@@ -77,7 +83,7 @@ export const StyledParagraphPDOkAutoSuggest = styled.p`
   font-size: 1.125rem;
   display: block;
   font-weight: 700;
-  margin: ${themeSpacing(5, 0, 0, 0)};
+  margin: 0;
 `
 
 export const StyledLabelPDOkAutoSuggest = styled.label`

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector_v2_removeafterfinishepic5440/LegendPanel/styled.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector_v2_removeafterfinishepic5440/LegendPanel/styled.tsx
@@ -4,6 +4,7 @@ import styled, { css } from 'styled-components'
 
 import type { LegendPanelProps } from './LegendPanel'
 import { DETAIL_PANEL_WIDTH } from '../../../constants'
+import { ScrollWrapper } from '../styled'
 
 /**
  * Panel is positioned off-screen by 200% of its own width (or height, depending on the orientation).
@@ -47,7 +48,6 @@ export const Panel = styled.div<{ slide: LegendPanelProps['slide'] }>`
     flex: 0 0 50vh;
     order: 1;
     position: fixed;
-    overflow-y: auto;
     transform: translate3d(
       0,
       ${({ slide }) => (slide === 'out' ? '200%' : '0')},
@@ -55,6 +55,11 @@ export const Panel = styled.div<{ slide: LegendPanelProps['slide'] }>`
     );
     width: 100vw;
     max-height: 50vh;
+  }
+
+  ${ScrollWrapper} {
+    padding: 0;
+    height: calc(100% - 22px);
   }
 `
 

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector_v2_removeafterfinishepic5440/styled.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector_v2_removeafterfinishepic5440/styled.tsx
@@ -117,6 +117,9 @@ export const ScrollWrapper = styled.div.attrs({
   'data-scroll-lock-scrollable': true,
 })`
   -webkit-overflow-scrolling: touch;
+  height: 100%;
+  overflow-y: auto;
+  padding: ${themeSpacing(5)};
 `
 
 export const Title = styled(Heading)`

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/eikenprocessierups.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/eikenprocessierups.ts
@@ -30,7 +30,7 @@ export const controls = {
         unregisteredId: undefined,
         objectTypeSingular: 'boom',
         objectTypePlural: 'bomen',
-        submit: 'Gebruik deze locatie',
+        submit: 'Bevestigen',
       },
       shortLabel: 'Boom',
       pathMerge: 'extra_properties',

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/straatverlichting-klokken.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/straatverlichting-klokken.ts
@@ -240,7 +240,7 @@ const straatverlichtingKlokken = {
         unregisteredId: 'Nummer van de klok',
         objectTypeSingular: 'klok',
         objectTypePlural: 'klokken',
-        submit: 'Gebruik deze locatie',
+        submit: 'Bevestigen',
       },
       label: 'Kies de klok waar het om gaat',
       shortLabel: 'Klok(ken) op kaart',

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/straatverlichting-klokken.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/straatverlichting-klokken.ts
@@ -44,7 +44,7 @@ const straatverlichtingKlokken = {
         objectTypeSingular: 'lichtpunt',
         objectTypePlural: 'lichtpunten',
         pdokLabel: 'Zoek op adres',
-        pdokInput: 'Adres of lichtpuntnummer',
+        pdokInput: 'Adres',
         submit: 'Gebruik deze locatie',
       },
       label: 'Kies de lamp of lantaarnpaal waar het om gaat',


### PR DESCRIPTION
**Fixes**
 
Stop flickering when reverse address search gets new address. Put a delay on icon list on click handler. Capitalize assetlist titles. Change drawer top position logic
Fix scroll, rearrange DrawerOverlay.tsx, resize icon list image

Ticket: [SIG-5438](https://gemeente-amsterdam.atlassian.net/browse/SIG-5438)

## Signalen

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)


[SIG-5438]: https://gemeente-amsterdam.atlassian.net/browse/SIG-5438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ