### PR TITLE
Remove i18n initialiser

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -17,9 +17,6 @@ import configuration from 'shared/services/configuration/configuration'
 
 // Import root app
 
-// Import translations
-import 'shared/services/i18n/i18n'
-
 // Import CSS and Global Styles
 import './global.css'
 import './polyfills'


### PR DESCRIPTION
Ticket: none

Since i18n functionality is still in development, it should be initialised. The initialisation causes a call to the backend which will always fail.