### PR TITLE
[fix]: Remove optional time selector

### DIFF
--- a/src/signals/incident/components/form/DateTimeInput/DateTime.test.tsx
+++ b/src/signals/incident/components/form/DateTimeInput/DateTime.test.tsx
@@ -184,13 +184,4 @@ describe('DateTime', () => {
       defaultTimestamp.getTime() - diffInMs
     )
   })
-
-  it('should not render the time selector when disabled', () => {
-    render(withAppContext(<DateTime {...props} timeSelectorDisabled={true} />))
-
-    userEvent.click(screen.getByLabelText('Eerder'))
-
-    expect(screen.queryByText('Hoe laat was het?')).not.toBeInTheDocument()
-    expect(onUpdate).toHaveBeenLastCalledWith(defaultTimestamp.getTime())
-  })
 })

--- a/src/signals/incident/components/form/DateTimeInput/DateTime.tsx
+++ b/src/signals/incident/components/form/DateTimeInput/DateTime.tsx
@@ -84,7 +84,6 @@ export const minutesOptions = [...Array(12).keys()].map((minute) => ({
 export interface DateTimeProps {
   onUpdate: (timestamp: Incident['timestamp']) => void
   value: Incident['timestamp']
-  timeSelectorDisabled?: boolean
 }
 
 type DateIndication = DateIndicator['id'] | ''
@@ -95,11 +94,7 @@ const dateIndicationValue: Record<string, DateIndication> = {
   number: 'earlier',
 }
 
-const DateTime: FC<DateTimeProps> = ({
-  onUpdate,
-  value,
-  timeSelectorDisabled = false,
-}) => {
+const DateTime: FC<DateTimeProps> = ({ onUpdate, value }) => {
   const [datetime, setDatetime] = useState(
     value && value !== 'now' ? new Date(value) : defaultTimestamp
   )
@@ -199,42 +194,40 @@ const DateTime: FC<DateTimeProps> = ({
             </FieldWrapper>
           </TimeFieldset>
 
-          {!timeSelectorDisabled && (
-            <TimeFieldset>
-              <legend>
-                <StyledLabel>Hoe laat was het?</StyledLabel>
-              </legend>
+          <TimeFieldset>
+            <legend>
+              <StyledLabel>Hoe laat was het?</StyledLabel>
+            </legend>
 
-              <TimeWrapper>
-                <div>
-                  <Select
-                    id="hours"
-                    aria-labelledby="uur"
-                    name="hours"
-                    data-testid="select-hours"
-                    value={datetime.getHours().toString()}
-                    onChange={updateTimestamp}
-                    options={hoursOptions}
-                  />
-                </div>
-                <Info id="uur">uur</Info>
-                <div>
-                  <Select
-                    id="minutes"
-                    name="minutes"
-                    aria-labelledby="min"
-                    data-testid="select-minutes"
-                    value={datetime.getMinutes().toString()}
-                    onChange={updateTimestamp}
-                    options={minutesOptions}
-                  />
-                </div>
-                <Info id="min" aria-label="minuten">
-                  min
-                </Info>
-              </TimeWrapper>
-            </TimeFieldset>
-          )}
+            <TimeWrapper>
+              <div>
+                <Select
+                  id="hours"
+                  aria-labelledby="uur"
+                  name="hours"
+                  data-testid="select-hours"
+                  value={datetime.getHours().toString()}
+                  onChange={updateTimestamp}
+                  options={hoursOptions}
+                />
+              </div>
+              <Info id="uur">uur</Info>
+              <div>
+                <Select
+                  id="minutes"
+                  name="minutes"
+                  aria-labelledby="min"
+                  data-testid="select-minutes"
+                  value={datetime.getMinutes().toString()}
+                  onChange={updateTimestamp}
+                  options={minutesOptions}
+                />
+              </div>
+              <Info id="min" aria-label="minuten">
+                min
+              </Info>
+            </TimeWrapper>
+          </TimeFieldset>
         </>
       )}
     </>

--- a/src/signals/incident/components/form/DateTimeInput/DateTimeInput.test.tsx
+++ b/src/signals/incident/components/form/DateTimeInput/DateTimeInput.test.tsx
@@ -17,7 +17,6 @@ const props = {
   hasError: () => false,
   meta: {
     isVisible: true,
-    timeSelectorDisabled: false,
   },
   parent: {
     meta: {

--- a/src/signals/incident/components/form/DateTimeInput/DateTimeInput.tsx
+++ b/src/signals/incident/components/form/DateTimeInput/DateTimeInput.tsx
@@ -31,11 +31,7 @@ const DateTimeInput: FC<DateTimeInputProps> = ({
       getError={getError}
       isFieldSet
     >
-      <DateTime
-        onUpdate={updateTimestamp}
-        value={value}
-        timeSelectorDisabled={!!meta.timeSelectorDisabled}
-      />
+      <DateTime onUpdate={updateTimestamp} value={value} />
     </FormField>
   )
 }

--- a/src/signals/incident/definitions/wizard-step-2-vulaan/overlast-bedrijven-en-horeca.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/overlast-bedrijven-en-horeca.ts
@@ -22,7 +22,6 @@ const overlastBedrijvenEnHoreca = {
       },
       label: 'Wanneer heeft u de overlast?',
       canBeNull: true,
-      timeSelectorDisabled: true,
     },
     options: {
       validators: [inPast, 'required'],


### PR DESCRIPTION
Making the time selector optional caused an error when you answered Wanneer was het > Eerder > Vandaag before 9.00. Without a time selector, the datetime is always 9.00, which means the `inPast` validation isn't met before 9.00.

Discussed this with UX and decided to remove the optional time selector.