### PR TITLE
[fix-5684]: Do not render AssetList when selectableFeatures is empty array

### DIFF
--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.test.tsx
@@ -127,6 +127,7 @@ describe('DetailPanel', () => {
       withAssetSelectContext(<DetailPanel {...props} />, {
         ...currentContextValue,
         selection: undefined,
+        selectableFeatures: [],
       })
     )
 

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/DetailPanel/DetailPanel.tsx
@@ -142,7 +142,8 @@ const DetailPanel: FC<DetailPanelProps> = ({ language, zoomLevel }) => {
               />
             </>
           )}
-          {((selection && selectionOnMap) || selectableFeatures) && (
+          {((selection && selectionOnMap) ||
+            (selectableFeatures && selectableFeatures.length > 0)) && (
             <StyledAssetList
               selection={selection}
               remove={removeItem}


### PR DESCRIPTION
Ticket: [SIG-5684](https://gemeente-amsterdam.atlassian.net/browse/SIG-5684)

Note: the List component will still render when a(n) item(s) are selected. They will appear with a checkbox. When deselected, they disappear again. Is that desirable?

left: localhost 
right: Den Haag production

<img width="3267" alt="Screenshot 2024-03-22 at 14 08 56" src="https://github.com/Amsterdam/signals-frontend/assets/46756331/53b30e43-1de3-422c-8899-23c0d09d8cdf">


[SIG-5684]: https://gemeente-amsterdam.atlassian.net/browse/SIG-5684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ