### PR TITLE
[feat-5611]: change extra questions THOR Nautisch

### DIFF
--- a/src/signals/incident/definitions/wizard-step-2-vulaan/overlast-op-het-water.test.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/overlast-op-het-water.test.ts
@@ -7,12 +7,15 @@ describe('definition overlast-op-het-water', () => {
     expect(keys).toStrictEqual([
       'locatie',
       'dateTime',
-      'extra_boten_snelheid_typeboot',
-      'extra_boten_snelheid_rederij',
-      'extra_boten_snelheid_naamboot',
-      'extra_boten_snelheid_meer',
-      'extra_boten_geluid_meer',
-      'extra_boten_gezonken_meer',
+      'extra_boten_frequentie',
+      'extra_boten_moment',
+      'extra_boten_beweging',
+      'extra_boten_soort',
+      'extra_boten_open_gesloten',
+      'extra_boten_drijfkracht',
+      'extra_boten_vast',
+      'extra_boten_lekken',
+      'extra_boten_meer',
     ])
   })
 })

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/overlast-op-het-water.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/overlast-op-het-water.ts
@@ -12,32 +12,19 @@ export const overlastOpHetWater = {
   locatie,
   dateTime: {
     meta: {
-      ifOneOf: {
-        subcategory: [
-          'blokkade-van-de-vaarweg',
-          'overig-boten',
-          'overlast-op-het-water-geluid',
-          'scheepvaart-nautisch-toezicht', // Wat is deze?
-          'overlast-op-het-water-snel-varen',
-          'overlast-op-het-water-gezonken-boot',
-        ],
-      },
       ignoreVisibility: true,
-      label: 'Wanneer was het?',
+      label: 'Wanneer heeft u de overlast?',
       canBeNull: true,
-      timeSelectorDisabled: true, // TODO: geldt dit ook voor de niet overig-boten cats?
+      timeSelectorDisabled: true,
     },
     options: {
-      validators: [falsyOrNumberOrNow, inPast],
+      validators: [falsyOrNumberOrNow, inPast, 'required'],
     },
     render: QuestionFieldType.DateTimeInput,
   },
 
   extra_boten_frequentie: {
     meta: {
-      ifOneOf: {
-        subcategory: ['blokkade-van-de-vaarweg', 'overig-boten'],
-      },
       values: {
         ja: 'Ja, het gebeurt vaker',
         nee: 'Nee, het is de eerste keer',
@@ -65,7 +52,13 @@ export const overlastOpHetWater = {
   extra_boten_beweging: {
     meta: {
       ifOneOf: {
-        subcategory: ['blokkade-van-de-vaarweg', 'overig-boten'],
+        subcategory: [
+          'blokkade-van-de-vaarweg',
+          'overig-boten',
+          'overlast-op-het-water-geluid',
+          'overlast-op-het-water-snel-varen',
+          'overlast-op-het-water-vaargedrag',
+        ],
       },
       values: {
         ja: 'Ja, de boot ligt stil',
@@ -81,7 +74,12 @@ export const overlastOpHetWater = {
   extra_boten_soort: {
     meta: {
       ifOneOf: {
-        subcategory: ['blokkade-van-de-vaarweg', 'overig-boten'],
+        subcategory: [
+          'overig-boten',
+          'overlast-op-het-water-geluid',
+          'overlast-op-het-water-snel-varen',
+          'overlast-op-het-water-vaargedrag',
+        ],
       },
       values: {
         plezier: '(Plezier)boot in privé-eigendom',
@@ -94,13 +92,19 @@ export const overlastOpHetWater = {
       shortLabel: 'Soort boot',
       pathMerge: 'extra_properties',
     },
+    options: { validators: ['required'] },
     render: QuestionFieldType.RadioInput,
   },
 
   extra_boten_open_gesloten: {
     meta: {
       ifOneOf: {
-        subcategory: ['blokkade-van-de-vaarweg', 'overig-boten'],
+        subcategory: [
+          'overig-boten',
+          'overlast-op-het-water-geluid',
+          'overlast-op-het-water-snel-varen',
+          'overlast-op-het-water-vaargedrag',
+        ],
       },
       values: {
         ja: 'Ja, het is een open boot (bijvoorbeeld een sloep, roeiboot, rondvaartboot met dak open)',
@@ -111,63 +115,70 @@ export const overlastOpHetWater = {
       shortLabel: 'Soort boot',
       pathMerge: 'extra_properties',
     },
+    options: { validators: ['required'] },
     render: QuestionFieldType.RadioInput,
   },
 
-  // extra_boten_snelheid_typeboot: {
-  //   meta: {
-  //     label: 'Wat voor type boot is het?',
-  //     shortLabel: 'Type boot',
-  //     pathMerge: 'extra_properties',
-  //     values: {
-  //       pleziervaart: 'Pleziervaart',
-  //       rondvaartboot_of_salonboot: 'Rondvaartboot of salonboot',
-  //       vrachtschip_of_binnenvaartschip: 'Vrachtschip of binnenvaartschip',
-  //       overig: 'Overig',
-  //     },
-  //     ifAllOf: {
-  //       subcategory: 'overlast-op-het-water-snel-varen',
-  //     },
-  //   },
-  //   options: { validators: ['required'] },
-  //   render: QuestionFieldType.RadioInput,
-  // },
-  // extra_boten_snelheid_rederij: {
-  //   meta: {
-  //     label: 'Wat is de naam van de rederij?',
-  //     shortLabel: 'Rederij',
-  //     pathMerge: 'extra_properties',
-  //     ifAllOf: {
-  //       subcategory: 'overlast-op-het-water-snel-varen',
-  //       extra_boten_snelheid_typeboot: 'rondvaartboot_of_salonboot',
-  //     },
-  //   },
-  //   render: QuestionFieldType.TextInput,
-  // },
-  // extra_boten_snelheid_naamboot: {
-  //   meta: {
-  //     label: 'Wat is de naam van de boot?',
-  //     shortLabel: 'Naam boot',
-  //     pathMerge: 'extra_properties',
-  //     ifAllOf: {
-  //       subcategory: 'overlast-op-het-water-snel-varen',
-  //       ifOneOf: {
-  //         extra_boten_snelheid_typeboot: [
-  //           'pleziervaart',
-  //           'rondvaartboot_of_salonboot',
-  //           'vrachtschip_of_binnenvaartschip',
-  //           'overig',
-  //         ],
-  //       },
-  //     },
-  //   },
-  //   render: QuestionFieldType.TextInput,
-  // },
+  extra_boten_drijfkracht: {
+    meta: {
+      ifOneOf: {
+        subcategory: 'overlast-op-het-water-gezonken-boot',
+      },
+      values: {
+        ja: 'Ja, de boot ligt volledig onder water',
+        nee: 'Nee, de boot kan nog drijven',
+      },
+      label: 'Ligt de boot volledig onder water of kan hij nog drijven?',
+      shortLabel: 'Drijfkracht',
+      pathMerge: 'extra_properties',
+    },
+    render: QuestionFieldType.RadioInput,
+  },
+
+  extra_boten_vast: {
+    meta: {
+      ifOneOf: {
+        subcategory: 'overlast-op-het-water-gezonken-boot',
+      },
+      values: {
+        ja: 'Ja, de boot ligt vast',
+        nee: 'Nee, de boot kan wegdrijven',
+      },
+      label:
+        'Ligt de boot nog vast? Of kan de boot wegdrijven zodat hij de vaarweg blokkeert?',
+      shortLabel: 'Boot vast?',
+      pathMerge: 'extra_properties',
+    },
+    render: QuestionFieldType.RadioInput,
+  },
+
+  extra_boten_lekken: {
+    meta: {
+      ifOneOf: {
+        subcategory: 'overlast-op-het-water-gezonken-boot',
+      },
+      values: {
+        ja: 'Ja, boot lekt vloeistof',
+        nee: 'Nee, boot lekt geen vloeistof',
+        weetniet: 'Weet ik niet',
+      },
+      label: 'Lekt de boot olie of een andere vloeistof?',
+      shortLabel: 'Boot vast?',
+      pathMerge: 'extra_properties',
+    },
+    render: QuestionFieldType.RadioInput,
+  },
 
   extra_boten_meer: {
     meta: {
       ifOneOf: {
-        subcategory: ['blokkade-van-de-vaarweg', 'overig-boten'],
+        subcategory: [
+          'blokkade-van-de-vaarweg',
+          'overig-boten',
+          'overlast-op-het-water-geluid',
+          'overlast-op-het-water-snel-varen',
+          'overlast-op-het-water-vaargedrag',
+        ],
       },
       label: 'Wat weet u nog meer over deze situatie?',
       shortLabel: 'Extra informatie',
@@ -177,56 +188,6 @@ export const overlastOpHetWater = {
     },
     render: QuestionFieldType.TextareaInput,
   },
-
-  // extra_boten_snelheid_meer: {
-  //   meta: {
-  //     label: 'Wat weet u nog meer over deze situatie?',
-  //     shortLabel: 'Extra informatie',
-  //     subtitle:
-  //       'Bijvoorbeeld: de kleur van de boot, aantal passagiers, vaarrichting, Y of Vignet nummer etc.',
-  //     pathMerge: 'extra_properties',
-  //     ifAllOf: {
-  //       subcategory: 'overlast-op-het-water-snel-varen',
-  //       ifOneOf: {
-  //         extra_boten_snelheid_typeboot: [
-  //           'pleziervaart',
-  //           'rondvaartboot_of_salonboot',
-  //           'vrachtschip_of_binnenvaartschip',
-  //           'overig',
-  //         ],
-  //       },
-  //     },
-  //   },
-  //   render: QuestionFieldType.TextareaInput,
-  // },
-
-  // extra_boten_geluid_meer: {
-  //   meta: {
-  //     label: 'Wat weet u nog meer over deze situatie?',
-  //     shortLabel: 'Extra informatie',
-  //     subtitle:
-  //       'Bijvoorbeeld: waar de boot naar toe vaart, kleur van de boot, aantal passagiers, kenteken, vignet, etc.',
-  //     pathMerge: 'extra_properties',
-  //     ifAllOf: {
-  //       subcategory: 'overlast-op-het-water-geluid',
-  //     },
-  //   },
-  //   render: QuestionFieldType.TextareaInput,
-  // },
-
-  // extra_boten_gezonken_meer: {
-  //   meta: {
-  //     label: 'Wat weet u nog meer over deze situatie?',
-  //     shortLabel: 'Extra informatie',
-  //     subtitle:
-  //       'Bijvoorbeeld: "er lekt olie", "gevaar voor andere boten", etc.',
-  //     pathMerge: 'extra_properties',
-  //     ifAllOf: {
-  //       subcategory: 'overlast-op-het-water-gezonken-boot',
-  //     },
-  //   },
-  //   render: QuestionFieldType.TextareaInput,
-  // },
 }
 
 export default overlastOpHetWater

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/overlast-op-het-water.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/overlast-op-het-water.ts
@@ -17,7 +17,7 @@ export const overlastOpHetWater = {
           'blokkade-van-de-vaarweg',
           'overig-boten',
           'overlast-op-het-water-geluid',
-          'scheepvaart-nautisch-toezicht',
+          'scheepvaart-nautisch-toezicht', // Wat is deze?
           'overlast-op-het-water-snel-varen',
           'overlast-op-het-water-gezonken-boot',
         ],
@@ -25,108 +25,208 @@ export const overlastOpHetWater = {
       ignoreVisibility: true,
       label: 'Wanneer was het?',
       canBeNull: true,
+      timeSelectorDisabled: true, // TODO: geldt dit ook voor de niet overig-boten cats?
     },
     options: {
       validators: [falsyOrNumberOrNow, inPast],
     },
     render: QuestionFieldType.DateTimeInput,
   },
-  extra_boten_snelheid_typeboot: {
+
+  extra_boten_frequentie: {
     meta: {
-      label: 'Wat voor type boot is het?',
-      shortLabel: 'Type boot',
-      pathMerge: 'extra_properties',
+      ifOneOf: {
+        subcategory: ['blokkade-van-de-vaarweg', 'overig-boten'],
+      },
       values: {
-        pleziervaart: 'Pleziervaart',
-        rondvaartboot_of_salonboot: 'Rondvaartboot of salonboot',
-        vrachtschip_of_binnenvaartschip: 'Vrachtschip of binnenvaartschip',
-        overig: 'Overig',
+        ja: 'Ja, het gebeurt vaker',
+        nee: 'Nee, het is de eerste keer',
       },
-      ifAllOf: {
-        subcategory: 'overlast-op-het-water-snel-varen',
-      },
+      label: 'Heeft u deze overlast al eerder gehad?',
+      shortLabel: 'Eerder overlast',
+      pathMerge: 'extra_properties',
     },
-    options: { validators: ['required'] },
     render: QuestionFieldType.RadioInput,
   },
-  extra_boten_snelheid_rederij: {
+
+  extra_boten_moment: {
     meta: {
-      label: 'Wat is de naam van de rederij?',
-      shortLabel: 'Rederij',
-      pathMerge: 'extra_properties',
       ifAllOf: {
-        subcategory: 'overlast-op-het-water-snel-varen',
-        extra_boten_snelheid_typeboot: 'rondvaartboot_of_salonboot',
+        extra_boten_frequentie: 'ja',
       },
+      label: 'Op welke momenten van de dag hebt u de overlast?',
+      shortLabel: 'Overlast momenten',
+      pathMerge: 'extra_properties',
     },
+    options: { validators: ['required'] },
     render: QuestionFieldType.TextInput,
   },
-  extra_boten_snelheid_naamboot: {
+
+  extra_boten_beweging: {
     meta: {
-      label: 'Wat is de naam van de boot?',
-      shortLabel: 'Naam boot',
-      pathMerge: 'extra_properties',
-      ifAllOf: {
-        subcategory: 'overlast-op-het-water-snel-varen',
-        ifOneOf: {
-          extra_boten_snelheid_typeboot: [
-            'pleziervaart',
-            'rondvaartboot_of_salonboot',
-            'vrachtschip_of_binnenvaartschip',
-            'overig',
-          ],
-        },
+      ifOneOf: {
+        subcategory: ['blokkade-van-de-vaarweg', 'overig-boten'],
       },
+      values: {
+        ja: 'Ja, de boot ligt stil',
+        nee: 'Nee, de boot vaart',
+      },
+      label: 'Ligt de boot stil?',
+      shortLabel: 'Beweging boot',
+      pathMerge: 'extra_properties',
     },
-    render: QuestionFieldType.TextInput,
+    render: QuestionFieldType.RadioInput,
   },
-  extra_boten_snelheid_meer: {
+
+  extra_boten_soort: {
     meta: {
+      ifOneOf: {
+        subcategory: ['blokkade-van-de-vaarweg', 'overig-boten'],
+      },
+      values: {
+        plezier: '(Plezier)boot in privé-eigendom',
+        rondvaart: 'Rondvaartboot of salonboot van rederij',
+        vracht: 'Vrachtschip of binnenvaartschip',
+        huur: 'Huurboot',
+        overig: 'Overig',
+      },
+      label: 'Wat voor soort boot is het?',
+      shortLabel: 'Soort boot',
+      pathMerge: 'extra_properties',
+    },
+    render: QuestionFieldType.RadioInput,
+  },
+
+  extra_boten_open_gesloten: {
+    meta: {
+      ifOneOf: {
+        subcategory: ['blokkade-van-de-vaarweg', 'overig-boten'],
+      },
+      values: {
+        ja: 'Ja, het is een open boot (bijvoorbeeld een sloep, roeiboot, rondvaartboot met dak open)',
+        nee: 'Nee, het is een gesloten boot (bijvoorbeeld een rondvaartboot, salonboot, kajuitboot)',
+        onduidelijk: 'Ik kan het niet zien',
+      },
+      label: 'Is het een open of een gesloten boot?',
+      shortLabel: 'Soort boot',
+      pathMerge: 'extra_properties',
+    },
+    render: QuestionFieldType.RadioInput,
+  },
+
+  // extra_boten_snelheid_typeboot: {
+  //   meta: {
+  //     label: 'Wat voor type boot is het?',
+  //     shortLabel: 'Type boot',
+  //     pathMerge: 'extra_properties',
+  //     values: {
+  //       pleziervaart: 'Pleziervaart',
+  //       rondvaartboot_of_salonboot: 'Rondvaartboot of salonboot',
+  //       vrachtschip_of_binnenvaartschip: 'Vrachtschip of binnenvaartschip',
+  //       overig: 'Overig',
+  //     },
+  //     ifAllOf: {
+  //       subcategory: 'overlast-op-het-water-snel-varen',
+  //     },
+  //   },
+  //   options: { validators: ['required'] },
+  //   render: QuestionFieldType.RadioInput,
+  // },
+  // extra_boten_snelheid_rederij: {
+  //   meta: {
+  //     label: 'Wat is de naam van de rederij?',
+  //     shortLabel: 'Rederij',
+  //     pathMerge: 'extra_properties',
+  //     ifAllOf: {
+  //       subcategory: 'overlast-op-het-water-snel-varen',
+  //       extra_boten_snelheid_typeboot: 'rondvaartboot_of_salonboot',
+  //     },
+  //   },
+  //   render: QuestionFieldType.TextInput,
+  // },
+  // extra_boten_snelheid_naamboot: {
+  //   meta: {
+  //     label: 'Wat is de naam van de boot?',
+  //     shortLabel: 'Naam boot',
+  //     pathMerge: 'extra_properties',
+  //     ifAllOf: {
+  //       subcategory: 'overlast-op-het-water-snel-varen',
+  //       ifOneOf: {
+  //         extra_boten_snelheid_typeboot: [
+  //           'pleziervaart',
+  //           'rondvaartboot_of_salonboot',
+  //           'vrachtschip_of_binnenvaartschip',
+  //           'overig',
+  //         ],
+  //       },
+  //     },
+  //   },
+  //   render: QuestionFieldType.TextInput,
+  // },
+
+  extra_boten_meer: {
+    meta: {
+      ifOneOf: {
+        subcategory: ['blokkade-van-de-vaarweg', 'overig-boten'],
+      },
       label: 'Wat weet u nog meer over deze situatie?',
       shortLabel: 'Extra informatie',
       subtitle:
-        'Bijvoorbeeld: de kleur van de boot, aantal passagiers, vaarrichting, Y of Vignet nummer etc.',
+        'Bijvoorbeeld: waar de boot naar toe vaart, naam boot, kleur van de boot, lengte en andere dingen die u opvallen, aantal passagiers',
       pathMerge: 'extra_properties',
-      ifAllOf: {
-        subcategory: 'overlast-op-het-water-snel-varen',
-        ifOneOf: {
-          extra_boten_snelheid_typeboot: [
-            'pleziervaart',
-            'rondvaartboot_of_salonboot',
-            'vrachtschip_of_binnenvaartschip',
-            'overig',
-          ],
-        },
-      },
     },
     render: QuestionFieldType.TextareaInput,
   },
-  extra_boten_geluid_meer: {
-    meta: {
-      label: 'Wat weet u nog meer over deze situatie?',
-      shortLabel: 'Extra informatie',
-      subtitle:
-        'Bijvoorbeeld: waar de boot naar toe vaart, kleur van de boot, aantal passagiers, kenteken, vignet, etc.',
-      pathMerge: 'extra_properties',
-      ifAllOf: {
-        subcategory: 'overlast-op-het-water-geluid',
-      },
-    },
-    render: QuestionFieldType.TextareaInput,
-  },
-  extra_boten_gezonken_meer: {
-    meta: {
-      label: 'Wat weet u nog meer over deze situatie?',
-      shortLabel: 'Extra informatie',
-      subtitle:
-        'Bijvoorbeeld: "er lekt olie", "gevaar voor andere boten", etc.',
-      pathMerge: 'extra_properties',
-      ifAllOf: {
-        subcategory: 'overlast-op-het-water-gezonken-boot',
-      },
-    },
-    render: QuestionFieldType.TextareaInput,
-  },
+
+  // extra_boten_snelheid_meer: {
+  //   meta: {
+  //     label: 'Wat weet u nog meer over deze situatie?',
+  //     shortLabel: 'Extra informatie',
+  //     subtitle:
+  //       'Bijvoorbeeld: de kleur van de boot, aantal passagiers, vaarrichting, Y of Vignet nummer etc.',
+  //     pathMerge: 'extra_properties',
+  //     ifAllOf: {
+  //       subcategory: 'overlast-op-het-water-snel-varen',
+  //       ifOneOf: {
+  //         extra_boten_snelheid_typeboot: [
+  //           'pleziervaart',
+  //           'rondvaartboot_of_salonboot',
+  //           'vrachtschip_of_binnenvaartschip',
+  //           'overig',
+  //         ],
+  //       },
+  //     },
+  //   },
+  //   render: QuestionFieldType.TextareaInput,
+  // },
+
+  // extra_boten_geluid_meer: {
+  //   meta: {
+  //     label: 'Wat weet u nog meer over deze situatie?',
+  //     shortLabel: 'Extra informatie',
+  //     subtitle:
+  //       'Bijvoorbeeld: waar de boot naar toe vaart, kleur van de boot, aantal passagiers, kenteken, vignet, etc.',
+  //     pathMerge: 'extra_properties',
+  //     ifAllOf: {
+  //       subcategory: 'overlast-op-het-water-geluid',
+  //     },
+  //   },
+  //   render: QuestionFieldType.TextareaInput,
+  // },
+
+  // extra_boten_gezonken_meer: {
+  //   meta: {
+  //     label: 'Wat weet u nog meer over deze situatie?',
+  //     shortLabel: 'Extra informatie',
+  //     subtitle:
+  //       'Bijvoorbeeld: "er lekt olie", "gevaar voor andere boten", etc.',
+  //     pathMerge: 'extra_properties',
+  //     ifAllOf: {
+  //       subcategory: 'overlast-op-het-water-gezonken-boot',
+  //     },
+  //   },
+  //   render: QuestionFieldType.TextareaInput,
+  // },
 }
 
 export default overlastOpHetWater

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/overlast-op-het-water.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/overlast-op-het-water.ts
@@ -24,6 +24,16 @@ export const overlastOpHetWater = {
 
   extra_boten_frequentie: {
     meta: {
+      ifOneOf: {
+        subcategory: [
+          'blokkade-van-de-vaarweg',
+          'overig-boten',
+          'overlast-op-het-water-geluid',
+          'overlast-op-het-water-gezonken-boot',
+          'overlast-op-het-water-snel-varen',
+          'overlast-op-het-water-vaargedrag',
+        ],
+      },
       values: {
         ja: 'Ja, het gebeurt vaker',
         nee: 'Nee, het is de eerste keer',

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/overlast-op-het-water.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/overlast-op-het-water.ts
@@ -15,7 +15,6 @@ export const overlastOpHetWater = {
       ignoreVisibility: true,
       label: 'Wanneer heeft u de overlast?',
       canBeNull: true,
-      timeSelectorDisabled: true,
     },
     options: {
       validators: [falsyOrNumberOrNow, inPast, 'required'],


### PR DESCRIPTION
Ticket: [SIG-5611](https://gemeente-amsterdam.atlassian.net/browse/SIG-5611)

'Overlast op het water' has two more subcategories, 'Nautisch toezicht / vaargedrag' and 'Olie op het water', I've asked Linda what questions these subcategories should get. -> 'Nautisch toezicht / vaargedrag' is unused, 'Olie op het water' should not change.

The PDF shows dateTime to have the time selector disabled, but I discussed this with UX, it should be enabled.


[SIG-5611]: https://gemeente-amsterdam.atlassian.net/browse/SIG-5611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ