### PR TITLE
[feat-6568]: Change projectmatig onderhoud to projectverzoek

### DIFF
--- a/app.amsterdam.json
+++ b/app.amsterdam.json
@@ -26,7 +26,7 @@
     "showThorButton": true,
     "showVulaanControls": true,
     "useProjectenSignalType": false,
-    "useProjectmatigOnderhoudSignalType": true
+    "useProjectverzoekSignalType": true
   },
   "head": {
     "androidIcon": "/icon_192x192.png",

--- a/app.base.json
+++ b/app.base.json
@@ -28,7 +28,7 @@
     "showThorButton": false,
     "showVulaanControls": false,
     "useProjectenSignalType": false,
-    "useProjectmatigOnderhoudSignalType": false
+    "useProjectverzoekSignalType": false
   },
   "head": {
     "androidIcon": "/icon_192x192.png",

--- a/internals/schemas/app.schema.json
+++ b/internals/schemas/app.schema.json
@@ -137,7 +137,7 @@
           "description": "When true, will make a textual change to the signal type 'Groot onderhoud', becoming 'Projecten'. This is temporarily needed until the signal types have been moved to the database.",
           "type": "boolean"
         },
-        "useProjectmatigOnderhoudSignalType": {
+        "useProjectverzoekSignalType": {
           "description": "When true, will add a signal type called 'Projectmatig onderhoud'.",
           "type": "boolean"
         },
@@ -192,7 +192,7 @@
         "showThorButton",
         "showVulaanControls",
         "useProjectenSignalType",
-        "useProjectmatigOnderhoudSignalType"
+        "useProjectverzoekSignalType"
       ],
       "title": "FeatureFlags"
     },

--- a/src/signals/incident-management/definitions/typesList.js
+++ b/src/signals/incident-management/definitions/typesList.js
@@ -32,11 +32,11 @@ export default [
       ? 'Een verzoek dat niet onder dagelijks beheer valt, maar onder een project.'
       : 'Een verzoek dat niet onder dagelijks beheer valt, maar onder een langdurig traject.',
   },
-  ...(configuration.featureFlags.useProjectmatigOnderhoudSignalType
+  ...(configuration.featureFlags.useProjectverzoekSignalType
     ? [
         {
           key: 'PRJ',
-          value: 'Projectmatig onderhoud',
+          value: 'Projectverzoek',
           info: 'Een verzoek dat niet onder dagelijks beheer valt, maar onder een langdurig traject.',
         },
       ]


### PR DESCRIPTION
Ticket: [SIG-6568](https://gemeente-amsterdam.atlassian.net/browse/SIG-6568)

### Release notes
- Change featureFlag useProjectenSignalType to useProjectverzoekSignalType 


[SIG-6568]: https://gemeente-amsterdam.atlassian.net/browse/SIG-6568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ