### PR TITLE
[feat-5594]: Filter address allow free input

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "clean:all": "npm run analyze:clean && npm run test:clean && npm run build:clean",
     "clean": "shjs ./internals/scripts/clean.js",
     "format": "prettier --write .",
-    "lint:eslint": "NODE_ENV=production eslint",
+    "lint:eslint": "cross-env NODE_ENV=production eslint",
     "lint:js": "npm run lint:eslint -- . ",
     "lint:verbose": "npm run lint:eslint -- --format=mo . ",
     "lint:fix": "npm run lint:js -- --fix",

--- a/src/components/AutoSuggest/AutoSuggest.test.tsx
+++ b/src/components/AutoSuggest/AutoSuggest.test.tsx
@@ -743,6 +743,20 @@ describe('src/components/AutoSuggest', () => {
     expect(onFocus).toHaveBeenCalled()
   })
 
+  it('calls onChange when passed', () => {
+    const onChange = jest.fn()
+
+    render(withAppContext(<AutoSuggest {...props} onChange={onChange} />))
+
+    expect(onChange).not.toHaveBeenCalled()
+
+    const input = screen.getByRole('textbox')
+
+    userEvent.type(input, 'Rembrandt')
+
+    expect(onChange).toHaveBeenCalled()
+  })
+
   describe('inline button', () => {
     it('should render a search input icon', () => {
       render(withAppContext(<AutoSuggest {...props} />))

--- a/src/components/AutoSuggest/AutoSuggest.tsx
+++ b/src/components/AutoSuggest/AutoSuggest.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2020 - 2023 Gemeente Amsterdam
 import { useCallback, useEffect, useState, useRef, useMemo } from 'react'
+import type { ChangeEvent } from 'react'
 
 import { Close, Search } from '@amsterdam/asc-assets'
 import { useDispatch } from 'react-redux'
@@ -30,12 +31,14 @@ export interface AutoSuggestProps {
   id?: string
   includeAuthHeaders?: boolean
   numOptionsDeterminer: (data: any) => number
+  onChange?: (event: ChangeEvent<HTMLInputElement>) => void
   onClear?: () => void
   onData?: (optionsList: any) => void
   onFocus?: () => void
   onSelect: (option: PdokResponse) => void
   placeholder?: string
   showInlineList?: boolean
+  showNoResultFeedback?: boolean
   tabIndex?: number
   url: string
   showListChanged?: (value: boolean) => void
@@ -63,12 +66,14 @@ const AutoSuggest = ({
   id = '',
   includeAuthHeaders = false,
   numOptionsDeterminer,
+  onChange,
   onClear,
   onData,
   onFocus,
   onSelect,
   placeholder = '',
   showInlineList = true,
+  showNoResultFeedback = true,
   url,
   value = '',
   showListChanged,
@@ -246,14 +251,14 @@ const AutoSuggest = ({
 
   const debouncedServiceRequest = useDebounce(serviceRequest, INPUT_DELAY)
 
-  const onChange = useCallback(
-    (event) => {
-      event.persist()
-      setShowInlineButton(true)
-      debouncedServiceRequest(event.target.value)
-    },
-    [debouncedServiceRequest]
-  )
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    if (onChange) {
+      onChange(event)
+    }
+    event.persist()
+    setShowInlineButton(true)
+    debouncedServiceRequest(event.target.value)
+  }
 
   const onSelectOption = useCallback(
     (option) => {
@@ -341,10 +346,11 @@ const AutoSuggest = ({
           onSelectOption={onSelectOption}
           options={options}
           role="listbox"
+          showNoResultFeedback={showNoResultFeedback}
         />
       )) ||
       null,
-    [activeIndex, options, onSelectOption]
+    [activeIndex, options, onSelectOption, showNoResultFeedback]
   )
 
   useEffect(() => {
@@ -368,7 +374,7 @@ const AutoSuggest = ({
           autoComplete="off"
           disabled={disabled}
           id={id}
-          onChange={onChange}
+          onChange={handleChange}
           onFocus={onFocus}
           placeholder={placeholder}
           ref={inputRef}

--- a/src/components/AutoSuggest/components/SuggestList/SuggestList.test.tsx
+++ b/src/components/AutoSuggest/components/SuggestList/SuggestList.test.tsx
@@ -219,4 +219,38 @@ describe('src/components/AutoSuggest/components/SuggestList', () => {
       fireEvent(thirdItem, arrowUpEvent)
     }
   })
+
+  it('should show feedback on no results', () => {
+    const noResults: PdokResponse[] = []
+
+    render(
+      withAppContext(
+        <SuggestList options={noResults} onSelectOption={onSelectOption} />
+      )
+    )
+
+    const feedback = screen.getByRole('option', {
+      name: 'Wij kennen dit adres niet. Probeer het opnieuw.',
+    })
+
+    expect(feedback).toBeInTheDocument()
+  })
+
+  it('should not show feedback when showNoResultFeedback is passed', () => {
+    const noResults: PdokResponse[] = []
+
+    const { container } = render(
+      withAppContext(
+        <SuggestList
+          options={noResults}
+          onSelectOption={onSelectOption}
+          showNoResultFeedback={false}
+        />
+      )
+    )
+
+    const feedback = container.querySelector('option')
+
+    expect(feedback).not.toBeTruthy()
+  })
 })

--- a/src/components/AutoSuggest/components/SuggestList/SuggestList.tsx
+++ b/src/components/AutoSuggest/components/SuggestList/SuggestList.tsx
@@ -50,6 +50,7 @@ type SuggestListProps = {
   options: Array<PdokResponse>
   /** aria-role for the listbox element */
   role?: string
+  showNoResultFeedback?: boolean
 }
 
 const SuggestList: FC<SuggestListProps> = ({
@@ -59,6 +60,7 @@ const SuggestList: FC<SuggestListProps> = ({
   onSelectOption,
   options,
   role = 'listbox',
+  showNoResultFeedback = true,
   ...rest
 }) => {
   const listRef = useRef<HTMLUListElement>(null)
@@ -111,7 +113,7 @@ const SuggestList: FC<SuggestListProps> = ({
   /**
    * Give feedback when address cannot be found
    */
-  if (options.length === 0) {
+  if (options.length === 0 && showNoResultFeedback) {
     options = [
       {
         id: 'feedbackEmpty',

--- a/src/signals/incident-management/components/FilterForm/FilterForm.tsx
+++ b/src/signals/incident-management/components/FilterForm/FilterForm.tsx
@@ -11,6 +11,7 @@ import {
   useState,
   useRef,
 } from 'react'
+import type { ChangeEvent } from 'react'
 
 import { Label as AscLabel } from '@amsterdam/asc-ui'
 import cloneDeep from 'lodash/cloneDeep'
@@ -304,6 +305,10 @@ const FilterForm = ({
     },
     [dispatch]
   )
+
+  const onAddressChange = (event: ChangeEvent<HTMLInputElement>) => {
+    dispatch(setAddress(event.target.value))
+  }
 
   const onAddressSelect = useCallback(
     (response: PdokResponse) => {
@@ -642,11 +647,13 @@ const FilterForm = ({
             <PDOKAutoSuggest
               id="filter_address"
               municipality={configuration.map?.municipality}
+              onChange={onAddressChange}
               onSelect={onAddressSelect}
               onClear={onAddressClear}
               placeholder="Zoek op straatnaam"
               value={state.options.address_text}
               streetNameOnly
+              showNoResultFeedback={false}
             />
           </FilterGroup>
 


### PR DESCRIPTION
Ticket: [SIG-5594](https://gemeente-amsterdam.atlassian.net/browse/SIG-5594)

This PR exposed the `onChange` event of `AutoSuggest`, to be able to use the contents of its `input` as a filter, instead of only the PDOK response. 

It also adds a `showNoResultFeedback` toggle to `AutoSuggest`, to be able to toggle whether you get feedback when there are no results. 

## Signalen

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)


[SIG-1234]: https://gemeente-amsterdam.atlassian.net/browse/SIG-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[SIG-5594]: https://gemeente-amsterdam.atlassian.net/browse/SIG-5594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ