### PR TITLE
Exclude datetime from extra properties

### DIFF
--- a/src/signals/incident/containers/IncidentContainer/constants.ts
+++ b/src/signals/incident/containers/IncidentContainer/constants.ts
@@ -35,13 +35,14 @@ export const REMOVE_FROM_SELECTION =
   'sia/IncidentContainer/REMOVE_FROM_SELECTION'
 
 export const LOCATION_SELECT_FIELD_TYPE = 'location_select'
+export const DATE_TIME_INPUT_FIELD_TYPE = 'date_time_input'
 
 export const FIELD_TYPE_MAP = {
   asset_select: QuestionFieldType.AssetSelect,
   caterpillar_select: QuestionFieldType.CaterpillarSelect,
   checkbox_input: QuestionFieldType.CheckboxInput,
   clock_select: QuestionFieldType.ClockSelect,
-  date_time_input: QuestionFieldType.DateTimeInput,
+  [DATE_TIME_INPUT_FIELD_TYPE]: QuestionFieldType.DateTimeInput,
   description_with_classification_input: QuestionFieldType.DescriptionInput,
   emphasis_checkbox_input: QuestionFieldType.EmphasisCheckboxInput,
   file_input: QuestionFieldType.FileInput,

--- a/src/signals/incident/containers/IncidentContainer/services.js
+++ b/src/signals/incident/containers/IncidentContainer/services.js
@@ -4,6 +4,7 @@ import {
   FIELD_TYPE_MAP,
   INPUT_VALIDATOR_MAP,
   LOCATION_SELECT_FIELD_TYPE,
+  DATE_TIME_INPUT_FIELD_TYPE,
 } from './constants'
 
 const mapValidatorWithArgs = ([key, ...args]) => [
@@ -13,18 +14,22 @@ const mapValidatorWithArgs = ([key, ...args]) => [
 const mapValidator = (key) =>
   Array.isArray(key) ? mapValidatorWithArgs(key) : INPUT_VALIDATOR_MAP[key]
 
+const excludedFromExtraProperties = [
+  LOCATION_SELECT_FIELD_TYPE,
+  DATE_TIME_INPUT_FIELD_TYPE,
+]
+
 export const resolveQuestions = (questions) =>
   questions.reduce(
     (acc, question) => ({
       ...acc,
       [question.key]: {
-        meta:
-          question.field_type === LOCATION_SELECT_FIELD_TYPE
-            ? question.meta
-            : {
-                ...question.meta,
-                pathMerge: 'extra_properties',
-              },
+        meta: excludedFromExtraProperties.includes(question.field_type)
+          ? question.meta
+          : {
+              ...question.meta,
+              pathMerge: 'extra_properties',
+            },
         options: {
           validators: [
             ...new Set([

--- a/src/signals/incident/containers/IncidentContainer/services.test.js
+++ b/src/signals/incident/containers/IncidentContainer/services.test.js
@@ -30,6 +30,13 @@ const mockedQuestions = [
     field_type: 'select_input',
     required: true,
   },
+  {
+    key: 'key5',
+    meta: {
+      metaProp: 'metaProp',
+    },
+    field_type: 'date_time_input',
+  },
 ]
 
 describe('Incident container services', () => {
@@ -45,7 +52,8 @@ describe('Incident container services', () => {
       expect(result).toHaveProperty('key2')
       expect(result).toHaveProperty('key3')
       expect(result).toHaveProperty('key4')
-      expect(Object.keys(result).length).toBe(4)
+      expect(result).toHaveProperty('key5')
+      expect(Object.keys(result).length).toBe(5)
     })
 
     it('should pass meta prop', () => {
@@ -61,7 +69,7 @@ describe('Incident container services', () => {
       })
     })
 
-    it('should not add extra_properties prop to meta when field type is location', () => {
+    it('should not add extra_properties prop to meta when field type is location or date time input', () => {
       const result = resolveQuestions(mockedQuestions)
       expect(result.key1).toMatchObject({
         meta: {
@@ -79,6 +87,11 @@ describe('Incident container services', () => {
         },
       })
       expect(result.key4).toMatchObject({
+        meta: {
+          pathMerge: 'extra_properties',
+        },
+      })
+      expect(result.key5).not.toMatchObject({
         meta: {
           pathMerge: 'extra_properties',
         },


### PR DESCRIPTION
Ticket: none

When fetchQuestionsFromBackend featureFlag is on all questions configured in Django are merged into the extra properties except location_select. DateTime should also be excluded from the extra properties since it is shown as "Overlast" in the melding detail page.

## Signalen

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
