### PR TITLE
[fix]: Remove double search calls

### DIFF
--- a/src/signals/incident-management/__tests__/saga.test.js
+++ b/src/signals/incident-management/__tests__/saga.test.js
@@ -6,7 +6,6 @@ import { expectSaga, testSaga } from 'redux-saga-test-plan'
 import * as matchers from 'redux-saga-test-plan/matchers'
 import { throwError } from 'redux-saga-test-plan/providers'
 
-import { SET_SEARCH_QUERY, RESET_SEARCH_QUERY } from 'containers/App/constants'
 import { makeSelectSearchQuery } from 'containers/App/selectors'
 import {
   authCall,
@@ -87,8 +86,6 @@ describe('signals/incident-management/saga', () => {
             CLEAR_FILTERS,
             SEARCH_INCIDENTS,
             REQUEST_INCIDENTS,
-            SET_SEARCH_QUERY,
-            RESET_SEARCH_QUERY,
             PAGE_CHANGED,
             ORDERING_CHANGED,
             PATCH_INCIDENT_SUCCESS,

--- a/src/signals/incident-management/saga.js
+++ b/src/signals/incident-management/saga.js
@@ -13,7 +13,6 @@ import {
   takeLatest,
 } from 'redux-saga/effects'
 
-import { SET_SEARCH_QUERY, RESET_SEARCH_QUERY } from 'containers/App/constants'
 import { makeSelectSearchQuery } from 'containers/App/selectors'
 import {
   authCall,
@@ -107,7 +106,6 @@ export function* searchIncidents() {
     yield put(applyFilterRefreshStop())
 
     const { page, page_size, ordering } = yield select(makeSelectFilterParams)
-
     const incidents = yield call(authCall, CONFIGURATION.SEARCH_ENDPOINT, {
       q,
       page,
@@ -283,8 +281,6 @@ export default function* watchIncidentManagementSaga() {
         CLEAR_FILTERS,
         SEARCH_INCIDENTS,
         REQUEST_INCIDENTS,
-        SET_SEARCH_QUERY,
-        RESET_SEARCH_QUERY,
         PAGE_CHANGED,
         ORDERING_CHANGED,
         PATCH_INCIDENT_SUCCESS,


### PR DESCRIPTION
Ticket: none

On the incidentOverview page there where some double calls when searching and clear the search. This PR removes somes actions that triggered the double search query. 

screenshot left localhost, right acceptance when searching and clearing the search.
<img width="3360" alt="Screenshot 2024-03-22 at 10 50 16" src="https://github.com/Amsterdam/signals-frontend/assets/46756331/50605562-7cbd-4027-8ba2-90f018c6f1dd">
