### PR TITLE
[fix]: Show attributionControl on IncidentMap and hide leaflet prefix

### DIFF
--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -77,14 +77,7 @@ const Map: FC<PropsWithChildren<MapProps>> = ({
   const { mapActive } = useSelector(makeSelectIncidentContainer)
 
   useEffect(() => {
-    /* istanbul ignore next */
-    const timeout = setTimeout(() => {
-      document.querySelector('.leaflet-control-attribution a')?.remove()
-      document.querySelector('.leaflet-control-attribution span')?.remove()
-    }, 0)
-
     return () => {
-      clearTimeout(timeout)
       if (mapActive) {
         dispatch(closeMap())
       }

--- a/src/components/MapInput/MapInput.tsx
+++ b/src/components/MapInput/MapInput.tsx
@@ -76,7 +76,7 @@ const MapInput = ({
   useEffect(() => {
     if (!map) return
     map.attributionControl.getContainer()?.setAttribute('aria-hidden', 'true')
-    map.attributionControl.setPrefix('')
+    map.attributionControl.setPrefix(false)
   }, [map])
 
   const clickFunc = useCallback(

--- a/src/components/OverviewMap/OverviewMap.tsx
+++ b/src/components/OverviewMap/OverviewMap.tsx
@@ -108,6 +108,8 @@ const OverviewMap: FC<OverviewMapProps> = ({
   const [incident, setIncident] = useState<IncidentSummary>()
   const [pollingCount, setPollingCount] = useState(0)
 
+  map?.attributionControl.setPrefix(false)
+
   const params = useMemo(
     () => ({
       ...filterParams,

--- a/src/signals/IncidentMap/components/IncidentMap/IncidentMap.tsx
+++ b/src/signals/IncidentMap/components/IncidentMap/IncidentMap.tsx
@@ -65,6 +65,8 @@ export const IncidentMap = () => {
 
   const { deviceMode, isMobile } = useDeviceMode()
 
+  map?.attributionControl.setPrefix(false)
+
   const closeDrawerOverlay = useCallback(() => {
     setDrawerState(DrawerState.Closed)
   }, [])
@@ -191,7 +193,6 @@ export const IncidentMap = () => {
           dragging: true,
           scrollWheelZoom: true,
           zoom: configuration.map.optionsIncidentMap.zoom,
-          attributionControl: false,
         }}
       >
         {isMobile(deviceMode) && (

--- a/src/signals/incident/components/form/MapSelectors/Asset/Selector/Selector.tsx
+++ b/src/signals/incident/components/form/MapSelectors/Asset/Selector/Selector.tsx
@@ -122,6 +122,7 @@ const Selector: FC = () => {
   const hasFeatureTypes = meta.featureTypes.length > 0
   const showMarker =
     coordinates && (!selection || selectionIsUndetermined(selection[0]))
+  map?.attributionControl.setPrefix(false)
 
   const mapClick = useCallback(
     ({ latlng }: LeafletMouseEvent) => {


### PR DESCRIPTION
Ticket: none
