### PR TITLE
[fix-5587]: Pass labels as props

### DIFF
--- a/src/components/AddNote/AddNote.test.tsx
+++ b/src/components/AddNote/AddNote.test.tsx
@@ -70,11 +70,16 @@ describe('AddNote', () => {
   })
 
   it('focuses the textarea', async () => {
-    const { unmount, rerender } = render(withAppContext(<AddNote />))
+    const { unmount, rerender } = render(
+      withAppContext(<AddNote label="Test label" />)
+    )
 
     // no ref, no focus
     userEvent.click(screen.getByTestId('add-note-new-note-button'))
     expect(screen.getByRole('textbox')).not.toHaveFocus()
+    expect(
+      screen.getByRole('textbox', { name: 'Test label' })
+    ).toBeInTheDocument()
 
     unmount()
 

--- a/src/components/AddNote/AddNote.tsx
+++ b/src/components/AddNote/AddNote.tsx
@@ -132,6 +132,7 @@ const AddNote = forwardRef<HTMLTextAreaElement, AddNoteProps>(
           onChange={onChange}
           ref={ref}
           rows={rows}
+          label={label}
           value={value || ''}
           {...rest}
         />

--- a/src/components/TextArea/TextArea.tsx
+++ b/src/components/TextArea/TextArea.tsx
@@ -74,11 +74,7 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
 
     return (
       <ErrorWrapper invalid={Boolean(errorMessage)}>
-        {label && (
-          <Label inline htmlFor={id}>
-            {label}
-          </Label>
-        )}
+        {label && <Label htmlFor={id}>{label}</Label>}
 
         <div role="status">
           {errorMessage && (


### PR DESCRIPTION
Ticket: [SIG-5587](https://gemeente-amsterdam.atlassian.net/browse/SIG-5587)

note: remove inline does not impact other use cases since label is often not used or it is overwritten by html.

[SIG-5587]: https://gemeente-amsterdam.atlassian.net/browse/SIG-5587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ