### PR TITLE
[fix]: Make possible to make dateTime required

### DIFF
--- a/src/signals/incident/components/IncidentPreview/IncidentPreview.test.tsx
+++ b/src/signals/incident/components/IncidentPreview/IncidentPreview.test.tsx
@@ -24,7 +24,7 @@ jest.mock('react-router-dom', () => ({
 
 const incident = {
   ...mock,
-  dateTime: null,
+  dateTime: 'now',
 }
 
 describe('<IncidentPreview />', () => {

--- a/src/signals/incident/components/IncidentPreview/components/DateTime/DateTime.tsx
+++ b/src/signals/incident/components/IncidentPreview/components/DateTime/DateTime.tsx
@@ -19,7 +19,7 @@ const getValue = (
   value: Incident['timestamp'],
   incident?: Incident
 ): DateTimeValue => {
-  if (value === null) {
+  if (value === 'now') {
     return 'Nu'
   }
 

--- a/src/signals/incident/components/IncidentPreview/components/DateTime/DateTimes.test.tsx
+++ b/src/signals/incident/components/IncidentPreview/components/DateTime/DateTimes.test.tsx
@@ -22,7 +22,7 @@ describe('DateTime', () => {
   })
 
   it('renders Nu', () => {
-    render(<DateTime value={null} />)
+    render(<DateTime value={'now'} />)
 
     expect(screen.getByTestId('preview-date-time')).toHaveTextContent('Nu')
   })

--- a/src/signals/incident/components/form/DateTimeInput/DateTime.test.tsx
+++ b/src/signals/incident/components/form/DateTimeInput/DateTime.test.tsx
@@ -13,7 +13,7 @@ import DateTime, {
 const onUpdate = jest.fn()
 const props = {
   onUpdate,
-  value: null,
+  value: 'now',
 }
 
 describe('DateTime', () => {
@@ -35,7 +35,7 @@ describe('DateTime', () => {
     expect(screen.getByLabelText('Eerder')).not.toBeChecked()
   })
 
-  it('renders when value is null', () => {
+  it('renders when value is now', () => {
     render(withAppContext(<DateTime {...props} />))
 
     expect(screen.getAllByRole('radio')).toHaveLength(2)
@@ -109,7 +109,7 @@ describe('DateTime', () => {
     userEvent.click(screen.getByLabelText('Nu'))
 
     expect(onUpdate).toHaveBeenCalledTimes(2)
-    expect(onUpdate).toHaveBeenLastCalledWith(null)
+    expect(onUpdate).toHaveBeenLastCalledWith('now')
   })
 
   it('calls onUpdate on selecting day', () => {

--- a/src/signals/incident/components/form/DateTimeInput/DateTime.tsx
+++ b/src/signals/incident/components/form/DateTimeInput/DateTime.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useState } from 'react'
 import type { FC } from 'react'
 
 import { Label, RadioGroup } from '@amsterdam/asc-ui'
@@ -91,7 +91,7 @@ type DateIndication = DateIndicator['id'] | ''
 
 const dateIndicationValue: Record<string, DateIndication> = {
   undefined: '',
-  object: 'now',
+  now: 'now',
   number: 'earlier',
 }
 
@@ -101,7 +101,7 @@ const DateTime: FC<DateTimeProps> = ({
   timeSelectorDisabled = false,
 }) => {
   const [datetime, setDatetime] = useState(
-    value ? new Date(value) : defaultTimestamp
+    value && value !== 'now' ? new Date(value) : defaultTimestamp
   )
 
   const [dateIndication, setDateIndication] = useState<DateIndication>(
@@ -109,7 +109,9 @@ const DateTime: FC<DateTimeProps> = ({
   )
 
   function getDateIndication(value: Incident['timestamp']): DateIndication {
-    return dateIndicationValue[typeof value]
+    return typeof value === 'number'
+      ? dateIndicationValue['number']
+      : dateIndicationValue[value]
   }
 
   const updateTimestamp = useCallback(
@@ -156,7 +158,7 @@ const DateTime: FC<DateTimeProps> = ({
         cloned.setSeconds(0)
 
         setDatetime(cloned)
-        onUpdate(null)
+        onUpdate('now')
       } else {
         setDatetime(defaultTimestamp)
         onUpdate(defaultTimestamp.getTime())
@@ -165,9 +167,6 @@ const DateTime: FC<DateTimeProps> = ({
     [onUpdate]
   )
 
-  useEffect(() => {
-    setDateIndication(getDateIndication(value))
-  }, [value])
   return (
     <>
       <RadioGroup>

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/afval.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/afval.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2018 - 2023 Gemeente Amsterdam
 import {
-  falsyOrNumber,
+  falsyOrNumberOrNow,
   inPast,
 } from 'signals/incident/services/custom-validators'
 import { QuestionFieldType } from 'types/question'
@@ -20,7 +20,7 @@ export const controls = {
       canBeNull: true,
     },
     options: {
-      validators: [falsyOrNumber, inPast],
+      validators: [falsyOrNumberOrNow, inPast],
     },
     render: QuestionFieldType.DateTimeInput,
   },

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/dateTime.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/dateTime.ts
@@ -1,5 +1,5 @@
 import {
-  falsyOrNumber,
+  falsyOrNumberOrNow,
   inPast,
 } from 'signals/incident/services/custom-validators'
 import { QuestionFieldType } from 'types/question'
@@ -11,7 +11,7 @@ const dateTime = {
     canBeNull: true,
   },
   options: {
-    validators: [falsyOrNumber, inPast],
+    validators: [falsyOrNumberOrNow, inPast],
   },
   render: QuestionFieldType.DateTimeInput,
 }

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/overlast-bedrijven-en-horeca.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/overlast-bedrijven-en-horeca.ts
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2018 - 2024 Gemeente Amsterdam
 import { inPast } from 'signals/incident/services/custom-validators'
-import { nullOrNumber } from 'signals/incident/services/custom-validators/custom-validators'
 import { QuestionFieldType } from 'types/question'
 
 import locatie from './locatie'
@@ -25,7 +24,7 @@ const overlastBedrijvenEnHoreca = {
       timeSelectorDisabled: true,
     },
     options: {
-      validators: [nullOrNumber(), inPast],
+      validators: [inPast, 'required'],
     },
     render: QuestionFieldType.DateTimeInput,
   },

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/overlast-op-het-water.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/overlast-op-het-water.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2021 - 2023 Gemeente Amsterdam
 import {
-  falsyOrNumber,
+  falsyOrNumberOrNow,
   inPast,
 } from 'signals/incident/services/custom-validators'
 import { QuestionFieldType } from 'types/question'
@@ -27,7 +27,7 @@ export const overlastOpHetWater = {
       canBeNull: true,
     },
     options: {
-      validators: [falsyOrNumber, inPast],
+      validators: [falsyOrNumberOrNow, inPast],
     },
     render: QuestionFieldType.DateTimeInput,
   },

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/overlast-van-en-door-personen-of-groepen.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/overlast-van-en-door-personen-of-groepen.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2018 - 2023 Gemeente Amsterdam
 import {
-  falsyOrNumber,
+  falsyOrNumberOrNow,
   inPast,
 } from 'signals/incident/services/custom-validators'
 import { QuestionFieldType } from 'types/question'
@@ -28,7 +28,7 @@ export const overlastPersonenEnGroepen = {
       canBeNull: true,
     },
     options: {
-      validators: [falsyOrNumber, inPast],
+      validators: [falsyOrNumberOrNow, inPast],
     },
     render: QuestionFieldType.DateTimeInput,
   },

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/wegen-verkeer-straatmeubilair.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/wegen-verkeer-straatmeubilair.ts
@@ -2,7 +2,7 @@
 // Copyright (C) 2018 - 2023 Gemeente Amsterdam
 import appConfiguration from 'shared/services/configuration/configuration'
 import {
-  falsyOrNumber,
+  falsyOrNumberOrNow,
   inPast,
 } from 'signals/incident/services/custom-validators'
 import { QuestionFieldType } from 'types/question'
@@ -26,7 +26,7 @@ export const wegenVerkeerStraatmeubilair = {
       canBeNull: true,
     },
     options: {
-      validators: [falsyOrNumber, inPast],
+      validators: [falsyOrNumberOrNow, inPast],
     },
     render: QuestionFieldType.DateTimeInput,
   },

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/wonen-leegstand.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/wonen-leegstand.ts
@@ -1,5 +1,5 @@
 import { QuestionFieldType } from '../../../../types/question'
-import { falsyOrNumber, inPast } from '../../services/custom-validators'
+import { falsyOrNumberOrNow, inPast } from '../../services/custom-validators'
 
 export const leegstand = {
   leegstand_dateTime: {
@@ -11,7 +11,7 @@ export const leegstand = {
       label: 'Wanneer was het?',
     },
     options: {
-      validators: [falsyOrNumber, inPast],
+      validators: [falsyOrNumberOrNow, inPast],
     },
     render: QuestionFieldType.DateTimeInput,
   },

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/wonen-onderhuur.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/wonen-onderhuur.ts
@@ -1,5 +1,5 @@
 import { QuestionFieldType } from '../../../../types/question'
-import { falsyOrNumber, inPast } from '../../services/custom-validators'
+import { falsyOrNumberOrNow, inPast } from '../../services/custom-validators'
 
 export const onderhuur = {
   onderhuur_dateTime: {
@@ -11,7 +11,7 @@ export const onderhuur = {
       label: 'Wanneer was het?',
     },
     options: {
-      validators: [falsyOrNumber, inPast],
+      validators: [falsyOrNumberOrNow, inPast],
     },
     render: QuestionFieldType.DateTimeInput,
   },

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/wonen-vakantieverhuur.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/wonen-vakantieverhuur.ts
@@ -1,6 +1,6 @@
 import configuration from '../../../../shared/services/configuration/configuration'
 import { QuestionFieldType } from '../../../../types/question'
-import { falsyOrNumber, inPast } from '../../services/custom-validators'
+import { falsyOrNumberOrNow, inPast } from '../../services/custom-validators'
 
 export const vakantieverhuur = {
   vakantieverhuur_dateTime: {
@@ -12,7 +12,7 @@ export const vakantieverhuur = {
       label: 'Wanneer was het?',
     },
     options: {
-      validators: [falsyOrNumber, inPast],
+      validators: [falsyOrNumberOrNow, inPast],
     },
     render: QuestionFieldType.DateTimeInput,
   },

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/wonen-woningdelen.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/wonen-woningdelen.ts
@@ -1,5 +1,5 @@
 import { QuestionFieldType } from '../../../../types/question'
-import { falsyOrNumber, inPast } from '../../services/custom-validators'
+import { falsyOrNumberOrNow, inPast } from '../../services/custom-validators'
 
 export const woningdelen = {
   woningdelen_dateTime: {
@@ -11,7 +11,7 @@ export const woningdelen = {
       label: 'Wanneer was het?',
     },
     options: {
-      validators: [falsyOrNumber, inPast],
+      validators: [falsyOrNumberOrNow, inPast],
     },
     render: QuestionFieldType.DateTimeInput,
   },

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/wonen-woningkwaliteit.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/wonen-woningkwaliteit.ts
@@ -1,5 +1,5 @@
 import { QuestionFieldType } from '../../../../types/question'
-import { falsyOrNumber, inPast } from '../../services/custom-validators'
+import { falsyOrNumberOrNow, inPast } from '../../services/custom-validators'
 
 export const woningkwaliteit = {
   woningkwaliteit_dateTime: {
@@ -11,7 +11,7 @@ export const woningkwaliteit = {
       label: 'Wanneer was het?',
     },
     options: {
-      validators: [falsyOrNumber, inPast],
+      validators: [falsyOrNumberOrNow, inPast],
     },
     render: QuestionFieldType.DateTimeInput,
   },

--- a/src/signals/incident/services/custom-validators/custom-validators.test.ts
+++ b/src/signals/incident/services/custom-validators/custom-validators.test.ts
@@ -1,9 +1,8 @@
 // SPDX-License-Identifier: MPL-2.0
 // Copyright (C) 2018 - 2024 Gemeente Amsterdam
 import {
-  falsyOrNumber,
+  falsyOrNumberOrNow,
   inPast,
-  nullOrNumber,
   validateObjectLocation,
   validatePhoneNumber,
 } from '.'
@@ -79,9 +78,9 @@ describe('The custom validators service', () => {
     })
   })
 
-  describe('falsyOrNumber', () => {
+  describe('falsyOrNumberOrNow', () => {
     it('returns a function', () => {
-      expect(falsyOrNumber).toBeInstanceOf(Function)
+      expect(falsyOrNumberOrNow).toBeInstanceOf(Function)
     })
 
     it('evaluates null values', () => {
@@ -98,10 +97,10 @@ describe('The custom validators service', () => {
         value: 'ajksdlfjlk',
       }
 
-      expect(falsyOrNumber(inputNull)).toBeNull()
-      expect(falsyOrNumber(inputUndefined)).toBeNull()
-      expect(falsyOrNumber(inputNumber)).toBeNull()
-      expect(falsyOrNumber(invalidInputNumber)).not.toBeNull()
+      expect(falsyOrNumberOrNow(inputNull)).toBeNull()
+      expect(falsyOrNumberOrNow(inputUndefined)).toBeNull()
+      expect(falsyOrNumberOrNow(inputNumber)).toBeNull()
+      expect(falsyOrNumberOrNow(invalidInputNumber)).not.toBeNull()
     })
   })
   describe('inPast', () => {
@@ -122,25 +121,6 @@ describe('The custom validators service', () => {
       expect(inPast(inputLaterThanNow)).toStrictEqual({
         custom: `Vul een tijdstip uit het verleden in`,
       })
-    })
-  })
-
-  describe('nullOrNumber', () => {
-    it('returns a function', () => {
-      expect(nullOrNumber).toBeInstanceOf(Function)
-    })
-
-    it('evaluates null values', () => {
-      const inputNull = {
-        value: null,
-      }
-
-      const inputNumber = {
-        value: 1234567890,
-      }
-
-      expect(nullOrNumber()(inputNull)).toBeNull()
-      expect(nullOrNumber()(inputNumber)).toBeNull()
     })
   })
 })

--- a/src/signals/incident/services/custom-validators/custom-validators.ts
+++ b/src/signals/incident/services/custom-validators/custom-validators.ts
@@ -20,8 +20,12 @@ export const validatePhoneNumber = (control?: Control<any>) => {
   }
 }
 
-export const falsyOrNumber = (control: Control<any>) => {
-  if (typeof control.value === 'number' || !control.value) {
+export const falsyOrNumberOrNow = (control: Control<any>) => {
+  if (
+    typeof control.value === 'number' ||
+    !control.value ||
+    control.value === 'now'
+  ) {
     return null
   }
   return {
@@ -29,25 +33,16 @@ export const falsyOrNumber = (control: Control<any>) => {
   }
 }
 
-export const nullOrNumber = (message = 'Dit is een verplicht veld') =>
-  function required(control: Control<any>) {
-    if (
-      !control ||
-      typeof control.value === 'number' ||
-      control.value === null
-    ) {
-      return null
-    }
-
-    return {
-      required: message,
-    }
-  }
-
-export const inPast = (control: Control<number>) => {
+export const inPast = (control: Control<number | string>) => {
   const newDate = new Date()
 
-  if (!control.value || control.value <= newDate.getTime()) return null
+  if (
+    !control.value ||
+    control.value === 'now' ||
+    control.value === null ||
+    (control.value as number) <= newDate.getTime()
+  )
+    return null
   return {
     custom: `Vul een tijdstip uit het verleden in`,
   }

--- a/src/signals/incident/services/custom-validators/index.ts
+++ b/src/signals/incident/services/custom-validators/index.ts
@@ -1,8 +1,7 @@
 export {
-  falsyOrNumber,
+  falsyOrNumberOrNow,
   inPast,
   isBlocking,
-  nullOrNumber,
   validateObjectLocation,
   validatePhoneNumber,
 } from './custom-validators'

--- a/src/signals/incident/services/map-controls-to-params/map-controls-to-params.ts
+++ b/src/signals/incident/services/map-controls-to-params/map-controls-to-params.ts
@@ -11,7 +11,7 @@ import mapValues from '../map-values'
 const mapControlsToParams = (incident: Incident, wizard: WizardSection) => {
   let params = {
     reporter: {},
-    incident_date_start: formatISO(incident.dateTime || Date.now()),
+    incident_date_start: formatISO((incident.dateTime as number) || Date.now()),
   }
 
   params = mapValues(params, incident, wizard)

--- a/src/signals/incident/services/yup-resolver/index.test.ts
+++ b/src/signals/incident/services/yup-resolver/index.test.ts
@@ -3,7 +3,7 @@
 
 import { setupSchema } from './index'
 import {
-  falsyOrNumber,
+  falsyOrNumberOrNow,
   inPast,
   validatePhoneNumber,
 } from '../custom-validators'
@@ -38,7 +38,7 @@ describe('Yup resolver takes a bunch of controls and returns it into a schema', 
       },
       falsyOrNumberQuestion: {
         options: {
-          validators: [falsyOrNumber],
+          validators: [falsyOrNumberOrNow],
         },
       },
       inPastQuestion: {

--- a/src/types/incident.ts
+++ b/src/types/incident.ts
@@ -22,7 +22,7 @@ type ExtraProps = {
 export interface Incident extends Record<string, any>, ExtraProps {
   category: string
   classification: Classification | null
-  dateTime: number | null
+  dateTime: number | null | string
   description: string
   email: string
   handling_message: string


### PR DESCRIPTION
Ticket: none

It used to be possible to make the dateTime question in additional questions possible. However, with a refactor to react-hook-form some code was lost and the functionality did not work anymore. This PR recreates this functionality. It's based on how the dateTime component is working currently, so not the nicest solution. 

Instead if `null` being used as value for "now", it's the string "now", so react-hook-form validator is validating to true when "Nu" is selected.



