### PR TITLE
Show attribution on incident map

### DIFF
--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -26,9 +26,11 @@ const StyledMap = styled(MapComponent)`
     cursor: all-scroll;
   }
 
-  .leaflet-control-attribution a,
-  span {
-    display: none;
+  .leaflet-control-attribution {
+    a,
+    span:first-of-type {
+      display: none;
+    }
   }
 `
 

--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -25,6 +25,11 @@ const StyledMap = styled(MapComponent)`
   &.leaflet-drag-target {
     cursor: all-scroll;
   }
+
+  .leaflet-control-attribution a,
+  span {
+    display: none;
+  }
 `
 
 export interface MapProps {
@@ -78,13 +83,7 @@ const Map: FC<PropsWithChildren<MapProps>> = ({
 
   useEffect(() => {
     /* istanbul ignore next */
-    const timeout = setTimeout(() => {
-      document.querySelector('.leaflet-control-attribution a')?.remove()
-      document.querySelector('.leaflet-control-attribution span')?.remove()
-    }, 0)
-
     return () => {
-      clearTimeout(timeout)
       if (mapActive) {
         dispatch(closeMap())
       }

--- a/src/signals/IncidentMap/components/IncidentMap/IncidentMap.tsx
+++ b/src/signals/IncidentMap/components/IncidentMap/IncidentMap.tsx
@@ -191,7 +191,6 @@ export const IncidentMap = () => {
           dragging: true,
           scrollWheelZoom: true,
           zoom: configuration.map.optionsIncidentMap.zoom,
-          attributionControl: false,
         }}
       >
         {isMobile(deviceMode) && (


### PR DESCRIPTION
This PR makes sure we also show the attribution on the incident map. We already show attribution on the map while reporting.

It also uses CSS to hide the Leaflet attribution, instead of a DOM manipulation. This solution avoids timing issues.

![image](https://github.com/Amsterdam/signals-frontend/assets/5213690/9a632252-a9db-4162-959f-bb5a50c84aa0)

