### PR TITLE
[feat-5589]: Add caterpillar to selectable objects

### DIFF
--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector_v2_removeafterfinishepic5440/WfsLayer/utils/map-data-to-selectable-feature.test.ts
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector_v2_removeafterfinishepic5440/WfsLayer/utils/map-data-to-selectable-feature.test.ts
@@ -4,11 +4,13 @@ import { mapDataToSelectableFeature } from './map-data-to-selectable-feature'
 import {
   mockContainerFeatureTypes,
   mockPublicLightsFeatureTypes,
+  mockCaterpillarFeatureTypes,
 } from './test/mock-feature-types'
 import {
   mockGlasContainer,
   mockPaperContainer,
   mockPublicLight,
+  mockCaterpillar,
 } from './test/mock-objects'
 
 describe('mapDataToSelectableFeature', () => {
@@ -49,6 +51,23 @@ describe('mapDataToSelectableFeature', () => {
         id: '000067',
         label: 'Overig lichtpunt - 000067',
         type: '4',
+      },
+    ])
+  })
+
+  it('should map caterpillar features to selectable features correctly', () => {
+    const selectableFeatures = mapDataToSelectableFeature(
+      [mockCaterpillar],
+      mockCaterpillarFeatureTypes
+    )
+
+    expect(selectableFeatures).toEqual([
+      {
+        id: 4108613,
+        type: 'Eikenboom',
+        description: 'Eikenboom',
+        coordinates: { lat: 52.38632248, lng: 4.87543579 },
+        label: 'Eikenboom - 4108613',
       },
     ])
   })

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector_v2_removeafterfinishepic5440/WfsLayer/utils/map-data-to-selectable-feature.ts
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector_v2_removeafterfinishepic5440/WfsLayer/utils/map-data-to-selectable-feature.ts
@@ -50,6 +50,21 @@ export const mapDataToSelectableFeature = (
           type: typeValue,
         }
       })
+    case FeatureTypes.CATERPILLAR:
+      return features.map((feature) => {
+        const { description, typeValue } = featureTypes[0]
+
+        const coordinates = featureToCoordinates(feature?.geometry as Geometrie)
+
+        return {
+          id: feature.id || '',
+          type: typeValue,
+          description,
+          coordinates,
+          label: [description, feature.id].filter(Boolean).join(' - '),
+        }
+      })
+
     default:
       return []
   }

--- a/src/signals/incident/components/form/MapSelectors/types.ts
+++ b/src/signals/incident/components/form/MapSelectors/types.ts
@@ -101,7 +101,7 @@ export enum FeatureTypes {
 export interface SelectableFeature {
   coordinates: LatLngLiteral
   description: string
-  id: string
+  id: string | number
   label: string
   type: string
   status?: any


### PR DESCRIPTION
Ticket: [SIG-5589](https://gemeente-amsterdam.atlassian.net/browse/SIG-5589)

Note:
- [this PR](https://github.com/Amsterdam/signals-frontend/pull/2794) fixes the issue that when an object has no address you does have coordinates you can still continue. Which is often the case for trees since they are in parks.


[SIG-5589]: https://gemeente-amsterdam.atlassian.net/browse/SIG-5589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ