### PR TITLE
feat: option to hide reopen request ("Verzoek tot Heropenen") status

### DIFF
--- a/app.base.json
+++ b/app.base.json
@@ -6,6 +6,7 @@
     "assignSignalToDepartment": false,
     "assignSignalToEmployee": false,
     "disableClosingCategoryOverigOverig": false,
+    "disableReopenRequestStatusOption": false,
     "enableAmsterdamSpecificOverigCategories": false,
     "enableCsvExport": false,
     "enableForwardIncidentToExternal": true,

--- a/internals/schemas/app.schema.json
+++ b/internals/schemas/app.schema.json
@@ -157,6 +157,10 @@
           "description": "Disallows processing of an issue that has category Overig-overig and status Afgehandeld",
           "type": "boolean"
         },
+        "disableReopenRequestStatusOption": {
+          "description": "Hides the status option Verzoek tot heropenen in the backoffice status form.",
+          "type": "boolean"
+        },
         "showStandardTextAdminV1": {
           "description": "Shows the old way of managing standard text for email responses.",
           "type": "boolean"

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.test.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.test.tsx
@@ -134,6 +134,7 @@ describe('signals/incident-management/containers/IncidentDetail/components/Statu
   afterEach(() => {
     fetch.resetMocks()
     update.mockReset()
+    configuration.featureFlags.disableReopenRequestStatusOption = false
     configuration.featureFlags.reporterMailHandledNegativeContactEnabled = true
   })
 
@@ -169,6 +170,23 @@ describe('signals/incident-management/containers/IncidentDetail/components/Statu
         document.querySelector(`option[value="${key}"]`)
       )
     })
+  })
+
+  it('hides the option Verzoek tot heropenen when disabled with a feature flag', () => {
+    configuration.featureFlags.disableReopenRequestStatusOption = true
+
+    render(renderWithContext())
+
+    const selectElement = screen.getByTestId('select-status')
+    const selectOptions =
+      getQueriesForElement(selectElement).getAllByRole('option')
+
+    expect(selectOptions.length).toEqual(changeStatusOptionList.length)
+    expect(
+      document.querySelector(
+        `option[value="${StatusCode.VerzoekTotHeropenen}"]`
+      )
+    ).not.toBeInTheDocument()
   })
 
   it('shows the number of available standard texts', () => {

--- a/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.tsx
+++ b/src/signals/incident-management/containers/IncidentDetail/components/StatusForm/StatusForm.tsx
@@ -109,6 +109,12 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
   const disableSubmit = Boolean(
     state.warnings.some(({ level }) => level === 'error')
   )
+  const statusOptions = configuration.featureFlags
+    .disableReopenRequestStatusOption
+    ? changeStatusOptionList.filter(
+        (status) => status.key !== StatusCode.VerzoekTotHeropenen
+      )
+    : changeStatusOptionList
 
   const onUpdate = useCallback(() => {
     const textValue = state.text.value || state.text.defaultValue
@@ -220,7 +226,7 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
 
     setEmailIsNotSend(emailIsNotSend)
 
-    const selectedStatus = changeStatusOptionList.find(
+    const selectedStatus = statusOptions.find(
       (status) => event.target.value === status.key
     )
     selectedStatus &&
@@ -277,7 +283,7 @@ const StatusForm: FunctionComponent<StatusFormProps> = ({
           onChange={onStatusChange}
         >
           <option key="default">Kies status</option>
-          {changeStatusOptionList.map((status: Status) => (
+          {statusOptions.map((status: Status) => (
             <option key={status.key} value={status.key}>
               {status.value}
             </option>


### PR DESCRIPTION
This PR introduces the option to hide the "Verzoek tot Heropenen" (reopen request) status in the StatusForm. This status was introduced in [PR #3351](https://github.com/Amsterdam/signals-frontend/pull/3351).

We received feedback that not every municipality uses this status. Therefore, this PR makes it configurable, allowing municipalities to hide the option when it is not applicable.

## Signalen

- [ ] Includes AI-assisted code via GitHub Copilot

Before opening a pull request, please ensure:

- Make sure your PR title follows naming conventions: [feat-1234]: name feature
- Double-check your branch is based on `main` and targets `main`
- Pull request has tests (we are going for 100% coverage!)
- Code is well-commented, linted and follows project conventions
- Committed source code is headed by the correct SPDX license expression

Be kind to code reviewers, please try to keep pull requests as small and focused as possible :)
