### PR TITLE
[fix-7326]: render anwers dateTime question in summary

### DIFF
--- a/src/signals/incident/components/form/DateTimeInput/DateTimeInput.test.tsx
+++ b/src/signals/incident/components/form/DateTimeInput/DateTimeInput.test.tsx
@@ -17,6 +17,7 @@ const props = {
   hasError: () => false,
   meta: {
     isVisible: true,
+    name: 'dateTime',
   },
   parent: {
     meta: {
@@ -46,11 +47,25 @@ describe('DateTimeInput', () => {
     const notVisible = {
       ...props,
       meta: {
+        ...props.meta,
         isVisible: false,
       },
     }
 
     render(withAppContext(<DateTimeInput {...notVisible} />))
+
+    expect(screen.queryByTestId('date-time')).not.toBeInTheDocument()
+  })
+
+  it('does not render without a name', () => {
+    const noName = {
+      ...props,
+      meta: {
+        isVisible: true,
+      },
+    }
+
+    render(withAppContext(<DateTimeInput {...noName} />))
 
     expect(screen.queryByTestId('date-time')).not.toBeInTheDocument()
   })
@@ -74,5 +89,26 @@ describe('DateTimeInput', () => {
     userEvent.click(screen.getByTestId('call-update'))
 
     expect(updateIncident).toHaveBeenCalledWith({ dateTime: customValue.value })
+  })
+
+  it('updates incident under the field name from meta', () => {
+    updateIncident.mockClear()
+
+    const customName = {
+      ...props,
+      meta: {
+        ...props.meta,
+        name: 'leegstand_dateTime',
+      },
+      value: 1234567890,
+    }
+
+    render(withAppContext(<DateTimeInput {...customName} />))
+
+    userEvent.click(screen.getByTestId('call-update'))
+
+    expect(updateIncident).toHaveBeenCalledWith({
+      leegstand_dateTime: customName.value,
+    })
   })
 })

--- a/src/signals/incident/components/form/DateTimeInput/DateTimeInput.tsx
+++ b/src/signals/incident/components/form/DateTimeInput/DateTimeInput.tsx
@@ -17,10 +17,12 @@ const DateTimeInput: FC<DateTimeInputProps> = ({
   validatorsOrOpts,
   value,
 }) => {
-  if (!meta?.isVisible) return null
+  if (!meta?.isVisible || !meta.name) return null
+
+  const { name } = meta
 
   const updateTimestamp = (timestamp: number) => {
-    parent.meta.updateIncident({ dateTime: timestamp })
+    parent.meta.updateIncident({ [name]: timestamp })
   }
 
   return (


### PR DESCRIPTION
Ticket: [SIG-7326](https://gemeente-amsterdam.atlassian.net/browse/SIG-7326)

Answer to the dateTime question was not shown on the summary page when the questions were fetched from the backend due to a fixed key in the updateTimeStamp. This PR resolves that issue.

## Signalen

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)


[SIG-7326]: https://gemeente-amsterdam.atlassian.net/browse/SIG-7326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ