### PR TITLE
[feat-5683]: Allow 'Assigned user email' column to be sorted

### DIFF
--- a/app.amsterdam.json
+++ b/app.amsterdam.json
@@ -127,7 +127,7 @@
     }
   },
   "oidc": {
-    "authEndpoint": "https://iam.amsterdam.nl/auth",
+    "authEndpoint": "https://acc.iam.amsterdam.nl/auth",
     "clientId": "sia-frontend",
     "realm": "datapunt-ad-acc",
     "responseType": "code",

--- a/app.amsterdam.json
+++ b/app.amsterdam.json
@@ -3,7 +3,7 @@
   "areaTypeCodeForDistrict": "stadsdeel",
   "featureFlags": {
     "assignSignalToDepartment": false,
-    "assignSignalToEmployee": true,
+    "assignSignalToEmployee": false,
     "disableClosingCategoryOverigOverig": true,
     "enableAmsterdamSpecificOverigCategories": true,
     "enableCsvExport": false,
@@ -127,7 +127,7 @@
     }
   },
   "oidc": {
-    "authEndpoint": "https://acc.iam.amsterdam.nl/auth",
+    "authEndpoint": "https://iam.amsterdam.nl/auth",
     "clientId": "sia-frontend",
     "realm": "datapunt-ad-acc",
     "responseType": "code",

--- a/app.amsterdam.json
+++ b/app.amsterdam.json
@@ -3,7 +3,7 @@
   "areaTypeCodeForDistrict": "stadsdeel",
   "featureFlags": {
     "assignSignalToDepartment": false,
-    "assignSignalToEmployee": false,
+    "assignSignalToEmployee": true,
     "disableClosingCategoryOverigOverig": true,
     "enableAmsterdamSpecificOverigCategories": true,
     "enableCsvExport": false,

--- a/src/signals/incident-management/containers/IncidentOverviewPage/components/IncidentOverviewTitle/index.js
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/components/IncidentOverviewTitle/index.js
@@ -24,8 +24,10 @@ const getSortInformation = (ordering) => {
     return sortOption.asc === ordering || sortOption.desc === ordering
   })
 
-  if (sort.asc === ordering) return `${sort.key} ${sort.asc_label}`
-  if (sort.desc === ordering) return `${sort.key} ${sort.desc_label}`
+  if (sort.asc === ordering)
+    return `${sort.label.toLowerCase()} ${sort.asc_label}`
+  if (sort.desc === ordering)
+    return `${sort.label.toLowerCase()} ${sort.desc_label}`
 }
 
 export const IncidentOverviewTitle = ({

--- a/src/signals/incident-management/containers/IncidentOverviewPage/components/List/index.tsx
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/components/List/index.tsx
@@ -162,7 +162,7 @@ const List: FunctionComponent<ListProps> = ({
             <ThSort
               StyledComponent={ThPriority}
               sortOption={SortOptions.PRIORITY_ASC}
-              headerText={SortOptionLabels.URGENTIE}
+              headerText={SortOptionLabels.PRIORITY}
               ordering={ordering}
               changeOrder={changeOrder}
               sortingDisabled={sortingDisabled}
@@ -179,7 +179,7 @@ const List: FunctionComponent<ListProps> = ({
             <ThSort
               StyledComponent={ThDate}
               sortOption={SortOptions.CREATED_AT_DESC}
-              headerText={SortOptionLabels.DATUM}
+              headerText={SortOptionLabels.DATE}
               ordering={ordering}
               changeOrder={changeOrder}
             />
@@ -205,7 +205,7 @@ const List: FunctionComponent<ListProps> = ({
               headerText={
                 configuration.featureFlags.fetchDistrictsFromBackend
                   ? configuration.language.district
-                  : SortOptionLabels.STADSDEEL
+                  : SortOptionLabels.DISTRICT
               }
               ordering={ordering}
               changeOrder={changeOrder}
@@ -214,7 +214,7 @@ const List: FunctionComponent<ListProps> = ({
             <ThSort
               StyledComponent={BaseTh}
               sortOption={SortOptions.ADDRESS_ASC}
-              headerText={SortOptionLabels.ADRES}
+              headerText={SortOptionLabels.ADDRESS}
               ordering={ordering}
               changeOrder={changeOrder}
               sortingDisabled={sortingDisabled}
@@ -223,7 +223,7 @@ const List: FunctionComponent<ListProps> = ({
               <ThSort
                 StyledComponent={BaseTh}
                 sortOption={SortOptions.ASSIGNED_USER_EMAIL_ASC}
-                headerText={SortOptionLabels.TOEGEWEZEN_AAN}
+                headerText={SortOptionLabels.ASSIGNED_USER_EMAIL}
                 ordering={ordering}
                 changeOrder={changeOrder}
                 sortingDisabled={sortingDisabled}

--- a/src/signals/incident-management/containers/IncidentOverviewPage/components/List/index.tsx
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/components/List/index.tsx
@@ -199,18 +199,25 @@ const List: FunctionComponent<ListProps> = ({
               changeOrder={changeOrder}
               sortingDisabled={sortingDisabled}
             />
-            <ThSort
-              StyledComponent={ThArea}
-              sortOption={SortOptions.BUROUGH_ASC}
-              headerText={
-                configuration.featureFlags.fetchDistrictsFromBackend
-                  ? configuration.language.district
-                  : SortOptionLabels.DISTRICT
-              }
-              ordering={ordering}
-              changeOrder={changeOrder}
-              sortingDisabled={sortingDisabled}
-            />
+            {configuration.featureFlags.fetchDistrictsFromBackend ? (
+              <ThSort
+                StyledComponent={ThArea}
+                sortOption={SortOptions.DISTRICT_ASC}
+                headerText={configuration.language.district}
+                ordering={ordering}
+                changeOrder={changeOrder}
+                sortingDisabled={sortingDisabled}
+              />
+            ) : (
+              <ThSort
+                StyledComponent={ThArea}
+                sortOption={SortOptions.BUROUGH_ASC}
+                headerText={SortOptionLabels.BUROUGH}
+                ordering={ordering}
+                changeOrder={changeOrder}
+                sortingDisabled={sortingDisabled}
+              />
+            )}
             <ThSort
               StyledComponent={BaseTh}
               sortOption={SortOptions.ADDRESS_ASC}

--- a/src/signals/incident-management/containers/IncidentOverviewPage/components/List/index.tsx
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/components/List/index.tsx
@@ -33,7 +33,6 @@ import {
   StyledList,
   Table,
   TdStyle,
-  Th,
   ThArea,
   ThDate,
   ThDay,
@@ -221,7 +220,14 @@ const List: FunctionComponent<ListProps> = ({
               sortingDisabled={sortingDisabled}
             />
             {configuration.featureFlags.assignSignalToEmployee && (
-              <Th>Toegewezen aan</Th>
+              <ThSort
+                StyledComponent={BaseTh}
+                sortOption={SortOptions.ASSIGNED_USER_EMAIL_ASC}
+                headerText={SortOptionLabels.TOEGEWEZEN_AAN}
+                ordering={ordering}
+                changeOrder={changeOrder}
+                sortingDisabled={sortingDisabled}
+              />
             )}
           </tr>
         </thead>

--- a/src/signals/incident-management/containers/IncidentOverviewPage/components/List/styles.ts
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/components/List/styles.ts
@@ -23,7 +23,7 @@ export const Table = styled.table`
   }
 `
 
-export const Th = styled.th`
+const Th = styled.th`
   white-space: nowrap;
 `
 

--- a/src/signals/incident-management/containers/IncidentOverviewPage/contants.ts
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/contants.ts
@@ -1,3 +1,5 @@
+import configuration from 'shared/services/configuration/configuration'
+
 export enum SortOptions {
   ADDRESS_ASC = 'address',
   ADDRESS_DESC = '-address',
@@ -31,11 +33,9 @@ export enum SortOptionKeys {
   ASSIGNED_USER_EMAIL = 'toegewezen_aan',
 }
 
-const discrict_label = `configuration.language.district`
-
 export enum SortOptionLabels {
   ADDRESS = 'Adres',
-  DISTRICT = `${discrict_label}`,
+  DISTRICT = `Wijk`,
   DATE = 'Datum',
   ID = 'Id',
   BUROUGH = 'Stadsdeel',
@@ -90,7 +90,7 @@ export const sortOptionsList: SortOption[] = [
     desc_label: '(z-a)',
   },
   {
-    label: SortOptionLabels.DISTRICT,
+    label: configuration.language.district ?? SortOptionLabels.DISTRICT,
     asc: SortOptions.DISTRICT_ASC,
     asc_label: '(a-z)',
     desc: SortOptions.DISTRICT_DESC,

--- a/src/signals/incident-management/containers/IncidentOverviewPage/contants.ts
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/contants.ts
@@ -20,25 +20,25 @@ export enum SortOptions {
 }
 
 export enum SortOptionKeys {
-  ADRES = 'adres',
-  DATUM = 'datum',
+  ADDRESS = 'adres',
+  DATE = 'datum',
   ID = 'id',
-  STADSDEEL = 'stadsdeel',
+  DISTRICT = 'stadsdeel',
   STATUS = 'status',
   SUBCATEGORY = 'subcategorie',
-  URGENTIE = 'urgentie',
-  TOEGEWEZEN_AAN = 'toegewezen_aan',
+  PRIORITY = 'urgentie',
+  ASSIGNED_USER_EMAIL = 'toegewezen_aan',
 }
 
 export enum SortOptionLabels {
-  ADRES = 'Adres',
-  DATUM = 'Datum',
+  ADDRESS = 'Adres',
+  DATE = 'Datum',
   ID = 'Id',
-  STADSDEEL = 'Stadsdeel',
+  DISTRICT = 'Stadsdeel',
   STATUS = 'Status',
   SUBCATEGORY = 'Subcategorie',
-  URGENTIE = 'Urgentie',
-  TOEGEWEZEN_AAN = 'Toegewezen aan',
+  PRIORITY = 'Urgentie',
+  ASSIGNED_USER_EMAIL = 'Toegewezen aan',
 }
 
 export type SortOption = {
@@ -52,24 +52,24 @@ export type SortOption = {
 
 export const sortOptionsList: SortOption[] = [
   {
-    key: SortOptionKeys.ADRES,
-    label: SortOptionLabels.ADRES,
+    key: SortOptionKeys.ADDRESS,
+    label: SortOptionLabels.ADDRESS,
     asc: SortOptions.ASSIGNED_USER_EMAIL_ASC,
     asc_label: '(a-z)',
     desc: SortOptions.ASSIGNED_USER_EMAIL_DESC,
     desc_label: '(z-a)',
   },
   {
-    key: SortOptionKeys.TOEGEWEZEN_AAN,
-    label: SortOptionLabels.TOEGEWEZEN_AAN,
+    key: SortOptionKeys.ASSIGNED_USER_EMAIL,
+    label: SortOptionLabels.ASSIGNED_USER_EMAIL,
     asc: SortOptions.ADDRESS_ASC,
     asc_label: '(a-z)',
     desc: SortOptions.ADDRESS_DESC,
     desc_label: '(z-a)',
   },
   {
-    key: SortOptionKeys.DATUM,
-    label: SortOptionLabels.DATUM,
+    key: SortOptionKeys.DATE,
+    label: SortOptionLabels.DATE,
     asc: SortOptions.CREATED_AT_ASC,
     asc_label: '(oud-nieuw)',
     desc: SortOptions.CREATED_AT_DESC,
@@ -84,8 +84,8 @@ export const sortOptionsList: SortOption[] = [
     desc_label: '(hoog-laag)',
   },
   {
-    key: SortOptionKeys.STADSDEEL,
-    label: SortOptionLabels.STADSDEEL,
+    key: SortOptionKeys.DISTRICT,
+    label: SortOptionLabels.DISTRICT,
     asc: SortOptions.BUROUGH_ASC,
     asc_label: '(a-z)',
     desc: SortOptions.BUROUGH_DESC,
@@ -108,8 +108,8 @@ export const sortOptionsList: SortOption[] = [
     desc_label: '(z-a)',
   },
   {
-    key: SortOptionKeys.URGENTIE,
-    label: SortOptionLabels.URGENTIE,
+    key: SortOptionKeys.PRIORITY,
+    label: SortOptionLabels.PRIORITY,
     asc: SortOptions.PRIORITY_ASC,
     asc_label: '(hoog-laag-normaal)',
     desc: SortOptions.PRIORITY_DESC,

--- a/src/signals/incident-management/containers/IncidentOverviewPage/contants.ts
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/contants.ts
@@ -46,7 +46,7 @@ export enum SortOptionLabels {
 }
 
 export type SortOption = {
-  label?: string
+  label: string
   asc: SortOptions
   desc: SortOptions
   asc_label: string

--- a/src/signals/incident-management/containers/IncidentOverviewPage/contants.ts
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/contants.ts
@@ -23,7 +23,8 @@ export enum SortOptionKeys {
   ADDRESS = 'adres',
   DATE = 'datum',
   ID = 'id',
-  DISTRICT = 'stadsdeel',
+  BUROUGH = 'stadsdeel',
+  DISTRICT = 'area_name',
   STATUS = 'status',
   SUBCATEGORY = 'subcategorie',
   PRIORITY = 'urgentie',
@@ -34,7 +35,7 @@ export enum SortOptionLabels {
   ADDRESS = 'Adres',
   DATE = 'Datum',
   ID = 'Id',
-  DISTRICT = 'Stadsdeel',
+  BUROUGH = 'Stadsdeel',
   STATUS = 'Status',
   SUBCATEGORY = 'Subcategorie',
   PRIORITY = 'Urgentie',
@@ -43,7 +44,7 @@ export enum SortOptionLabels {
 
 export type SortOption = {
   key: SortOptionKeys
-  label: string
+  label?: string
   asc: SortOptions
   desc: SortOptions
   asc_label: string
@@ -84,11 +85,18 @@ export const sortOptionsList: SortOption[] = [
     desc_label: '(hoog-laag)',
   },
   {
-    key: SortOptionKeys.DISTRICT,
-    label: SortOptionLabels.DISTRICT,
+    key: SortOptionKeys.BUROUGH,
+    label: SortOptionLabels.BUROUGH,
     asc: SortOptions.BUROUGH_ASC,
     asc_label: '(a-z)',
     desc: SortOptions.BUROUGH_DESC,
+    desc_label: '(z-a)',
+  },
+  {
+    key: SortOptionKeys.DISTRICT,
+    asc: SortOptions.DISTRICT_ASC,
+    asc_label: '(a-z)',
+    desc: SortOptions.DISTRICT_DESC,
     desc_label: '(z-a)',
   },
   {

--- a/src/signals/incident-management/containers/IncidentOverviewPage/contants.ts
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/contants.ts
@@ -1,5 +1,3 @@
-import configuration from 'shared/services/configuration/configuration'
-
 export enum SortOptions {
   ADDRESS_ASC = 'address',
   ADDRESS_DESC = '-address',
@@ -33,8 +31,11 @@ export enum SortOptionKeys {
   ASSIGNED_USER_EMAIL = 'toegewezen_aan',
 }
 
+const discrict_label = `configuration.language.district`
+
 export enum SortOptionLabels {
   ADDRESS = 'Adres',
+  DISTRICT = `${discrict_label}`,
   DATE = 'Datum',
   ID = 'Id',
   BUROUGH = 'Stadsdeel',
@@ -89,8 +90,7 @@ export const sortOptionsList: SortOption[] = [
     desc_label: '(z-a)',
   },
   {
-    // Only used we when fetchDistrictsFromBackend is enabled
-    label: configuration.language.district,
+    label: SortOptionLabels.DISTRICT,
     asc: SortOptions.DISTRICT_ASC,
     asc_label: '(a-z)',
     desc: SortOptions.DISTRICT_DESC,

--- a/src/signals/incident-management/containers/IncidentOverviewPage/contants.ts
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/contants.ts
@@ -1,3 +1,5 @@
+import configuration from 'shared/services/configuration/configuration'
+
 export enum SortOptions {
   ADDRESS_ASC = 'address',
   ADDRESS_DESC = '-address',
@@ -43,7 +45,6 @@ export enum SortOptionLabels {
 }
 
 export type SortOption = {
-  key: SortOptionKeys
   label?: string
   asc: SortOptions
   desc: SortOptions
@@ -53,23 +54,20 @@ export type SortOption = {
 
 export const sortOptionsList: SortOption[] = [
   {
-    key: SortOptionKeys.ADDRESS,
-    label: SortOptionLabels.ADDRESS,
+    label: SortOptionLabels.ASSIGNED_USER_EMAIL,
     asc: SortOptions.ASSIGNED_USER_EMAIL_ASC,
     asc_label: '(a-z)',
     desc: SortOptions.ASSIGNED_USER_EMAIL_DESC,
     desc_label: '(z-a)',
   },
   {
-    key: SortOptionKeys.ASSIGNED_USER_EMAIL,
-    label: SortOptionLabels.ASSIGNED_USER_EMAIL,
+    label: SortOptionLabels.ADDRESS,
     asc: SortOptions.ADDRESS_ASC,
     asc_label: '(a-z)',
     desc: SortOptions.ADDRESS_DESC,
     desc_label: '(z-a)',
   },
   {
-    key: SortOptionKeys.DATE,
     label: SortOptionLabels.DATE,
     asc: SortOptions.CREATED_AT_ASC,
     asc_label: '(oud-nieuw)',
@@ -77,7 +75,6 @@ export const sortOptionsList: SortOption[] = [
     desc_label: '(nieuw-oud)',
   },
   {
-    key: SortOptionKeys.ID,
     label: SortOptionLabels.ID,
     asc: SortOptions.ID_ASC,
     asc_label: '(laag-hoog)',
@@ -85,7 +82,6 @@ export const sortOptionsList: SortOption[] = [
     desc_label: '(hoog-laag)',
   },
   {
-    key: SortOptionKeys.BUROUGH,
     label: SortOptionLabels.BUROUGH,
     asc: SortOptions.BUROUGH_ASC,
     asc_label: '(a-z)',
@@ -93,14 +89,14 @@ export const sortOptionsList: SortOption[] = [
     desc_label: '(z-a)',
   },
   {
-    key: SortOptionKeys.DISTRICT,
+    // Only used we when fetchDistrictsFromBackend is enabled
+    label: configuration.language.district,
     asc: SortOptions.DISTRICT_ASC,
     asc_label: '(a-z)',
     desc: SortOptions.DISTRICT_DESC,
     desc_label: '(z-a)',
   },
   {
-    key: SortOptionKeys.STATUS,
     label: SortOptionLabels.STATUS,
     asc: SortOptions.STATUS_ASC,
     asc_label: '(a-z)',
@@ -108,7 +104,6 @@ export const sortOptionsList: SortOption[] = [
     desc_label: '(z-a)',
   },
   {
-    key: SortOptionKeys.SUBCATEGORY,
     label: SortOptionLabels.SUBCATEGORY,
     asc: SortOptions.SUBCATEGORY_ASC,
     asc_label: '(a-z)',
@@ -116,7 +111,6 @@ export const sortOptionsList: SortOption[] = [
     desc_label: '(z-a)',
   },
   {
-    key: SortOptionKeys.PRIORITY,
     label: SortOptionLabels.PRIORITY,
     asc: SortOptions.PRIORITY_ASC,
     asc_label: '(hoog-laag-normaal)',

--- a/src/signals/incident-management/containers/IncidentOverviewPage/contants.ts
+++ b/src/signals/incident-management/containers/IncidentOverviewPage/contants.ts
@@ -27,6 +27,7 @@ export enum SortOptionKeys {
   STATUS = 'status',
   SUBCATEGORY = 'subcategorie',
   URGENTIE = 'urgentie',
+  TOEGEWEZEN_AAN = 'toegewezen_aan',
 }
 
 export enum SortOptionLabels {
@@ -37,6 +38,7 @@ export enum SortOptionLabels {
   STATUS = 'Status',
   SUBCATEGORY = 'Subcategorie',
   URGENTIE = 'Urgentie',
+  TOEGEWEZEN_AAN = 'Toegewezen aan',
 }
 
 export type SortOption = {
@@ -52,6 +54,14 @@ export const sortOptionsList: SortOption[] = [
   {
     key: SortOptionKeys.ADRES,
     label: SortOptionLabels.ADRES,
+    asc: SortOptions.ASSIGNED_USER_EMAIL_ASC,
+    asc_label: '(a-z)',
+    desc: SortOptions.ASSIGNED_USER_EMAIL_DESC,
+    desc_label: '(z-a)',
+  },
+  {
+    key: SortOptionKeys.TOEGEWEZEN_AAN,
+    label: SortOptionLabels.TOEGEWEZEN_AAN,
     asc: SortOptions.ADDRESS_ASC,
     asc_label: '(a-z)',
     desc: SortOptions.ADDRESS_DESC,


### PR DESCRIPTION
Ticket: [SIG-5683](https://gemeente-amsterdam.atlassian.net/browse/SIG-5683)

Includes some refactoring:
- Changing keys to English
- Sorting information is now a label instead of key, so removed the key from `type SortOption`
- [bug] When `fetchDistrictsFromBackend` is enabled only the header title was changed. However, the query should have changed too to use `area_name` instead of "stadsdeel". 


[SIG-5683]: https://gemeente-amsterdam.atlassian.net/browse/SIG-5683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ