### PR TITLE
[fix]: Add formatISO type bug tests

### DIFF
--- a/src/signals/incident/services/map-controls-to-params/index.test.ts
+++ b/src/signals/incident/services/map-controls-to-params/index.test.ts
@@ -55,4 +55,22 @@ describe('map-controls-to-params', () => {
       varFromMapPaths: 'bar',
     })
   })
+
+  it('should return the current date when dateTime is `now`', () => {
+    const incidentWithDateTimeNow = { ...mock, dateTime: 'now' }
+
+    expect(mapControlsToParams(incidentWithDateTimeNow, wizard)).toEqual({
+      reporter: {},
+      incident_date_start: formatISO(Date.now()),
+    })
+  })
+
+  it('should return the current date when dateTime is null', () => {
+    const incidentWithDateTimeNull = { ...mock, dateTime: null }
+
+    expect(mapControlsToParams(incidentWithDateTimeNull, wizard)).toEqual({
+      reporter: {},
+      incident_date_start: formatISO(Date.now()),
+    })
+  })
 })

--- a/src/signals/incident/services/map-controls-to-params/map-controls-to-params.ts
+++ b/src/signals/incident/services/map-controls-to-params/map-controls-to-params.ts
@@ -12,9 +12,9 @@ const mapControlsToParams = (incident: Incident, wizard: WizardSection) => {
   let params = {
     reporter: {},
     incident_date_start:
-      typeof incident.dateTime === 'string' || incident.dateTime === null
-        ? formatISO(Date.now())
-        : formatISO(incident.dateTime as number),
+      typeof incident.dateTime === 'number'
+        ? formatISO(incident.dateTime)
+        : formatISO(Date.now()),
   }
 
   params = mapValues(params, incident, wizard)

--- a/src/types/incident.ts
+++ b/src/types/incident.ts
@@ -22,7 +22,7 @@ type ExtraProps = {
 export interface Incident extends Record<string, any>, ExtraProps {
   category: string
   classification: Classification | null
-  dateTime: number | null | string
+  dateTime?: number | null | string
   description: string
   email: string
   handling_message: string


### PR DESCRIPTION
No ticket.

[This PR](https://github.com/Amsterdam/signals-frontend/pull/2813) created a bug when trying to submit a _melding_ where you answered ‘Nu’ to the question ‘Wanneer was het?’. [This PR](https://github.com/Amsterdam/signals-frontend/pull/2815) fixed that bug.

The current PR adds tests to prevent that bug from happening in the future.

To discuss:

- Maybe we want to turn the check around? So:

```
      typeof incident.dateTime === 'number'
        ? formatISO(incident.dateTime as number),
        :  formatISO(Date.now())
```

- Should we change the [Incident type](https://github.com/Amsterdam/signals-frontend/blob/b53f397d5efe5fc127eb0a4813e50a27dd37fb73/src/types/incident.ts#L25) as well? It says it can be `number | null | string`, but it can be `undefined` as well.