### PR TITLE
[fix]: Fix date time question

### DIFF
--- a/src/signals/incident/components/IncidentForm/index.tsx
+++ b/src/signals/incident/components/IncidentForm/index.tsx
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2018 - 2023 Gemeente Amsterdam
+// Copyright (C) 2018 - 2024 Gemeente Amsterdam
 import type { BaseSyntheticEvent, ForwardedRef } from 'react'
 import {
   useState,

--- a/src/signals/incident/components/IncidentForm/index.tsx
+++ b/src/signals/incident/components/IncidentForm/index.tsx
@@ -258,7 +258,6 @@ const IncidentForm = forwardRef<any, any>(
                     key={key}
                     name={value.meta?.name || 'hidden'}
                     control={reactHookFormProps.control}
-                    defaultValue={null}
                     render={({ field: { value: v, onChange } }) => {
                       return (
                         <value.render

--- a/src/signals/incident/components/form/DateTimeInput/DateTime.test.tsx
+++ b/src/signals/incident/components/form/DateTimeInput/DateTime.test.tsx
@@ -39,7 +39,7 @@ describe('DateTime', () => {
     render(withAppContext(<DateTime {...props} />))
 
     expect(screen.getAllByRole('radio')).toHaveLength(2)
-    expect(screen.getByLabelText('Nu')).not.toBeChecked()
+    expect(screen.getByLabelText('Nu')).toBeChecked()
   })
 
   it('renders more options', () => {

--- a/src/signals/incident/components/form/DateTimeInput/DateTime.tsx
+++ b/src/signals/incident/components/form/DateTimeInput/DateTime.tsx
@@ -109,7 +109,6 @@ const DateTime: FC<DateTimeProps> = ({
   )
 
   function getDateIndication(value: Incident['timestamp']): DateIndication {
-    if (!value) return ''
     return dateIndicationValue[typeof value]
   }
 

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/overlast-bedrijven-en-horeca.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/overlast-bedrijven-en-horeca.ts
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2018 - 2024 Gemeente Amsterdam
-import {
-  falsyOrNumber,
-  inPast,
-} from 'signals/incident/services/custom-validators'
+import { inPast } from 'signals/incident/services/custom-validators'
+import { nullOrNumber } from 'signals/incident/services/custom-validators/custom-validators'
 import { QuestionFieldType } from 'types/question'
 
 import locatie from './locatie'
@@ -19,7 +17,7 @@ const overlastBedrijvenEnHoreca = {
       timeSelectorDisabled: true,
     },
     options: {
-      validators: [falsyOrNumber, inPast, 'required'],
+      validators: [nullOrNumber(), inPast],
     },
     render: QuestionFieldType.DateTimeInput,
   },

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/overlast-bedrijven-en-horeca.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/overlast-bedrijven-en-horeca.ts
@@ -11,7 +11,16 @@ const overlastBedrijvenEnHoreca = {
 
   dateTime: {
     meta: {
-      ignoreVisibility: true,
+      ifOneOf: {
+        subcategory: [
+          'geluidsoverlast-installaties',
+          'geluidsoverlast-muziek',
+          'overig-horecabedrijven',
+          'overlast-terrassen',
+          'stankoverlast',
+        ],
+      },
+      // ignoreVisibility: true,
       label: 'Wanneer heeft u de overlast?',
       canBeNull: true,
       timeSelectorDisabled: true,
@@ -26,6 +35,15 @@ const overlastBedrijvenEnHoreca = {
 
   extra_bedrijven_horeca_frequentie: {
     meta: {
+      ifOneOf: {
+        subcategory: [
+          'geluidsoverlast-installaties',
+          'geluidsoverlast-muziek',
+          'overig-horecabedrijven',
+          'overlast-terrassen',
+          'stankoverlast',
+        ],
+      },
       values: {
         ja: 'Ja, het gebeurt vaker',
         nee: 'Nee, het is de eerste keer',
@@ -52,6 +70,15 @@ const overlastBedrijvenEnHoreca = {
 
   extra_bedrijven_horeca_wat: {
     meta: {
+      ifOneOf: {
+        subcategory: [
+          'geluidsoverlast-installaties',
+          'geluidsoverlast-muziek',
+          'overig-horecabedrijven',
+          'overlast-terrassen',
+          'stankoverlast',
+        ],
+      },
       label: 'Uw melding gaat over:',
       shortLabel: 'Soort bedrijf',
       pathMerge: 'extra_properties',
@@ -107,6 +134,15 @@ const overlastBedrijvenEnHoreca = {
 
   extra_bedrijven_horeca_adres: {
     meta: {
+      ifOneOf: {
+        subcategory: [
+          'geluidsoverlast-installaties',
+          'geluidsoverlast-muziek',
+          'overig-horecabedrijven',
+          'overlast-terrassen',
+          'stankoverlast',
+        ],
+      },
       label:
         'In welk gebouw of woning heeft u de overlast? Vul alstublieft het adres in.',
       shortLabel: 'Adres overlast',

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/overlast-bedrijven-en-horeca.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/overlast-bedrijven-en-horeca.ts
@@ -20,7 +20,6 @@ const overlastBedrijvenEnHoreca = {
           'stankoverlast',
         ],
       },
-      // ignoreVisibility: true,
       label: 'Wanneer heeft u de overlast?',
       canBeNull: true,
       timeSelectorDisabled: true,
@@ -30,8 +29,6 @@ const overlastBedrijvenEnHoreca = {
     },
     render: QuestionFieldType.DateTimeInput,
   },
-
-  /** General */
 
   extra_bedrijven_horeca_frequentie: {
     meta: {

--- a/src/signals/incident/services/custom-validators/custom-validators.test.ts
+++ b/src/signals/incident/services/custom-validators/custom-validators.test.ts
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2018 - 2023 Gemeente Amsterdam
+// Copyright (C) 2018 - 2024 Gemeente Amsterdam
 import {
   falsyOrNumber,
   inPast,
+  nullOrNumber,
   validateObjectLocation,
   validatePhoneNumber,
 } from '.'
@@ -121,6 +122,25 @@ describe('The custom validators service', () => {
       expect(inPast(inputLaterThanNow)).toStrictEqual({
         custom: `Vul een tijdstip uit het verleden in`,
       })
+    })
+  })
+
+  describe('nullOrNumber', () => {
+    it('returns a function', () => {
+      expect(nullOrNumber).toBeInstanceOf(Function)
+    })
+
+    it('evaluates null values', () => {
+      const inputNull = {
+        value: null,
+      }
+
+      const inputNumber = {
+        value: 1234567890,
+      }
+
+      expect(nullOrNumber()(inputNull)).toBeNull()
+      expect(nullOrNumber()(inputNumber)).toBeNull()
     })
   })
 })

--- a/src/signals/incident/services/custom-validators/custom-validators.ts
+++ b/src/signals/incident/services/custom-validators/custom-validators.ts
@@ -29,6 +29,21 @@ export const falsyOrNumber = (control: Control<any>) => {
   }
 }
 
+export const nullOrNumber = (message = 'Dit is een verplicht veld') =>
+  function required(control: Control<any>) {
+    if (
+      !control ||
+      typeof control.value === 'number' ||
+      control.value === null
+    ) {
+      return null
+    }
+
+    return {
+      required: message,
+    }
+  }
+
 export const inPast = (control: Control<number>) => {
   const newDate = new Date()
 

--- a/src/signals/incident/services/custom-validators/custom-validators.ts
+++ b/src/signals/incident/services/custom-validators/custom-validators.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MPL-2.0
-// Copyright (C) 2018 - 2023 Gemeente Amsterdam
+// Copyright (C) 2018 - 2024 Gemeente Amsterdam
 type Control<T> = {
   value: T
 }

--- a/src/signals/incident/services/custom-validators/index.ts
+++ b/src/signals/incident/services/custom-validators/index.ts
@@ -2,6 +2,7 @@ export {
   falsyOrNumber,
   inPast,
   isBlocking,
+  nullOrNumber,
   validateObjectLocation,
   validatePhoneNumber,
 } from './custom-validators'


### PR DESCRIPTION
Ticket: none

- since a default value of `null` was added to the incidentForm field, the required logic of DateTImeInput didn't work anymore. Brought in back the old code when it was working.
- A new subcategory is added in the main category "Bedrijven en horeca" which did not need the general questions. So specified them for the subcategories that need them.