### PR TITLE
[fix-5574] : autosuggest remove default value

### DIFF
--- a/src/components/AutoSuggest/AutoSuggest.test.tsx
+++ b/src/components/AutoSuggest/AutoSuggest.test.tsx
@@ -742,4 +742,18 @@ describe('src/components/AutoSuggest', () => {
 
     expect(onFocus).toHaveBeenCalled()
   })
+
+  describe('inline button', () => {
+    it('should render a search input icon', () => {
+      render(withAppContext(<AutoSuggest {...props} />))
+
+      expect(screen.getByTestId('search-input')).toBeInTheDocument()
+    })
+
+    it('should render a clear input', () => {
+      render(withAppContext(<AutoSuggest {...props} value="Dam" />))
+
+      expect(screen.getByTestId('clear-input')).toBeInTheDocument()
+    })
+  })
 })

--- a/src/components/AutoSuggest/AutoSuggest.tsx
+++ b/src/components/AutoSuggest/AutoSuggest.tsx
@@ -74,7 +74,7 @@ const AutoSuggest = ({
   showListChanged,
   ...rest
 }: AutoSuggestProps) => {
-  const [showClearButton, setShowClearButton] = useState(!!value)
+  const [showInlineButton, setShowInlineButton] = useState(!!value)
 
   const [data, setData] = useState<RevGeo>()
   const [initialRender, setInitialRender] = useState(false)
@@ -120,7 +120,7 @@ const AutoSuggest = ({
 
       setActiveIndex(-1)
       setShowList(false)
-      setShowClearButton(false)
+      setShowInlineButton(false)
       if (onClear) {
         onClear()
       }
@@ -249,7 +249,7 @@ const AutoSuggest = ({
   const onChange = useCallback(
     (event) => {
       event.persist()
-      setShowClearButton(true)
+      setShowInlineButton(true)
       debouncedServiceRequest(event.target.value)
     },
     [debouncedServiceRequest]
@@ -259,7 +259,7 @@ const AutoSuggest = ({
     (option) => {
       setActiveIndex(-1)
       setShowList(false)
-      setShowClearButton(true)
+      setShowInlineButton(true)
       if (inputRef.current) {
         inputRef.current.value = option.value
       }
@@ -374,7 +374,7 @@ const AutoSuggest = ({
           ref={inputRef}
           {...rest}
         />
-        {showClearButton ? (
+        {showInlineButton ? (
           <InlineButton
             aria-label="Input verwijderen"
             title="Verwijderen"

--- a/src/components/AutoSuggest/AutoSuggest.tsx
+++ b/src/components/AutoSuggest/AutoSuggest.tsx
@@ -13,7 +13,7 @@ import { getAuthHeaders } from 'shared/services/auth/auth'
 import type { PdokResponse } from 'shared/services/map-location'
 import type { RevGeo } from 'types/pdok/revgeo'
 
-import { Wrapper, Input, List, ClearInput } from './styled'
+import { Wrapper, Input, List, InlineButton } from './styled'
 
 export const INPUT_DELAY = 350
 
@@ -74,7 +74,8 @@ const AutoSuggest = ({
   showListChanged,
   ...rest
 }: AutoSuggestProps) => {
-  const [defaultValue, setDefaultValue] = useState(value)
+  const [showClearButton, setShowClearButton] = useState(!!value)
+
   const [data, setData] = useState<RevGeo>()
   const [initialRender, setInitialRender] = useState(false)
   const [showList, setShowList] = useState(false)
@@ -119,8 +120,7 @@ const AutoSuggest = ({
 
       setActiveIndex(-1)
       setShowList(false)
-      setDefaultValue('')
-
+      setShowClearButton(false)
       if (onClear) {
         onClear()
       }
@@ -249,7 +249,7 @@ const AutoSuggest = ({
   const onChange = useCallback(
     (event) => {
       event.persist()
-      setDefaultValue(event.target.value)
+      setShowClearButton(true)
       debouncedServiceRequest(event.target.value)
     },
     [debouncedServiceRequest]
@@ -259,8 +259,7 @@ const AutoSuggest = ({
     (option) => {
       setActiveIndex(-1)
       setShowList(false)
-      setDefaultValue(option.value)
-
+      setShowClearButton(true)
       if (inputRef.current) {
         inputRef.current.value = option.value
       }
@@ -375,8 +374,8 @@ const AutoSuggest = ({
           ref={inputRef}
           {...rest}
         />
-        {defaultValue || value ? (
-          <ClearInput
+        {showClearButton ? (
+          <InlineButton
             aria-label="Input verwijderen"
             title="Verwijderen"
             data-testid="clear-input"
@@ -387,7 +386,7 @@ const AutoSuggest = ({
             variant="blank"
           />
         ) : (
-          <ClearInput
+          <InlineButton
             aria-label="Zoeken"
             title="Zoeken"
             data-testid="search-input"

--- a/src/components/AutoSuggest/styled.tsx
+++ b/src/components/AutoSuggest/styled.tsx
@@ -35,7 +35,7 @@ export const List = styled(SuggestList)`
   z-index: 2;
 `
 
-export const ClearInput = styled(Button)`
+export const InlineButton = styled(Button)`
   position: absolute;
   top: 11px;
   right: 11px;


### PR DESCRIPTION
Ticket: [SIG-5574](https://gemeente-amsterdam.atlassian.net/browse/SIG-5574)

The name "default value" was actually used to show and hide the inline button. So changed it.

[SIG-5574]: https://gemeente-amsterdam.atlassian.net/browse/SIG-5574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ