### PR TITLE
[fix]: Make comparison less strict

### DIFF
--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/AssetLayer/AssetLayer.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/AssetLayer/AssetLayer.tsx
@@ -52,7 +52,7 @@ export const AssetLayer: FC = () => {
 
     const { description, typeValue, idField } = featureType
     const id = feature.properties[idField] || ''
-    const isSelected = Boolean(selection?.find((item) => item.id === id))
+    const isSelected = Boolean(selection?.find((item) => item.id == id))
 
     const iconUrl = isSelected
       ? '/assets/images/feature-selected-marker.svg'


### PR DESCRIPTION
Ticket: none

Since an Id can be a number or string, it should not have a strict comparison when determining whether the object is selector or not.

Object appear selected on the map

<img width="1719" alt="Screenshot 2024-03-28 at 13 37 38" src="https://github.com/Amsterdam/signals-frontend/assets/46756331/944db8f8-1073-45ff-8edb-8be7638ad233">
