### PR TITLE
[chore] When address response is within 100ms, clear timeout and set new address

### DIFF
--- a/src/signals/incident/components/form/MapSelectors/Asset/AssetSelect.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/AssetSelect.tsx
@@ -63,6 +63,7 @@ export interface AssetSelectProps {
 const AssetSelect: FC<AssetSelectProps> = ({ value, layer, meta, parent }) => {
   const { selection, location } = value || {}
   const [message, setMessage] = useState<string>()
+  const [addressLoading, setAddressLoading] = useState(false)
   const [selectableFeatures, setSelectableFeatures] = useState<
     FeatureCollection | undefined
   >(undefined)
@@ -148,11 +149,11 @@ const AssetSelect: FC<AssetSelectProps> = ({ value, layer, meta, parent }) => {
       updateIncident(payload)
 
       if (payload.location) {
+        setAddressLoading(true)
         const response = await reverseGeocoderService(latLng)
-
         payload.location.address = response?.data?.address
-
         updateIncident(payload)
+        setAddressLoading(false)
       }
     },
     [address, getUpdatePayload, updateIncident]
@@ -203,6 +204,7 @@ const AssetSelect: FC<AssetSelectProps> = ({ value, layer, meta, parent }) => {
         layer,
         message,
         selectableFeatures,
+        addressLoading,
         meta: {
           ...meta,
           featureTypes,
@@ -214,6 +216,7 @@ const AssetSelect: FC<AssetSelectProps> = ({ value, layer, meta, parent }) => {
         fetchLocation,
         setMessage,
         setSelectableFeatures,
+        setAddressLoading,
       }}
     >
       {!mapActive && !hasSelection && <Intro />}

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector_v2_removeafterfinishepic5440/DetailPanel/DetailPanel.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector_v2_removeafterfinishepic5440/DetailPanel/DetailPanel.test.tsx
@@ -30,6 +30,7 @@ jest.mock(
       featureTypes,
       featureStatusTypes,
       selection,
+      selectableFeatures,
       ...props
     }: AssetListProps) =>
       selection && (

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector_v2_removeafterfinishepic5440/DetailPanel/DetailPanel.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector_v2_removeafterfinishepic5440/DetailPanel/DetailPanel.tsx
@@ -1,14 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 import type { FC } from 'react'
 // Copyright (C) 2021 - 2023 Gemeente Amsterdam, Vereniging van Nederlandse Gemeenten
-import {
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react'
+import { useCallback, useContext, useMemo, useState } from 'react'
 
 import { ChevronLeft } from '@amsterdam/asc-assets'
 import { ascDefaultTheme, breakpoint } from '@amsterdam/asc-ui'
@@ -30,12 +23,12 @@ import {
   StyledLabelPDOkAutoSuggest,
   StyledParagraphPDOkAutoSuggest,
 } from './styled'
+import { useCurrentAddress } from './useCurrentAddress'
 import { useResetDrawerState } from './useResetDrawerState'
 import {
   DrawerOverlay,
   DrawerState,
 } from '../../../../../../../../components/DrawerOverlay'
-import type { Address } from '../../../../../../../../types/address'
 import AssetSelectContext from '../../context'
 import Legend from '../Legend'
 import { ScrollWrapper, StyledPDOKAutoSuggest } from '../styled'
@@ -60,15 +53,11 @@ const DetailPanel: FC<DetailPanelProps> = ({ language, zoomLevel }) => {
     setLocation,
     meta,
     selectableFeatures,
+    addressLoading,
   } = useContext(AssetSelectContext)
   const { featureTypes } = meta
   const featureStatusTypes = meta.featureStatusTypes || []
   const addressValue = address ? formatAddress(address) : ''
-  const [currentAddress, setCurrentAddress] = useState<Address | undefined>(
-    undefined
-  )
-  const newAddressRef = useRef<Address | undefined>(address)
-
   const selectionOnMap =
     selection && selectionIsObject(selection[0]) ? selection : undefined
 
@@ -99,17 +88,11 @@ const DetailPanel: FC<DetailPanelProps> = ({ language, zoomLevel }) => {
       : 100
   }, [selection, zoomLevel, featureTypes, legendOpen])
 
-  useEffect(() => {
-    newAddressRef.current = address
+  const currentAddress = useCurrentAddress({
+    address,
+    addressLoading,
+  })
 
-    const timeoutId = setTimeout(() => {
-      setCurrentAddress(newAddressRef.current)
-    }, 100)
-
-    return () => {
-      clearTimeout(timeoutId)
-    }
-  }, [address])
   return (
     <DrawerOverlay
       state={drawerState}

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector_v2_removeafterfinishepic5440/DetailPanel/useCurrentAddress.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector_v2_removeafterfinishepic5440/DetailPanel/useCurrentAddress.test.tsx
@@ -1,0 +1,54 @@
+// SPDX-License-IdentifiaddressExampleer: MPL-2.0
+// Copyright (C) 2023 Gemeente Amsterdam
+import { renderHook } from '@testing-library/react-hooks'
+import { act } from 'react-test-renderer'
+
+import { useCurrentAddress } from './useCurrentAddress'
+
+const addressExample = {
+  postcode: '1234AB',
+  huisnummer: '1',
+  huisnummer_toevoeging: 'B',
+  openbare_ruimte: 'Straatnaam',
+  woonplaats: 'Amsterdam',
+}
+
+describe('useCurrentAddress', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('should get current address', () => {
+    let addressLoading = true
+    const { result, rerender } = renderHook(() =>
+      useCurrentAddress({
+        address: addressExample,
+        addressLoading,
+      })
+    )
+
+    expect(result.current).toEqual(undefined)
+
+    addressLoading = false
+
+    rerender()
+
+    act(() => {
+      jest.advanceTimersByTime(50)
+    })
+
+    addressLoading = true
+
+    rerender()
+
+    act(() => {
+      jest.runAllTimers()
+    })
+
+    expect(result.current).toEqual(addressExample)
+  })
+})

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector_v2_removeafterfinishepic5440/DetailPanel/useCurrentAddress.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector_v2_removeafterfinishepic5440/DetailPanel/useCurrentAddress.tsx
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: MPL-2.0
+// Copyright (C) 2023 Gemeente Amsterdam
+import { useEffect, useRef, useState } from 'react'
+
+import type { Address } from '../../../../../../../../types/address'
+
+type Props = {
+  address: Address | undefined
+  addressLoading: boolean
+}
+
+export const useCurrentAddress = ({ address, addressLoading }: Props) => {
+  const newAddressRef = useRef<Address | undefined>(address)
+  const [currentAddress, setCurrentAddress] = useState<Address | undefined>(
+    undefined
+  )
+  const prevAddressLoading = useRef<boolean | undefined>(undefined)
+  useEffect(() => {
+    newAddressRef.current = address
+
+    const timeoutId = setTimeout(() => {
+      setCurrentAddress(newAddressRef.current)
+      prevAddressLoading.current = addressLoading
+    }, 100)
+
+    if (!addressLoading && prevAddressLoading.current) {
+      setCurrentAddress(newAddressRef.current)
+      clearTimeout(timeoutId)
+      prevAddressLoading.current = addressLoading
+      return
+    }
+
+    prevAddressLoading.current = addressLoading
+
+    return () => {
+      clearTimeout(timeoutId)
+    }
+  }, [address, addressLoading])
+
+  return currentAddress
+}

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector_v2_removeafterfinishepic5440/NearbyLayer/NearbyLayer.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector_v2_removeafterfinishepic5440/NearbyLayer/NearbyLayer.tsx
@@ -76,7 +76,8 @@ export function findAssetMatch(
 }
 
 export const NearbyLayer: FC<NearbyLayerProps> = ({ zoomLevel }) => {
-  const { selection, setItem } = useContext(AssetSelectContext)
+  const { selection, setItem, setAddressLoading } =
+    useContext(AssetSelectContext)
   const bbox = useBoundingBox()
   const layerVisible = useLayerVisible(zoomLevel)
   const mapInstance = useMapInstance()
@@ -106,16 +107,17 @@ export const NearbyLayer: FC<NearbyLayerProps> = ({ zoomLevel }) => {
 
         setItem(item, location)
 
+        setAddressLoading(true)
         const response = await reverseGeocoderService(coordinates)
-
         if (response) {
           location.address = response.data.address
           item.address = response.data.address
         }
 
         setItem(item, location)
+        setAddressLoading(false)
       },
-    [setItem, setActiveLayer]
+    [setItem, setAddressLoading]
   )
 
   useEffect(() => {

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector_v2_removeafterfinishepic5440/WfsLayer/AssetLayer/AssetLayer.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector_v2_removeafterfinishepic5440/WfsLayer/AssetLayer/AssetLayer.tsx
@@ -28,7 +28,7 @@ import WfsDataContext from '../context'
 
 export const AssetLayer: FC = () => {
   const data = useContext<FeatureCollection>(WfsDataContext)
-  const { selection, removeItem, setItem, meta } =
+  const { selection, removeItem, setItem, setAddressLoading, meta } =
     useContext(AssetSelectContext)
   const { featureTypes } = meta
   const featureStatusTypes = meta.featureStatusTypes || []
@@ -94,6 +94,7 @@ export const AssetLayer: FC = () => {
 
         setItem(item, location)
 
+        setAddressLoading(true)
         const response = await reverseGeocoderService(coordinates)
 
         if (response) {
@@ -102,6 +103,7 @@ export const AssetLayer: FC = () => {
         }
 
         setItem(item, location)
+        setAddressLoading(false)
       }
     }
 

--- a/src/signals/incident/components/form/MapSelectors/Asset/__tests__/withAssetSelectContext.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/__tests__/withAssetSelectContext.tsx
@@ -44,11 +44,13 @@ export const contextValue: AssetSelectValue = {
     woonplaats: 'Amsterdam',
   },
   selectableFeatures: undefined,
+  addressLoading: false,
   setItem: jest.fn(),
   fetchLocation: jest.fn(),
   setLocation: jest.fn(),
   setMessage: jest.fn(),
   setSelectableFeatures: jest.fn(),
+  setAddressLoading: jest.fn(),
 }
 
 const withAssetSelectContext = (Component: ReactNode, context = contextValue) =>

--- a/src/signals/incident/components/form/MapSelectors/Asset/context.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/context.tsx
@@ -17,12 +17,14 @@ export const initialValue: AssetSelectValue = {
   },
   selection: undefined,
   selectableFeatures: undefined,
+  addressLoading: false,
   fetchLocation: /* istanbul ignore next */ () => {},
   setLocation: /* istanbul ignore next */ () => {},
   setMessage: /* istanbul ignore next */ () => {},
   setItem: /* istanbul ignore next */ () => {},
   removeItem: /* istanbul ignore next */ () => {},
   setSelectableFeatures: /* istanbul ignore next */ () => {},
+  setAddressLoading: /* istanbul ignore next */ () => {},
 }
 
 const AssetSelectContext = createContext(initialValue)

--- a/src/signals/incident/components/form/MapSelectors/Asset/types.ts
+++ b/src/signals/incident/components/form/MapSelectors/Asset/types.ts
@@ -21,11 +21,13 @@ export interface AssetSelectValue {
   selectableFeatures?: FeatureCollection
   removeItem: (item?: Item) => void
   selection?: Item[]
+  addressLoading: boolean
   setItem: (item: Item, location?: Location) => void
   fetchLocation: (latLng: LatLngLiteral) => void
   setLocation: (location: Location) => void
   setMessage: (message?: string) => void
   setSelectableFeatures: (features?: FeatureCollection) => void
+  setAddressLoading: React.Dispatch<React.SetStateAction<boolean>>
 }
 
 export interface AssetSelectRendererProps extends FormFieldProps {

--- a/src/signals/incident/components/form/MapSelectors/Caterpillar/CaterpillarLayer/CaterpillarLayer.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Caterpillar/CaterpillarLayer/CaterpillarLayer.tsx
@@ -24,7 +24,8 @@ import { getFeatureStatusType } from '../../Asset/Selector_v2_removeafterfinishe
 /* istanbul ignore next */
 export const CaterpillarLayer: FC = () => {
   const { features } = useContext<FeatureCollection>(WfsDataContext)
-  const { selection, meta, setItem, removeItem } = useContext(SelectContext)
+  const { selection, meta, setItem, removeItem, setAddressLoading } =
+    useContext(SelectContext)
   const getMarker = useCallback(
     (feat: any, featureStatusTypes: FeatureStatusType[]) => {
       const feature = feat as Feature
@@ -83,6 +84,7 @@ export const CaterpillarLayer: FC = () => {
 
         setItem(item, location)
 
+        setAddressLoading(true)
         const response = await reverseGeocoderService(coordinates)
 
         if (response) {
@@ -91,6 +93,7 @@ export const CaterpillarLayer: FC = () => {
         }
 
         setItem(item, location)
+        setAddressLoading(false)
       }
 
       return (


### PR DESCRIPTION
**context**
when you click on the map on an object or just a new location there used to be a flickering. New address coming in from the reverse proxy endpoint and for an under the 100 ms no address. Therefore I build a threshold of 100ms that it will use the last known address before replacing it with the new one(or none). 

This will make sure the new address from the reserve proxy endpoint will be used instantly.

## Signalen

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
