### PR TITLE
[fix-6019] feedback update when question

### DIFF
--- a/src/signals/incident/definitions/wizard-step-2-vulaan/overlast-op-het-water.ts
+++ b/src/signals/incident/definitions/wizard-step-2-vulaan/overlast-op-het-water.ts
@@ -9,6 +9,13 @@ export const overlastOpHetWater = {
   locatie,
   dateTime: {
     meta: {
+      ifOneOf: {
+        subcategory: [
+          'olie-op-het-water',
+          'overlast-op-het-water-vaargedrag',
+          'overlast-vanaf-het-water',
+        ],
+      },
       label: 'Wanneer heeft u de overlast?',
     },
     options: {

--- a/src/signals/incident/definitions/wizard-step-4-summary.js
+++ b/src/signals/incident/definitions/wizard-step-4-summary.js
@@ -8,6 +8,7 @@ import { QuestionFieldType } from 'types/question'
 
 import afvalControls from './wizard-step-2-vulaan/afval'
 import afvalContainerControls from './wizard-step-2-vulaan/afval-container'
+import afvalThorControls from './wizard-step-2-vulaan/afval-thor'
 import boomIllegaleKap from './wizard-step-2-vulaan/boom-illegale-kap'
 import bouwSloopOverlast from './wizard-step-2-vulaan/bouw-sloop-overlast'
 import civieleConstructies from './wizard-step-2-vulaan/civieleConstructies'
@@ -17,9 +18,11 @@ import locatie from './wizard-step-2-vulaan/locatie'
 import overlastBedrijvenEnHorecaControls from './wizard-step-2-vulaan/overlast-bedrijven-en-horeca'
 import overlastInDeOpenbareRuimteControls from './wizard-step-2-vulaan/overlast-in-de-openbare-ruimte'
 import overlastOpHetWaterControls from './wizard-step-2-vulaan/overlast-op-het-water'
+import overlastOpHetWaterThorControls from './wizard-step-2-vulaan/overlast-op-het-water-thor'
 import overlastVanDieren from './wizard-step-2-vulaan/overlast-van-dieren'
 import overlastPersonenEnGroepenControls from './wizard-step-2-vulaan/overlast-van-en-door-personen-of-groepen'
 import straatverlichtingKlokkenControls from './wizard-step-2-vulaan/straatverlichting-klokken'
+import verkeersoverlastControls from './wizard-step-2-vulaan/verkeersoverlast'
 import wegenVerkeerStraatmeubilairControls from './wizard-step-2-vulaan/wegen-verkeer-straatmeubilair'
 import { controls as wonenControls } from './wizard-step-2-vulaan/wonen'
 import IncidentNavigation from '../components/IncidentNavigation'
@@ -123,9 +126,11 @@ const getExtraQuestions = (category, subcategory, questions) => {
     case 'afval': {
       if (subcategory.startsWith('container')) {
         return summary(afvalContainerControls)
-      } else {
-        return summary(afvalControls)
       }
+      if (['asbest-accu', 'handhaving-op-afval'].includes(subcategory)) {
+        return summary(afvalThorControls)
+      }
+      return summary(afvalControls)
     }
 
     case 'civiele-constructies':
@@ -143,6 +148,18 @@ const getExtraQuestions = (category, subcategory, questions) => {
     }
 
     case 'overlast-op-het-water':
+      if (
+        [
+          'blokkade-van-de-vaarweg',
+          'overig-boten',
+          'overlast-op-het-water-geluid',
+          'overlast-op-het-water-snel-varen',
+          'scheepvaart-nautisch-toezicht',
+        ].includes(subcategory)
+      ) {
+        return summary(overlastOpHetWaterThorControls)
+      }
+
       return summary(overlastOpHetWaterControls)
 
     case 'overlast-van-en-door-personen-of-groepen':
@@ -157,6 +174,10 @@ const getExtraQuestions = (category, subcategory, questions) => {
       )
         ? straatverlichtingKlokkenControls
         : wegenVerkeerStraatmeubilairControls
+
+      if (subcategory === 'verkeersoverlast') {
+        return summary(verkeersoverlastControls)
+      }
 
       return summary(config)
     }


### PR DESCRIPTION
Ticket: [SIG-6019](https://gemeente-amsterdam.atlassian.net/browse/SIG-6019)

Some fixes after feedback from UX:

- The summary didn't show the correct labels for the Afval and Overlast op het water categories, and the Verkeersoverlast subcategory
- The subcategory Wrak in het water should not show the 'when' question


[SIG-6019]: https://gemeente-amsterdam.atlassian.net/browse/SIG-6019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ