### PR TITLE
Fix datetime bug

### DIFF
--- a/src/signals/incident/services/map-controls-to-params/map-controls-to-params.ts
+++ b/src/signals/incident/services/map-controls-to-params/map-controls-to-params.ts
@@ -11,7 +11,10 @@ import mapValues from '../map-values'
 const mapControlsToParams = (incident: Incident, wizard: WizardSection) => {
   let params = {
     reporter: {},
-    incident_date_start: formatISO((incident.dateTime as number) || Date.now()),
+    incident_date_start:
+      typeof incident.dateTime === 'string' || incident.dateTime === null
+        ? formatISO(Date.now())
+        : formatISO(incident.dateTime as number),
   }
 
   params = mapValues(params, incident, wizard)


### PR DESCRIPTION
No ticket.

Adding 'string' to the incident datetime type cause a bug when passing this to `formatISO`, this check should fix that.