### PR TITLE
Only show link to reports map when it is enabled

### DIFF
--- a/src/signals/incident/definitions/wizard-step-1-beschrijf.js
+++ b/src/signals/incident/definitions/wizard-step-1-beschrijf.js
@@ -52,7 +52,9 @@ const getControls = memoize(
           value: `Voordat u een melding doet kunt u op de [meldingenkaart](/meldingenkaart) zien welke meldingen bekend zijn bij de
           gemeente.`,
         },
-        render: FormComponents.PlainText,
+        render: configuration.featureFlags.enablePublicIncidentsMap
+          ? FormComponents.PlainText
+          : null,
       },
       source: {
         meta: {


### PR DESCRIPTION
This fix only shows the links to the reports map when it is enabled.
