### PR TITLE
Explicitly define workflow permissions

### DIFF
--- a/.github/workflows/build_and_push_to_docker_hub.yml
+++ b/.github/workflows/build_and_push_to_docker_hub.yml
@@ -1,8 +1,9 @@
 name: Build Docker image and push to Docker Hub
-
 on:
   release:
     types: [ published ]
+permissions:
+  contents: read
 
 jobs:
   build_and_push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,8 @@ on:
     branches:
       - main
   pull_request:
-
+permissions:
+  contents: read
 env:
   TZ: 'Europe/Amsterdam'
   CI: 'true'


### PR DESCRIPTION
See security tab above. The default permissions might change over time, potentially leaving us in a vulnerable position.
So it's better to explicitly define them.