### PR TITLE
[fix]: Fix api key bug

### DIFF
--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/WfsLayer.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/WfsLayer.test.tsx
@@ -11,6 +11,7 @@ import type { MapOptions } from 'leaflet'
 
 import MAP_OPTIONS from 'shared/services/configuration/map-options'
 import assetsJson from 'utils/__tests__/fixtures/assets.json'
+import configuration from 'shared/services/configuration/configuration'
 
 import WfsDataContext, { NO_DATA } from './context'
 import WfsLayer from './index'
@@ -22,6 +23,7 @@ import { AssetSelectProvider } from '../../context'
 import type { AssetSelectValue } from '../../types'
 
 const fetchMock = fetch as FetchMock
+jest.mock('shared/services/configuration/configuration')
 
 const options = {
   ...MAP_OPTIONS,
@@ -66,6 +68,9 @@ describe('src/signals/incident/components/form/AssetSelect/WfsLayer', () => {
   afterEach(() => {
     consoleErrorSpy.mockClear()
     jest.resetAllMocks()
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    configuration.__reset()
   })
 
   it('should not render when outside zoom level does not allow it', () => {
@@ -268,5 +273,35 @@ describe('src/signals/incident/components/form/AssetSelect/WfsLayer', () => {
       expect.objectContaining({})
     )
     await act(() => promise)
+  })
+
+  it('should not set x-api-key header by default', async () => {
+    render(
+      withMapAsset(
+        <AssetSelectProvider value={assetSelectProviderValue}>
+          <WfsLayer>
+            <TestLayer />
+          </WfsLayer>
+        </AssetSelectProvider>
+      )
+    )
+
+    expect(fetchMock.mock.lastCall[1]?.headers).toBeFalsy()
+  })
+
+  it('should only set x-api-key header when keys.dataPlatform is filled in the config', async () => {
+    configuration.map.keys.dataPlatform = '1234'
+
+    render(
+      withMapAsset(
+        <AssetSelectProvider value={assetSelectProviderValue}>
+          <WfsLayer>
+            <TestLayer />
+          </WfsLayer>
+        </AssetSelectProvider>
+      )
+    )
+
+    expect(fetchMock.mock.lastCall[1]?.headers).toEqual({ 'X-Api-Key': '1234' })
   })
 })

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/WfsLayer.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/WfsLayer.test.tsx
@@ -9,9 +9,9 @@ import type { FeatureCollection } from 'geojson'
 import type { FetchMock } from 'jest-fetch-mock'
 import type { MapOptions } from 'leaflet'
 
+import configuration from 'shared/services/configuration/configuration'
 import MAP_OPTIONS from 'shared/services/configuration/map-options'
 import assetsJson from 'utils/__tests__/fixtures/assets.json'
-import configuration from 'shared/services/configuration/configuration'
 
 import WfsDataContext, { NO_DATA } from './context'
 import WfsLayer from './index'
@@ -275,7 +275,7 @@ describe('src/signals/incident/components/form/AssetSelect/WfsLayer', () => {
     await act(() => promise)
   })
 
-  it('should not set x-api-key header by default', async () => {
+  it('should not set x-api-key header by default', () => {
     render(
       withMapAsset(
         <AssetSelectProvider value={assetSelectProviderValue}>
@@ -289,7 +289,7 @@ describe('src/signals/incident/components/form/AssetSelect/WfsLayer', () => {
     expect(fetchMock.mock.lastCall[1]?.headers).toBeFalsy()
   })
 
-  it('should only set x-api-key header when keys.dataPlatform is filled in the config', async () => {
+  it('should only set x-api-key header when keys.dataPlatform is filled in the config', () => {
     configuration.map.keys.dataPlatform = '1234'
 
     render(

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/WfsLayer.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/WfsLayer.tsx
@@ -72,9 +72,14 @@ const WfsLayer: FunctionComponent<WfsLayerProps> = ({
       params.append('filter', filter)
     }
 
-    const { request, controller } = fetchWithAbort(url.toString(), {
-      headers: { 'X-Api-Key': configuration.map.keys.dataPlatform },
-    })
+    const { request, controller } = fetchWithAbort(
+      url.toString(),
+      configuration.map.keys.dataPlatform
+        ? {
+            headers: { 'X-Api-Key': configuration.map.keys.dataPlatform },
+          }
+        : undefined
+    )
 
     request
       .then(async (result) => result.json())


### PR DESCRIPTION
Always setting an X-Api-Key header for WFS layer fetches causes issues for Den Bosch.

See mail 'Koppeling met MOON kapot na nieuwe versie' on 29-1-2024.

This PR makes sure that we're only setting a header when X-Api-Key is defined in the config. 