### PR TITLE
Add X-Frame-Options DENY header

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -4,12 +4,14 @@ server {
 
     root /usr/share/nginx/html/;
 
-    # disable content-type sniffing on some browsers.
+    # Disable content-type sniffing on some browsers.
     add_header X-Content-Type-Options nosniff;
     # This header enables the Cross-site scripting (XSS) filter
     add_header X-XSS-Protection "1; mode=block";
     # This will enforce HTTP browsing into HTTPS and avoid ssl stripping attack
     add_header Strict-Transport-Security "max-age=31536000; includeSubdomains;";
+    # This header will prevent the browser from loading the page in a frame
+    add_header X-Frame-Options DENY;
 
     # Add GZIP compression for speed optimization
     gzip on;


### PR DESCRIPTION
This PR adds the X-Frame-Options header and sets it to DENY. I think this is a safe default to avoid clickjacking.
