### PR TITLE
[feat-5540]: Update split form styling

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "preanalyze": "npm run analyze:clean",
     "pretest": "npm run test:clean",
     "prestart:prod": "npm run build",
-    "start": "cross-env NODE_ENV=development npx webpack s --allowed-hosts localhost bs-local.com --config ./internals/webpack/webpack.dev.babel --port=3001 --hot --compress --history-api-fallback --watch-files=./src/* --watch-files=./src/**/*",
+    "start": "cross-env NODE_ENV=development CONFIG=app.amsterdam.json npx webpack s --allowed-hosts localhost bs-local.com --config ./internals/webpack/webpack.dev.babel --port=3001 --hot --compress --history-api-fallback --watch-files=./src/* --watch-files=./src/**/*",
     "test": "cross-env NODE_ENV=test jest --coverage --runInBand",
     "test:logHeapUsage": "cross-env NODE_ENV=test node --expose-gc ./node_modules/.bin/jest --runInBand --logHeapUsage",
     "test:clean": "rimraf ./coverage",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "pretest": "npm run test:clean",
     "prestart:prod": "npm run build",
     "start": "cross-env NODE_ENV=development npx webpack s --allowed-hosts localhost bs-local.com --config ./internals/webpack/webpack.dev.babel --port=3001 --hot --compress --history-api-fallback --watch-files=./src/* --watch-files=./src/**/*",
+    "start:amsterdam": "cross-env CONFIG=app.amsterdam.json npm start",
     "test": "cross-env NODE_ENV=test jest --coverage --runInBand",
     "test:logHeapUsage": "cross-env NODE_ENV=test node --expose-gc ./node_modules/.bin/jest --runInBand --logHeapUsage",
     "test:clean": "rimraf ./coverage",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "preanalyze": "npm run analyze:clean",
     "pretest": "npm run test:clean",
     "prestart:prod": "npm run build",
-    "start": "cross-env NODE_ENV=development CONFIG=app.amsterdam.json npx webpack s --allowed-hosts localhost bs-local.com --config ./internals/webpack/webpack.dev.babel --port=3001 --hot --compress --history-api-fallback --watch-files=./src/* --watch-files=./src/**/*",
+    "start": "cross-env NODE_ENV=development npx webpack s --allowed-hosts localhost bs-local.com --config ./internals/webpack/webpack.dev.babel --port=3001 --hot --compress --history-api-fallback --watch-files=./src/* --watch-files=./src/**/*",
     "test": "cross-env NODE_ENV=test jest --coverage --runInBand",
     "test:logHeapUsage": "cross-env NODE_ENV=test node --expose-gc ./node_modules/.bin/jest --runInBand --logHeapUsage",
     "test:clean": "rimraf ./coverage",

--- a/src/signals/incident-management/containers/IncidentSplitContainer/components/IncidentSplitForm/IncidentSplitForm.tsx
+++ b/src/signals/incident-management/containers/IncidentSplitContainer/components/IncidentSplitForm/IncidentSplitForm.tsx
@@ -68,7 +68,7 @@ const IncidentSplitForm: FC<IncidentSplitFormProps> = ({
   onSubmit,
   isSubmitting,
 }) => {
-  const maxNoteLength = 1000
+  const maxNoteLength = 3000
   const formMethods = useForm({ reValidateMode: 'onSubmit' })
   const { handleSubmit, control } = formMethods
   const navigate = useNavigate()

--- a/src/signals/incident-management/containers/IncidentSplitContainer/components/IncidentSplitForm/IncidentSplitForm.tsx
+++ b/src/signals/incident-management/containers/IncidentSplitContainer/components/IncidentSplitForm/IncidentSplitForm.tsx
@@ -3,7 +3,7 @@
 import { useCallback, Fragment } from 'react'
 import type { FC } from 'react'
 
-import { Heading, themeSpacing } from '@amsterdam/asc-ui'
+import { Heading, themeSpacing, Row } from '@amsterdam/asc-ui'
 import { Controller, useForm, FormProvider } from 'react-hook-form'
 import { useNavigate } from 'react-router-dom'
 import styled from 'styled-components'
@@ -13,11 +13,12 @@ import Button from 'components/Button'
 import type { SubcategoriesGrouped } from 'models/categories/selectors'
 
 import {
-  FormWrapper,
   StyledDefinitionList,
   StyledForm,
   StyledSubmitButton,
   ThinLabel,
+  StyledMainContainer,
+  StyledButtonContainer,
 } from '../../styled'
 import IncidentSplitFormIncident from '../IncidentSplitFormIncident'
 import IncidentSplitRadioInput from '../IncidentSplitRadioInput'
@@ -78,88 +79,90 @@ const IncidentSplitForm: FC<IncidentSplitFormProps> = ({
 
   return (
     <FormProvider {...formMethods}>
-      <FormWrapper>
+      <Row>
         <StyledForm
           onSubmit={handleSubmit((data) => {
             onSubmit(data)
           })}
           data-testid="incident-split-form"
         >
-          <Heading>Deelmelding maken</Heading>
+          <StyledMainContainer>
+            <Heading>Deelmelding maken</Heading>
 
-          <fieldset>
-            <Heading forwardedAs="h2">Hoofdmelding</Heading>
+            <fieldset>
+              <Heading forwardedAs="h2">Hoofdmelding</Heading>
 
-            <StyledDefinitionList>
-              <dt>Melding</dt>
-              <dd data-testid="incident-split-form-parent-incident-id">
-                {parentIncident.id}
-              </dd>
+              <StyledDefinitionList>
+                <dt>Melding</dt>
+                <dd data-testid="incident-split-form-parent-incident-id">
+                  {parentIncident.id}
+                </dd>
 
-              <dt>Status</dt>
-              <dd data-testid="incident-split-form-status-display-name">
-                {parentIncident.statusDisplayName}
-              </dd>
+                <dt>Status</dt>
+                <dd data-testid="incident-split-form-status-display-name">
+                  {parentIncident.statusDisplayName}
+                </dd>
 
-              <dt>Subcategorie (verantwoordelijke afdeling)</dt>
-              <dd data-testid="incident-split-form-subcategory-display-name">
-                {parentIncident.subcategoryDisplayName}
-              </dd>
-            </StyledDefinitionList>
+                <dt>Subcategorie (verantwoordelijke afdeling)</dt>
+                <dd data-testid="incident-split-form-subcategory-display-name">
+                  {parentIncident.subcategoryDisplayName}
+                </dd>
+              </StyledDefinitionList>
 
-            <Controller
-              name="department"
-              defaultValue={parentIncident.directingDepartment}
-              render={({ field: { onChange } }) => (
-                <StyledIncidentSplitRadioInput
-                  data-testid="incident-split-form-radio-iInput-department"
-                  display="Regie"
-                  id="department"
-                  initialValue={parentIncident.directingDepartment}
-                  name="department"
-                  options={directingDepartments}
-                  onChange={onChange}
-                />
-              )}
-            />
+              <Controller
+                name="department"
+                defaultValue={parentIncident.directingDepartment}
+                render={({ field: { onChange } }) => (
+                  <StyledIncidentSplitRadioInput
+                    data-testid="incident-split-form-radio-iInput-department"
+                    display="Regie"
+                    id="department"
+                    initialValue={parentIncident.directingDepartment}
+                    name="department"
+                    options={directingDepartments}
+                    onChange={onChange}
+                  />
+                )}
+              />
 
-            <Controller
-              name="noteText"
-              control={control}
-              defaultValue=""
-              rules={{
-                validate: (text: string) => {
-                  const error = getAddNoteError({
-                    maxContentLength: maxNoteLength,
-                    text,
-                    shouldContainAtLeastOneChar: false,
-                  })
+              <Controller
+                name="noteText"
+                control={control}
+                defaultValue=""
+                rules={{
+                  validate: (text: string) => {
+                    const error = getAddNoteError({
+                      maxContentLength: maxNoteLength,
+                      text,
+                      shouldContainAtLeastOneChar: false,
+                    })
 
-                  return error || true
-                },
-              }}
-              render={({ field, fieldState: { error } }) => (
-                <AddNote
-                  {...field}
-                  error={error?.message}
-                  isStandalone={false}
-                  label={
-                    <Fragment>
-                      Notitie <ThinLabel>(niet verplicht)</ThinLabel>
-                    </Fragment>
-                  }
-                  maxContentLength={maxNoteLength}
-                />
-              )}
-            />
-          </fieldset>
+                    return error || true
+                  },
+                }}
+                render={({ field, fieldState: { error } }) => (
+                  <AddNote
+                    {...field}
+                    error={error?.message}
+                    isStandalone={false}
+                    label={
+                      <Fragment>
+                        Notitie <ThinLabel>(niet verplicht)</ThinLabel>
+                      </Fragment>
+                    }
+                    maxContentLength={maxNoteLength}
+                  />
+                )}
+              />
+            </fieldset>
+          </StyledMainContainer>
 
           <IncidentSplitFormIncident
             parentIncident={parentIncident}
             subcategories={subcategories}
           />
 
-          <div>
+          <StyledButtonContainer>
             <StyledSubmitButton
               data-testid="incident-split-form-submit-button"
               variant="secondary"
@@ -176,9 +179,9 @@ const IncidentSplitForm: FC<IncidentSplitFormProps> = ({
             >
               Annuleer
             </Button>
-          </div>
+          </StyledButtonContainer>
         </StyledForm>
-      </FormWrapper>
+      </Row>
     </FormProvider>
   )
 }

--- a/src/signals/incident-management/containers/IncidentSplitContainer/components/IncidentSplitFormIncident/IncidentSplitFormIncident.tsx
+++ b/src/signals/incident-management/containers/IncidentSplitContainer/components/IncidentSplitFormIncident/IncidentSplitFormIncident.tsx
@@ -22,6 +22,7 @@ import {
   StyledHeading,
   StyledFieldset,
   StyledHeadingWrapper,
+  StyledExtraIncidentButtonContainer,
 } from '../../styled'
 import type { ParentIncident } from '../IncidentSplitForm'
 import IncidentSplitRadioInput from '../IncidentSplitRadioInput'
@@ -70,25 +71,25 @@ const IncidentSplitFormIncident: FC<IncidentSplitFormIncidentProps> = ({
 
         return (
           <StyledFieldset key={`incident-splitform-incident-${id}`}>
-            <StyledGrid>
-              <StyledHeadingWrapper>
-                <StyledHeading
-                  forwardedAs="h2"
-                  data-testid="incident-split-form-incident-title"
-                >
-                  Deelmelding {subIncidentNumber}
-                </StyledHeading>
+            <StyledHeadingWrapper>
+              <StyledHeading
+                forwardedAs="h2"
+                data-testid="incident-split-form-incident-title"
+              >
+                Deelmelding {subIncidentNumber}
+              </StyledHeading>
 
-                {canRemoveIncident && (
-                  <RemoveButton
-                    icon={<TrashBin />}
-                    iconSize={16}
-                    onClick={(event) => removeSubIncident(event, id)}
-                    variant="application"
-                    aria-label="Verwijder deelmelding"
-                  />
-                )}
-              </StyledHeadingWrapper>
+              {canRemoveIncident && (
+                <RemoveButton
+                  icon={<TrashBin />}
+                  iconSize={16}
+                  onClick={(event) => removeSubIncident(event, id)}
+                  variant="application"
+                  aria-label="Verwijder deelmelding"
+                />
+              )}
+            </StyledHeadingWrapper>
+            <StyledGrid>
               {groups.length > 0 && options.length > 0 ? (
                 <Controller
                   name={`incidents.${id}.subcategory`}
@@ -136,7 +137,9 @@ const IncidentSplitFormIncident: FC<IncidentSplitFormIncidentProps> = ({
                   />
                 )}
               />
+            </StyledGrid>
 
+            <StyledGrid>
               <Controller
                 control={control}
                 defaultValue={parentIncident.priority}
@@ -177,7 +180,7 @@ const IncidentSplitFormIncident: FC<IncidentSplitFormIncidentProps> = ({
 
       {subIncidents.length <
         INCIDENT_SPLIT_LIMIT - parentIncident.childrenCount && (
-        <fieldset>
+        <StyledExtraIncidentButtonContainer>
           <Button
             data-testid="incident-split-form-incident-split-button"
             type="button"
@@ -186,7 +189,7 @@ const IncidentSplitFormIncident: FC<IncidentSplitFormIncidentProps> = ({
           >
             Extra deelmelding toevoegen
           </Button>
-        </fieldset>
+        </StyledExtraIncidentButtonContainer>
       )}
     </>
   )

--- a/src/signals/incident-management/containers/IncidentSplitContainer/styled.js
+++ b/src/signals/incident-management/containers/IncidentSplitContainer/styled.js
@@ -75,26 +75,22 @@ export const StyledLabel = styled(Label)`
 
 export const StyledMainContainer = styled.div`
   display: grid;
-  grid-column: span 7;
+  grid-column: span 1;
   row-gap: ${themeSpacing(8)};
 
-  @media screen and ${breakpoint('max-width', 'laptopM')} {
-    grid-column: span 10;
-  }
-
   @media screen and ${breakpoint('max-width', 'laptop')} {
-    grid-column: span 12;
+    grid-column: span 2;
   }
 `
 
 export const StyledButtonContainer = styled.div`
-  grid-column: span 7;
+  grid-column: span 1;
 `
 
 export const StyledFieldset = styled.fieldset`
   background-color: ${themeColor('tint', 'level3')};
   scroll-margin-top: ${themeSpacing(15)};
-  grid-column: span 12;
+  grid-column: span 2;
   padding: ${themeSpacing(5)};
   margin-inline: -${themeSpacing(5)};
   display: grid;
@@ -136,9 +132,12 @@ export const StyledInfoText = styled(InfoText)`
 
 export const StyledForm = styled.form`
   display: grid;
-  grid-row-gap: ${themeSpacing(8)};
-  grid-template-columns: repeat(12, 1fr);
   padding-top: ${themeSpacing(8)};
+
+  @media (min-width: ${({ theme }) => theme.layouts.large.max}px) {
+    column-gap: ${({ theme }) => theme.layouts.large.gutter}px;
+    grid-template-columns: 7fr 5fr;
+  }
 
   fieldset {
     padding-bottom: ${themeSpacing(8)};
@@ -153,7 +152,7 @@ export const StyledHeadingWrapper = styled.div`
 
 export const StyledExtraIncidentButtonContainer = styled.fieldset`
   border-bottom: 2px solid ${themeColor('tint', 'level3')};
-  grid-column: span 7;
+  grid-column: span 2;
 `
 
 export const RemoveButton = styled(Button)`

--- a/src/signals/incident-management/containers/IncidentSplitContainer/styled.js
+++ b/src/signals/incident-management/containers/IncidentSplitContainer/styled.js
@@ -4,6 +4,7 @@ import {
   Heading,
   Label,
   RadioGroup,
+  breakpoint,
   themeColor,
   themeSpacing,
 } from '@amsterdam/asc-ui'
@@ -22,17 +23,17 @@ export const StyledDefinitionList = styled.dl`
   grid-row-gap: 0;
   padding-bottom: ${themeSpacing(4)};
 
-  @media (min-width: ${({ theme }) => theme.layouts.medium.max}px) {
+  @media ${breakpoint('min-width', 'tabletM')} {
     grid-template-columns: 3fr 3fr;
   }
 
-  @media (min-width: ${({ theme }) => theme.layouts.large.min}px) {
+  @media ${breakpoint('min-width', 'laptop')} {
     grid-template-columns: 3fr 2fr;
   }
 
   dt,
   dd {
-    @media (min-width: ${({ theme }) => theme.layouts.medium.max}px) {
+    @media ${breakpoint('min-width', 'tabletM')} {
       padding: ${themeSpacing(2)} 0;
     }
   }
@@ -92,7 +93,7 @@ export const StyledFieldset = styled.fieldset`
   row-gap: ${themeSpacing(8)};
   margin-bottom: ${themeSpacing(8)};
 
-  @media (min-width: ${({ theme }) => theme.layouts.large.max}px) {
+  @media ${breakpoint('min-width', 'tabletM')} {
     column-gap: ${({ theme }) => theme.layouts.large.gutter}px;
     grid-column: span 2;
     grid-template-columns: 7fr 5fr;
@@ -112,7 +113,7 @@ export const StyledGrid = styled.div`
   display: grid;
   grid-row-gap: ${themeSpacing(8)};
 
-  @media (min-width: ${({ theme }) => theme.layouts.large.max}px) {
+  @media ${breakpoint('min-width', 'tabletM')} {
     grid-column: span 1;
   }
 `
@@ -133,7 +134,7 @@ export const StyledForm = styled.form`
   display: grid;
   padding-top: ${themeSpacing(8)};
 
-  @media (min-width: ${({ theme }) => theme.layouts.large.max}px) {
+  @media ${breakpoint('min-width', 'tabletM')} {
     column-gap: ${({ theme }) => theme.layouts.large.gutter}px;
     grid-template-columns: 7fr 5fr;
   }
@@ -143,7 +144,7 @@ export const StyledHeadingWrapper = styled.div`
   display: flex;
   justify-content: space-between;
 
-  @media (min-width: ${({ theme }) => theme.layouts.large.max}px) {
+  @media ${breakpoint('min-width', 'tabletM')} {
     grid-column: span 2;
   }
 `
@@ -153,7 +154,7 @@ export const StyledExtraIncidentButtonContainer = styled.fieldset`
   padding-bottom: ${themeSpacing(8)};
   margin-bottom: ${themeSpacing(2)};
 
-  @media (min-width: ${({ theme }) => theme.layouts.large.max}px) {
+  @media ${breakpoint('min-width', 'tabletM')} {
     grid-column: span 2;
   }
 `

--- a/src/signals/incident-management/containers/IncidentSplitContainer/styled.js
+++ b/src/signals/incident-management/containers/IncidentSplitContainer/styled.js
@@ -76,7 +76,7 @@ export const StyledLabel = styled(Label)`
 export const StyledMainContainer = styled.div`
   display: grid;
   grid-column: span 7;
-  row-gap: 32px;
+  row-gap: ${themeSpacing(8)};
 
   @media screen and ${breakpoint('max-width', 'laptopM')} {
     grid-column: span 10;
@@ -95,8 +95,8 @@ export const StyledFieldset = styled.fieldset`
   background-color: ${themeColor('tint', 'level3')};
   scroll-margin-top: ${themeSpacing(15)};
   grid-column: span 12;
-  padding: 20px;
-  margin-inline: -20px;
+  padding: ${themeSpacing(5)};
+  margin-inline: -${themeSpacing(5)};
   display: grid;
   column-gap: ${themeSpacing(16)};
   row-gap: ${themeSpacing(8)};

--- a/src/signals/incident-management/containers/IncidentSplitContainer/styled.js
+++ b/src/signals/incident-management/containers/IncidentSplitContainer/styled.js
@@ -146,7 +146,9 @@ export const StyledForm = styled.form`
 `
 
 export const StyledHeadingWrapper = styled.div`
+  display: flex;
   grid-column: span 2;
+  justify-content: space-between;
 `
 
 export const StyledExtraIncidentButtonContainer = styled.fieldset`

--- a/src/signals/incident-management/containers/IncidentSplitContainer/styled.js
+++ b/src/signals/incident-management/containers/IncidentSplitContainer/styled.js
@@ -6,7 +6,6 @@ import {
   RadioGroup,
   themeColor,
   themeSpacing,
-  breakpoint,
 } from '@amsterdam/asc-ui'
 import { Button } from '@amsterdam/asc-ui'
 import styled from 'styled-components'
@@ -77,10 +76,6 @@ export const StyledMainContainer = styled.div`
   display: grid;
   grid-column: span 1;
   row-gap: ${themeSpacing(8)};
-
-  @media screen and ${breakpoint('max-width', 'laptop')} {
-    grid-column: span 2;
-  }
 `
 
 export const StyledButtonContainer = styled.div`
@@ -90,13 +85,16 @@ export const StyledButtonContainer = styled.div`
 export const StyledFieldset = styled.fieldset`
   background-color: ${themeColor('tint', 'level3')};
   scroll-margin-top: ${themeSpacing(15)};
-  grid-column: span 2;
   padding: ${themeSpacing(5)};
   margin-inline: -${themeSpacing(5)};
   display: grid;
-  column-gap: ${themeSpacing(16)};
   row-gap: ${themeSpacing(8)};
-  grid-template-columns: 7fr 5fr;
+
+  @media (min-width: ${({ theme }) => theme.layouts.large.max}px) {
+    column-gap: ${({ theme }) => theme.layouts.large.gutter}px;
+    grid-column: span 2;
+    grid-template-columns: 7fr 5fr;
+  }
 `
 
 export const StyledHeading = styled(Heading)`
@@ -146,13 +144,19 @@ export const StyledForm = styled.form`
 
 export const StyledHeadingWrapper = styled.div`
   display: flex;
-  grid-column: span 2;
   justify-content: space-between;
+
+  @media (min-width: ${({ theme }) => theme.layouts.large.max}px) {
+    grid-column: span 2;
+  }
 `
 
 export const StyledExtraIncidentButtonContainer = styled.fieldset`
   border-bottom: 2px solid ${themeColor('tint', 'level3')};
-  grid-column: span 2;
+
+  @media (min-width: ${({ theme }) => theme.layouts.large.max}px) {
+    grid-column: span 2;
+  }
 `
 
 export const RemoveButton = styled(Button)`

--- a/src/signals/incident-management/containers/IncidentSplitContainer/styled.js
+++ b/src/signals/incident-management/containers/IncidentSplitContainer/styled.js
@@ -6,7 +6,6 @@ import {
   RadioGroup,
   themeColor,
   themeSpacing,
-  Row,
   breakpoint,
 } from '@amsterdam/asc-ui'
 import { Button } from '@amsterdam/asc-ui'
@@ -111,15 +110,6 @@ export const StyledHeading = styled(Heading)`
 export const StyledWrapper = styled.div`
   padding-top: ${themeSpacing(6)};
   padding-bottom: ${themeSpacing(6)};
-`
-
-export const FormWrapper = styled(Row)`
-  display: grid;
-
-  @media (min-width: ${({ theme }) => theme.layouts.large.max}px) {
-    column-gap: ${({ theme }) => theme.layouts.large.gutter}px;
-    grid-template-columns: 7fr 5fr;
-  }
 `
 
 export const StyledGrid = styled.div`

--- a/src/signals/incident-management/containers/IncidentSplitContainer/styled.js
+++ b/src/signals/incident-management/containers/IncidentSplitContainer/styled.js
@@ -76,6 +76,7 @@ export const StyledMainContainer = styled.div`
   display: grid;
   grid-column: span 1;
   row-gap: ${themeSpacing(8)};
+  padding-bottom: ${themeSpacing(8)};
 `
 
 export const StyledButtonContainer = styled.div`
@@ -89,6 +90,7 @@ export const StyledFieldset = styled.fieldset`
   margin-inline: -${themeSpacing(5)};
   display: grid;
   row-gap: ${themeSpacing(8)};
+  margin-bottom: ${themeSpacing(8)};
 
   @media (min-width: ${({ theme }) => theme.layouts.large.max}px) {
     column-gap: ${({ theme }) => theme.layouts.large.gutter}px;
@@ -109,10 +111,9 @@ export const StyledWrapper = styled.div`
 export const StyledGrid = styled.div`
   display: grid;
   grid-row-gap: ${themeSpacing(8)};
-  grid-column: span 2;
 
-  @media (min-width: ${({ theme }) => theme.layouts.medium.max}px) {
-    grid-column: auto;
+  @media (min-width: ${({ theme }) => theme.layouts.large.max}px) {
+    grid-column: span 1;
   }
 `
 
@@ -136,10 +137,6 @@ export const StyledForm = styled.form`
     column-gap: ${({ theme }) => theme.layouts.large.gutter}px;
     grid-template-columns: 7fr 5fr;
   }
-
-  fieldset {
-    padding-bottom: ${themeSpacing(8)};
-  }
 `
 
 export const StyledHeadingWrapper = styled.div`
@@ -153,6 +150,8 @@ export const StyledHeadingWrapper = styled.div`
 
 export const StyledExtraIncidentButtonContainer = styled.fieldset`
   border-bottom: 2px solid ${themeColor('tint', 'level3')};
+  padding-bottom: ${themeSpacing(8)};
+  margin-bottom: ${themeSpacing(2)};
 
   @media (min-width: ${({ theme }) => theme.layouts.large.max}px) {
     grid-column: span 2;

--- a/src/signals/incident-management/containers/IncidentSplitContainer/styled.js
+++ b/src/signals/incident-management/containers/IncidentSplitContainer/styled.js
@@ -7,6 +7,7 @@ import {
   themeColor,
   themeSpacing,
   Row,
+  breakpoint,
 } from '@amsterdam/asc-ui'
 import { Button } from '@amsterdam/asc-ui'
 import styled from 'styled-components'
@@ -73,8 +74,34 @@ export const StyledLabel = styled(Label)`
   }
 `
 
+export const StyledMainContainer = styled.div`
+  display: grid;
+  grid-column: span 7;
+  row-gap: 32px;
+
+  @media screen and ${breakpoint('max-width', 'laptopM')} {
+    grid-column: span 10;
+  }
+
+  @media screen and ${breakpoint('max-width', 'laptop')} {
+    grid-column: span 12;
+  }
+`
+
+export const StyledButtonContainer = styled.div`
+  grid-column: span 7;
+`
+
 export const StyledFieldset = styled.fieldset`
+  background-color: ${themeColor('tint', 'level3')};
   scroll-margin-top: ${themeSpacing(15)};
+  grid-column: span 12;
+  padding: 20px;
+  margin-inline: -20px;
+  display: grid;
+  column-gap: ${themeSpacing(16)};
+  row-gap: ${themeSpacing(8)};
+  grid-template-columns: 7fr 5fr;
 `
 
 export const StyledHeading = styled(Heading)`
@@ -98,6 +125,11 @@ export const FormWrapper = styled(Row)`
 export const StyledGrid = styled.div`
   display: grid;
   grid-row-gap: ${themeSpacing(8)};
+  grid-column: span 2;
+
+  @media (min-width: ${({ theme }) => theme.layouts.medium.max}px) {
+    grid-column: auto;
+  }
 `
 
 export const StyledSelect = styled.div`
@@ -113,23 +145,23 @@ export const StyledInfoText = styled(InfoText)`
 `
 
 export const StyledForm = styled.form`
-  padding-top: ${themeSpacing(8)};
-
   display: grid;
   grid-row-gap: ${themeSpacing(8)};
+  grid-template-columns: repeat(12, 1fr);
+  padding-top: ${themeSpacing(8)};
 
   fieldset {
-    padding: ${themeSpacing(0, 0, 8)};
-    position: relative;
-    border: 0;
-    border-bottom: 2px solid ${themeColor('tint', 'level3')};
-    margin: 0;
+    padding-bottom: ${themeSpacing(8)};
   }
 `
 
 export const StyledHeadingWrapper = styled.div`
-  display: flex;
-  justify-content: space-between;
+  grid-column: span 2;
+`
+
+export const StyledExtraIncidentButtonContainer = styled.fieldset`
+  border-bottom: 2px solid ${themeColor('tint', 'level3')};
+  grid-column: span 7;
 `
 
 export const RemoveButton = styled(Button)`

--- a/src/signals/incident-management/containers/IncidentSplitContainer/styled.js
+++ b/src/signals/incident-management/containers/IncidentSplitContainer/styled.js
@@ -149,7 +149,7 @@ export const StyledHeadingWrapper = styled.div`
   }
 `
 
-export const StyledExtraIncidentButtonContainer = styled.fieldset`
+export const StyledExtraIncidentButtonContainer = styled.div`
   border-bottom: 2px solid ${themeColor('tint', 'level3')};
   padding-bottom: ${themeSpacing(8)};
   margin-bottom: ${themeSpacing(2)};


### PR DESCRIPTION
Ticket: [SIG-5540](https://gemeente-amsterdam.atlassian.net/browse/SIG-5540)

To discuss:

- The styling file for the incident split components is outside of the components folder. What's the convention here?
- The 'Extra deelmelding toevoegen'-button is wrapped in a `fieldset`, that seems a little odd. It's not really a form section, right?
- Is there a reason not to use the ASC `breakpoint` utility? It's not used everywhere.

## Signalen

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)


[SIG-5540]: https://gemeente-amsterdam.atlassian.net/browse/SIG-5540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ