### PR TITLE
[feat-5872]: dataplatform key fix

### DIFF
--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/WfsLayer.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/WfsLayer.test.tsx
@@ -305,9 +305,16 @@ describe('src/signals/incident/components/form/AssetSelect/WfsLayer', () => {
     expect(fetchMock.mock.lastCall[1]?.headers).toBeFalsy()
   })
 
-  it('should only set x-api-key header when keys.dataPlatform is filled in the config', () => {
+  it('should only set x-api-key header when hos is api.data.amsterdam.nl', () => {
     configuration.map.keys.dataPlatform = '1234'
-
+    const assetSelectProviderValue: AssetSelectValue = {
+      ...assetSelectContextValue,
+      meta: {
+        ...assetSelectContextValue.meta,
+        endpoint: 'https://api.data.amsterdam.nl',
+      },
+      setItem: jest.fn(() => promise),
+    }
     render(
       withMapAsset(
         <AssetSelectProvider value={assetSelectProviderValue}>

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/WfsLayer.test.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/WfsLayer.test.tsx
@@ -305,7 +305,7 @@ describe('src/signals/incident/components/form/AssetSelect/WfsLayer', () => {
     expect(fetchMock.mock.lastCall[1]?.headers).toBeFalsy()
   })
 
-  it('should only set x-api-key header when hos is api.data.amsterdam.nl', () => {
+  it('should only set x-api-key header when host is api.data.amsterdam.nl', () => {
     configuration.map.keys.dataPlatform = '1234'
     const assetSelectProviderValue: AssetSelectValue = {
       ...assetSelectContextValue,

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/WfsLayer.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/WfsLayer.tsx
@@ -77,7 +77,7 @@ const WfsLayer: FunctionComponent<WfsLayerProps> = ({
 
     const { request, controller } = fetchWithAbort(
       url.toString(),
-      configuration.map.keys.dataPlatform
+      url.host === 'api.data.amsterdam.nl'
         ? {
             headers: { 'X-Api-Key': configuration.map.keys.dataPlatform },
           }

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/WfsLayer.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/WfsLayer.tsx
@@ -77,7 +77,7 @@ const WfsLayer: FunctionComponent<WfsLayerProps> = ({
 
     const { request, controller } = fetchWithAbort(
       url.toString(),
-      url.host === 'api.data.amsterdam.nl'
+      configuration.map.keys.dataPlatform && url.host === 'api.data.amsterdam.nl'
         ? {
             headers: { 'X-Api-Key': configuration.map.keys.dataPlatform },
           }

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/utils/is-caterpillar-category.ts
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/WfsLayer/utils/is-caterpillar-category.ts
@@ -1,6 +1,10 @@
 import type { Feature as FeatureGeo } from 'geojson'
 
-export const isCaterpillarCategory = (feature: FeatureGeo) => {
+export const isCaterpillarCategory = (
+  feature: FeatureGeo | null | undefined
+) => {
+  if (!feature) return false
+
   return (
     typeof feature.id === 'number' &&
     feature.properties &&


### PR DESCRIPTION
Ticket: [SIG-5872](https://gemeente-amsterdam.atlassian.net/browse/SIG-5872)

- only send key when host is api.data.amsterdam.nl
- fix small bug. A error was thrown when no features where there and the util function tries to read `id`.

### Release Notes
- key should be added to acceptance and production config files

[SIG-5872]: https://gemeente-amsterdam.atlassian.net/browse/SIG-5872?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ