### PR TITLE
[bugfix 5573] Error handling when sorting

### DIFF
--- a/src/signals/incident-management/__tests__/saga.test.js
+++ b/src/signals/incident-management/__tests__/saga.test.js
@@ -128,7 +128,7 @@ describe('signals/incident-management/saga', () => {
       const filter = { name: 'filter', refresh: false }
       const page = 2
       const ordering = '-created_at'
-      const incidents = [{}, {}]
+      const incidents = { 0: {}, 1: {}, orderedAs: '-created_at' }
       const params = { test: 'test' }
       const filterParams = {
         page,
@@ -182,7 +182,7 @@ describe('signals/incident-management/saga', () => {
           [select(makeSelectActiveFilter), {}],
           [matchers.call.fn(authCall), []],
         ])
-        .put(requestIncidentsSuccess([]))
+        .put(requestIncidentsSuccess({ orderedAs: '' }))
         .dispatch({ type: CLEAR_FILTERS })
         .silentRun())
 
@@ -192,7 +192,7 @@ describe('signals/incident-management/saga', () => {
           [select(makeSelectActiveFilter), {}],
           [matchers.call.fn(authCall), []],
         ])
-        .put(requestIncidentsSuccess([]))
+        .put(requestIncidentsSuccess({ orderedAs: '' }))
         .dispatch({ type: PAGE_CHANGED, payload: 4 })
         .silentRun())
 
@@ -202,7 +202,7 @@ describe('signals/incident-management/saga', () => {
           [select(makeSelectActiveFilter), {}],
           [matchers.call.fn(authCall), []],
         ])
-        .put(requestIncidentsSuccess([]))
+        .put(requestIncidentsSuccess({ orderedAs: '' }))
         .dispatch({
           type: ORDERING_CHANGED,
           payload: 'incident-id-in-asc-order',
@@ -225,7 +225,7 @@ describe('signals/incident-management/saga', () => {
         .select(makeSelectFilterParams)
         .call.like(authCall, CONFIGURATION.SEARCH_ENDPOINT, { q })
         .not.put(push('/manage/incidents'))
-        .put(searchIncidentsSuccess(incidentsJSON))
+        .put(searchIncidentsSuccess({ ...incidentsJSON, orderedAs: '' }))
         .run()
     })
 

--- a/src/signals/incident-management/containers/IncidentOverviewPage/contants.ts
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/contants.ts
@@ -106,6 +106,3 @@ export const sortOptionsList: SortOption[] = [
     desc_label: '(hoog-laag)',
   },
 ]
-
-export const TYPE_GLOBAL = 'global'
-export const VARIANT_NOTICE = 'notice'

--- a/src/signals/incident-management/containers/IncidentOverviewPage/contants.ts
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/contants.ts
@@ -106,3 +106,6 @@ export const sortOptionsList: SortOption[] = [
     desc_label: '(hoog-laag)',
   },
 ]
+
+export const TYPE_GLOBAL = 'global'
+export const VARIANT_NOTICE = 'notice'

--- a/src/signals/incident-management/containers/IncidentOverviewPage/index.js
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/index.js
@@ -42,7 +42,6 @@ import { parseToAPIData } from 'signals/shared/filter/parse'
 import List from './components/List'
 import QuickFilter from './components/QuickFilter'
 import SubNav from './components/SubNav'
-import { TYPE_GLOBAL, VARIANT_NOTICE } from './contants'
 import {
   TitleRow,
   PageHeaderItem,
@@ -55,8 +54,10 @@ import {
   StyledPagination,
 } from './styled'
 import {
+  TYPE_GLOBAL,
   TYPE_LOCAL,
   VARIANT_ERROR,
+  VARIANT_NOTICE,
 } from '../../../../containers/Notification/constants'
 import { MAP_URL } from '../../routes'
 import FilterTagList from '../FilterTagList/FilterTagList'

--- a/src/signals/incident-management/containers/IncidentOverviewPage/index.js
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/index.js
@@ -14,7 +14,6 @@ import LoadingIndicator from 'components/LoadingIndicator'
 import Modal from 'components/Modal'
 import OverviewMap from 'components/OverviewMap'
 import { showGlobalNotification } from 'containers/App/actions'
-import { VARIANT_NOTICE, TYPE_GLOBAL } from 'containers/App/constants'
 import { makeSelectSearchQuery } from 'containers/App/selectors'
 import MapContext from 'containers/MapContext'
 import useEventEmitter from 'hooks/useEventEmitter'
@@ -32,6 +31,7 @@ import MyFilters from 'signals/incident-management/containers/MyFilters'
 import dataLists from 'signals/incident-management/definitions'
 import {
   makeSelectActiveFilter,
+  makeSelectErrorMessage,
   makeSelectFiltersOnOverview,
   makeSelectIncidents,
   makeSelectOrdering,
@@ -42,6 +42,7 @@ import { parseToAPIData } from 'signals/shared/filter/parse'
 import List from './components/List'
 import QuickFilter from './components/QuickFilter'
 import SubNav from './components/SubNav'
+import { TYPE_GLOBAL, VARIANT_NOTICE } from './contants'
 import {
   TitleRow,
   PageHeaderItem,
@@ -53,6 +54,10 @@ import {
   StyledButton,
   StyledPagination,
 } from './styled'
+import {
+  TYPE_LOCAL,
+  VARIANT_ERROR,
+} from '../../../../containers/Notification/constants'
 import { MAP_URL } from '../../routes'
 import FilterTagList from '../FilterTagList/FilterTagList'
 
@@ -68,6 +73,7 @@ export const IncidentOverviewPageContainerComponent = ({
   orderingChangedAction,
   page,
   pageChangedAction,
+  errorMessage,
 }) => {
   const location = useLocation()
   const dispatch = useDispatch()
@@ -97,6 +103,19 @@ export const IncidentOverviewPageContainerComponent = ({
 
   const disableFilters = hasActiveOrdering || searchQueryIncidents
   const disableSorting = hasActiveFilters || searchQueryIncidents
+
+  useEffect(() => {
+    if (errorMessage) {
+      dispatch(
+        showGlobalNotification({
+          title: 'Let op, het sorteren is niet gelukt',
+          message: errorMessage,
+          variant: VARIANT_ERROR,
+          type: TYPE_LOCAL,
+        })
+      )
+    }
+  }, [errorMessage, dispatch])
 
   const showNotification = useCallback(() => {
     dispatch(
@@ -278,7 +297,7 @@ export const IncidentOverviewPageContainerComponent = ({
 
             {canRenderList && (
               <List
-                ordering={ordering}
+                ordering={incidents.orderedAs}
                 orderingChangedAction={orderingChangedAction}
                 incidents={incidents.results}
                 incidentsCount={count}
@@ -318,6 +337,7 @@ IncidentOverviewPageContainerComponent.propTypes = {
   pageChangedAction: PropTypes.func.isRequired,
   ordering: PropTypes.string.isRequired,
   page: PropTypes.number,
+  errorMessage: PropTypes.string,
 }
 
 const mapStateToProps = createStructuredSelector({
@@ -326,6 +346,7 @@ const mapStateToProps = createStructuredSelector({
   incidents: makeSelectIncidents,
   ordering: makeSelectOrdering,
   page: makeSelectPage,
+  errorMessage: makeSelectErrorMessage,
 })
 
 export const mapDispatchToProps = (dispatch) =>

--- a/src/signals/incident-management/containers/IncidentOverviewPage/index.test.js
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/index.test.js
@@ -4,6 +4,7 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import Adapter from '@wojtekmaj/enzyme-adapter-react-17'
 import Enzyme, { mount } from 'enzyme'
+import fetchMock from 'jest-fetch-mock'
 import { mocked } from 'jest-mock'
 import * as reactRedux from 'react-redux'
 import { disablePageScroll, enablePageScroll } from 'scroll-lock'
@@ -14,7 +15,6 @@ import { withAppContext } from 'test/utils'
 import incidentJson from 'utils/__tests__/fixtures/incident.json'
 
 import IncidentOverviewPage, { IncidentOverviewPageContainerComponent } from '.'
-import fetchMock from 'jest-fetch-mock'
 
 Enzyme.configure({ adapter: new Adapter() })
 

--- a/src/signals/incident-management/containers/IncidentOverviewPage/index.test.js
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/index.test.js
@@ -14,15 +14,10 @@ import { withAppContext } from 'test/utils'
 import incidentJson from 'utils/__tests__/fixtures/incident.json'
 
 import IncidentOverviewPage, { IncidentOverviewPageContainerComponent } from '.'
+import fetchMock from 'jest-fetch-mock'
 
 Enzyme.configure({ adapter: new Adapter() })
 
-const mockedGlobalNotification = mocked(
-  actions.showGlobalNotification,
-  true
-).mockReturnValue({
-  type: 'sia/App/SHOW_GLOBAL_NOTIFICATION',
-})
 jest.mock('containers/App/actions')
 
 jest.mock('scroll-lock')
@@ -86,6 +81,10 @@ describe('signals/incident-management/containers/IncidentOverviewPage', () => {
       pageChangedAction: jest.fn(),
       clearFiltersAction: jest.fn(),
     }
+  })
+  afterEach(() => {
+    jest.resetAllMocks()
+    fetchMock.resetMocks()
   })
 
   it('should render modal buttons', () => {
@@ -217,6 +216,39 @@ describe('signals/incident-management/containers/IncidentOverviewPage', () => {
     )
 
     expect(screen.getByText('Geen meldingen')).toBeInTheDocument()
+  })
+
+  it('should show notification when sorting is not working', async () => {
+    const mockedGlobalNotification = mocked(
+      actions.showGlobalNotification,
+      true
+    ).mockReturnValue({
+      type: 'sia/App/SHOW_GLOBAL_NOTIFICATION',
+    })
+
+    const incidents = generateIncidents()
+
+    render(
+      withAppContext(
+        <IncidentOverviewPageContainerComponent
+          {...props}
+          incidents={{
+            count: incidents.length,
+            results: incidents,
+            loadingIncidents: false,
+          }}
+          errorMessage="testing"
+        />
+      )
+    )
+    await waitFor(() => {
+      expect(mockedGlobalNotification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Let op, het sorteren is niet gelukt',
+          message: 'testing',
+        })
+      )
+    })
   })
 
   it('should have props from structured selector', () => {
@@ -440,6 +472,13 @@ describe('signals/incident-management/containers/IncidentOverviewPage', () => {
     })
 
     it('should disable filter buttons when ordering is active and show notification when clicked', async () => {
+      const mockedGlobalNotification = mocked(
+        actions.showGlobalNotification,
+        true
+      ).mockReturnValue({
+        type: 'sia/App/SHOW_GLOBAL_NOTIFICATION',
+      })
+
       render(
         withAppContext(
           <IncidentOverviewPageContainerComponent
@@ -465,6 +504,12 @@ describe('signals/incident-management/containers/IncidentOverviewPage', () => {
     })
 
     it('should disable filter buttons when search is active and show notification when clicked', async () => {
+      const mockedGlobalNotification = mocked(
+        actions.showGlobalNotification,
+        true
+      ).mockReturnValue({
+        type: 'sia/App/SHOW_GLOBAL_NOTIFICATION',
+      })
       jest.spyOn(reactRedux, 'useSelector').mockReturnValue('mock-search-query')
 
       render(

--- a/src/signals/incident-management/reducer.js
+++ b/src/signals/incident-management/reducer.js
@@ -44,12 +44,14 @@ export const initialState = fromJS({
   incidents: {
     count: undefined,
     results: [],
+    orderedAs: '', //ordering of results
   },
   loading: false,
   loadingDistricts: false,
   loadingFilters: false,
   loadingIncidents: false,
-  ordering: '',
+  ordering: '', //ordering as user wants, may have failed. Old ordering still available in incidients.orderedAs
+
   page: 1,
 })
 

--- a/src/signals/incident-management/saga.js
+++ b/src/signals/incident-management/saga.js
@@ -88,7 +88,9 @@ export function* fetchIncidents() {
       params
     )
 
-    yield put(requestIncidentsSuccess(incidents))
+    yield put(
+      requestIncidentsSuccess({ ...incidents, orderedAs: params.ordering })
+    )
 
     if (filter && filter.refresh) {
       yield put(applyFilterRefresh())
@@ -113,7 +115,7 @@ export function* searchIncidents() {
       ordering,
     })
 
-    yield put(searchIncidentsSuccess(incidents))
+    yield put(searchIncidentsSuccess({ ...incidents, orderedAs: ordering }))
   } catch (error) {
     if (error.response && error.response.status === 500) {
       // Getting an error response with status code 500 from the search endpoint

--- a/src/signals/incident-management/selectors.js
+++ b/src/signals/incident-management/selectors.js
@@ -189,6 +189,15 @@ export const makeSelectIncidents = createSelector(
   }
 )
 
+export const makeSelectErrorMessage = createSelector(
+  selectIncidentManagementDomain,
+  (state) => {
+    const obj = state.toJS()
+
+    return obj.errorMessage
+  }
+)
+
 export const makeSelectIncidentsCount = createSelector(
   selectIncidentManagementDomain,
   (state) => {


### PR DESCRIPTION
Showing chevron after answer from backend has returned

- Chevron is now shown in column that has either a successful return from the backend, or in the column that was previous ordered.
- create selector makeSelectErrorMessage
- made prop errorMessage in IncidentOverviewPageContainerComponent
- set globalNotification when errorMessage changes and is not undefined.

Ticket: [SIG-5573](https://gemeente-amsterdam.atlassian.net/browse/SIG-5573)

## Signalen

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)


[SIG-5573]: https://gemeente-amsterdam.atlassian.net/browse/SIG-5573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ