### PR TITLE
[fix]: Don't use addNote label when used in form

### DIFF
--- a/src/components/AddNote/AddNote.test.tsx
+++ b/src/components/AddNote/AddNote.test.tsx
@@ -256,4 +256,22 @@ describe('AddNote', () => {
       screen.queryByTestId('add-note-new-note-button')
     ).not.toBeInTheDocument()
   })
+
+  it('does not render a label when inForm is true', () => {
+    const { container } = render(
+      withAppContext(<AddNote label="Test label" inForm={true} />)
+    )
+
+    userEvent.click(screen.getByTestId('add-note-new-note-button'))
+
+    expect(container.querySelector('label')).not.toBeInTheDocument()
+  })
+
+  it('renders the passed id', () => {
+    const { container } = render(withAppContext(<AddNote id="test" />))
+
+    userEvent.click(screen.getByTestId('add-note-new-note-button'))
+
+    expect(container.querySelector('#test')).toBeInTheDocument()
+  })
 })

--- a/src/components/AddNote/AddNote.tsx
+++ b/src/components/AddNote/AddNote.tsx
@@ -12,6 +12,7 @@ import TextArea from 'components/TextArea'
 export interface AddNoteProps {
   className?: string
   error?: string
+  inForm?: boolean
   isStandalone?: boolean
   label?: ReactNode
   maxContentLength?: number
@@ -23,6 +24,7 @@ export interface AddNoteProps {
     value?: string | null
   ) => boolean
   onCancel?: () => void
+  id?: string
   rows?: number
   value?: string
   withToggle?: boolean
@@ -65,6 +67,7 @@ const AddNote = forwardRef<HTMLTextAreaElement, AddNoteProps>(
       className,
       error,
       isStandalone,
+      inForm,
       withToggle,
       label,
       maxContentLength,
@@ -73,6 +76,7 @@ const AddNote = forwardRef<HTMLTextAreaElement, AddNoteProps>(
       onChange,
       onSubmit,
       onCancel,
+      id,
       rows,
       value,
       ...rest
@@ -125,14 +129,14 @@ const AddNote = forwardRef<HTMLTextAreaElement, AddNoteProps>(
         <TextArea
           data-testid="add-note-text"
           errorMessage={error}
-          id="addNoteText"
+          id={id || 'addNoteText'}
           maxContentLength={maxContentLength}
           name={name}
           onBlur={onBlur}
           onChange={onChange}
           ref={ref}
           rows={rows}
-          label={label}
+          label={!inForm && label}
           value={value || ''}
           {...rest}
         />
@@ -166,6 +170,7 @@ const AddNote = forwardRef<HTMLTextAreaElement, AddNoteProps>(
 AddNote.defaultProps = {
   className: '',
   isStandalone: true,
+  inForm: false,
   label: 'Notitie toevoegen',
   rows: 10,
   withToggle: true,

--- a/src/signals/incident/components/form/TextareaInput/TextareaInput.tsx
+++ b/src/signals/incident/components/form/TextareaInput/TextareaInput.tsx
@@ -58,7 +58,7 @@ const TextareaInput: FunctionComponent<TextAreaInputProps> = ({
       hasError={hasError}
       getError={getError}
     >
-      <AddNote {...props} />
+      <AddNote inForm id={meta.name} {...props} />
     </FormField>
   )
 }


### PR DESCRIPTION
No ticket

Textarea's in step 2 showed the label twice, because is was added in TextareaInput and again in AddNote.
This PR makes it possible to pass an `inForm` prop to Addnote, which doesn't render the label in AddNote. 