### PR TITLE
[feat-6568]: Add projectmatig onderhoud signal type behind feature flag

### DIFF
--- a/app.amsterdam.json
+++ b/app.amsterdam.json
@@ -25,7 +25,8 @@
     "showStandardTextAdminV2": true,
     "showThorButton": true,
     "showVulaanControls": true,
-    "useProjectenSignalType": false
+    "useProjectenSignalType": false,
+    "useProjectmatigOnderhoudSignalType": true
   },
   "head": {
     "androidIcon": "/icon_192x192.png",

--- a/app.base.json
+++ b/app.base.json
@@ -27,7 +27,8 @@
     "showStandardTextAdminV2": false,
     "showThorButton": false,
     "showVulaanControls": false,
-    "useProjectenSignalType": false
+    "useProjectenSignalType": false,
+    "useProjectmatigOnderhoudSignalType": false
   },
   "head": {
     "androidIcon": "/icon_192x192.png",

--- a/internals/schemas/app.schema.json
+++ b/internals/schemas/app.schema.json
@@ -138,7 +138,7 @@
           "type": "boolean"
         },
         "useProjectmatigOnderhoudSignalType": {
-          "description": "When true, will add a signal type 'Projectmatig onderhoud' which is used in Amsterdam.",
+          "description": "When true, will add a signal type called 'Projectmatig onderhoud'.",
           "type": "boolean"
         },
         "reporterMailHandledNegativeContactEnabled": {

--- a/internals/schemas/app.schema.json
+++ b/internals/schemas/app.schema.json
@@ -137,6 +137,10 @@
           "description": "When true, will make a textual change to the signal type 'Groot onderhoud', becoming 'Projecten'. This is temporarily needed until the signal types have been moved to the database.",
           "type": "boolean"
         },
+        "useProjectmatigOnderhoudSignalType": {
+          "description": "When true, will add a signal type 'Projectmatig onderhoud' which is used in Amsterdam.",
+          "type": "boolean"
+        },
         "reporterMailHandledNegativeContactEnabled": {
           "description": "When true, will show a feedback text based on the satisfaction value yes or no.",
           "type": "boolean"
@@ -187,7 +191,8 @@
         "mapFilter24Hours",
         "showThorButton",
         "showVulaanControls",
-        "useProjectenSignalType"
+        "useProjectenSignalType",
+        "useProjectmatigOnderhoudSignalType"
       ],
       "title": "FeatureFlags"
     },

--- a/src/signals/incident-management/definitions/typesList.js
+++ b/src/signals/incident-management/definitions/typesList.js
@@ -32,4 +32,13 @@ export default [
       ? 'Een verzoek dat niet onder dagelijks beheer valt, maar onder een project.'
       : 'Een verzoek dat niet onder dagelijks beheer valt, maar onder een langdurig traject.',
   },
+  ...(configuration.featureFlags.useProjectmatigOnderhoudSignalType
+    ? [
+        {
+          key: 'PRO',
+          value: 'Projectmatig onderhoud',
+          info: 'Een verzoek dat niet onder dagelijks beheer valt, maar onder een langdurig traject.',
+        },
+      ]
+    : []),
 ]


### PR DESCRIPTION
Ticket: [SIG-6568](https://gemeente-amsterdam.atlassian.net/browse/SIG-6568)

NOTES:
- Should not be merged and released before [backend ticket](https://gemeente-amsterdam.atlassian.net/browse/SIG-6538) is done. 

### Release notes
- add default feature flag


[SIG-6568]: https://gemeente-amsterdam.atlassian.net/browse/SIG-6568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ